### PR TITLE
Fix duplicated trailing commas for records and arrays

### DIFF
--- a/shared/src/main/scala/mlscript/codegen/Codegen.scala
+++ b/shared/src/main/scala/mlscript/codegen/Codegen.scala
@@ -26,7 +26,7 @@ class SourceLine(val content: Str, indent: Int = 0) {
 }
 
 object SourceLine {
-  def from(line: Str): SourceLine = new SourceLine(line)
+  def apply(line: Str): SourceLine = new SourceLine(line)
 }
 
 class SourceCode(val lines: Ls[SourceLine]) {
@@ -89,9 +89,9 @@ class SourceCode(val lines: Ls[SourceLine]) {
       case 1 => new SourceCode(lines map { _.between("(", ")") })
       case _ =>
         new SourceCode(
-          SourceLine.from("(")
+          SourceLine("(")
             :: lines.map({ _.indented })
-            ::: Ls(SourceLine.from(")"))
+            ::: Ls(SourceLine(")"))
         )
     }
   // Surround the source code with braces in a array style.
@@ -101,9 +101,9 @@ class SourceCode(val lines: Ls[SourceLine]) {
       case 1 => new SourceCode(lines map { _.between("[", "]") })
       case _ =>
         new SourceCode(
-          SourceLine.from("[")
+          SourceLine("[")
             :: lines.map({ _.indented.withPostfix(",") })
-            ::: Ls(SourceLine.from("]"))
+            ::: Ls(SourceLine("]"))
         )
     }
   // Surround the source code with braces in a block style.
@@ -112,9 +112,9 @@ class SourceCode(val lines: Ls[SourceLine]) {
       case 0 => SourceCode("{}")
       case _ =>
         new SourceCode(
-          SourceLine.from("{")
+          SourceLine("{")
             :: lines.map({ _.indented })
-            ::: Ls(SourceLine.from("}"))
+            ::: Ls(SourceLine("}"))
         )
     }
   override def toString: Str = lines.mkString("\n")

--- a/shared/src/main/scala/mlscript/codegen/Codegen.scala
+++ b/shared/src/main/scala/mlscript/codegen/Codegen.scala
@@ -128,7 +128,7 @@ object SourceCode {
       case sole :: Nil => SourceCode("{ ") + sole + SourceCode(" }")
       case _ =>
         (entries.zipWithIndex.foldLeft(SourceCode("{")) { case (acc, (entry, index)) =>
-          acc + (if (index + 1 == entries.length) { entry }
+          acc + (if (index + 1 === entries.length) { entry }
                  else { entry ++ SourceCode.comma }).indented
         }) + SourceCode("}")
     }
@@ -142,7 +142,7 @@ object SourceCode {
       case sole :: Nil => SourceCode("[") + sole + SourceCode("]")
       case _ =>
         (entries.zipWithIndex.foldLeft(SourceCode("[")) { case (acc, (entry, index)) =>
-          acc + (if (index + 1 == entries.length) { entry }
+          acc + (if (index + 1 === entries.length) { entry }
                  else { entry ++ SourceCode.comma }).indented
         }) + SourceCode("]")
     }

--- a/shared/src/main/scala/mlscript/codegen/Codegen.scala
+++ b/shared/src/main/scala/mlscript/codegen/Codegen.scala
@@ -125,10 +125,12 @@ object SourceCode {
   def apply(lines: Ls[Str]): SourceCode = new SourceCode(lines map {
     new SourceLine(_, 0)
   })
-  def space: SourceCode = SourceCode(" ")
-  def semicolon: SourceCode = SourceCode(";")
-  def comma: SourceCode = SourceCode(",")
-  def empty: SourceCode = new SourceCode(Nil)
+
+  val space: SourceCode = SourceCode(" ")
+  val semicolon: SourceCode = SourceCode(";")
+  val comma: SourceCode = SourceCode(",")
+  val empty: SourceCode = SourceCode(Nil)
+  
   def concat(codes: Ls[SourceCode]): SourceCode =
     codes.foldLeft(SourceCode.empty) { _ + _ }
   def record(entries: Ls[SourceCode]): SourceCode =


### PR DESCRIPTION
This PR fixes duplicated trailing commas for records and arrays. This PR also makes it easier to create `SourceCode` and `SourceLine` by implementing `.apply`.

Before the fix,

```
def nested = { a = { value = "a"; level = 0 }; b = { value = "b"; level = 1 } }
```

generates

```js
let nested = {
  a: {,
    value: "a",,
    level: 0,,
  },
  b: {,
    value: "b",,
    level: 1,,
  },
};
```

After the fix, it generates

```js
let nested = {
  a: {
    value: "a",
    level: 0
  },
  b: {
    value: "b",
    level: 1
  }
};
```