### PR TITLE
Fix #39 (rigid method params, pattern typing, name hints...)

### DIFF
--- a/shared/src/main/scala/mlscript/TypeSimplifier.scala
+++ b/shared/src/main/scala/mlscript/TypeSimplifier.scala
@@ -192,7 +192,11 @@ trait TypeSimplifier { self: Typer =>
       println(s"[v] $v ${coOccurrences.get(true -> v)} ${coOccurrences.get(false -> v)}")
       pols.foreach { pol =>
         coOccurrences.get(pol -> v).iterator.flatMap(_.iterator).foreach {
-          case w: TypeVariable if !(w is v) && !varSubst.contains(w) && (recVars.contains(v) === recVars.contains(w)) =>
+          case w: TypeVariable if !(w is v) && !varSubst.contains(w)
+              && (recVars.contains(v) === recVars.contains(w))
+              && (v.nameHint.nonEmpty || w.nameHint.isEmpty)
+              // ^ Don't merge in this direction if that would override a nameHint
+            =>
             // Note: We avoid merging rec and non-rec vars, because the non-rec one may not be strictly polar ^
             //       As an example of this, see [test:T1].
             println(s"[w] $w ${coOccurrences.get(pol -> w)}")

--- a/shared/src/test/diff/mlscript/Ascribe.mls
+++ b/shared/src/test/diff/mlscript/Ascribe.mls
@@ -26,9 +26,36 @@ class Foo[A]: { field: A }
 //│ Defined class Foo
 
 def foo(f: Foo['a]) = f.field
-//│ foo: (Foo['a] & {field: 'a & 'b}) -> 'b
+//│ foo: Foo['a] -> 'a
 
 
 (succ 1): int
 //│ res: int
+
+
+def foo({ a; b }: { a: int; b: string}) = { b; a }
+//│ foo: {a: int, b: string} -> {a: int, b: string}
+
+:e
+def foo({ a = "hey" }: { a: string}) = 0
+//│ ╔══[ERROR] Type mismatch in type ascription:
+//│ ║  l.40: 	def foo({ a = "hey" }: { a: string}) = 0
+//│ ║        	        ^^^^^^^^^^^^^
+//│ ╟── expression of type `string` does not match type `"hey"`
+//│ ║  l.40: 	def foo({ a = "hey" }: { a: string}) = 0
+//│ ║        	                            ^^^^^^
+//│ ╟── Note: constraint arises from string literal:
+//│ ║  l.40: 	def foo({ a = "hey" }: { a: string}) = 0
+//│ ╙──      	              ^^^^^
+//│ foo: {a: string} -> 0
+
+:e
+def foo({ a; b }: { a: int }) = b
+//│ ╔══[ERROR] Type mismatch in type ascription:
+//│ ║  l.53: 	def foo({ a; b }: { a: int }) = b
+//│ ║        	        ^^^^^^^^
+//│ ╟── expression of type `{a: int}` does not have field 'b'
+//│ ║  l.53: 	def foo({ a; b }: { a: int }) = b
+//│ ╙──      	                  ^^^^^^^^^^
+//│ foo: {a: int} -> nothing
 

--- a/shared/src/test/diff/mlscript/ExprProb.mls
+++ b/shared/src/test/diff/mlscript/ExprProb.mls
@@ -85,10 +85,10 @@ def eval1_ty = eval1
 //│ ('a -> int) -> ((Add['d .. 'e] with {lhs: 'c, rhs: 'c}) & 'b | Lit & 'b | 'a & 'b & ~add & ~lit as 'c) -> int
 //│ /!!!\ Uncaught error: java.lang.AssertionError: assertion failed
 //│ 	at: scala.Predef$.assert(Predef.scala:264)
-//│ 	at: mlscript.ConstraintSolver.freshen$1(ConstraintSolver.scala:440)
-//│ 	at: mlscript.ConstraintSolver.freshen$1(ConstraintSolver.scala:462)
-//│ 	at: mlscript.ConstraintSolver.freshen$1(ConstraintSolver.scala:462)
-//│ 	at: mlscript.ConstraintSolver.freshenAbove(ConstraintSolver.scala:474)
+//│ 	at: mlscript.ConstraintSolver.freshen$1(ConstraintSolver.scala:446)
+//│ 	at: mlscript.ConstraintSolver.freshen$1(ConstraintSolver.scala:468)
+//│ 	at: mlscript.ConstraintSolver.freshen$1(ConstraintSolver.scala:468)
+//│ 	at: mlscript.ConstraintSolver.freshenAbove(ConstraintSolver.scala:480)
 //│ 	at: mlscript.TyperDatatypes$PolymorphicType.rigidify(TyperDatatypes.scala:30)
 //│ 	at: mlscript.ConstraintSolver.subsume(ConstraintSolver.scala:377)
 //│ 	at: mlscript.DiffTests.$anonfun$new$22(DiffTests.scala:290)

--- a/shared/src/test/diff/mlscript/MethodAndMatches.mls
+++ b/shared/src/test/diff/mlscript/MethodAndMatches.mls
@@ -28,7 +28,7 @@ d1 = Derived1 { x = 1 }
 
 foo d1
 foo d1 0
-//│ res: 'a -> (Base1['a] | Derived1)
+//│ res: 'A -> (Base1['A] | Derived1)
 //│ res: Base1['A .. 0 | 'A] | Derived1
 
 def bar0: Base1[int] -> int -> Base1[int]

--- a/shared/src/test/diff/mlscript/Methods.mls
+++ b/shared/src/test/diff/mlscript/Methods.mls
@@ -3,7 +3,7 @@ class Foo[A, B]: { x: A; y: B }
     method Fun[C, D] (f: C -> D) = f
 //│ Defined class Foo
 //│ Declared Foo.Fun: Foo['A, 'B] -> ('A -> 'B -> 'C) -> 'A -> 'B -> 'C
-//│ Defined Foo.Fun: Foo['A, 'B] -> (nothing -> anything & 'a) -> 'a
+//│ Defined Foo.Fun: Foo['A, 'B] -> ('C -> 'D) -> 'C -> 'D
 
 class Bar: Foo[int, bool]
     method Fun f = f
@@ -128,7 +128,7 @@ class Pair[A, B]: AbstractPair[A, B]
     method Test(f: A -> B -> bool) = f this.x this.y
     method Map fx fy = Pair { x = fx this.x; y = fy this.y }
 //│ Defined class Pair
-//│ Defined Pair.Test: Pair['A, 'B] -> ('A -> 'B -> (bool & 'a)) -> 'a
+//│ Defined Pair.Test: Pair['A, 'B] -> ('A -> 'B -> bool) -> bool
 //│ Defined Pair.Map: Pair['A, 'B] -> ('A -> ('a & 'A0)) -> ('B -> ('b & 'B0)) -> (Pair['A0, 'B0] with {x: 'a, y: 'b})
 
 class True[A, B]: Pair[A, B]
@@ -253,15 +253,24 @@ Test3B.F
 
 
 
-
 :w
 class Test4A[A]: { x: A }
     method Mth4A[A]: A
 //│ ╔══[WARNING] Method type parameter A
-//│ ║  l.258: 	class Test4A[A]: { x: A }
+//│ ║  l.257: 	class Test4A[A]: { x: A }
 //│ ║         	             ^
 //│ ╟── shadows class type parameter A
-//│ ║  l.259: 	    method Mth4A[A]: A
+//│ ║  l.258: 	    method Mth4A[A]: A
 //│ ╙──       	                 ^
 //│ Defined class Test4A
 //│ Declared Test4A.Mth4A: Test4A['A] -> nothing
+
+
+class Test[A]: { x: A }
+    method Mth[B]: (A -> B) -> B
+    method Mth[B] (f: A -> B) = f this.x
+//│ Defined class Test
+//│ Declared Test.Mth: Test['A] -> ('A -> 'B) -> 'B
+//│ Defined Test.Mth: Test['A] -> ('A -> 'B) -> 'B
+
+

--- a/shared/src/test/diff/mlscript/Paper.mls
+++ b/shared/src/test/diff/mlscript/Paper.mls
@@ -38,20 +38,33 @@ rec def map2 f ls = case ls of {
 
 
 
+:e
 def safeDiv x (y: ~0) = div x y
+//│ ╔══[ERROR] Type mismatch in application:
+//│ ║  l.42: 	def safeDiv x (y: ~0) = div x y
+//│ ║        	                        ^^^^^^^
+//│ ╟── expression of type `~0` does not match type `int`
+//│ ║  l.42: 	def safeDiv x (y: ~0) = div x y
+//│ ║        	                  ^^
+//│ ╟── but it flows into reference with expected type `int`
+//│ ║  l.42: 	def safeDiv x (y: ~0) = div x y
+//│ ╙──      	                              ^
+//│ safeDiv: int -> ~0 -> (error | int)
+
+def safeDiv x (y: int & ~0) = div x y
 //│ safeDiv: int -> (int & ~0) -> int
 
 :e
 safeDiv 1 0
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.45: 	safeDiv 1 0
+//│ ║  l.58: 	safeDiv 1 0
 //│ ║        	^^^^^^^^^^^
 //│ ╟── expression of type `0` does not match type `~0`
-//│ ║  l.45: 	safeDiv 1 0
+//│ ║  l.58: 	safeDiv 1 0
 //│ ║        	          ^
 //│ ╟── Note: constraint arises from type negation:
-//│ ║  l.41: 	def safeDiv x (y: ~0) = div x y
-//│ ╙──      	                  ^^
+//│ ║  l.54: 	def safeDiv x (y: int & ~0) = div x y
+//│ ╙──      	                        ^^
 //│ res: error | int
 
 fun x -> safeDiv 1 x
@@ -60,8 +73,23 @@ fun x -> safeDiv 1 x
 fun x -> case x of { int -> safeDiv 1 x | _ -> None{} }
 //│ res: (int & ~0 | ~int) -> (int | None)
 
-// TOOD mayeb we shouldn't refine x's type here...
+:e // we no longer refine x's type here, as that was rather unexpected
 fun (x: int) -> safeDiv 1 x
+//│ ╔══[ERROR] Type mismatch in application:
+//│ ║  l.77: 	fun (x: int) -> safeDiv 1 x
+//│ ║        	                ^^^^^^^^^^^
+//│ ╟── expression of type `int` does not match type `~0`
+//│ ║  l.77: 	fun (x: int) -> safeDiv 1 x
+//│ ║        	        ^^^
+//│ ╟── but it flows into reference with expected type `~0`
+//│ ║  l.77: 	fun (x: int) -> safeDiv 1 x
+//│ ║        	                          ^
+//│ ╟── Note: constraint arises from type negation:
+//│ ║  l.54: 	def safeDiv x (y: int & ~0) = div x y
+//│ ╙──      	                        ^^
+//│ res: int -> (error | int)
+
+fun (x: int & ~0) -> safeDiv 1 x
 //│ res: (int & ~0) -> int
 
 def tryDiv: int -> int -> Option[int]

--- a/shared/src/test/diff/mlscript/SimpleMethods.mls
+++ b/shared/src/test/diff/mlscript/SimpleMethods.mls
@@ -1,0 +1,83 @@
+
+:e
+class C0
+  method Foo0[A](a: A) = a + 1
+  method Foo1[A](a: A) = { a }
+//│ ╔══[ERROR] Type mismatch in operator application:
+//│ ║  l.4: 	  method Foo0[A](a: A) = a + 1
+//│ ║       	                         ^^^
+//│ ╟── expression of type `A` does not match type `int`
+//│ ║  l.4: 	  method Foo0[A](a: A) = a + 1
+//│ ╙──     	                         ^
+//│ Defined class C0
+//│ Defined C0.Foo0: C0 -> anything -> (error | int)
+//│ Defined C0.Foo1: C0 -> 'A -> {a: 'A}
+
+(C0{}).Foo0
+//│ res: anything -> (error | int)
+
+f1 = (C0{}).Foo1
+//│ f1: 'A -> {a: 'A}
+
+f1 1
+//│ res: {a: 1}
+
+
+class C1
+  method F: int
+  method F = 1
+//│ Defined class C1
+//│ Declared C1.F: C1 -> int
+//│ Defined C1.F: C1 -> 1
+
+class C2: C1
+  method F = 2
+//│ Defined class C2
+//│ Defined C2.F: C2 -> 2
+
+
+class C3
+  method F: 'a -> 'a
+  method F = id
+//│ Defined class C3
+//│ Declared C3.F: C3 -> 'a -> 'a
+//│ Defined C3.F: C3 -> 'a -> 'a
+
+class C4: C3
+  method F = id
+//│ Defined class C4
+//│ Defined C4.F: C4 -> 'a -> 'a
+
+
+:e
+class C5[A]
+  method F(x: A) = x + 1
+//│ ╔══[ERROR] Type mismatch in operator application:
+//│ ║  l.54: 	  method F(x: A) = x + 1
+//│ ║        	                   ^^^
+//│ ╟── expression of type `A` does not match type `int`
+//│ ║  l.54: 	  method F(x: A) = x + 1
+//│ ╙──      	                   ^
+//│ Defined class C5
+//│ Defined C5.F: C5['A] -> 'A -> (error | int)
+
+
+class True[A]
+    method Test f = true
+    method True = this.Test (fun x -> error)
+//│ Defined class True
+//│ Defined True.Test: true -> anything -> true
+//│ Defined True.True: true -> true
+
+
+:e
+class Hey
+    rec method A = B
+    rec method B = 1
+//│ ╔══[ERROR] identifier not found: B
+//│ ║  l.75: 	    rec method A = B
+//│ ╙──      	                   ^
+//│ Defined class Hey
+//│ Defined Hey.A: Hey -> error
+//│ Defined Hey.B: Hey -> 1
+

--- a/shared/src/test/diff/mlscript/Subsume.mls
+++ b/shared/src/test/diff/mlscript/Subsume.mls
@@ -137,7 +137,7 @@ def id n = add n 1
 
 :e
 def id (x: int) = x
-//│ (int & 'a) -> 'a
+//│ int -> int
 //│   <:  id:
 //│ 'a -> 'a
 //│ ╔══[ERROR] Type mismatch in def definition:
@@ -149,6 +149,18 @@ def id (x: int) = x
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.139: 	def id (x: int) = x
 //│ ╙──       	           ^^^
+//│ ╔══[ERROR] Type mismatch in def definition:
+//│ ║  l.139: 	def id (x: int) = x
+//│ ║         	        ^^^^^^^^^^^
+//│ ╟── expression of type `int` does not match type `'a`
+//│ ║  l.139: 	def id (x: int) = x
+//│ ║         	           ^^^
+//│ ╟── but it flows into reference with expected type `'a`
+//│ ║  l.139: 	def id (x: int) = x
+//│ ║         	                  ^
+//│ ╟── Note: constraint arises from type variable:
+//│ ║  l.91: 	def id: 'a -> 'a
+//│ ╙──      	              ^^
 
 
 
@@ -164,13 +176,13 @@ def f = impl
 //│   <:  f:
 //│ (int & 'a) -> 'a
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.162: 	def f = impl
+//│ ║  l.174: 	def f = impl
 //│ ║         	        ^^^^
 //│ ╟── expression of type `int & 'a` does not match type `?a -> ?b`
-//│ ║  l.155: 	def f: (int & 'a) -> 'a
+//│ ║  l.167: 	def f: (int & 'a) -> 'a
 //│ ║         	        ^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.158: 	def impl a = a a
+//│ ║  l.170: 	def impl a = a a
 //│ ╙──       	             ^^^
 
 f 1 
@@ -193,13 +205,13 @@ def f a b = if gt a b then a else b b // mistake!
 //│   <:  f:
 //│ (int & 'a) -> (int & 'a) -> 'a
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.191: 	def f a b = if gt a b then a else b b // mistake!
+//│ ║  l.203: 	def f a b = if gt a b then a else b b // mistake!
 //│ ║         	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `int & 'a` does not match type `?a -> ?b`
-//│ ║  l.180: 	def f: (int & 'a) -> (int & 'a) -> 'a 
+//│ ║  l.192: 	def f: (int & 'a) -> (int & 'a) -> 'a 
 //│ ║         	                      ^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.191: 	def f a b = if gt a b then a else b b // mistake!
+//│ ║  l.203: 	def f a b = if gt a b then a else b b // mistake!
 //│ ╙──       	                                  ^^^
 
 f 1 
@@ -217,16 +229,16 @@ def g a = add a 1
 //│   <:  g:
 //│ (int & 'a) -> 'a
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.214: 	def g a = add a 1
+//│ ║  l.226: 	def g a = add a 1
 //│ ║         	      ^^^^^^^^^^^
 //│ ╟── expression of type `int` does not match type `'a`
-//│ ║  l.214: 	def g a = add a 1
+//│ ║  l.226: 	def g a = add a 1
 //│ ║         	          ^^^^^^^
 //│ ╟── but it flows into function of type `?a -> ?b`
-//│ ║  l.214: 	def g a = add a 1
+//│ ║  l.226: 	def g a = add a 1
 //│ ║         	      ^^^^^^^^^^^
 //│ ╟── which does not match type `(int & 'a) -> 'a`
 //│ ╟── Note: constraint arises from type variable:
-//│ ║  l.213: 	def g: (int & 'a) -> 'a
+//│ ║  l.225: 	def g: (int & 'a) -> 'a
 //│ ╙──       	                     ^^
 

--- a/shared/src/test/diff/mlscript/TypeDefs.mls
+++ b/shared/src/test/diff/mlscript/TypeDefs.mls
@@ -117,9 +117,9 @@ type TypeC = TypeA
 //│ res: int
 
 
-// FIXME? maybe x's type should be upcasted in the body
+
 def test = fun (x: TypeB) -> x
-//│ test: (int & 'a) -> 'a
+//│ test: int -> int
 
 
 


### PR DESCRIPTION
 * Fix explicit method type parameters (they were not rigid)
 * Fix method signature typing level
 * Fix typing of type ascriptions in patterns – constrain in both directions
 * Propagates name hints more

Let's merge this after https://github.com/hkust-taco/mlscript/pull/38 as it's based on it.