### PR TITLE
Rigidify bounded type vars

### DIFF
--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -199,7 +199,7 @@ class BadPair[A, B]: AbstractPair[A, B]
 //│ ╙──       	                                              ^^^^^^^^^^^^^^^^^^
 //│ Defined class BadPair
 //│ Defined BadPair.Test: BadPair['A, 'B] -> ('A -> 'A -> 'a) -> 'a
-//│ Defined BadPair.Map: BadPair['A, 'B] -> ('A -> ('B0 & 'A0 & 'a)) -> anything -> (BadPair['A0, 'B0] with {x: 'a, y: 'a})
+//│ Defined BadPair.Map: BadPair['A, 'B] -> ('A -> ('A0 & 'B0 & 'a)) -> anything -> (BadPair['A0, 'B0] with {x: 'a, y: 'a})
 
 bp = BadPair { x = 42; y = true }
 bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)

--- a/shared/src/test/diff/mlscript/ExprProb.mls
+++ b/shared/src/test/diff/mlscript/ExprProb.mls
@@ -78,22 +78,10 @@ def eval1_ty: ('a -> int) -> (Lit | Add['b] | 'a & ~lit & ~add as 'b) -> int
 eval1_ty
 //│ res: ('a -> int) -> ((Add['d .. 'e] with {lhs: 'c, rhs: 'c}) & 'b | Lit & 'b | 'a & 'b & ~add & ~lit as 'c) -> int
 
-// TODO this requires bounded variable rigidification to work... (currently unimplemented)
 def eval1_ty = eval1
 //│ ('a -> int) -> ((Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit as 'b) -> int
 //│   <:  eval1_ty:
 //│ ('a -> int) -> ((Add['d .. 'e] with {lhs: 'c, rhs: 'c}) & 'b | Lit & 'b | 'a & 'b & ~add & ~lit as 'c) -> int
-//│ /!!!\ Uncaught error: java.lang.AssertionError: assertion failed
-//│ 	at: scala.Predef$.assert(Predef.scala:264)
-//│ 	at: mlscript.ConstraintSolver.freshen$1(ConstraintSolver.scala:446)
-//│ 	at: mlscript.ConstraintSolver.freshen$1(ConstraintSolver.scala:468)
-//│ 	at: mlscript.ConstraintSolver.freshen$1(ConstraintSolver.scala:468)
-//│ 	at: mlscript.ConstraintSolver.freshenAbove(ConstraintSolver.scala:480)
-//│ 	at: mlscript.TyperDatatypes$PolymorphicType.rigidify(TyperDatatypes.scala:30)
-//│ 	at: mlscript.ConstraintSolver.subsume(ConstraintSolver.scala:377)
-//│ 	at: mlscript.DiffTests.$anonfun$new$22(DiffTests.scala:290)
-//│ 	at: mlscript.DiffTests.$anonfun$new$22$adapted(DiffTests.scala:268)
-//│ 	at: scala.collection.immutable.List.foreach(List.scala:333)
 
 // Workaround:
 :ns
@@ -217,7 +205,7 @@ eval1 done e2
 //│ ║  l.+1: 	eval1 done e2
 //│ ║        	^^^^^^^^^^^^^
 //│ ╟── expression of type `Nega[?E] & {arg: ?arg}` does not match type `nothing`
-//│ ║  l.177: 	e2 = add (lit 1) (nega e1)
+//│ ║  l.165: 	e2 = add (lit 1) (nega e1)
 //│ ║         	                  ^^^^^^^
 //│ ╟── but it flows into reference with expected type `Lit & ?a | Add[?] & ?b | ?c & ~add & ~lit`
 //│ ║  l.+1: 	eval1 done e2
@@ -254,19 +242,19 @@ prettier2 done eval1 e1
 //│ ║        	               ^^^^^
 //│ ╟── which does not match type `?f -> ?g`
 //│ ╟── Note: constraint arises from argument:
-//│ ║  l.125: 	      in if ev e == 0 then tmp else concat tmp (pretty1 k e.rhs)
+//│ ║  l.113: 	      in if ev e == 0 then tmp else concat tmp (pretty1 k e.rhs)
 //│ ║         	            ^^^^
 //│ ╟── from argument:
-//│ ║  l.169: 	  }) ev
+//│ ║  l.157: 	  }) ev
 //│ ║         	     ^^
 //│ ╟── from argument:
-//│ ║  l.167: 	  | Nega -> concat "-" (prettier2 k ev x.arg)
+//│ ║  l.155: 	  | Nega -> concat "-" (prettier2 k ev x.arg)
 //│ ╙──       	                                    ^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval1 e1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `Add[?E] & {lhs: ?lhs, rhs: ?rhs}` does not match type `?a -> ?b`
-//│ ║  l.141: 	e1 = add (lit 1) (add (lit 2) (lit 3))
+//│ ║  l.129: 	e1 = add (lit 1) (add (lit 2) (lit 3))
 //│ ║         	     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `Lit & ?c | Add[?] & ?d | ?e & ~add & ~lit`
 //│ ║  l.+1: 	prettier2 done eval1 e1
@@ -275,10 +263,10 @@ prettier2 done eval1 e1
 //│ ║  l.47: 	  | _ -> k e
 //│ ║        	         ^^^
 //│ ╟── from argument:
-//│ ║  l.125: 	      in if ev e == 0 then tmp else concat tmp (pretty1 k e.rhs)
+//│ ║  l.113: 	      in if ev e == 0 then tmp else concat tmp (pretty1 k e.rhs)
 //│ ║         	               ^
 //│ ╟── from refined scrutinee:
-//│ ║  l.121: 	rec def prettier1 k ev e = case e of {
+//│ ║  l.109: 	rec def prettier1 k ev e = case e of {
 //│ ╙──       	                                ^
 //│ res: error | string
 

--- a/shared/src/test/diff/mlscript/RecursiveTypes.mls
+++ b/shared/src/test/diff/mlscript/RecursiveTypes.mls
@@ -91,3 +91,177 @@ if true then l else r
 //│ res: int -> int -> int -> int -> int -> int -> 'a as 'a
 
 
+
+// ------ // ------ // ------ // ------ // ------ // ------ //
+
+
+
+class C[A]: { a: A }
+//│ Defined class C
+
+
+
+:ns
+rec def foo (c: C['a]) = foo (c.a)
+//│ foo: 'b | (C['a & 'c .. 'a] as 'c) -> 'd
+
+// TODO figure ou why some type variables are not simplified here
+foo
+//│ res: ((C[?] with {a: 'c & 'b & 'a}) as 'b) -> nothing
+
+type Rec = C[Rec]
+def foo_ty: Rec -> nothing
+//│ Defined type alias Rec
+//│ foo_ty: ((C['b .. 'c] with {a: 'a}) as 'a) -> nothing
+
+foo_ty = foo
+//│ ((C[?] with {a: 'c & 'b & 'a}) as 'b) -> nothing
+//│   <:  foo_ty:
+//│ ((C['b .. 'c] with {a: 'a}) as 'a) -> nothing
+
+def foo_ty2: (C['r] as 'r) -> nothing
+//│ foo_ty2: ((C['b .. 'c] with {a: 'a}) & 'r as 'a) -> nothing
+
+:ns
+foo_ty2
+//│ res: (C['r .. C['r .. 'r0] as 'r0] as 'r) -> nothing
+
+foo_ty = foo_ty2
+//│ ((C['b .. 'c] with {a: 'a}) & 'r as 'a) -> nothing
+//│   <:  foo_ty:
+//│ ((C['b .. 'c] with {a: 'a}) as 'a) -> nothing
+
+foo_ty2 = foo_ty
+//│ ((C['b .. 'c] with {a: 'a}) as 'a) -> nothing
+//│   <:  foo_ty2:
+//│ ((C['b .. 'c] with {a: 'a}) & 'r as 'a) -> nothing
+
+foo_ty2 = foo
+//│ ((C[?] with {a: 'c & 'b & 'a}) as 'b) -> nothing
+//│   <:  foo_ty2:
+//│ ((C['b .. 'c] with {a: 'a}) & 'r as 'a) -> nothing
+
+
+
+rec def bar = C { a = bar }
+//│ bar: (C[?] with {a: 'a}) as 'a
+
+type Rec2 = C[Rec2]
+def bar_ty: Rec2
+//│ Defined type alias Rec2
+//│ bar_ty: (C[(C['c .. 'd] with {a: 'b}) as 'b .. 'a] with {a: 'a}) as 'a
+
+bar_ty = bar
+//│ (C[?] with {a: 'a}) as 'a
+//│   <:  bar_ty:
+//│ (C[(C['c .. 'd] with {a: 'b}) as 'b .. 'a] with {a: 'a}) as 'a
+
+def bar_ty2: C['r] as 'r
+//│ bar_ty2: 'r | (C[(C['c .. 'd] with {a: 'b}) & 'r as 'b .. 'a] with {a: 'a}) as 'a
+
+:ns
+bar_ty2
+//│ res: C[C['r0 .. 'r] as 'r0 .. 'r] as 'r
+
+bar_ty2
+//│ res: 'r | (C[(C['c .. 'd] with {a: 'b}) & 'r as 'b .. 'a] with {a: 'a}) as 'a
+
+bar_ty = bar_ty2
+//│ 'r | (C[(C['c .. 'd] with {a: 'b}) & 'r as 'b .. 'a] with {a: 'a}) as 'a
+//│   <:  bar_ty:
+//│ (C[(C['c .. 'd] with {a: 'b}) as 'b .. 'a] with {a: 'a}) as 'a
+
+bar_ty2 = bar_ty
+//│ (C[(C['c .. 'd] with {a: 'b}) as 'b .. 'a] with {a: 'a}) as 'a
+//│   <:  bar_ty2:
+//│ 'r | (C[(C['c .. 'd] with {a: 'b}) & 'r as 'b .. 'a] with {a: 'a}) as 'a
+
+bar_ty2 = bar
+//│ (C[?] with {a: 'a}) as 'a
+//│   <:  bar_ty2:
+//│ 'r | (C[(C['c .. 'd] with {a: 'b}) & 'r as 'b .. 'a] with {a: 'a}) as 'a
+
+
+
+type Rec3 = { x: Rec3 }
+//│ Defined type alias Rec3
+
+def bar2_ty: Rec3
+//│ bar2_ty: {x: 'a} as 'a
+
+def bar2_ty2: { x: 'r } as 'r
+//│ bar2_ty2: {x: 'a} as 'a
+
+bar2_ty = bar2_ty2
+//│ {x: 'a} as 'a
+//│   <:  bar2_ty:
+//│ {x: 'a} as 'a
+
+bar2_ty2 = bar2_ty
+//│ {x: 'a} as 'a
+//│   <:  bar2_ty2:
+//│ {x: 'a} as 'a
+
+:e
+bar2_ty2 = bar_ty2
+//│ 'r | (C[(C['c .. 'd] with {a: 'b}) & 'r as 'b .. 'a] with {a: 'a}) as 'a
+//│   <:  bar2_ty2:
+//│ {x: 'a} as 'a
+//│ ╔══[ERROR] Type mismatch in def definition:
+//│ ║  l.206: 	bar2_ty2 = bar_ty2
+//│ ║         	^^^^^^^^^^^^^^^^^^
+//│ ╟── expression of type `C[?r]` does not match type `'r | {x: ?r0}`
+//│ ║  l.159: 	def bar_ty2: C['r] as 'r
+//│ ║         	             ^^^^^
+//│ ╟── but it flows into reference with expected type `'r | {x: ?r1}`
+//│ ║  l.206: 	bar2_ty2 = bar_ty2
+//│ ║         	           ^^^^^^^
+//│ ╟── Note: constraint arises from local type binding:
+//│ ║  l.192: 	def bar2_ty2: { x: 'r } as 'r
+//│ ╙──       	              ^^^^^^^^^
+
+:e
+bar_ty2 = bar2_ty2
+//│ {x: 'a} as 'a
+//│   <:  bar_ty2:
+//│ 'r | (C[(C['c .. 'd] with {a: 'b}) & 'r as 'b .. 'a] with {a: 'a}) as 'a
+//│ ╔══[ERROR] Type mismatch in def definition:
+//│ ║  l.224: 	bar_ty2 = bar2_ty2
+//│ ║         	^^^^^^^^^^^^^^^^^^
+//│ ╟── expression of type `{x: ?r}` does not match type `'r | C[?r0]`
+//│ ║  l.192: 	def bar2_ty2: { x: 'r } as 'r
+//│ ║         	              ^^^^^^^^^
+//│ ╟── but it flows into reference with expected type `'r | C[?r1]`
+//│ ║  l.224: 	bar_ty2 = bar2_ty2
+//│ ║         	          ^^^^^^^^
+//│ ╟── Note: constraint arises from local type binding:
+//│ ║  l.159: 	def bar_ty2: C['r] as 'r
+//│ ╙──       	             ^^^^^
+//│ ╔══[ERROR] Type mismatch in def definition:
+//│ ║  l.224: 	bar_ty2 = bar2_ty2
+//│ ║         	^^^^^^^^^^^^^^^^^^
+//│ ╟── expression of type `{x: ?r}` does not match type `'r | C[?r0]`
+//│ ║  l.192: 	def bar2_ty2: { x: 'r } as 'r
+//│ ║         	              ^^^^^^^^^
+//│ ╟── but it flows into reference with expected type `'r | C[?r1]`
+//│ ║  l.224: 	bar_ty2 = bar2_ty2
+//│ ║         	          ^^^^^^^^
+//│ ╟── Note: constraint arises from local type binding:
+//│ ║  l.159: 	def bar_ty2: C['r] as 'r
+//│ ╙──       	             ^^^^^
+//│ ╔══[ERROR] Type mismatch in def definition:
+//│ ║  l.224: 	bar_ty2 = bar2_ty2
+//│ ║         	^^^^^^^^^^^^^^^^^^
+//│ ╟── expression of type `{x: ?r}` does not match type `'r | C[?r0]`
+//│ ║  l.192: 	def bar2_ty2: { x: 'r } as 'r
+//│ ║         	              ^^^^^^^^^
+//│ ╟── but it flows into reference with expected type `'r | C[?r1]`
+//│ ║  l.224: 	bar_ty2 = bar2_ty2
+//│ ║         	          ^^^^^^^^
+//│ ╟── Note: constraint arises from local type binding:
+//│ ║  l.159: 	def bar_ty2: C['r] as 'r
+//│ ╙──       	             ^^^^^
+
+
+
+


### PR DESCRIPTION
This allows using `as` types in annotated type signatures, which was not possible before because `as` types are desugared into bounded type variables.