### PR TITLE
Bug fixes for method typing

### DIFF
--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -15,13 +15,13 @@ class Bar[A]: Foo[A]
 //│ Defined class Foo
 //│ Declared Foo.Map: (foo & {Foo#A = 'A, x: 'A}) -> ('A -> anything) -> 'A
 //│ Defined class Bar
-//│ Declared Bar.Map: (bar & {Foo#A = 'A, Bar#A = 'A, x: 'A}) -> (('a -> (anything -> 'a) -> 'b) -> 'b as 'a)
+//│ Declared Bar.Map: (bar & {Foo#A = 'A, Bar#A = 'A, x: 'A}) -> anything -> 'A
 //│ Defined Bar.Map: (bar & {Foo#A = 'A, Bar#A = 'A, x: 'A}) -> (('a -> (anything -> 'a) -> 'b) -> 'b as 'a)
 
 Foo.Map
 Bar.Map
 //│ res: (foo & {Foo#A = 'A, x: 'A}) -> ('A -> anything) -> 'A
-//│ res: (bar & {Foo#A = 'A, Bar#A = 'A, x: 'A}) -> (('a -> (anything -> 'a) -> 'b) -> 'b as 'a)
+//│ res: (bar & {Foo#A = 'A, Bar#A = 'A, x: 'A}) -> anything -> 'A
 
 
 
@@ -199,7 +199,7 @@ class BadPair[A, B]: AbstractPair[A, B]
 //│ ╙──       	                                              ^^^^^^^^^^^^^^^^^^
 //│ Defined class BadPair
 //│ Defined BadPair.Test: (badPair & {BadPair#A = 'A, AbstractPair#A = 'A, x: 'A, y: 'B, BadPair#B = 'B, AbstractPair#B = 'B}) -> ('A -> 'A -> 'a) -> 'a
-//│ Defined BadPair.Map: (badPair & {BadPair#A = 'A, AbstractPair#A = 'A, x: 'A, y: 'B, BadPair#B = 'B, AbstractPair#B = 'B}) -> ('A -> ('B0 & 'a & 'A0)) -> anything -> (badPair & {BadPair#A = 'A0, AbstractPair#A = 'A0, x: 'a, y: 'a, BadPair#B = 'B0, AbstractPair#B = 'B0})
+//│ Defined BadPair.Map: (badPair & {BadPair#A = 'A, AbstractPair#A = 'A, x: 'A, y: 'B, BadPair#B = 'B, AbstractPair#B = 'B}) -> ('A -> ('a & 'A0 & 'B0)) -> anything -> (badPair & {BadPair#A = 'A0, AbstractPair#A = 'A0, x: 'a, y: 'a, BadPair#B = 'B0, AbstractPair#B = 'B0})
 
 bp = BadPair { x = 42; y = true }
 bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
@@ -210,20 +210,23 @@ bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
 //│ ╟── expression of type `42` does not match type `bool`
 //│ ║  l.204: 	bp = BadPair { x = 42; y = true }
 //│ ║         	                   ^^
-//│ ╟── Note: constraint arises from argument:
+//│ ╟── but it flows into application with expected type `bool`
 //│ ║  l.205: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
-//│ ╙──       	                                         ^
-//│ res: 42 | error
+//│ ║         	                                         ^^^^^^^^^^^^^^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.158: 	    method Test: (A -> B -> bool) -> bool
+//│ ╙──       	                            ^^^^
+//│ res: bool | error
 
 BadPair = BadPair { x = 42; y = 0 }
 BadPair.Map
 BadPair.(BadPair.Map)
 //│ BadPair: badPair & {BadPair#A :> 'A | 42 <: 'A, AbstractPair#A :> 'A | 42 <: 'A, x: 42, y: 0, BadPair#B :> 'B | 0 <: 'B, AbstractPair#B :> 'B | 0 <: 'B}
-//│ res: (badPair & {BadPair#A = 'A, AbstractPair#A = 'A, x: 'A, y: 'B, BadPair#B = 'B, AbstractPair#B = 'B}) -> ('A -> ('A0 & 'a & 'B0)) -> anything -> (badPair & {BadPair#A = 'A0, AbstractPair#A = 'A0, x: 'a, y: 'a, BadPair#B = 'B0, AbstractPair#B = 'B0})
+//│ res: (badPair & {BadPair#A = 'A, AbstractPair#A = 'A, x: 'A, y: 'B, BadPair#B = 'B, AbstractPair#B = 'B}) -> ('A -> 'C) -> ('B -> 'D) -> (abstractPair & {AbstractPair#B = 'D, y: 'D, AbstractPair#A = 'C, x: 'C})
 //│ ╔══[ERROR] Class BadPair has no method BadPair.Map
-//│ ║  l.220: 	BadPair.(BadPair.Map)
+//│ ║  l.223: 	BadPair.(BadPair.Map)
 //│ ╙──       	^^^^^^^^^^^^^^^^^^^^^
-//│ res: (42 -> ('A & 'a & 'B)) -> anything -> (badPair & {BadPair#A = 'A, AbstractPair#A = 'A, x: 'a, y: 'a, BadPair#B = 'B, AbstractPair#B = 'B})
+//│ res: (42 -> 'C) -> (0 -> 'D) -> (abstractPair & {AbstractPair#B = 'D, y: 'D, AbstractPair#A = 'C, x: 'C})
 
 
 class ClassA
@@ -235,19 +238,19 @@ class ClassA
 class ClassB: ClassA
     method MtdA = 43
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.236: 	    method MtdA = 43
+//│ ║  l.239: 	    method MtdA = 43
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.236: 	    method MtdA = 43
+//│ ║  l.239: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `43` does not match type `42`
-//│ ║  l.236: 	    method MtdA = 43
+//│ ║  l.239: 	    method MtdA = 43
 //│ ║         	                  ^^
 //│ ╟── but it flows into method definition with expected type `42`
-//│ ║  l.236: 	    method MtdA = 43
+//│ ║  l.239: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.230: 	    method MtdA = 42
+//│ ║  l.233: 	    method MtdA = 42
 //│ ╙──       	                  ^^
 //│ Defined class ClassB
 //│ Defined ClassB.MtdA: classB -> 43
@@ -257,37 +260,37 @@ class ClassC: ClassA
     method MtdA: int
     method MtdA = 43
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.257: 	    method MtdA: int
+//│ ║  l.260: 	    method MtdA: int
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method declaration:
-//│ ║  l.257: 	    method MtdA: int
+//│ ║  l.260: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `int` does not match type `42`
-//│ ║  l.257: 	    method MtdA: int
+//│ ║  l.260: 	    method MtdA: int
 //│ ║         	                 ^^^
 //│ ╟── but it flows into method declaration with expected type `42`
-//│ ║  l.257: 	    method MtdA: int
+//│ ║  l.260: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.230: 	    method MtdA = 42
+//│ ║  l.233: 	    method MtdA = 42
 //│ ╙──       	                  ^^
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.258: 	    method MtdA = 43
+//│ ║  l.261: 	    method MtdA = 43
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.258: 	    method MtdA = 43
+//│ ║  l.261: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `43` does not match type `42`
-//│ ║  l.258: 	    method MtdA = 43
+//│ ║  l.261: 	    method MtdA = 43
 //│ ║         	                  ^^
 //│ ╟── but it flows into method definition with expected type `42`
-//│ ║  l.258: 	    method MtdA = 43
+//│ ║  l.261: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.230: 	    method MtdA = 42
+//│ ║  l.233: 	    method MtdA = 42
 //│ ╙──       	                  ^^
 //│ Defined class ClassC
-//│ Declared ClassC.MtdA: classC -> 43
+//│ Declared ClassC.MtdA: classC -> int
 //│ Defined ClassC.MtdA: classC -> 43
 
 :e
@@ -296,22 +299,22 @@ class ClassD: ClassA
 class ClassE: ClassD
     method MtdA = 43
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.295: 	    method MtdA: int
+//│ ║  l.298: 	    method MtdA: int
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method declaration:
-//│ ║  l.295: 	    method MtdA: int
+//│ ║  l.298: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `int` does not match type `42`
-//│ ║  l.295: 	    method MtdA: int
+//│ ║  l.298: 	    method MtdA: int
 //│ ║         	                 ^^^
 //│ ╟── but it flows into method declaration with expected type `42`
-//│ ║  l.295: 	    method MtdA: int
+//│ ║  l.298: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.230: 	    method MtdA = 42
+//│ ║  l.233: 	    method MtdA = 42
 //│ ╙──       	                  ^^
 //│ Defined class ClassD
-//│ Declared ClassD.MtdA: classD -> 42
+//│ Declared ClassD.MtdA: classD -> int
 //│ Defined class ClassE
 //│ Defined ClassE.MtdA: classE -> 43
 
@@ -327,19 +330,19 @@ trait Trait2A[B]
 class Class2B: Class2A[int] & Trait2A[string]
     method MtdA = "ok"
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.328: 	    method MtdA = "ok"
+//│ ║  l.331: 	    method MtdA = "ok"
 //│ ║         	           ^^^^^^^^^^^
 //│ ╟── expression of type `"ok"` does not match type `int`
-//│ ║  l.328: 	    method MtdA = "ok"
+//│ ║  l.331: 	    method MtdA = "ok"
 //│ ║         	                  ^^^^
 //│ ╟── but it flows into method definition with expected type `int`
-//│ ║  l.328: 	    method MtdA = "ok"
+//│ ║  l.331: 	    method MtdA = "ok"
 //│ ║         	           ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.327: 	class Class2B: Class2A[int] & Trait2A[string]
+//│ ║  l.330: 	class Class2B: Class2A[int] & Trait2A[string]
 //│ ║         	                       ^^^
 //│ ╟── from method declaration:
-//│ ║  l.324: 	    method MtdA: A
+//│ ║  l.327: 	    method MtdA: A
 //│ ╙──       	           ^^^^^^^
 //│ Defined class Class2A
 //│ Declared Class2A.MtdA: (class2A & {Class2A#A = 'A}) -> 'A
@@ -357,7 +360,7 @@ type Type3A = Class3A[string]
 class Class3B: Type3A
     method MtdA = 1
 //│ ╔══[ERROR] cannot inherit from a type alias
-//│ ║  l.357: 	class Class3B: Type3A
+//│ ║  l.360: 	class Class3B: Type3A
 //│ ╙──       	      ^^^^^^^^^^^^^^^
 //│ Defined class Class3A
 //│ Declared Class3A.MtdA: Class3A['A] -> 'A
@@ -367,7 +370,7 @@ class Class3B: Type3A
 :e
 Oops.M
 //│ ╔══[ERROR] Method M not found
-//│ ║  l.368: 	Oops.M
+//│ ║  l.371: 	Oops.M
 //│ ╙──       	^^^^^^
 //│ res: error
 
@@ -376,25 +379,32 @@ class Test4A
     method Mth4A: anything
     method Mth4A = true
 //│ Defined class Test4A
-//│ Declared Test4A.Mth4A: test4A -> true
+//│ Declared Test4A.Mth4A: test4A -> anything
 //│ Defined Test4A.Mth4A: test4A -> true
 :e
 class Test4B: Test4A
     method Mth4A: int
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.377: 	    method Mth4A = true
+//│ ║  l.380: 	    method Mth4A = true
 //│ ║         	           ^^^^^^^^^^^^
 //│ ╟── expression of type `true` does not match type `int`
-//│ ║  l.377: 	    method Mth4A = true
+//│ ║  l.380: 	    method Mth4A = true
 //│ ║         	                   ^^^^
 //│ ╟── but it flows into method definition with expected type `int`
-//│ ║  l.377: 	    method Mth4A = true
+//│ ║  l.380: 	    method Mth4A = true
 //│ ║         	           ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.383: 	    method Mth4A: int
+//│ ║  l.386: 	    method Mth4A: int
 //│ ╙──       	                  ^^^
 //│ Defined class Test4B
-//│ Declared Test4B.Mth4A: test4B -> true
+//│ Declared Test4B.Mth4A: test4B -> int
+
+o = Test4A {}
+o.Mth4A
+o.(Test4A.Mth4A)
+//│ o: test4A
+//│ res: anything
+//│ res: anything
 
 :e
 class Test5A
@@ -402,16 +412,16 @@ class Test5A
 class Test5B: Test5A
     method Mth5A = 43
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.403: 	    method Mth5A = 43
+//│ ║  l.413: 	    method Mth5A = 43
 //│ ║         	           ^^^^^^^^^^
 //│ ╟── expression of type `43` does not match type `42`
-//│ ║  l.403: 	    method Mth5A = 43
+//│ ║  l.413: 	    method Mth5A = 43
 //│ ║         	                   ^^
 //│ ╟── but it flows into method definition with expected type `42`
-//│ ║  l.403: 	    method Mth5A = 43
+//│ ║  l.413: 	    method Mth5A = 43
 //│ ║         	           ^^^^^^^^^^
 //│ ╟── Note: constraint arises from method declaration:
-//│ ║  l.401: 	    method Mth5A: 42
+//│ ║  l.411: 	    method Mth5A: 42
 //│ ╙──       	           ^^^^^
 //│ Defined class Test5A
 //│ Declared Test5A.Mth5A: test5A -> 42

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -144,7 +144,10 @@ class Simple3[A, B]: Simple2[A]
 //│ ╔══[ERROR] Type mismatch in method declaration:
 //│ ║  l.143: 	    method Get: B
 //│ ║         	           ^^^^^^
-//│ ╙── expression of type `B` does not match type `A`
+//│ ╟── expression of type `B` does not match type `A`
+//│ ╟── Note: constraint arises from method declaration:
+//│ ║  l.138: 	    method Get: A
+//│ ╙──       	           ^^^^^^
 //│ Defined class Simple3
 //│ Declared Simple3.Get: (simple3 & {a: 'A, Simple3#B = 'B, Simple2#A = 'A, Simple3#A = 'A}) -> 'B
 
@@ -162,37 +165,37 @@ class BadPair[A, B]: AbstractPair[A, B]
     method Test f = f this.x this.x
     method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.162: 	    method Test f = f this.x this.x
+//│ ║  l.165: 	    method Test f = f this.x this.x
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `A` does not match type `B`
-//│ ║  l.162: 	    method Test f = f this.x this.x
+//│ ║  l.165: 	    method Test f = f this.x this.x
 //│ ╙──       	                             ^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.163: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.166: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `C` does not match type `D`
-//│ ║  l.163: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.166: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into function of type `?a -> ?b`
-//│ ║  l.163: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.166: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── which does not match type `(B -> D) -> AbstractPair[C, D]`
 //│ ╟── Note: constraint arises from record type:
-//│ ║  l.154: 	class AbstractPair[A, B]: { x: A; y: B }
+//│ ║  l.157: 	class AbstractPair[A, B]: { x: A; y: B }
 //│ ║         	                          ^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.156: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║  l.159: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ╙──       	                                              ^^^^^^^^^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.163: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.166: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `C` does not match type `D`
 //│ ╟── but it flows into application of type `?a`
-//│ ║  l.163: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.166: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── which does not match type `AbstractPair[C, D]`
 //│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.156: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║  l.159: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ╙──       	                                              ^^^^^^^^^^^^^^^^^^
 //│ Defined class BadPair
 //│ Defined BadPair.Test: (badPair & {BadPair#A = 'A, AbstractPair#A = 'A, x: 'A, y: 'B, BadPair#B = 'B, AbstractPair#B = 'B}) -> ('A -> 'A -> 'a) -> 'a
@@ -202,13 +205,13 @@ bp = BadPair { x = 42; y = true }
 bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
 //│ bp: badPair & {BadPair#A :> 'A | 42 <: 'A, AbstractPair#A :> 'A | 42 <: 'A, x: 42, y: true, BadPair#B :> 'B | true <: 'B, AbstractPair#B :> 'B | true <: 'B}
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.202: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
+//│ ║  l.205: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `42` does not match type `bool`
-//│ ║  l.201: 	bp = BadPair { x = 42; y = true }
+//│ ║  l.204: 	bp = BadPair { x = 42; y = true }
 //│ ║         	                   ^^
 //│ ╟── Note: constraint arises from argument:
-//│ ║  l.202: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
+//│ ║  l.205: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
 //│ ╙──       	                                         ^
 //│ res: 42 | error
 
@@ -216,11 +219,11 @@ BadPair = BadPair { x = 42; y = 0 }
 BadPair.Map
 BadPair.(BadPair.Map)
 //│ BadPair: badPair & {BadPair#A :> 'A | 42 <: 'A, AbstractPair#A :> 'A | 42 <: 'A, x: 42, y: 0, BadPair#B :> 'B | 0 <: 'B, AbstractPair#B :> 'B | 0 <: 'B}
-//│ res: (badPair & {BadPair#A = 'A, AbstractPair#A = 'A, x: 'A, y: 'B, BadPair#B = 'B, AbstractPair#B = 'B}) -> ('A -> ('a & 'A0 & 'B0)) -> anything -> (badPair & {BadPair#A = 'A0, AbstractPair#A = 'A0, x: 'a, y: 'a, BadPair#B = 'B0, AbstractPair#B = 'B0})
+//│ res: (badPair & {BadPair#A = 'A, AbstractPair#A = 'A, x: 'A, y: 'B, BadPair#B = 'B, AbstractPair#B = 'B}) -> ('A -> ('A0 & 'a & 'B0)) -> anything -> (badPair & {BadPair#A = 'A0, AbstractPair#A = 'A0, x: 'a, y: 'a, BadPair#B = 'B0, AbstractPair#B = 'B0})
 //│ ╔══[ERROR] Class BadPair has no method BadPair.Map
-//│ ║  l.217: 	BadPair.(BadPair.Map)
+//│ ║  l.220: 	BadPair.(BadPair.Map)
 //│ ╙──       	^^^^^^^^^^^^^^^^^^^^^
-//│ res: (42 -> ('B & 'a & 'A)) -> anything -> (badPair & {BadPair#A = 'A, AbstractPair#A = 'A, x: 'a, y: 'a, BadPair#B = 'B, AbstractPair#B = 'B})
+//│ res: (42 -> ('A & 'a & 'B)) -> anything -> (badPair & {BadPair#A = 'A, AbstractPair#A = 'A, x: 'a, y: 'a, BadPair#B = 'B, AbstractPair#B = 'B})
 
 
 class ClassA
@@ -232,16 +235,19 @@ class ClassA
 class ClassB: ClassA
     method MtdA = 43
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.233: 	    method MtdA = 43
+//│ ║  l.236: 	    method MtdA = 43
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.233: 	    method MtdA = 43
+//│ ║  l.236: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `43` does not match type `42`
-//│ ║  l.233: 	    method MtdA = 43
+//│ ║  l.236: 	    method MtdA = 43
 //│ ║         	                  ^^
+//│ ╟── but it flows into method definition with expected type `42`
+//│ ║  l.236: 	    method MtdA = 43
+//│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.227: 	    method MtdA = 42
+//│ ║  l.230: 	    method MtdA = 42
 //│ ╙──       	                  ^^
 //│ Defined class ClassB
 //│ Defined ClassB.MtdA: classB -> 43
@@ -251,28 +257,34 @@ class ClassC: ClassA
     method MtdA: int
     method MtdA = 43
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.251: 	    method MtdA: int
+//│ ║  l.257: 	    method MtdA: int
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method declaration:
-//│ ║  l.251: 	    method MtdA: int
+//│ ║  l.257: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `int` does not match type `42`
-//│ ║  l.251: 	    method MtdA: int
+//│ ║  l.257: 	    method MtdA: int
 //│ ║         	                 ^^^
+//│ ╟── but it flows into method declaration with expected type `42`
+//│ ║  l.257: 	    method MtdA: int
+//│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.227: 	    method MtdA = 42
+//│ ║  l.230: 	    method MtdA = 42
 //│ ╙──       	                  ^^
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.252: 	    method MtdA = 43
+//│ ║  l.258: 	    method MtdA = 43
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.252: 	    method MtdA = 43
+//│ ║  l.258: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `43` does not match type `42`
-//│ ║  l.252: 	    method MtdA = 43
+//│ ║  l.258: 	    method MtdA = 43
 //│ ║         	                  ^^
+//│ ╟── but it flows into method definition with expected type `42`
+//│ ║  l.258: 	    method MtdA = 43
+//│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.227: 	    method MtdA = 42
+//│ ║  l.230: 	    method MtdA = 42
 //│ ╙──       	                  ^^
 //│ Defined class ClassC
 //│ Declared ClassC.MtdA: classC -> 43
@@ -284,16 +296,19 @@ class ClassD: ClassA
 class ClassE: ClassD
     method MtdA = 43
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.283: 	    method MtdA: int
+//│ ║  l.295: 	    method MtdA: int
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method declaration:
-//│ ║  l.283: 	    method MtdA: int
+//│ ║  l.295: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `int` does not match type `42`
-//│ ║  l.283: 	    method MtdA: int
+//│ ║  l.295: 	    method MtdA: int
 //│ ║         	                 ^^^
+//│ ╟── but it flows into method declaration with expected type `42`
+//│ ║  l.295: 	    method MtdA: int
+//│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.227: 	    method MtdA = 42
+//│ ║  l.230: 	    method MtdA = 42
 //│ ╙──       	                  ^^
 //│ Defined class ClassD
 //│ Declared ClassD.MtdA: classD -> 42
@@ -312,14 +327,20 @@ trait Trait2A[B]
 class Class2B: Class2A[int] & Trait2A[string]
     method MtdA = "ok"
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.313: 	    method MtdA = "ok"
+//│ ║  l.328: 	    method MtdA = "ok"
 //│ ║         	           ^^^^^^^^^^^
 //│ ╟── expression of type `"ok"` does not match type `int`
-//│ ║  l.313: 	    method MtdA = "ok"
+//│ ║  l.328: 	    method MtdA = "ok"
 //│ ║         	                  ^^^^
+//│ ╟── but it flows into method definition with expected type `int`
+//│ ║  l.328: 	    method MtdA = "ok"
+//│ ║         	           ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.312: 	class Class2B: Class2A[int] & Trait2A[string]
-//│ ╙──       	                       ^^^
+//│ ║  l.327: 	class Class2B: Class2A[int] & Trait2A[string]
+//│ ║         	                       ^^^
+//│ ╟── from method declaration:
+//│ ║  l.324: 	    method MtdA: A
+//│ ╙──       	           ^^^^^^^
 //│ Defined class Class2A
 //│ Declared Class2A.MtdA: (class2A & {Class2A#A = 'A}) -> 'A
 //│ Defined trait Trait2A
@@ -336,7 +357,7 @@ type Type3A = Class3A[string]
 class Class3B: Type3A
     method MtdA = 1
 //│ ╔══[ERROR] cannot inherit from a type alias
-//│ ║  l.336: 	class Class3B: Type3A
+//│ ║  l.357: 	class Class3B: Type3A
 //│ ╙──       	      ^^^^^^^^^^^^^^^
 //│ Defined class Class3A
 //│ Declared Class3A.MtdA: Class3A['A] -> 'A
@@ -346,7 +367,53 @@ class Class3B: Type3A
 :e
 Oops.M
 //│ ╔══[ERROR] Method M not found
-//│ ║  l.347: 	Oops.M
+//│ ║  l.368: 	Oops.M
 //│ ╙──       	^^^^^^
 //│ res: error
 
+
+class Test4A
+    method Mth4A: anything
+    method Mth4A = true
+//│ Defined class Test4A
+//│ Declared Test4A.Mth4A: test4A -> true
+//│ Defined Test4A.Mth4A: test4A -> true
+:e
+class Test4B: Test4A
+    method Mth4A: int
+//│ ╔══[ERROR] Type mismatch in method definition:
+//│ ║  l.377: 	    method Mth4A = true
+//│ ║         	           ^^^^^^^^^^^^
+//│ ╟── expression of type `true` does not match type `int`
+//│ ║  l.377: 	    method Mth4A = true
+//│ ║         	                   ^^^^
+//│ ╟── but it flows into method definition with expected type `int`
+//│ ║  l.377: 	    method Mth4A = true
+//│ ║         	           ^^^^^^^^^^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.383: 	    method Mth4A: int
+//│ ╙──       	                  ^^^
+//│ Defined class Test4B
+//│ Declared Test4B.Mth4A: test4B -> true
+
+:e
+class Test5A
+    method Mth5A: 42
+class Test5B: Test5A
+    method Mth5A = 43
+//│ ╔══[ERROR] Type mismatch in method definition:
+//│ ║  l.403: 	    method Mth5A = 43
+//│ ║         	           ^^^^^^^^^^
+//│ ╟── expression of type `43` does not match type `42`
+//│ ║  l.403: 	    method Mth5A = 43
+//│ ║         	                   ^^
+//│ ╟── but it flows into method definition with expected type `42`
+//│ ║  l.403: 	    method Mth5A = 43
+//│ ║         	           ^^^^^^^^^^
+//│ ╟── Note: constraint arises from method declaration:
+//│ ║  l.401: 	    method Mth5A: 42
+//│ ╙──       	           ^^^^^
+//│ Defined class Test5A
+//│ Declared Test5A.Mth5A: test5A -> 42
+//│ Defined class Test5B
+//│ Defined Test5B.Mth5A: test5B -> 43

--- a/shared/src/test/diff/mlscript/MethodAndMatches.mls
+++ b/shared/src/test/diff/mlscript/MethodAndMatches.mls
@@ -51,6 +51,9 @@ def bar0 = foo
 //│ ╟── Note: constraint arises from record type:
 //│ ║  l.3: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                             ^^^^^^^^^^
+//│ ╟── from method definition:
+//│ ║  l.4: 	  method M1 y = Derived1 { x = add this.x y }
+//│ ║       	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from reference:
 //│ ║  l.21: 	  | Derived1 -> b.M2
 //│ ║        	                ^
@@ -69,10 +72,10 @@ bar1 d1 0
 def bar1 = foo
 //│ (derived1 & {Base1#A = int, x: int} | base1 & {Base1#A = 'A} & ~derived1) -> 'A -> (derived1 & {Base1#A = int, x: int} | base1 & {Base1#A = 'A})  <:  bar1: (derived1 & {Base1#A = int, x: int} | derived2 & {Base1#A = {c: 'a, d: 'b}, Derived2#D = 'b, Derived2#C = 'a}) -> int -> (derived1 & {Base1#A = int, x: int} | derived2 & {Base1#A = {c: 'a0, d: 'b0}, Derived2#D = 'b0, Derived2#C = 'a0})
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `int` does not match type `{c: ?a, d: ?b}`
-//│ ║  l.61: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.64: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ║        	                        ^^^
 //│ ╟── Note: constraint arises from record type:
 //│ ║  l.6: 	class Derived2[C, D]: Base1[{ c: C; d: D }]
@@ -81,10 +84,10 @@ def bar1 = foo
 //│ ║  l.22: 	  | Base1 -> b.M1 x
 //│ ╙──      	                  ^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `int` does not match type `{c: ?a, d: ?b}`
-//│ ║  l.61: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.64: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ║        	                        ^^^
 //│ ╟── Note: constraint arises from record type:
 //│ ║  l.6: 	class Derived2[C, D]: Base1[{ c: C; d: D }]
@@ -93,29 +96,29 @@ def bar1 = foo
 //│ ║  l.22: 	  | Base1 -> b.M1 x
 //│ ╙──      	                  ^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `base1 & {Base1#A = ?A}` does not match type `Derived1 | Derived2[?a, ?b]`
 //│ ║  l.2: 	  method M1: A -> Base1[A]
 //│ ║       	                  ^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from union type:
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.61: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.64: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `int` does not match type `{c: ?a, d: ?b}`
-//│ ║  l.61: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.64: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ║        	                        ^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from record type:
@@ -125,48 +128,48 @@ def bar1 = foo
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.61: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.64: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `base1 & {Base1#A = ?A}` does not match type `Derived1 | Derived2[?a, ?b]`
 //│ ║  l.2: 	  method M1: A -> Base1[A]
 //│ ║       	                  ^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from union type:
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.61: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.64: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `base1 & {Base1#A = ?A}` does not match type `Derived1 | Derived2[?a, ?b]`
 //│ ║  l.2: 	  method M1: A -> Base1[A]
 //│ ║       	                  ^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from union type:
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.61: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.64: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `{c: ?a, d: ?b}` does not match type `int`
 //│ ║  l.6: 	class Derived2[C, D]: Base1[{ c: C; d: D }]
 //│ ║       	                            ^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from type reference:
@@ -176,16 +179,16 @@ def bar1 = foo
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.61: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.64: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `{c: ?a, d: ?b}` does not match type `int`
 //│ ║  l.6: 	class Derived2[C, D]: Base1[{ c: C; d: D }]
 //│ ║       	                            ^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from type reference:
@@ -195,16 +198,16 @@ def bar1 = foo
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.61: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.64: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `{c: ?a, d: ?b}` does not match type `int`
 //│ ║  l.6: 	class Derived2[C, D]: Base1[{ c: C; d: D }]
 //│ ║       	                            ^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from type reference:
@@ -214,23 +217,23 @@ def bar1 = foo
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.61: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.64: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `base1 & {Base1#A = ?A}` does not match type `Derived1 | Derived2[?a, ?b]`
 //│ ║  l.2: 	  method M1: A -> Base1[A]
 //│ ║       	                  ^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.69: 	def bar1 = foo
+//│ ║  l.72: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from union type:
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.61: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.64: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 
 def bar2: Base1['a] -> 'a -> Base1['a]
@@ -245,23 +248,26 @@ bar2 d1 0
 def bar2 = foo
 //│ (derived1 & {Base1#A = int, x: int} | base1 & {Base1#A = 'A} & ~derived1) -> 'A -> (derived1 & {Base1#A = int, x: int} | base1 & {Base1#A = 'A})  <:  bar2: (base1 & {Base1#A = 'a}) -> 'a -> (base1 & {Base1#A = 'a})
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.245: 	def bar2 = foo
+//│ ║  l.248: 	def bar2 = foo
 //│ ║         	           ^^^
 //│ ╟── expression of type `int` does not match type `'a`
 //│ ║  l.3: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                      ^^^
 //│ ╟── Note: constraint arises from type variable:
-//│ ║  l.236: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║  l.239: 	def bar2: Base1['a] -> 'a -> Base1['a]
 //│ ╙──       	                ^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.245: 	def bar2 = foo
+//│ ║  l.248: 	def bar2 = foo
 //│ ║         	           ^^^
 //│ ╟── expression of type `'a` does not match type `int`
-//│ ║  l.236: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║  l.239: 	def bar2: Base1['a] -> 'a -> Base1['a]
 //│ ║         	                ^^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.3: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                      ^^^
+//│ ╟── from method definition:
+//│ ║  l.4: 	  method M1 y = Derived1 { x = add this.x y }
+//│ ║       	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from reference:
 //│ ║  l.21: 	  | Derived1 -> b.M2
 //│ ║        	                ^
@@ -269,14 +275,17 @@ def bar2 = foo
 //│ ║  l.20: 	def foo b x = case b of {
 //│ ╙──      	                   ^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.245: 	def bar2 = foo
+//│ ║  l.248: 	def bar2 = foo
 //│ ║         	           ^^^
 //│ ╟── expression of type `base1 & {Base1#A = 'a} & ~(base1 & ?a & ~derived1)` does not match type `{x: int}`
-//│ ║  l.236: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║  l.239: 	def bar2: Base1['a] -> 'a -> Base1['a]
 //│ ║         	          ^^^^^^^^^
 //│ ╟── Note: constraint arises from record type:
 //│ ║  l.3: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                             ^^^^^^^^^^
+//│ ╟── from method definition:
+//│ ║  l.4: 	  method M1 y = Derived1 { x = add this.x y }
+//│ ║       	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from reference:
 //│ ║  l.21: 	  | Derived1 -> b.M2
 //│ ║        	                ^

--- a/shared/src/test/diff/mlscript/Methods.mls
+++ b/shared/src/test/diff/mlscript/Methods.mls
@@ -211,9 +211,15 @@ class Class3C: Class2C
 //│ ╟── expression of type `42` does not match type `bool`
 //│ ║  l.207: 	    method MtdB = 42
 //│ ║         	                  ^^
+//│ ╟── but it flows into method definition with expected type `bool`
+//│ ║  l.207: 	    method MtdB = 42
+//│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.191: 	class Class2C: Class2B[int, bool]
-//│ ╙──       	                            ^^^^
+//│ ║         	                            ^^^^
+//│ ╟── from method declaration:
+//│ ║  l.190: 	    method MtdB: B
+//│ ╙──       	           ^^^^^^^
 //│ Defined class Class3C
 //│ Defined Class3C.MtdA: (class3C & {Class2B#A = int, Class1A#A = int, Class2B#B = bool, Trait2A#A = bool} & trait2A) -> 42
 //│ Defined Class3C.MtdB: (class3C & {Class2B#A = int, Class1A#A = int, Class2B#B = bool, Trait2A#A = bool} & trait2A) -> 42

--- a/shared/src/test/diff/mlscript/Methods.mls
+++ b/shared/src/test/diff/mlscript/Methods.mls
@@ -1,7 +1,9 @@
 class Foo[A, B]: { x: A; y: B }
     method Fun[C]: (A -> B -> C) -> (A -> B -> C)
+    method Fun[C, D] (f: C -> D) = f
 //│ Defined class Foo
 //│ Declared Foo.Fun: (foo & {Foo#B = 'B, Foo#A = 'A, y: 'B, x: 'A}) -> ('A -> 'B -> 'C) -> 'A -> 'B -> 'C
+//│ Defined Foo.Fun: (foo & {Foo#B = 'B, Foo#A = 'A, y: 'B, x: 'A}) -> (nothing -> anything & 'a) -> 'a
 
 class Bar: Foo[int, bool]
     method Fun f = f
@@ -11,7 +13,7 @@ class Bar: Foo[int, bool]
 Foo.Fun
 Bar.Fun
 //│ res: (foo & {Foo#B = 'B, Foo#A = 'A, y: 'B, x: 'A}) -> ('A -> 'B -> 'C) -> 'A -> 'B -> 'C
-//│ res: (bar & {Foo#B = bool, Foo#A = int, y: bool, x: int}) -> 'a -> 'a
+//│ res: (bar & {Foo#B = bool, Foo#A = int, y: bool, x: int}) -> (int -> bool -> 'C) -> int -> bool -> 'C
 
 f = Foo { x = 1; y = 2 }
 //│ f: foo & {Foo#B :> 'B | 2 <: 'B, Foo#A :> 'A | 1 <: 'A, y: 2, x: 1}
@@ -35,12 +37,12 @@ g = Bar { x = 42; y = true }
 g.(Foo.Fun)
 g.(Bar.Fun)
 //│ res: (int -> bool -> 'C) -> int -> bool -> 'C
-//│ res: 'a -> 'a
+//│ res: (int -> bool -> 'C) -> int -> bool -> 'C
 
 Foo.Fun g
 Bar.Fun g
 //│ res: (int -> bool -> 'C) -> int -> bool -> 'C
-//│ res: 'a -> 'a
+//│ res: (int -> bool -> 'C) -> int -> bool -> 'C
 
 g.Fun
 //│ res: (int -> bool -> 'C) -> int -> bool -> 'C
@@ -54,9 +56,12 @@ h.Fun
 
 
 class Wrapper[A]: { x: A }
+    method Apply f = Wrapper { x = f this.x }
     method Apply[B]: (A -> B) -> Wrapper[B]
+    // method Apply f = Wrapper { x = f this.x }
 //│ Defined class Wrapper
 //│ Declared Wrapper.Apply: (wrapper & {Wrapper#A = 'A, x: 'A}) -> ('A -> 'B) -> (wrapper & {Wrapper#A = 'B, x: 'B})
+//│ Defined Wrapper.Apply: (wrapper & {Wrapper#A = 'A, x: 'A}) -> ('A -> ('a & 'A0)) -> (wrapper & {Wrapper#A = 'A0, x: 'a})
 
 class IntWrapper: Wrapper[int]
     method Apply f = Wrapper { x = f this.x }
@@ -67,21 +72,21 @@ class Psyduck[B]: Wrapper[B]
     method Apply[A]: (B -> A) -> Psyduck[A]
     method Apply f = Psyduck { x = f this.x }
 //│ Defined class Psyduck
-//│ Declared Psyduck.Apply: (psyduck & {Psyduck#B = 'B, Wrapper#A = 'B, x: 'B}) -> ('B -> ('a & 'B0)) -> (psyduck & {Psyduck#B = 'B0, Wrapper#A = 'B0, x: 'a})
+//│ Declared Psyduck.Apply: (psyduck & {Psyduck#B = 'B, Wrapper#A = 'B, x: 'B}) -> ('B -> 'A) -> (psyduck & {Psyduck#B = 'A, Wrapper#A = 'A, x: 'A})
 //│ Defined Psyduck.Apply: (psyduck & {Psyduck#B = 'B, Wrapper#A = 'B, x: 'B}) -> ('B -> ('a & 'B0)) -> (psyduck & {Psyduck#B = 'B0, Wrapper#A = 'B0, x: 'a})
 
 class WrapperWrapper[A]: Wrapper[Wrapper[A]]
     method Apply2[B]: (A -> B) -> WrapperWrapper[B]
     method Apply2 f = WrapperWrapper { x = this.x.Apply f }
 //│ Defined class WrapperWrapper
-//│ Declared WrapperWrapper.Apply2: (wrapperWrapper & {Wrapper#A = wrapper & {Wrapper#A = 'A, x: 'A}, WrapperWrapper#A = 'A, x: wrapper & {Wrapper#A = 'A, x: 'A}}) -> ('A -> 'a) -> (wrapperWrapper & {Wrapper#A = wrapper & {Wrapper#A = 'a, x: 'a}, WrapperWrapper#A = 'a, x: wrapper & {Wrapper#A = 'a, x: 'a}})
+//│ Declared WrapperWrapper.Apply2: (wrapperWrapper & {Wrapper#A = wrapper & {Wrapper#A = 'A, x: 'A}, WrapperWrapper#A = 'A, x: wrapper & {Wrapper#A = 'A, x: 'A}}) -> ('A -> 'B) -> (wrapperWrapper & {Wrapper#A = wrapper & {Wrapper#A = 'B, x: 'B}, WrapperWrapper#A = 'B, x: wrapper & {Wrapper#A = 'B, x: 'B}})
 //│ Defined WrapperWrapper.Apply2: (wrapperWrapper & {Wrapper#A = wrapper & {Wrapper#A = 'A, x: 'A}, WrapperWrapper#A = 'A, x: wrapper & {Wrapper#A = 'A, x: 'A}}) -> ('A -> 'a) -> (wrapperWrapper & {Wrapper#A = wrapper & {Wrapper#A = 'a, x: 'a}, WrapperWrapper#A = 'a, x: wrapper & {Wrapper#A = 'a, x: 'a}})
 
 WrapperWrapper { x = Psyduck { x = 0 } }
 //│ res: wrapperWrapper & {Wrapper#A :> wrapper & {Wrapper#A :> 'A | 0 <: 'A, x: 'A | 0} <: wrapper & {Wrapper#A :> 'A <: 'A | 0, x: 'A}, WrapperWrapper#A :> 'A | 0 <: 'A, x: psyduck & {Psyduck#B :> 'A | 0 <: 'A, Wrapper#A :> 'A | 0 <: 'A, x: 0}}
 
 res.Apply2 (fun x -> mul x 2)
-//│ res: wrapperWrapper & {Wrapper#A :> wrapper & {Wrapper#A :> 'a | int <: 'a, x: 'a | int} <: wrapper & {Wrapper#A :> 'a <: 'a | int, x: 'a}, WrapperWrapper#A :> 'a | int <: 'a, x: wrapper & {Wrapper#A :> 'a | int <: 'a, x: 'a | int}}
+//│ res: wrapperWrapper & {Wrapper#A :> wrapper & {Wrapper#A :> 'B | int <: 'B, x: 'B | int} <: wrapper & {Wrapper#A :> 'B <: 'B | int, x: 'B}, WrapperWrapper#A :> 'B | int <: 'B, x: wrapper & {Wrapper#A :> 'B | int <: 'B, x: 'B | int}}
 
 Wrapper
 //│ res: {x: 'x & 'A} -> (wrapper & {Wrapper#A = 'A, x: 'x})
@@ -138,7 +143,7 @@ class True2[A, B]: Pair[A, B]
     method True = this.Test (fun x -> error)
     method Test f = true
 //│ Defined class True2
-//│ Declared True2.Test: (true2 & {Pair#B = 'B, True2#B = 'B, AbstractPair#A = 'A, x: 'A, Pair#A = 'A, y: 'B, True2#A = 'A, AbstractPair#B = 'B}) -> anything -> true
+//│ Declared True2.Test: (true2 & {Pair#B = 'B, True2#B = 'B, AbstractPair#A = 'A, x: 'A, Pair#A = 'A, y: 'B, True2#A = 'A, AbstractPair#B = 'B}) -> anything -> bool
 //│ Defined True2.True: (true2 & {Pair#B = 'B, True2#B = 'B, AbstractPair#A = 'A, x: 'A, Pair#A = 'A, y: 'B, True2#A = 'A, AbstractPair#B = 'B}) -> bool
 //│ Defined True2.Test: (true2 & {Pair#B = 'B, True2#B = 'B, AbstractPair#A = 'A, x: 'A, Pair#A = 'A, y: 'B, True2#A = 'A, AbstractPair#B = 'B}) -> anything -> true
 
@@ -206,19 +211,19 @@ class Class3C: Class2C
     method MtdA = 42
     method MtdB = 42
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.207: 	    method MtdB = 42
+//│ ║  l.212: 	    method MtdB = 42
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `42` does not match type `bool`
-//│ ║  l.207: 	    method MtdB = 42
+//│ ║  l.212: 	    method MtdB = 42
 //│ ║         	                  ^^
 //│ ╟── but it flows into method definition with expected type `bool`
-//│ ║  l.207: 	    method MtdB = 42
+//│ ║  l.212: 	    method MtdB = 42
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.191: 	class Class2C: Class2B[int, bool]
+//│ ║  l.196: 	class Class2C: Class2B[int, bool]
 //│ ║         	                            ^^^^
 //│ ╟── from method declaration:
-//│ ║  l.190: 	    method MtdB: B
+//│ ║  l.195: 	    method MtdB: B
 //│ ╙──       	           ^^^^^^^
 //│ Defined class Class3C
 //│ Defined Class3C.MtdA: (class3C & {Class2B#A = int, Class1A#A = int, Class2B#B = bool, Trait2A#A = bool} & trait2A) -> 42

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -253,13 +253,11 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite {
                   // ^ it may not end up being defined if there's an error
                 output(s"Defined " + td.kind.str + " " + td.nme.name)
                 val ttd = ctx.tyDefs(td.nme.name)
-                val thisTy = typer.TypeRef(ttd, ttd.tparams.flatMap(p => 
-                  ctx.getTargsMaps(ttd.nme.name, N, p.name)))(typer.TypeProvenance(ttd.toLoc, "type definition"), ctx)
                 (ttd.mthDecls ++ ttd.mthDefs).foreach { case MethodDef(_, _, nme, tps, rhs) =>
                   val fullName = td.nme.name + "." + nme.name
-                  val bodyTy = rhs.fold(_ => ctx.mthDefs(td.nme.name)(nme.name), _ => ctx.mthDecls(td.nme.name)(nme.name))
-                  val mty = typer.PolymorphicType(bodyTy.level, typer.FunctionType(thisTy, bodyTy.body)(bodyTy.prov))
-                  val res = getType(mty.instantiate(0))
+                  val bodyTy = rhs.fold(_ => ctx.mthDefs, _ => ctx.mthDecls)(td.nme.name)(nme.name)
+                  val mthTy = typer.wrapMethod(ttd.nme.name, bodyTy)(bodyTy.prov, ctx)
+                  val res = getType(mthTy.instantiate(0))
                   output(s"${rhs.fold(_ => "Defined", _ => "Declared")} ${fullName}: ${res.show}")
                 }
               }

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -253,9 +253,12 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite {
                   // ^ it may not end up being defined if there's an error
                 output(s"Defined " + td.kind.str + " " + td.nme.name)
                 val ttd = ctx.tyDefs(td.nme.name)
+                val thisTy = typer.TypeRef(ttd, ttd.tparams.flatMap(p => 
+                  ctx.getTargsMaps(ttd.nme.name, N, p.name)))(typer.TypeProvenance(ttd.toLoc, "type definition"), ctx)
                 (ttd.mthDecls ++ ttd.mthDefs).foreach { case MethodDef(_, _, nme, tps, rhs) =>
                   val fullName = td.nme.name + "." + nme.name
-                  val mty = ctx.env(fullName)
+                  val bodyTy = rhs.fold(_ => ctx.mthDefs(td.nme.name)(nme.name), _ => ctx.mthDecls(td.nme.name)(nme.name))
+                  val mty = typer.PolymorphicType(bodyTy.level, typer.FunctionType(thisTy, bodyTy.body)(bodyTy.prov))
                   val res = getType(mty.instantiate(0))
                   output(s"${rhs.fold(_ => "Defined", _ => "Declared")} ${fullName}: ${res.show}")
                 }


### PR DESCRIPTION
Issue: subsumption checking was not performed on propagated method definitions, allowing this to be typed:
```scala
class Test4A
    method Mth4A: anything
    method Mth4A = true
//│ Defined class Test4A
//│ Declared Test4A.Mth4A: test4A -> true
//│ Defined Test4A.Mth4A: test4A -> true
:e
class Test4B: Test4A
    method Mth4A: int
//│ Defined class Test4B
//│ Declared Test4B.Mth4A: test4B -> true
```

It now emits an error:
https://github.com/hkust-taco/mlscript/blob/1e7cee08b7a7ae7de95b52249cc1aea5da33d855/shared/src/test/diff/mlscript/BadMethods.mls#L373-L384

Side effect: the error message are improved in some cases:
https://github.com/hkust-taco/mlscript/compare/048e0a1..1e7cee0#diff-271f81eabb0cf04b1f9fe33d0620031626c2c2cb6c311ebafa625a54caf951cbL144-R150