### PR TITLE
Forbid instantiating abstract classes

### DIFF
--- a/shared/src/main/scala/mlscript/ConstraintSolver.scala
+++ b/shared/src/main/scala/mlscript/ConstraintSolver.scala
@@ -416,7 +416,10 @@ class ConstraintSolver extends NormalForms { self: Typer =>
   def errType(implicit prov: TypeProvenance): SimpleType = ClassTag(ErrTypeId, Set.empty)(prov)
   
   def warn(msg: Message, loco: Opt[Loc])(implicit raise: Raise): Unit =
-    raise(Warning((msg, loco) :: Nil))
+    warn(msg -> loco :: Nil)
+
+  def warn(msgs: List[Message -> Opt[Loc]])(implicit raise: Raise): Unit =
+    raise(Warning(msgs))
   
   
   // Note: maybe this and `extrude` should be merged?

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -420,10 +420,10 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
             err(msg"Method names must start with a capital letter", nme.toLoc)
           if (defs.isDefinedAt(nme.name))
             err(msg"Method '${tn}.${nme.name}' is already defined.", nme.toLoc)
-          (targsMap.keySet & targsMap2.keySet).foreach { s =>
-            warn((s"Method type parameter ${targsMap2(s).nameHint.getOrElse("")}" -> targsMap2(s).prov.loco)
-              :: (s"shadows class type parameter ${td.targsMap(s).nameHint.getOrElse("")}" -> td.targsMap(s).prov.loco)
-              :: Nil map (x => Message.fromStr(x._1) -> x._2))
+          td.tparams.flatMap(tp1 => tparams.find(_.name === tp1.name).map(tp1 -> _)).foreach { case tp1 -> tp2 =>
+            warn((msg"Method type parameter ${tp1}" -> tp1.toLoc)
+              :: (msg"shadows class type parameter ${tp2}" -> tp2.toLoc)
+              :: Nil)
           }
           val bodyTy = rhs.fold(
             term => subst(typeLetRhs(rec, nme.name, term)(thisCtx, raise, targsMap ++ targsMap2), reverseRigid),

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -23,6 +23,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
     kind: TypeDefKind,
     nme: TypeName,
     tparams: List[TypeName],
+    targs: List[TypeVariable],
     body: Type,
     mthDecls: List[MethodDef[Right[Term, Type]]],
     mthDefs: List[MethodDef[Left[Term, Type]]],
@@ -33,6 +34,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
       baseClasses.map(v => Var(v.name.toList.mapHead(_.toLower).mkString)) ++
         baseClasses.iterator.filterNot(traversed).flatMap(v =>
           ctx.tyDefs.get(v.name).fold(Set.empty[Var])(_.allBaseClasses(ctx)(traversed + v)))
+    val targsMap: Map[Str, TypeVariable] = tparams.map(_.name).zip(targs).toMap
   }
   
   /** targsMaps: stores the map from type parameters to type variables for polymorphic classes and methods
@@ -44,26 +46,19 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
    */
   case class Ctx(parent: Opt[Ctx], env: MutMap[Str, TypeScheme], lvl: Int, inPattern: Bool, tyDefs: Map[Str, TypeDef],
       mthDecls: Map[Str, Map[Str, PolymorphicType]], mthDefs: Map[Str, Map[Str, PolymorphicType]],
-      targsMaps: MutMap[Str, MutMap[Option[Str], Map[Str, SimpleType]]], methodBase: MutMap[Str, Option[Var]],
-      abcCache: MutMap[Str, Set[Var]]) {
+      methodBase: MutMap[Str, Option[Var]], abcCache: MutMap[Str, Set[Var]]) {
     def +=(b: Binding): Unit = env += b
     def ++=(bs: IterableOnce[Binding]): Unit = bs.iterator.foreach(+=)
     def get(name: Str): Opt[TypeScheme] = env.get(name) orElse parent.dlof(_.get(name))(N)
     def contains(name: Str): Bool = env.contains(name) || parent.exists(_.contains(name))
-    def nest: Ctx = copy(Some(this), MutMap.empty, targsMaps = MutMap.empty)
+    def nest: Ctx = copy(Some(this), MutMap.empty)
     def nextLevel: Ctx = copy(lvl = lvl + 1)
-    def getTargsMaps(cls: Str): Option[MutMap[Option[Str], Map[Str, SimpleType]]] =
-      targsMaps.get(cls) orElse parent.dlof(_.getTargsMaps(cls))(N)
-    def getTargsMaps(cls: Str, mth: Option[Str]): Option[Map[Str, SimpleType]] =
-      getTargsMaps(cls).dlof(_.get(mth) orElse parent.dlof(_.getTargsMaps(cls, mth))(N))(N)
-    def getTargsMaps(cls: Str, mth: Option[Str], targ: Str): Option[SimpleType] =
-      getTargsMaps(cls, mth).dlof(_.get(targ) orElse parent.dlof(_.getTargsMaps(cls, mth, targ))(N))(N)
     def allBaseClassesOf(name: Str): Set[Var] = abcCache.getOrElse(name,
       tyDefs.get(name).fold(Set.empty[Var])(_.allBaseClasses(this)(Set.empty).tap(abcCache += name -> _)))
     private val thisTyCache = MutMap.empty[Str, TypeRef]
     def thisType(tn: Str)(implicit prov: TypeProvenance): TypeRef = thisTyCache.getOrElse(tn, {
       val td = tyDefs(tn)
-      TypeRef(td, td.tparams.flatMap(p => getTargsMaps(tn, N, p.name)))(prov, this).tap(thisTyCache += tn -> _)
+      TypeRef(td, td.targs)(prov, this).tap(thisTyCache += tn -> _)
     })
   }
   object Ctx {
@@ -75,7 +70,6 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
       tyDefs = Map.from(builtinTypes.map(t => t.nme.name -> t)),
       mthDecls = Map.empty,
       mthDefs = Map.empty,
-      targsMaps = MutMap.empty,
       methodBase = MutMap.empty,
       abcCache = MutMap.empty)
   }
@@ -115,14 +109,14 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
       "anything" -> TopType, "nothing" -> BotType)
   
   val builtinTypes: Ls[TypeDef] =
-    TypeDef(Cls, TypeName("int"), Nil, Top, List.empty, List.empty, Set.single(Var("number")), N) ::
-    TypeDef(Cls, TypeName("number"), Nil, Top, List.empty, List.empty, Set.empty, N) ::
-    TypeDef(Cls, TypeName("bool"), Nil, Top, List.empty, List.empty, Set.empty, N) ::
-    TypeDef(Cls, TypeName("true"), Nil, Top, List.empty, List.empty, Set.single(Var("bool")), N) ::
-    TypeDef(Cls, TypeName("false"), Nil, Top, List.empty, List.empty, Set.single(Var("bool")), N) ::
-    TypeDef(Cls, TypeName("string"), Nil, Top, List.empty, List.empty, Set.empty, N) ::
-    TypeDef(Als, TypeName("anything"), Nil, Top, List.empty, List.empty, Set.empty, N) ::
-    TypeDef(Als, TypeName("nothing"), Nil, Bot, List.empty, List.empty, Set.empty, N) ::
+    TypeDef(Cls, TypeName("int"), Nil, Nil, Top, List.empty, List.empty, Set.single(Var("number")), N) ::
+    TypeDef(Cls, TypeName("number"), Nil, Nil, Top, List.empty, List.empty, Set.empty, N) ::
+    TypeDef(Cls, TypeName("bool"), Nil, Nil, Top, List.empty, List.empty, Set.empty, N) ::
+    TypeDef(Cls, TypeName("true"), Nil, Nil, Top, List.empty, List.empty, Set.single(Var("bool")), N) ::
+    TypeDef(Cls, TypeName("false"), Nil, Nil, Top, List.empty, List.empty, Set.single(Var("bool")), N) ::
+    TypeDef(Cls, TypeName("string"), Nil, Nil, Top, List.empty, List.empty, Set.empty, N) ::
+    TypeDef(Als, TypeName("anything"), Nil, Nil, Top, List.empty, List.empty, Set.empty, N) ::
+    TypeDef(Als, TypeName("nothing"), Nil, Nil, Bot, List.empty, List.empty, Set.empty, N) ::
     Nil
   val primitiveTypes: Set[Str] =
     builtinTypes.iterator.filter(_.kind is Cls).map(_.nme.name).toSet
@@ -208,12 +202,12 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
   
   /** Extract the mapping of type arguments applied to the base classes and traits from the body of a type definition.
    *  Only inheritance from a conjunction of `TypeName`s, `AppliedType`s and `Record`s are legal. */
-  def targsAppOf(tyDef: TypeDef)(implicit ctx: Ctx, raise: Raise, lookup: Option[(Str, Option[Str])] = N,
+  def targsAppOf(tyDef: TypeDef)(implicit ctx: Ctx, raise: Raise,
       vars: Map[Str, SimpleType] = Map.empty): Map[Str, Map[Str, SimpleType]] = {
     def rec(ty: Type): Map[Str, Map[Str, SimpleType]] = ty match {
       case Inter(l, r) => rec(l) ++ rec(r)
       case AppliedType(TypeName(bn), ts) => ctx.tyDefs.get(bn).fold(Map(bn -> Map.empty[Str, SimpleType])) {
-        td => Map(bn -> td.tparams.map(_.name).zip(ts.map(typeType(_)(ctx.nextLevel, raise, lookup, vars))).toMap)
+        td => Map(bn -> td.tparams.map(_.name).zip(ts.map(typeType(_)(ctx.nextLevel, raise, vars))).toMap)
       }
       case Record(_) => Map.empty
       case TypeName(_) => Map.empty
@@ -236,7 +230,9 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
       }
       if (!n.name.head.isUpper) err(
         msg"Type names must start with a capital letter", n.toLoc)
-      val td1 = TypeDef(td.kind, td.nme, td.tparams, td.body, td.mthDecls, td.mthDefs, 
+      val dummyTargs = td.tparams.map(p =>
+        freshVar(originProv(p.toLoc, s"${td.kind.str} type parameter"), S(p.name))(ctx.lvl + 1))
+      val td1 = TypeDef(td.kind, td.nme, td.tparams, dummyTargs, td.body, td.mthDecls, td.mthDefs, 
         baseClassesOf(td), td.toLoc)
       allDefs += n.name -> td1
       td1
@@ -246,8 +242,8 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
     def getSubsMap(tn: Str)(implicit ctx: Ctx): Map[Str, Map[SimpleType, SimpleType]] = subsMapCache.getOrElse(tn,
       (ctx.tyDefs.get(tn) match {
         case S(td) =>
-          val targsApp = targsAppOf(td)(ctx, raise, S((tn, N)))
-          td.baseClasses.flatMap { case Var(bn) => ctx.getTargsMaps(bn, N).map(bn -> _) }.map { case bn -> m =>
+          val targsApp = targsAppOf(td)(ctx, raise, ctx.tyDefs(tn).targsMap)
+          td.baseClasses.flatMap { case Var(bn) => ctx.tyDefs.get(bn).map(_.targsMap).map(bn -> _) }.map { case bn -> m =>
             bn -> m.map[SimpleType, SimpleType] {
               case targ -> (tv: TypeVariable) => tv -> targsApp(bn).getOrElse(targ,
                 freshVar(noProv)(tv.level)) // Q: Is this `freshVar` legit? Seems it should never happen
@@ -263,10 +259,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
       ctx.copy(tyDefs = oldDefs ++ newDefs.flatMap { td =>
         implicit val prov: TypeProvenance = tp(td.toLoc, "type definition")
         val n = td.nme
-        val dummyTargs = td.tparams.map(p =>
-          freshVar(originProv(p.toLoc, s"${td.kind.str} type parameter"), S(p.name))(ctx.lvl + 1))
-        ctx.targsMaps += n.name -> MutMap(N -> td.tparams.map(_.name).zip(dummyTargs).toMap)
-        val body_ty = typeType(td.body, simplify = false)(ctx.nextLevel, raise, S((n.name, N)))
+        val body_ty = typeType(td.body, simplify = false)(ctx.nextLevel, raise, td.targsMap)
         var fields = SortedMap.empty[Var, SimpleType]
         def allDeclMths(td: TypeDef): Set[Str] = td.baseClasses.flatMap(bc => ctx.mthDecls.get(bc.name).map(_.keySet)
           .getOrElse(allDeclMths(ctx.tyDefs(bc.name)))) ++ td.mthDecls.map(_.nme.name)
@@ -349,7 +342,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
             checkParents(body_ty) &&
                 checkCycleComputeFields(body_ty, computeFields = td.kind is Cls)(Set.single(td)) &&
                 ((allDeclMths(td) -- allDefMths(td)).nonEmpty || {
-              val tparamTags = td.tparams.lazyZip(dummyTargs).map((tp, tv) =>
+              val tparamTags = td.tparams.lazyZip(td.targs).map((tp, tv) =>
                 tparamField(td.nme, tp) -> FunctionType(tv, tv)(noProv)).toList
               val ctor = k match {
                 case Cls =>
@@ -388,7 +381,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
                   err(msg"Type definition is not regular: it occurs within itself as ${
                     expandType(tr, true).show
                   }, but is defined as ${
-                    expandType(TypeRef(defn, dummyTargs)(noProv, ctx), true).show
+                    expandType(TypeRef(defn, td.targs)(noProv, ctx), true).show
                   }", td.toLoc)(raise, noProv)
                 false
               } else true
@@ -397,7 +390,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
         }
         // Note: this will end up going through some types several times... We could make sure to
         //    only go through each type once, but the error messages would be worse.
-        if (rightParents && checkRegular(body_ty)(Map(n.name -> dummyTargs)))
+        if (rightParents && checkRegular(body_ty)(Map(n.name -> td.targs)))
           td.nme.name -> td :: Nil
         else Nil
       })
@@ -411,30 +404,26 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
         val tn = td.nme
         val decls = MutMap.empty[Str, PolymorphicType]
         val defs = MutMap.empty[Str, PolymorphicType]
-        val targsMap = ctx.getTargsMaps(td.nme.name, N).getOrElse(Map.empty)
         val thisCtx = ctx.nest
-        val m = MutMap.empty[SimpleType, SimpleType]
-        thisCtx.targsMaps += td.nme.name -> MutMap(N -> targsMap.map { 
-          case s -> (tv: TypeVariable) =>
-            val rigid = freshenAbove(ctx.lvl, tv, true)
-            m += rigid -> tv
-            s -> rigid
+        val targsMap = td.targsMap.map { 
+          case s -> (tv: TypeVariable) => s -> freshenAbove(ctx.lvl, tv, true)
           case _ => die
-        })
-        val reverseRigid = m.toMap
-        thisCtx += "this" -> thisCtx.thisType(tn.name)
+        }
+        val rigid = td.targsMap.map { case pn -> tv => tv -> targsMap(pn) }.toMap[SimpleType, SimpleType]
+        val reverseRigid = rigid.map(_.swap).toMap
+        thisCtx += "this" -> subst(thisCtx.thisType(tn.name), rigid)
         (td.mthDecls ++ td.mthDefs).foreach { case md @ MethodDef(rec, prt, nme, tparams, rhs) =>
           implicit val prov: TypeProvenance = tp(md.toLoc, rhs.fold(_ => "method definition", _ => "method declaration"))
           val dummyTargs2 = tparams.map(p => freshVar(originProv(p.toLoc, "method type parameter"), S(p.name))(ctx.lvl + 2))
-          ctx.targsMaps(tn.name) += S(nme.name) -> tparams.map(_.name).zip(dummyTargs2).toMap
+          val targsMap2 = tparams.map(_.name).zip(dummyTargs2).toMap
           // ^ overwrites. fine for now as the maps are not used afterwards. may pass vars instead
           if (!nme.name.head.isUpper)
             err(msg"Method names must start with a capital letter", nme.toLoc)
           if (defs.isDefinedAt(nme.name))
             err(msg"Method '${tn}.${nme.name}' is already defined.", nme.toLoc)
-          val bodyTy = rhs.fold(
-            term => subst(typeLetRhs(rec, nme.name, term)(thisCtx, raise, S((tn.name, S(nme.name)))), reverseRigid),
-            ty => PolymorphicType(thisCtx.lvl, subst(typeType(ty)(thisCtx, raise, S((tn.name, S(nme.name)))), reverseRigid))
+          val bodyTy = rhs.fold( // TODO: warn about shadowing?
+            term => subst(typeLetRhs(rec, nme.name, term)(thisCtx, raise, targsMap ++ targsMap2), reverseRigid),
+            ty => PolymorphicType(thisCtx.lvl, subst(typeType(ty)(thisCtx, raise, targsMap ++ targsMap2), reverseRigid))
           )
           rhs.fold(_ => defs, _ => decls) += nme.name -> (bodyTy match {
             case PolymorphicType(level, body) => PolymorphicType(level, ProvType(body)(prov))
@@ -480,7 +469,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
         val tn = td.nme
         val decls = ctx.mthDecls(tn.name)
         val defs = ctx.mthDefs(tn.name)
-        val rigidSubsMap = ctx.getTargsMaps(tn.name, N).getOrElse(Map.empty).map { 
+        val rigidSubsMap = td.targsMap.map { 
           case s -> (tv: TypeVariable) => tv -> freshenAbove(ctx.lvl, tv, true)
           case _ => die
         }.toMap[SimpleType, SimpleType]
@@ -517,16 +506,11 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
   }
   // TODO better record type provenances!
   def typeType(ty: Type, simplify: Bool = true)(implicit ctx: Ctx, raise: Raise,
-      lookup: Option[(Str, Option[Str])] = N, vars: Map[Str, SimpleType] = Map.empty): SimpleType = {
+      vars: Map[Str, SimpleType] = Map.empty): SimpleType = {
     val typeType = ()
     def typeNamed(loc: Opt[Loc], name: Str): (() => ST) \/ TypeDef =
       ctx.tyDefs.get(name).toRight(() =>
         err("type identifier not found: " + name, loc)(raise, tp(loc, "missing type")))
-    val allVars = vars ++ (lookup match {
-      case S((tn, S(mn))) => ctx.getTargsMaps(tn, N).getOrElse(Map.empty) ++ ctx.getTargsMaps(tn, S(mn)).getOrElse(Map.empty)
-      case S((tn, N)) => ctx.getTargsMaps(tn, N).getOrElse(Map.empty)
-      case N => Map.empty
-    })
     val localVars = mutable.Map.empty[TypeVar, TypeVariable]
     def rec(ty: Type)(implicit ctx: Ctx, recVars: Map[TypeVar, TypeVariable]): SimpleType = ty match {
       case Top => ExtrType(false)(tp(ty.toLoc, "top type"))
@@ -553,7 +537,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
       case TypeName(name) =>
         val tyLoc = ty.toLoc
         val tpr = tp(tyLoc, "type reference")
-        allVars.get(name).getOrElse {
+        vars.get(name).getOrElse {
           typeNamed(tyLoc, name) match {
             case R(td) =>
               if (td.tparams.nonEmpty) {
@@ -601,8 +585,8 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
     rec(ty)(ctx, Map.empty)
   }
   
-  def typePattern(pat: Term)(implicit ctx: Ctx, raise: Raise, lookup: Option[(Str, Option[Str])] = N): SimpleType =
-    typeTerm(pat)(ctx.copy(inPattern = true), raise, lookup)
+  def typePattern(pat: Term)(implicit ctx: Ctx, raise: Raise, vars: Map[Str, SimpleType] = Map.empty): SimpleType =
+    typeTerm(pat)(ctx.copy(inPattern = true), raise, vars)
   
   
   def typeStatement(s: DesugaredStatement, allowPure: Bool)
@@ -639,15 +623,15 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
   }
   
   /** Infer the type of a let binding right-hand side. */
-  def typeLetRhs(isrec: Boolean, nme: Str, rhs: Term)
-        (implicit ctx: Ctx, raise: Raise, lookup: Option[(Str, Option[Str])] = N): PolymorphicType = {
+  def typeLetRhs(isrec: Boolean, nme: Str, rhs: Term)(implicit ctx: Ctx, raise: Raise,
+      vars: Map[Str, SimpleType] = Map.empty): PolymorphicType = {
     val res = if (isrec) {
       val e_ty = freshVar(TypeProvenance(rhs.toLoc, "let-bound value"))(lvl + 1)
       ctx += nme -> e_ty
-      val ty = typeTerm(rhs)(ctx.nextLevel, raise, lookup)
+      val ty = typeTerm(rhs)(ctx.nextLevel, raise, vars)
       constrain(ty, e_ty)(raise, TypeProvenance(rhs.toLoc, "binding of " + rhs.describe))
       e_ty
-    } else typeTerm(rhs)(ctx.nextLevel, raise, lookup)
+    } else typeTerm(rhs)(ctx.nextLevel, raise, vars)
     PolymorphicType(lvl, res)
   }
   
@@ -682,7 +666,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
   }
   
   /** Infer the type of a term. */
-  def typeTerm(term: Term)(implicit ctx: Ctx, raise: Raise, lookup: Option[(Str, Option[Str])] = N): SimpleType
+  def typeTerm(term: Term)(implicit ctx: Ctx, raise: Raise, vars: Map[Str, SimpleType] = Map.empty): SimpleType
         = trace(s"$lvl. Typing ${if (ctx.inPattern) "pattern" else "term"} $term") {
     implicit val prov: TypeProvenance = ttp(term)
     
@@ -703,7 +687,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
         freshVar(tp(v.toLoc, "wildcard"))
       case Asc(trm, ty) =>
         val trm_ty = typeTerm(trm)
-        val ty_ty = typeType(ty)(ctx.copy(inPattern = false), raise, lookup)
+        val ty_ty = typeType(ty)(ctx.copy(inPattern = false), raise, vars)
         con(trm_ty, ty_ty, ty_ty)
         if (ctx.inPattern) trm_ty else ty_ty
       case (v @ ValidPatVar(nme)) =>
@@ -750,9 +734,9 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
       case Lam(pat, body) =>
         val newBindings = mutable.Map.empty[Str, TypeVariable]
         val newCtx = ctx.nest
-        val param_ty = typePattern(pat)(newCtx, raise, lookup)
+        val param_ty = typePattern(pat)(newCtx, raise, vars)
         newCtx ++= newBindings
-        val body_ty = typeTerm(body)(newCtx, raise, lookup)
+        val body_ty = typeTerm(body)(newCtx, raise, vars)
         FunctionType(param_ty, body_ty)(tp(term.toLoc, "function"))
       case App(App(Var("and"), lhs), rhs) =>
         val lhs_ty = typeTerm(lhs)

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -700,8 +700,8 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
           (ctx.tyDefs.get(name), ctx.mthDecls.get(name).map(_ -- ctx.mthDefs(name).keys)) match {
             case (S(td), S(abstMths)) if abstMths.nonEmpty => err(
               (msg"Instantiation of an abstract type is forbidden" -> term.toLoc)
-              :: (msg"${td.kind.str} ${td.nme} is abstract:" -> td.toLoc)
-              :: abstMths.map { case mn -> mthTy => msg"method $mn is abstract" -> mthTy.prov.loco }.toList)
+              :: (msg"Note that ${td.kind.str} ${td.nme} is abstract:" -> td.toLoc)
+              :: abstMths.map { case mn -> mthTy => msg"Hint: method $mn is abstract" -> mthTy.prov.loco }.toList)
             case _ => err("identifier not found: " + name, term.toLoc)
           }
         }.instantiate

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -420,11 +420,13 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
             err(msg"Method names must start with a capital letter", nme.toLoc)
           if (defs.isDefinedAt(nme.name))
             err(msg"Method '${tn}.${nme.name}' is already defined.", nme.toLoc)
-          td.tparams.flatMap(tp1 => tparams.find(_.name === tp1.name).map(tp1 -> _)).foreach { case tp1 -> tp2 =>
-            warn((msg"Method type parameter ${tp1}" -> tp1.toLoc)
+          val tp1s = td.tparams.map(tp => tp.name -> tp).toMap
+          tparams.foreach(tp2 => tp1s.get(tp2.name) match {
+            case S(tp1) => warn((msg"Method type parameter ${tp1}" -> tp1.toLoc)
               :: (msg"shadows class type parameter ${tp2}" -> tp2.toLoc)
               :: Nil)
-          }
+            case N =>
+          })
           val bodyTy = rhs.fold(
             term => subst(typeLetRhs(rec, nme.name, term)(thisCtx, raise, targsMap ++ targsMap2), reverseRigid),
             ty => PolymorphicType(thisCtx.lvl, subst(typeType(ty)(thisCtx, raise, targsMap ++ targsMap2), reverseRigid))

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -447,13 +447,13 @@ Test6A
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
 //│ ║  l.446: 	Test6A
 //│ ║         	^^^^^^
-//│ ╟── class Test6A is abstract:
+//│ ╟── Note that class Test6A is abstract:
 //│ ║  l.432: 	class Test6A[A]
 //│ ║         	      ^^^^^^^^
-//│ ╟── method Mth6B is abstract
+//│ ╟── Hint: method Mth6B is abstract
 //│ ║  l.434: 	    method Mth6B[B]: (A -> B) -> B
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── method Mth6A is abstract
+//│ ╟── Hint: method Mth6A is abstract
 //│ ║  l.433: 	    method Mth6A: A
 //│ ╙──       	           ^^^^^^^^
 //│ res: error
@@ -463,10 +463,10 @@ Test6B
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
 //│ ║  l.462: 	Test6B
 //│ ║         	^^^^^^
-//│ ╟── trait Test6B is abstract:
+//│ ╟── Note that trait Test6B is abstract:
 //│ ║  l.435: 	trait Test6B
 //│ ║         	      ^^^^^^
-//│ ╟── method Mth6A is abstract
+//│ ╟── Hint: method Mth6A is abstract
 //│ ║  l.436: 	    method Mth6A: bool
 //│ ╙──       	           ^^^^^^^^^^^
 //│ res: error
@@ -476,13 +476,13 @@ Test6C
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
 //│ ║  l.475: 	Test6C
 //│ ║         	^^^^^^
-//│ ╟── class Test6C is abstract:
+//│ ╟── Note that class Test6C is abstract:
 //│ ║  l.437: 	class Test6C: Test6A[int] & Test6B
 //│ ║         	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── method Mth6B is abstract
+//│ ╟── Hint: method Mth6B is abstract
 //│ ║  l.434: 	    method Mth6B[B]: (A -> B) -> B
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── method Mth6A is abstract
+//│ ╟── Hint: method Mth6A is abstract
 //│ ║  l.437: 	class Test6C: Test6A[int] & Test6B
 //│ ╙──       	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -427,3 +427,62 @@ class Test5B: Test5A
 //│ Declared Test5A.Mth5A: test5A -> 42
 //│ Defined class Test5B
 //│ Defined Test5B.Mth5A: test5B -> 43
+
+
+class Test6A[A]
+    method Mth6A: A
+    method Mth6B[B]: (A -> B) -> B
+trait Test6B
+    method Mth6A: bool
+class Test6C: Test6A[int] & Test6B
+//│ Defined class Test6A
+//│ Declared Test6A.Mth6A: (test6A & {Test6A#A = 'A}) -> 'A
+//│ Declared Test6A.Mth6B: (test6A & {Test6A#A = 'A}) -> ('A -> 'B) -> 'B
+//│ Defined trait Test6B
+//│ Declared Test6B.Mth6A: test6B -> bool
+//│ Defined class Test6C
+
+:e
+Test6A
+//│ ╔══[ERROR] Instantiation of an abstract type is forbidden
+//│ ║  l.446: 	Test6A
+//│ ║         	^^^^^^
+//│ ╟── class Test6A is abstract:
+//│ ║  l.432: 	class Test6A[A]
+//│ ║         	      ^^^^^^^^
+//│ ╟── method Mth6B is abstract
+//│ ║  l.434: 	    method Mth6B[B]: (A -> B) -> B
+//│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── method Mth6A is abstract
+//│ ║  l.433: 	    method Mth6A: A
+//│ ╙──       	           ^^^^^^^^
+//│ res: error
+
+:e
+Test6B
+//│ ╔══[ERROR] Instantiation of an abstract type is forbidden
+//│ ║  l.462: 	Test6B
+//│ ║         	^^^^^^
+//│ ╟── trait Test6B is abstract:
+//│ ║  l.435: 	trait Test6B
+//│ ║         	      ^^^^^^
+//│ ╟── method Mth6A is abstract
+//│ ║  l.436: 	    method Mth6A: bool
+//│ ╙──       	           ^^^^^^^^^^^
+//│ res: error
+
+:e
+Test6C
+//│ ╔══[ERROR] Instantiation of an abstract type is forbidden
+//│ ║  l.475: 	Test6C
+//│ ║         	^^^^^^
+//│ ╟── class Test6C is abstract:
+//│ ║  l.437: 	class Test6C: Test6A[int] & Test6B
+//│ ║         	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── method Mth6B is abstract
+//│ ║  l.434: 	    method Mth6B[B]: (A -> B) -> B
+//│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── method Mth6A is abstract
+//│ ║  l.437: 	class Test6C: Test6A[int] & Test6B
+//│ ╙──       	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ res: error

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -199,7 +199,7 @@ class BadPair[A, B]: AbstractPair[A, B]
 //│ ╙──       	                                              ^^^^^^^^^^^^^^^^^^
 //│ Defined class BadPair
 //│ Defined BadPair.Test: (badPair & {AbstractPair#A = 'A, AbstractPair#B = 'B, BadPair#A = 'A, BadPair#B = 'B, x: 'A, y: 'B}) -> ('A -> 'A -> 'a) -> 'a
-//│ Defined BadPair.Map: (badPair & {AbstractPair#A = 'A, AbstractPair#B = 'B, BadPair#A = 'A, BadPair#B = 'B, x: 'A, y: 'B}) -> ('A -> ('A0 & 'B0 & 'a)) -> anything -> (badPair & {AbstractPair#A = 'A0, AbstractPair#B = 'B0, BadPair#A = 'A0, BadPair#B = 'B0, x: 'a, y: 'a})
+//│ Defined BadPair.Map: (badPair & {AbstractPair#A = 'A, AbstractPair#B = 'B, BadPair#A = 'A, BadPair#B = 'B, x: 'A, y: 'B}) -> ('A -> ('a & 'B0 & 'A0)) -> anything -> (badPair & {AbstractPair#A = 'A0, AbstractPair#B = 'B0, BadPair#A = 'A0, BadPair#B = 'B0, x: 'a, y: 'a})
 
 bp = BadPair { x = 42; y = true }
 bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)

--- a/shared/src/test/diff/mlscript/ExprProb.mls
+++ b/shared/src/test/diff/mlscript/ExprProb.mls
@@ -85,10 +85,10 @@ def eval1_ty = eval1
 //│ ('a -> int) -> (add & {Add#E :> 'a & ~add & ~lit | 'b | add & {Add#E :> 'c <: 'd, lhs: 'd, rhs: 'd} | lit & {val: int} as 'd <: 'c, lhs: 'c, rhs: 'c} & 'b | lit & {val: int} & 'b | 'a & 'b & ~add & ~lit as 'c) -> int
 //│ /!!!\ Uncaught error: java.lang.AssertionError: assertion failed
 //│ 	at: scala.Predef$.assert(Predef.scala:264)
-//│ 	at: mlscript.ConstraintSolver.freshen$1(ConstraintSolver.scala:437)
-//│ 	at: mlscript.ConstraintSolver.freshen$1(ConstraintSolver.scala:459)
-//│ 	at: mlscript.ConstraintSolver.freshen$1(ConstraintSolver.scala:459)
-//│ 	at: mlscript.ConstraintSolver.freshenAbove(ConstraintSolver.scala:471)
+//│ 	at: mlscript.ConstraintSolver.freshen$1(ConstraintSolver.scala:440)
+//│ 	at: mlscript.ConstraintSolver.freshen$1(ConstraintSolver.scala:462)
+//│ 	at: mlscript.ConstraintSolver.freshen$1(ConstraintSolver.scala:462)
+//│ 	at: mlscript.ConstraintSolver.freshenAbove(ConstraintSolver.scala:474)
 //│ 	at: mlscript.TyperDatatypes$PolymorphicType.rigidify(TyperDatatypes.scala:30)
 //│ 	at: mlscript.ConstraintSolver.subsume(ConstraintSolver.scala:377)
 //│ 	at: mlscript.DiffTests.$anonfun$new$22(DiffTests.scala:288)

--- a/shared/src/test/diff/mlscript/GenericClasses2.mls
+++ b/shared/src/test/diff/mlscript/GenericClasses2.mls
@@ -53,10 +53,10 @@ Bar3
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
 //│ ║  l.51: 	Bar3
 //│ ║        	^^^^
-//│ ╟── class Bar3 is abstract:
+//│ ╟── Note that class Bar3 is abstract:
 //│ ║  l.45: 	class Bar3: Foo2[int]
 //│ ║        	      ^^^^^^^^^^^^^^^
-//│ ╟── method M2 is abstract
+//│ ╟── Hint: method M2 is abstract
 //│ ║  l.37: 	  method M2: A
 //│ ╙──      	         ^^^^^
 //│ res: error
@@ -68,10 +68,10 @@ Bar3
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
 //│ ║  l.66: 	Bar3
 //│ ║        	^^^^
-//│ ╟── class Bar3 is abstract:
+//│ ╟── Note that class Bar3 is abstract:
 //│ ║  l.45: 	class Bar3: Foo2[int]
 //│ ║        	      ^^^^^^^^^^^^^^^
-//│ ╟── method M2 is abstract
+//│ ╟── Hint: method M2 is abstract
 //│ ║  l.37: 	  method M2: A
 //│ ╙──      	         ^^^^^
 //│ res: error

--- a/shared/src/test/diff/mlscript/GenericClasses2.mls
+++ b/shared/src/test/diff/mlscript/GenericClasses2.mls
@@ -45,28 +45,48 @@ class Bar2: Foo2[int] & { x: int }
 class Bar3: Foo2[int]
 //│ Defined class Bar3
 
+:e
 :ns
 Bar2
 Bar3
 //│ res: {x: 'x & int} -> (bar2 & {Foo2#A = int, x: 'x})
-//│ res: anything -> (bar3 & {Foo2#A = int})
+//│ ╔══[ERROR] Instantiation of an abstract type is forbidden
+//│ ║  l.51: 	Bar3
+//│ ║        	^^^^
+//│ ╟── class Bar3 is abstract:
+//│ ║  l.45: 	class Bar3: Foo2[int]
+//│ ║        	      ^^^^^^^^^^^^^^^
+//│ ╟── method M2 is abstract
+//│ ║  l.37: 	  method M2: A
+//│ ╙──      	         ^^^^^
+//│ res: error
 
+:e
 Bar2
 Bar3
 //│ res: {x: int & 'x} -> (bar2 & {Foo2#A = int, x: 'x})
-//│ res: anything -> (bar3 & {Foo2#A = int})
+//│ ╔══[ERROR] Instantiation of an abstract type is forbidden
+//│ ║  l.66: 	Bar3
+//│ ║        	^^^^
+//│ ╟── class Bar3 is abstract:
+//│ ║  l.45: 	class Bar3: Foo2[int]
+//│ ║        	      ^^^^^^^^^^^^^^^
+//│ ╟── method M2 is abstract
+//│ ║  l.37: 	  method M2: A
+//│ ╙──      	         ^^^^^
+//│ res: error
 
 :e
 {A = 1}
 //│ ╔══[ERROR] Field identifiers must start with a small letter
-//│ ║  l.60: 	{A = 1}
+//│ ║  l.80: 	{A = 1}
 //│ ╙──      	^^^^^^^
 //│ res: {A: 1}
 
 :e
 error: {A: 1}
 //│ ╔══[ERROR] Field identifiers must start with a small letter
-//│ ║  l.67: 	error: {A: 1}
+//│ ║  l.87: 	error: {A: 1}
 //│ ╙──      	        ^
 //│ res: {A: 1}
 
@@ -76,10 +96,10 @@ b = Bar2{x = 1}
 :e
 c = b: Foo2[string]
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.77: 	c = b: Foo2[string]
+//│ ║  l.97: 	c = b: Foo2[string]
 //│ ║        	    ^
 //│ ╟── expression of type `string` does not match type `int`
-//│ ║  l.77: 	c = b: Foo2[string]
+//│ ║  l.97: 	c = b: Foo2[string]
 //│ ║        	            ^^^^^^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.38: 	class Bar2: Foo2[int] & { x: int }
@@ -101,10 +121,10 @@ d: Foo2['a]
 :e
 d: Foo2[string]
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.102: 	d: Foo2[string]
+//│ ║  l.122: 	d: Foo2[string]
 //│ ║         	^
 //│ ╟── expression of type `string` does not match type `int`
-//│ ║  l.102: 	d: Foo2[string]
+//│ ║  l.122: 	d: Foo2[string]
 //│ ║         	        ^^^^^^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.38: 	class Bar2: Foo2[int] & { x: int }

--- a/shared/src/test/diff/mlscript/Methods.mls
+++ b/shared/src/test/diff/mlscript/Methods.mls
@@ -254,3 +254,10 @@ Test3B.F
 
 
 
+:w
+class Test4A[A]: { x: A }
+    method Mth4A[A]: A
+//│ ╔══[WARNING] Method type parameter A
+//│ ╙── shadows class type parameter A
+//│ Defined class Test4A
+//│ Declared Test4A.Mth4A: (test4A & {Test4A#A = 'A, x: 'A}) -> nothing

--- a/shared/src/test/diff/mlscript/Methods.mls
+++ b/shared/src/test/diff/mlscript/Methods.mls
@@ -258,6 +258,10 @@ Test3B.F
 class Test4A[A]: { x: A }
     method Mth4A[A]: A
 //│ ╔══[WARNING] Method type parameter A
-//│ ╙── shadows class type parameter A
+//│ ║  l.258: 	class Test4A[A]: { x: A }
+//│ ║         	             ^
+//│ ╟── shadows class type parameter A
+//│ ║  l.259: 	    method Mth4A[A]: A
+//│ ╙──       	                 ^
 //│ Defined class Test4A
 //│ Declared Test4A.Mth4A: (test4A & {Test4A#A = 'A, x: 'A}) -> nothing


### PR DESCRIPTION
Closes #31

The error message lists the methods with missing implementations, which could potentially become too long if many methods are abstract and the class is instantiated many times. May consider listing only at the first time when it raises an error, and only keep the first line in subsequent errors. (But I don't think there is a mechanism to do that currently.)