### PR TITLE
Refactor method typing

### DIFF
--- a/shared/src/main/scala/mlscript/ConstraintSolver.scala
+++ b/shared/src/main/scala/mlscript/ConstraintSolver.scala
@@ -456,7 +456,7 @@ class ConstraintSolver extends NormalForms { self: Typer =>
   
   /** Copies a type up to its type variables of wrong level (and their extruded bounds). */
   def extrude(ty: SimpleType, lvl: Int, pol: Boolean)
-      (implicit cache: MutMap[TV, TV] = MutMap.empty): SimpleType =
+      (implicit ctx: Ctx, cache: MutMap[TV, TV] = MutMap.empty): SimpleType =
     if (ty.level <= lvl) ty else ty match {
       case t @ TypeBounds(lb, ub) => if (pol) extrude(ub, lvl, true) else extrude(lb, lvl, false)
       case t @ FunctionType(l, r) => FunctionType(extrude(l, lvl, !pol), extrude(r, lvl, pol))(t.prov)
@@ -484,7 +484,7 @@ class ConstraintSolver extends NormalForms { self: Typer =>
             to always extrude in both directions: */
         // TypeRef(d, ts.map(t =>
         //   TypeBounds(extrude(t, lvl, pol), extrude(t, lvl, pol))(noProv)))(tr.prov, tr.ctx) // FIXME pol...
-        extrude(tr.expand(_ => ()), lvl, pol).withProvOf(tr)
+        extrude(tr.expand, lvl, pol).withProvOf(tr)
     }
   
   
@@ -561,7 +561,7 @@ class ConstraintSolver extends NormalForms { self: Typer =>
       case p @ ProxyType(und) => freshen(und)
       case _: ClassTag | _: TraitTag => ty
       case w @ Without(b, ns) => Without(freshen(b), ns)(w.prov)
-      case tr @ TypeRef(d, ts) => TypeRef(d, ts.map(freshen(_)))(tr.prov, tr.ctx)
+      case tr @ TypeRef(d, ts) => TypeRef(d, ts.map(freshen(_)))(tr.prov)
     }
     freshen(ty)
   }

--- a/shared/src/main/scala/mlscript/MLParser.scala
+++ b/shared/src/main/scala/mlscript/MLParser.scala
@@ -167,11 +167,11 @@ class MLParser(origin: Origin, indent: Int = 0, recordLocations: Bool = true) {
   def tyParams[_: P]: P[Ls[TypeName]] =
     ("[" ~ tyName.rep(0, ",") ~ "]").?.map(_.toList.flatten)
   def mthDecl[_: P](prt: TypeName): P[R[MethodDef[Right[Term, Type]]]] = 
-    P(kw("method") ~ tyName ~ tyParams ~ ":" ~/ ty map {
+    P(kw("method") ~ variable ~ tyParams ~ ":" ~/ ty map {
       case (id, ts, t) => R(MethodDef[Right[Term, Type]](true, prt, id, ts, R(t)))
     })
   def mthDef[_: P](prt: TypeName): P[L[MethodDef[Left[Term, Type]]]] = 
-    P(kw("rec").!.?.map(_.isDefined) ~ kw("method") ~ tyName ~ tyParams ~ subterm.rep ~ "=" ~/ term map {
+    P(kw("rec").!.?.map(_.isDefined) ~ kw("method") ~ variable ~ tyParams ~ subterm.rep ~ "=" ~/ term map {
       case (rec, id, ts, ps, bod) =>
         L(MethodDef(rec, prt, id, ts, L(ps.foldRight(bod)((i, acc) => Lam(toParams(i), acc)))))
     })

--- a/shared/src/main/scala/mlscript/NormalForms.scala
+++ b/shared/src/main/scala/mlscript/NormalForms.scala
@@ -73,6 +73,7 @@ class NormalForms extends TyperDatatypes { self: Typer =>
       case (_, LhsTop) => true
       case (LhsTop, _) => false
       case (LhsRefined(b1, ts1, rt1), LhsRefined(b2, ts2, rt2)) =>
+        implicit val ctx: Ctx = Ctx.empty
         b2.forall(b2 => b1.exists(_ <:< b2)) && ts2.forall(ts1) && rt1 <:< rt2
     }
   }
@@ -159,7 +160,7 @@ class NormalForms extends TyperDatatypes { self: Typer =>
         S(RhsBases(p, S(R(RhsField(n1, t1 | that._2)))))
       case _: RhsField | _: RhsBases => N
     }
-    def <:< (that: RhsNf): Bool = this.toType() <:< that.toType() // TODO less inefficient! (uncached calls to toType)
+    def <:< (that: RhsNf): Bool = this.toType().<:<(that.toType())(Ctx.empty) // TODO less inefficient! (uncached calls to toType)
   }
   case class RhsField(name: Var, ty: SimpleType) extends RhsNf
     { def name_ty: Var -> ST = name -> ty }
@@ -202,7 +203,7 @@ class NormalForms extends TyperDatatypes { self: Typer =>
       // }(r => s"!! $r")
     def & (that: Conjunct): Opt[Conjunct] =
       // trace(s"?? $this & $that ${lnf & that.lnf} ${rnf | that.rnf}") {
-      if (lnf.toType() <:< that.rnf.toType()) N // TODO support <:< on any Nf? // TODO less inefficient! (uncached calls to toType)
+      if (lnf.toType().<:<(that.rnf.toType())(Ctx.empty)) N // TODO support <:< on any Nf? // TODO less inefficient! (uncached calls to toType)
       else S(Conjunct.mk(lnf & that.lnf getOrElse (return N), vars | that.vars
         , rnf | that.rnf getOrElse (return N)
         , nvars | that.nvars))
@@ -317,7 +318,7 @@ class NormalForms extends TyperDatatypes { self: Typer =>
     def of(tvs: Set[TypeVariable]): DNF = DNF(Conjunct.of(tvs) :: Nil)
     def extr(pol: Bool): DNF = if (pol) of(LhsTop) else DNF(Nil)
     def merge(pol: Bool)(l: DNF, r: DNF): DNF = if (pol) l | r else l & r
-    def mk(ty: SimpleType, pol: Bool): DNF = (if (pol) ty.pushPosWithout(_ => ()) else ty) match {
+    def mk(ty: SimpleType, pol: Bool)(implicit ctx: Ctx): DNF = (if (pol) ty.pushPosWithout else ty) match {
       case bt: BaseType => of(bt)
       case bt: TraitTag => of(bt)
       case rt @ RecordType(fs) => of(rt)
@@ -326,7 +327,7 @@ class NormalForms extends TyperDatatypes { self: Typer =>
       case NegType(und) => DNF(CNF.mk(und, !pol).ds.map(_.neg))
       case tv: TypeVariable => of(Set.single(tv))
       case ProxyType(underlying) => mk(underlying, pol)
-      case tr @ TypeRef(defn, targs) => mk(tr.expand(_ => ()), pol) // TODO try to keep them?
+      case tr @ TypeRef(defn, targs) => mk(tr.expand, pol) // TODO try to keep them?
       case TypeBounds(lb, ub) => mk(if (pol) ub else lb, pol)
     }
   }
@@ -351,7 +352,7 @@ class NormalForms extends TyperDatatypes { self: Typer =>
       Disjunct(RhsField(f._1, f._2), Set.empty, LhsTop, Set.empty)).toList)
     def extr(pol: Bool): CNF = if (pol) CNF(Nil) else of(RhsBot)
     def merge(pol: Bool)(l: CNF, r: CNF): CNF = if (pol) l | r else l & r
-    def mk(ty: SimpleType, pol: Bool): CNF =
+    def mk(ty: SimpleType, pol: Bool)(implicit ctx: Ctx): CNF =
       // trace(s"?C $ty") {
       ty match {
         case bt: BaseType => of(bt)
@@ -362,7 +363,7 @@ class NormalForms extends TyperDatatypes { self: Typer =>
         case NegType(und) => CNF(DNF.mk(und, !pol).cs.map(_.neg))
         case tv: TypeVariable => of(Set.single(tv))
         case ProxyType(underlying) => mk(underlying, pol)
-        case tr @ TypeRef(defn, targs) => mk(tr.expand(_ => ()), pol) // TODO try to keep them?
+        case tr @ TypeRef(defn, targs) => mk(tr.expand, pol) // TODO try to keep them?
         case TypeBounds(lb, ub) => mk(if (pol) ub else lb, pol)
       }
       // }(r => s"!C $r")

--- a/shared/src/main/scala/mlscript/NormalForms.scala
+++ b/shared/src/main/scala/mlscript/NormalForms.scala
@@ -160,7 +160,7 @@ class NormalForms extends TyperDatatypes { self: Typer =>
         S(RhsBases(p, S(R(RhsField(n1, t1 | that._2)))))
       case _: RhsField | _: RhsBases => N
     }
-    def <:< (that: RhsNf): Bool = this.toType().<:<(that.toType())(Ctx.empty) // TODO less inefficient! (uncached calls to toType)
+    def <:< (that: RhsNf): Bool = (this.toType() <:< that.toType())(Ctx.empty) // TODO less inefficient! (uncached calls to toType)
   }
   case class RhsField(name: Var, ty: SimpleType) extends RhsNf
     { def name_ty: Var -> ST = name -> ty }
@@ -203,7 +203,7 @@ class NormalForms extends TyperDatatypes { self: Typer =>
       // }(r => s"!! $r")
     def & (that: Conjunct): Opt[Conjunct] =
       // trace(s"?? $this & $that ${lnf & that.lnf} ${rnf | that.rnf}") {
-      if (lnf.toType().<:<(that.rnf.toType())(Ctx.empty)) N // TODO support <:< on any Nf? // TODO less inefficient! (uncached calls to toType)
+      if ((lnf.toType() <:< that.rnf.toType())(Ctx.empty)) N // TODO support <:< on any Nf? // TODO less inefficient! (uncached calls to toType)
       else S(Conjunct.mk(lnf & that.lnf getOrElse (return N), vars | that.vars
         , rnf | that.rnf getOrElse (return N)
         , nvars | that.nvars))

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -295,13 +295,13 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
       ctx.copy(tyDefs = oldDefs ++ newDefs.flatMap { td =>
         implicit val prov: TypeProvenance = tp(td.toLoc, "type definition")
         val n = td.nme
-        def gatherMthNames(td: TypeDef): (Set[TypeName], Set[TypeName]) =
+        def gatherMthNames(td: TypeDef): (Set[Var], Set[Var]) =
           td.baseClasses.iterator.flatMap(bn => ctx.tyDefs.get(bn.name)).map(gatherMthNames(_)).fold(
             (td.mthDecls.iterator.map(md => md.nme.copy().withLocOf(md)).toSet,
             td.mthDefs.iterator.map(md => md.nme.copy().withLocOf(md)).toSet)
           ) { case ((decls1, defns1), (decls2, defns2)) => (
             (decls1.toSeq ++ decls2.toSeq).groupBy(identity).map { case (mn, mns) =>
-              if (mns.size > 1) TypeName(mn.name).withLoc(td.toLoc) else mn }.toSet,
+              if (mns.size > 1) Var(mn.name).withLoc(td.toLoc) else mn }.toSet,
             defns1 ++ defns2
           )}
         def checkCycle(ty: SimpleType)(implicit travsersed: Set[TypeName \/ TV]): Bool =
@@ -818,7 +818,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
             val td = ctx.tyDefs(name)
             err((msg"Instantiation of an abstract type is forbidden" -> term.toLoc)
               :: (msg"Note that ${td.kind.str} ${td.nme} is abstract:" -> td.toLoc)
-              :: absMths.map { case mn => msg"Hint: method $mn is abstract" -> mn.toLoc }.toList)
+              :: absMths.map { case mn => msg"Hint: method ${mn.name} is abstract" -> mn.toLoc }.toList)
           case ty => ty
         }.instantiate
         mkProxy(ty, prov)

--- a/shared/src/main/scala/mlscript/TyperDatatypes.scala
+++ b/shared/src/main/scala/mlscript/TyperDatatypes.scala
@@ -52,13 +52,13 @@ abstract class TyperDatatypes extends TyperHelpers { self: Typer =>
     def unapply(mt: MethodType): S[(Int, SimpleType, List[TypeName])] = S((mt.level, mt.body, mt.parents))
   }
 
-  class AbstractConstructor(val absMths: Set[TypeName])(body: SimpleType) extends PolymorphicType(0, body) {
+  class AbstractConstructor(val absMths: Set[Var])(body: SimpleType) extends PolymorphicType(0, body) {
     override def toString: Str = s"AbstractConstructor($absMths)"
   }
   object AbstractConstructor {
-    def apply(absMths: Set[TypeName])(implicit prov: TypeProvenance): AbstractConstructor =
+    def apply(absMths: Set[Var])(implicit prov: TypeProvenance): AbstractConstructor =
       new AbstractConstructor(absMths)(errType(prov))
-    def unapply(ctor: AbstractConstructor): S[Set[TypeName]] = S(ctor.absMths)
+    def unapply(ctor: AbstractConstructor): S[Set[Var]] = S(ctor.absMths)
   }
   
   /** A type without universally quantified type variables. */

--- a/shared/src/main/scala/mlscript/TyperDatatypes.scala
+++ b/shared/src/main/scala/mlscript/TyperDatatypes.scala
@@ -16,10 +16,14 @@ abstract class TyperDatatypes extends TyperHelpers { self: Typer =>
     def & (that: TypeProvenance): TypeProvenance = this // arbitrary; maybe should do better
     override def toString: Str = "‹"+loco.fold(desc)(desc+":"+_)+"›"
   }
+
+  sealed abstract class TypeInfo
+
+  case class AbstractConstructor(absMths: Set[Var]) extends TypeInfo
   
   /** A type that potentially contains universally quantified type variables,
    *  and which can be isntantiated to a given level. */
-  sealed abstract class TypeScheme {
+  sealed abstract class TypeScheme extends TypeInfo {
     def instantiate(implicit lvl: Int): SimpleType
   }
   
@@ -50,15 +54,6 @@ abstract class TyperDatatypes extends TyperHelpers { self: Typer =>
     private def apply(level: Int, body: SimpleType, parents: List[TypeName], single: Bool): MethodType =
       new MethodType(level, body, parents, single)
     def unapply(mt: MethodType): S[(Int, SimpleType, List[TypeName])] = S((mt.level, mt.body, mt.parents))
-  }
-
-  class AbstractConstructor(val absMths: Set[Var])(body: SimpleType) extends PolymorphicType(0, body) {
-    override def toString: Str = s"AbstractConstructor($absMths)"
-  }
-  object AbstractConstructor {
-    def apply(absMths: Set[Var])(implicit prov: TypeProvenance): AbstractConstructor =
-      new AbstractConstructor(absMths)(errType(prov))
-    def unapply(ctor: AbstractConstructor): S[Set[Var]] = S(ctor.absMths)
   }
   
   /** A type without universally quantified type variables. */

--- a/shared/src/main/scala/mlscript/TyperDatatypes.scala
+++ b/shared/src/main/scala/mlscript/TyperDatatypes.scala
@@ -35,6 +35,7 @@ abstract class TyperDatatypes extends TyperHelpers { self: Typer =>
     def rigidify(implicit lvl: Int): SimpleType = freshenAbove(level, body, rigidify = true)
   }
   
+  // single: whether the method declaration comes from a single class, and not the intersection of multiple inherited declarations
   class MethodType(val level: Int, val body: Opt[SimpleType], val parents: List[TypeName], val single: Bool)
       (implicit val prov: TypeProvenance = body.fold(noProv)(_.prov)) {
     def &(that: MethodType): MethodType = {
@@ -49,6 +50,7 @@ abstract class TyperDatatypes extends TyperHelpers { self: Typer =>
     def rigidify(implicit lvl: Int): SimpleType = toPT.rigidify
     def copy(level: Int = this.level, body: Opt[SimpleType] = this.body, parents: List[TypeName] = this.parents): MethodType =
       MethodType(level, body, parents, this.single)
+    override def toString: Str = s"MethodType($level,$body,$parents,$single)"
   }
   object MethodType {
     def apply(level: Int, body: Opt[SimpleType], parent: TypeName)(implicit prov: TypeProvenance): MethodType =

--- a/shared/src/main/scala/mlscript/helpers.scala
+++ b/shared/src/main/scala/mlscript/helpers.scala
@@ -298,14 +298,15 @@ trait Located {
     spanEnd = e
     this
   }
-  def withLocOf(that: Located): this.type = {
-    that.toLoc.foreach { that =>
+  def withLoc(loco: Opt[Loc]): this.type = {
+    loco.foreach { that =>
       spanStart = that.spanStart
       spanEnd = that.spanEnd
       origin = S(that.origin)
     }
     this
   }
+  def withLocOf(that: Located): this.type = withLoc(that.toLoc)
   def hasLoc: Bool = origin.isDefined
   lazy val toLoc: Opt[Loc] = getLoc
   private def getLoc: Opt[Loc] = {

--- a/shared/src/main/scala/mlscript/syntax.scala
+++ b/shared/src/main/scala/mlscript/syntax.scala
@@ -22,7 +22,7 @@ final case class TypeDef(
 final case class MethodDef[RHS <: Term \/ Type](
   rec: Bool,
   prt: TypeName,
-  nme: TypeName,
+  nme: Var,
   tparams: List[TypeName],
   rhs: RHS,
 ) extends Located {

--- a/shared/src/main/scala/mlscript/utils/package.scala
+++ b/shared/src/main/scala/mlscript/utils/package.scala
@@ -36,6 +36,9 @@ package object utils {
       else newStr
     }
     def isCapitalized: Bool = self.nonEmpty && self.head.isUpper
+    def decapitalize: String =
+      if (self.length === 0 || !self.charAt(0).isUpper) self
+      else self.updated(0, self.charAt(0).toLower)
   }
   
   implicit class IterableOps[A](private val self: IterableOnce[A]) extends AnyVal {

--- a/shared/src/test/diff/basics/Datatypes.fun
+++ b/shared/src/test/diff/basics/Datatypes.fun
@@ -27,39 +27,21 @@ data type Bool2 of True2 & False2
 //│ Desugared: type alias Bool2 = &[True2, False2]
 //│ Desugared: class &[True2, False2]: {False2: False2, True2: True2}
 //│ Desugared: def &: [True2, False2] -> True2 -> False2 -> &[True2, False2]
+//│ ╔══[ERROR] type identifier not found: True2
+//│ ║  l.25: 	data type Bool2 of True2 & False2
+//│ ╙──      	                   ^^^^^
+//│ ╔══[ERROR] type identifier not found: False2
+//│ ║  l.25: 	data type Bool2 of True2 & False2
+//│ ╙──      	                           ^^^^^^
 //│ ╔══[ERROR] Type names must start with a capital letter
 //│ ║  l.25: 	data type Bool2 of True2 & False2
 //│ ╙──      	                         ^
-//│ ╔══[ERROR] type identifier not found: True2
-//│ ║  l.25: 	data type Bool2 of True2 & False2
-//│ ╙──      	                   ^^^^^
-//│ ╔══[ERROR] type identifier not found: False2
-//│ ║  l.25: 	data type Bool2 of True2 & False2
-//│ ╙──      	                           ^^^^^^
 //│ ╔══[ERROR] Field identifiers must start with a small letter
 //│ ║  l.25: 	data type Bool2 of True2 & False2
 //│ ╙──      	                           ^^^^^^
 //│ ╔══[ERROR] Field identifiers must start with a small letter
 //│ ║  l.25: 	data type Bool2 of True2 & False2
 //│ ╙──      	                   ^^^^^
-//│ ╔══[ERROR] Field identifiers must start with a small letter
-//│ ║  l.25: 	data type Bool2 of True2 & False2
-//│ ╙──      	                           ^^^^^^
-//│ ╔══[ERROR] Field identifiers must start with a small letter
-//│ ║  l.25: 	data type Bool2 of True2 & False2
-//│ ╙──      	                   ^^^^^
-//│ ╔══[ERROR] Field identifiers must start with a small letter
-//│ ║  l.25: 	data type Bool2 of True2 & False2
-//│ ╙──      	                           ^^^^^^
-//│ ╔══[ERROR] Field identifiers must start with a small letter
-//│ ║  l.25: 	data type Bool2 of True2 & False2
-//│ ╙──      	                   ^^^^^
-//│ ╔══[ERROR] type identifier not found: True2
-//│ ║  l.25: 	data type Bool2 of True2 & False2
-//│ ╙──      	                   ^^^^^
-//│ ╔══[ERROR] type identifier not found: False2
-//│ ║  l.25: 	data type Bool2 of True2 & False2
-//│ ╙──      	                           ^^^^^^
 //│ Defined type alias Bool2
 //│ Defined class &
 //│ &: 'a -> 'b -> &['a, 'b]
@@ -84,7 +66,7 @@ data type Bool4 of
 :e
 Boolean
 //│ ╔══[ERROR] identifier not found: Boolean
-//│ ║  l.85: 	Boolean
+//│ ║  l.67: 	Boolean
 //│ ╙──      	^^^^^^^
 //│ res: error
 
@@ -95,24 +77,24 @@ True
 True as Boolean
 True : Boolean
 //│ ╔══[ERROR] identifier not found: Boolean
-//│ ║  l.95: 	True as Boolean
+//│ ║  l.77: 	True as Boolean
 //│ ╙──      	        ^^^^^^^
 //│ res: error
 //│ ╔══[ERROR] identifier not found: Boolean
-//│ ║  l.96: 	True : Boolean
+//│ ║  l.78: 	True : Boolean
 //│ ╙──      	       ^^^^^^^
 //│ res: (True: error,)
 
 :e // Maybe we shouldn't interpret capitalized identifiers as field names...
 True : Boolean
 //│ ╔══[ERROR] identifier not found: Boolean
-//│ ║  l.107: 	True : Boolean
-//│ ╙──       	       ^^^^^^^
+//│ ║  l.89: 	True : Boolean
+//│ ╙──      	       ^^^^^^^
 //│ res: (True: error,)
 
 :pe
 (True) : Boolean
-//│ /!\ Parse error: Expected end-of-input:1:8, found ": Boolean\n" at l.114:8: (True) : Boolean
+//│ /!\ Parse error: Expected end-of-input:1:8, found ": Boolean\n" at l.96:8: (True) : Boolean
 
 
 // TODO treat the ending curly-blocks as bodies (not params)?
@@ -147,10 +129,7 @@ data type Ls of LsA a
 //│ Desugared: class LsA[a]: {a: a}
 //│ Desugared: def LsA: [a] -> a -> LsA[a]
 //│ ╔══[ERROR] type identifier not found: a
-//│ ║  l.144: 	data type Ls of LsA a
-//│ ╙──       	                    ^
-//│ ╔══[ERROR] type identifier not found: a
-//│ ║  l.144: 	data type Ls of LsA a
+//│ ║  l.126: 	data type Ls of LsA a
 //│ ╙──       	                    ^
 //│ Defined type alias Ls
 //│ Defined class LsA
@@ -187,46 +166,46 @@ not (Cons false Nil).head
 :e
 not (Cons 42 Nil).head
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.188: 	not (Cons 42 Nil).head
+//│ ║  l.167: 	not (Cons 42 Nil).head
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `42` does not match type `bool`
-//│ ║  l.188: 	not (Cons 42 Nil).head
+//│ ║  l.167: 	not (Cons 42 Nil).head
 //│ ║         	          ^^
 //│ ╟── but it flows into field selection with expected type `bool`
-//│ ║  l.188: 	not (Cons 42 Nil).head
+//│ ║  l.167: 	not (Cons 42 Nil).head
 //│ ╙──       	                 ^^^^^
 //│ res: bool | error
 
 :e
 (Cons 4).head
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.201: 	(Cons 4).head
+//│ ║  l.180: 	(Cons 4).head
 //│ ║         	        ^^^^^
 //│ ╟── expression of type `(tail: List[?a],) -> Cons[?a]` does not have field 'head'
-//│ ║  l.127: 	data type List a of
+//│ ║  l.109: 	data type List a of
 //│ ║         	               ^^^^
-//│ ║  l.128: 	  Nil
+//│ ║  l.110: 	  Nil
 //│ ║         	^^^^^
-//│ ║  l.129: 	  Cons (head: a) (tail: List a)
+//│ ║  l.111: 	  Cons (head: a) (tail: List a)
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into receiver with expected type `{head: ?b}`
-//│ ║  l.201: 	(Cons 4).head
+//│ ║  l.180: 	(Cons 4).head
 //│ ╙──       	^^^^^^^^
 //│ res: error
 
 :e
 Cons 1 2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.218: 	Cons 1 2
+//│ ║  l.197: 	Cons 1 2
 //│ ║         	^^^^^^^^
 //│ ╟── expression of type `2` does not match type `Nil[?a] | Cons[?a]`
-//│ ║  l.218: 	Cons 1 2
+//│ ║  l.197: 	Cons 1 2
 //│ ║         	       ^
 //│ ╟── Note: constraint arises from union type:
-//│ ║  l.127: 	data type List a of
+//│ ║  l.109: 	data type List a of
 //│ ║         	               ^
 //│ ╟── from applied type reference:
-//│ ║  l.129: 	  Cons (head: a) (tail: List a)
+//│ ║  l.111: 	  Cons (head: a) (tail: List a)
 //│ ╙──       	                        ^^^^^^
 //│ res: ((Cons['b .. 1 | 'b] with {tail: 'c | 'a | Nil['b .. 1 | 'b]}) as 'a) | error
 
@@ -234,7 +213,7 @@ Cons 1 2
 :e
 let List.head = () // ...
 //│ ╔══[ERROR] Unsupported pattern shape
-//│ ║  l.235: 	let List.head = () // ...
+//│ ║  l.214: 	let List.head = () // ...
 //│ ╙──       	        ^^^^^
 //│ <error>: ()
 

--- a/shared/src/test/diff/mlscript/BadAlias.mls
+++ b/shared/src/test/diff/mlscript/BadAlias.mls
@@ -35,39 +35,35 @@ type B = Oops
 //│ ╙──      	         ^^^^
 //│ Defined type alias B
 
-:e // TODO should probaby not report the error again
 42: B
-//│ ╔══[ERROR] type identifier not found: Oops
-//│ ║  l.32: 	type B = Oops
-//│ ╙──      	         ^^^^
 //│ res: error
 //│    = 42
 
 :e
 type NonReg[A] = { x: NonReg[NonReg[A]] }
 //│ ╔══[ERROR] Type definition is not regular: it occurs within itself as NonReg[NonReg['A]], but is defined as NonReg['A]
-//│ ║  l.47: 	type NonReg[A] = { x: NonReg[NonReg[A]] }
+//│ ║  l.43: 	type NonReg[A] = { x: NonReg[NonReg[A]] }
 //│ ╙──      	     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :e
 type B = NonReg[A]
 //│ ╔══[ERROR] Type 'B' is already defined.
-//│ ║  l.53: 	type B = NonReg[A]
+//│ ║  l.49: 	type B = NonReg[A]
 //│ ╙──      	     ^
 //│ ╔══[ERROR] type identifier not found: NonReg
-//│ ║  l.53: 	type B = NonReg[A]
+//│ ║  l.49: 	type B = NonReg[A]
 //│ ╙──      	         ^^^^^^^^^
 
 :e
 type NonReg[A] = { x: NonReg[int] }
 //│ ╔══[ERROR] Type definition is not regular: it occurs within itself as NonReg[int], but is defined as NonReg['A]
-//│ ║  l.62: 	type NonReg[A] = { x: NonReg[int] }
+//│ ║  l.58: 	type NonReg[A] = { x: NonReg[int] }
 //│ ╙──      	     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :e
 42: NonReg[int]
 //│ ╔══[ERROR] type identifier not found: NonReg
-//│ ║  l.68: 	42: NonReg[int]
+//│ ║  l.64: 	42: NonReg[int]
 //│ ╙──      	    ^^^^^^^^^^^
 //│ res: error
 //│    = 42
@@ -76,7 +72,7 @@ type NonReg[A] = { x: NonReg[int] }
 type NonReg[A] = { x: NonReg[int] }
 type RefToNongReg[A] = { x: NonReg[A] }
 //│ ╔══[ERROR] Type definition is not regular: it occurs within itself as NonReg[int], but is defined as NonReg['A]
-//│ ║  l.76: 	type NonReg[A] = { x: NonReg[int] }
+//│ ║  l.72: 	type NonReg[A] = { x: NonReg[int] }
 //│ ╙──      	     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ Defined type alias RefToNongReg
 
@@ -92,15 +88,15 @@ type Id[A] = A
 :e
 type FalseNeg[A] = { x: FalseNeg[Id[A]] }
 //│ ╔══[ERROR] Type definition is not regular: it occurs within itself as FalseNeg[Id['A]], but is defined as FalseNeg['A]
-//│ ║  l.93: 	type FalseNeg[A] = { x: FalseNeg[Id[A]] }
+//│ ║  l.89: 	type FalseNeg[A] = { x: FalseNeg[Id[A]] }
 //│ ╙──      	     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 :e
 42: Id
 //│ ╔══[ERROR] Type Id takes parameters
-//│ ║  l.100: 	42: Id
-//│ ╙──       	    ^^
+//│ ║  l.96: 	42: Id
+//│ ╙──      	    ^^
 //│ res: error
 //│    = 42
 

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -665,3 +665,81 @@ class H2: D2 & E2
 //│ Declared E2.G2: e2 -> bool
 //│ Defined class H2
 
+
+
+
+trait Test7A
+  method Mth7A: int
+  method Mth7A = 42
+trait Test7B
+  method Mth7A: int
+  method Mth7A = 43
+//│ Defined trait Test7A
+//│ Declared Test7A.Mth7A: test7A -> int
+//│ Defined Test7A.Mth7A: test7A -> 42
+//│ Defined trait Test7B
+//│ Declared Test7B.Mth7A: test7B -> int
+//│ Defined Test7B.Mth7A: test7B -> 43
+
+:e
+class Test7C: Test7A & Test7B
+//│ ╔══[ERROR] A method definition must be given when inheriting multiple method definitions
+//│ ║  l.685: 	class Test7C: Test7A & Test7B
+//│ ║         	      ^^^^^^
+//│ ╟── Definitions of method Mth7A inherited from:
+//│ ╟── • Test7A
+//│ ║  l.673: 	  method Mth7A = 42
+//│ ║         	         ^^^^^^^^^^
+//│ ╟── • Test7B
+//│ ║  l.676: 	  method Mth7A = 43
+//│ ╙──       	         ^^^^^^^^^^
+//│ Defined class Test7C
+
+class Test7D: Test7A & Test7B
+  method Mth7A = this.(Test7A.Mth7A) * this.(Test7B.Mth7A)
+//│ Defined class Test7D
+//│ Defined Test7D.Mth7A: (Test7D & test7A & test7B) -> int
+
+:e // TODO: suppress?
+class Test7E: Test7C
+  method Mth7A = 0
+//│ ╔══[ERROR] A method definition must be given when inheriting multiple method definitions
+//│ ║  l.685: 	class Test7C: Test7A & Test7B
+//│ ║         	      ^^^^^^
+//│ ╟── Definitions of method Mth7A inherited from:
+//│ ╟── • Test7A
+//│ ║  l.673: 	  method Mth7A = 42
+//│ ║         	         ^^^^^^^^^^
+//│ ╟── • Test7B
+//│ ║  l.676: 	  method Mth7A = 43
+//│ ╙──       	         ^^^^^^^^^^
+//│ Defined class Test7E
+//│ Defined Test7E.Mth7A: (Test7E & test7A & test7B) -> 0
+
+:e
+trait Test7F
+  method Mth7A = 0
+class Test7G: Test7C & Test7F
+//│ ╔══[ERROR] A method definition must be given when inheriting multiple method definitions
+//│ ║  l.685: 	class Test7C: Test7A & Test7B
+//│ ║         	      ^^^^^^
+//│ ╟── Definitions of method Mth7A inherited from:
+//│ ╟── • Test7A
+//│ ║  l.673: 	  method Mth7A = 42
+//│ ║         	         ^^^^^^^^^^
+//│ ╟── • Test7B
+//│ ║  l.676: 	  method Mth7A = 43
+//│ ╙──       	         ^^^^^^^^^^
+//│ ╔══[ERROR] A method definition must be given when inheriting multiple method definitions
+//│ ║  l.722: 	class Test7G: Test7C & Test7F
+//│ ║         	      ^^^^^^
+//│ ╟── Definitions of method Mth7A inherited from:
+//│ ╟── • Test7C
+//│ ║  l.685: 	class Test7C: Test7A & Test7B
+//│ ║         	      ^^^^^^
+//│ ╟── • Test7F
+//│ ║  l.721: 	  method Mth7A = 0
+//│ ╙──       	         ^^^^^^^^^
+//│ Defined trait Test7F
+//│ Defined Test7F.Mth7A: test7F -> 0
+//│ Defined class Test7G

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -409,6 +409,12 @@ class Test4B: Test4A
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.399: 	    method Mth4A: int
 //│ ╙──       	                  ^^^
+//│ ╔══[ERROR] Overriding method Test4A.Mth4A without an overriding definition is not allowed.
+//│ ║  l.399: 	    method Mth4A: int
+//│ ║         	           ^^^^^^^^^^
+//│ ╟── Note: method definition inherited from
+//│ ║  l.393: 	    method Mth4A = true
+//│ ╙──       	           ^^^^^^^^^^^^
 //│ Defined class Test4B
 //│ Declared Test4B.Mth4A: Test4B -> int
 
@@ -425,16 +431,16 @@ class Test5A
 class Test5B: Test5A
     method Mth5A = 43
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.426: 	    method Mth5A = 43
+//│ ║  l.432: 	    method Mth5A = 43
 //│ ║         	           ^^^^^^^^^^
 //│ ╟── expression of type `43` does not match type `42`
-//│ ║  l.426: 	    method Mth5A = 43
+//│ ║  l.432: 	    method Mth5A = 43
 //│ ║         	                   ^^
 //│ ╟── but it flows into method definition with expected type `42`
-//│ ║  l.426: 	    method Mth5A = 43
+//│ ║  l.432: 	    method Mth5A = 43
 //│ ║         	           ^^^^^^^^^^
 //│ ╟── Note: constraint arises from inherited method declaration:
-//│ ║  l.424: 	    method Mth5A: 42
+//│ ║  l.430: 	    method Mth5A: 42
 //│ ╙──       	           ^^^^^
 //│ Defined class Test5A
 //│ Declared Test5A.Mth5A: Test5A -> 42
@@ -458,45 +464,45 @@ class Test6C: Test6A[int] & Test6B
 :e
 Test6A
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
-//│ ║  l.459: 	Test6A
+//│ ║  l.465: 	Test6A
 //│ ║         	^^^^^^
 //│ ╟── Note that class Test6A is abstract:
-//│ ║  l.445: 	class Test6A[A]
+//│ ║  l.451: 	class Test6A[A]
 //│ ║         	      ^^^^^^^^
 //│ ╟── Hint: method Mth6A is abstract
-//│ ║  l.446: 	    method Mth6A: A
+//│ ║  l.452: 	    method Mth6A: A
 //│ ║         	           ^^^^^^^^
 //│ ╟── Hint: method Mth6B is abstract
-//│ ║  l.447: 	    method Mth6B[B]: (A -> B) -> B
+//│ ║  l.453: 	    method Mth6B[B]: (A -> B) -> B
 //│ ╙──       	           ^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error
 
 :e
 Test6B
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
-//│ ║  l.475: 	Test6B
+//│ ║  l.481: 	Test6B
 //│ ║         	^^^^^^
 //│ ╟── Note that trait Test6B is abstract:
-//│ ║  l.448: 	trait Test6B
+//│ ║  l.454: 	trait Test6B
 //│ ║         	      ^^^^^^
 //│ ╟── Hint: method Mth6A is abstract
-//│ ║  l.449: 	    method Mth6A: bool
+//│ ║  l.455: 	    method Mth6A: bool
 //│ ╙──       	           ^^^^^^^^^^^
 //│ res: error
 
 :e
 Test6C
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
-//│ ║  l.488: 	Test6C
+//│ ║  l.494: 	Test6C
 //│ ║         	^^^^^^
 //│ ╟── Note that class Test6C is abstract:
-//│ ║  l.450: 	class Test6C: Test6A[int] & Test6B
+//│ ║  l.456: 	class Test6C: Test6A[int] & Test6B
 //│ ║         	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Hint: method Mth6B is abstract
-//│ ║  l.447: 	    method Mth6B[B]: (A -> B) -> B
+//│ ║  l.453: 	    method Mth6B[B]: (A -> B) -> B
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Hint: method Mth6A is abstract
-//│ ║  l.450: 	class Test6C: Test6A[int] & Test6B
+//│ ║  l.456: 	class Test6C: Test6A[int] & Test6B
 //│ ╙──       	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error
 
@@ -509,24 +515,24 @@ class Dup[A, A]: { x: A }
         B]: (A -> B) -> B
     method MthDup f = f this.x
 //│ ╔══[ERROR] Multiple declarations of type parameter A in class definition
-//│ ║  l.507: 	class Dup[A, A]: { x: A }
+//│ ║  l.513: 	class Dup[A, A]: { x: A }
 //│ ║         	      ^^^^^^^^^^^^^^^^^^^
 //│ ╟── Declared at
-//│ ║  l.507: 	class Dup[A, A]: { x: A }
+//│ ║  l.513: 	class Dup[A, A]: { x: A }
 //│ ║         	          ^
 //│ ╟── Declared at
-//│ ║  l.507: 	class Dup[A, A]: { x: A }
+//│ ║  l.513: 	class Dup[A, A]: { x: A }
 //│ ╙──       	             ^
 //│ ╔══[ERROR] Multiple declarations of type parameter B in method declaration
-//│ ║  l.508: 	    method MthDup[B, C, // random comment
+//│ ║  l.514: 	    method MthDup[B, C, // random comment
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.509: 	        B]: (A -> B) -> B
+//│ ║  l.515: 	        B]: (A -> B) -> B
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Declared at
-//│ ║  l.508: 	    method MthDup[B, C, // random comment
+//│ ║  l.514: 	    method MthDup[B, C, // random comment
 //│ ║         	                  ^
 //│ ╟── Declared at
-//│ ║  l.509: 	        B]: (A -> B) -> B
+//│ ║  l.515: 	        B]: (A -> B) -> B
 //│ ╙──       	        ^
 //│ Defined class Dup
 //│ Declared Dup.MthDup: Dup['A | 'A0 .. 'A & 'A0, 'A | 'A0 .. 'A & 'A0] -> ('A0 -> 'B) -> 'B
@@ -545,19 +551,19 @@ t : Dup[bool, int]
 :stats
 t : Dup[int, bool]
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.546: 	t : Dup[int, bool]
+//│ ║  l.552: 	t : Dup[int, bool]
 //│ ║         	^
 //│ ╟── expression of type `42` does not match type `bool`
-//│ ║  l.535: 	t = Dup { x = 42 }
+//│ ║  l.541: 	t = Dup { x = 42 }
 //│ ║         	              ^^
 //│ ╟── but it flows into reference with expected type `Dup[int, bool]`
-//│ ║  l.546: 	t : Dup[int, bool]
+//│ ║  l.552: 	t : Dup[int, bool]
 //│ ║         	^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.546: 	t : Dup[int, bool]
+//│ ║  l.552: 	t : Dup[int, bool]
 //│ ║         	             ^^^^
 //│ ╟── from record type:
-//│ ║  l.507: 	class Dup[A, A]: { x: A }
+//│ ║  l.513: 	class Dup[A, A]: { x: A }
 //│ ╙──       	                 ^^^^^^^^
 //│ res: Dup[bool | int .. nothing, bool | int .. nothing]
 //│ constrain calls  : 58
@@ -588,7 +594,7 @@ class B: { x: int }
   method F1: int
   method F1 = 1
 //│ ╔══[ERROR] Method F1 not found
-//│ ║  l.586: 	  method Nope = this.Yes.F1
+//│ ║  l.592: 	  method Nope = this.Yes.F1
 //│ ╙──       	                ^^^^^^^^^^^
 //│ Defined class A
 //│ Defined A.Yes: A -> (B & {x: 1})
@@ -605,22 +611,22 @@ trait E
 class H: D & E
   method G = 2
 //│ ╔══[ERROR] Overriding method D.G without explicit declaration is not allowed.
-//│ ║  l.606: 	  method G = 2
+//│ ║  l.612: 	  method G = 2
 //│ ║         	         ^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.602: 	  method G = 1
+//│ ║  l.608: 	  method G = 1
 //│ ╙──       	         ^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.606: 	  method G = 2
+//│ ║  l.612: 	  method G = 2
 //│ ║         	         ^^^^^
 //│ ╟── expression of type `2` does not match type `1`
-//│ ║  l.606: 	  method G = 2
+//│ ║  l.612: 	  method G = 2
 //│ ║         	             ^
 //│ ╟── but it flows into method definition with expected type `1`
-//│ ║  l.606: 	  method G = 2
+//│ ║  l.612: 	  method G = 2
 //│ ║         	         ^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.602: 	  method G = 1
+//│ ║  l.608: 	  method G = 1
 //│ ╙──       	             ^
 //│ Defined trait D
 //│ Defined D.G: d -> 1
@@ -648,16 +654,16 @@ trait E2
   method G2: bool
 class H2: D2 & E2
 //│ ╔══[ERROR] Type mismatch in inherited method definition:
-//│ ║  l.646: 	  method G2 = 1
+//│ ║  l.652: 	  method G2 = 1
 //│ ║         	         ^^^^^^
 //│ ╟── expression of type `1` does not match type `bool`
-//│ ║  l.646: 	  method G2 = 1
+//│ ║  l.652: 	  method G2 = 1
 //│ ║         	              ^
 //│ ╟── but it flows into inherited method definition with expected type `bool`
-//│ ║  l.646: 	  method G2 = 1
+//│ ║  l.652: 	  method G2 = 1
 //│ ║         	         ^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.648: 	  method G2: bool
+//│ ║  l.654: 	  method G2: bool
 //│ ╙──       	             ^^^^
 //│ Defined trait D2
 //│ Defined D2.G2: d2 -> 1
@@ -684,14 +690,14 @@ trait Test7B
 :e
 class Test7C: Test7A & Test7B
 //│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
-//│ ║  l.685: 	class Test7C: Test7A & Test7B
+//│ ║  l.691: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
 //│ ╟── • Test7A
-//│ ║  l.673: 	  method Mth7A = 42
+//│ ║  l.679: 	  method Mth7A = 42
 //│ ║         	         ^^^^^^^^^^
 //│ ╟── • Test7B
-//│ ║  l.676: 	  method Mth7A = 43
+//│ ║  l.682: 	  method Mth7A = 43
 //│ ╙──       	         ^^^^^^^^^^
 //│ Defined class Test7C
 
@@ -704,14 +710,14 @@ class Test7D: Test7A & Test7B
 class Test7E: Test7C
   method Mth7A = 0
 //│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
-//│ ║  l.685: 	class Test7C: Test7A & Test7B
+//│ ║  l.691: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
 //│ ╟── • Test7A
-//│ ║  l.673: 	  method Mth7A = 42
+//│ ║  l.679: 	  method Mth7A = 42
 //│ ║         	         ^^^^^^^^^^
 //│ ╟── • Test7B
-//│ ║  l.676: 	  method Mth7A = 43
+//│ ║  l.682: 	  method Mth7A = 43
 //│ ╙──       	         ^^^^^^^^^^
 //│ Defined class Test7E
 //│ Defined Test7E.Mth7A: (Test7E & test7A & test7B) -> 0
@@ -724,23 +730,58 @@ trait Test7F
 :e
 class Test7G: Test7C & Test7F
 //│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
-//│ ║  l.685: 	class Test7C: Test7A & Test7B
+//│ ║  l.691: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
 //│ ╟── • Test7A
-//│ ║  l.673: 	  method Mth7A = 42
+//│ ║  l.679: 	  method Mth7A = 42
 //│ ║         	         ^^^^^^^^^^
 //│ ╟── • Test7B
-//│ ║  l.676: 	  method Mth7A = 43
+//│ ║  l.682: 	  method Mth7A = 43
 //│ ╙──       	         ^^^^^^^^^^
 //│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
-//│ ║  l.725: 	class Test7G: Test7C & Test7F
+//│ ║  l.731: 	class Test7G: Test7C & Test7F
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
 //│ ╟── • Test7C
-//│ ║  l.685: 	class Test7C: Test7A & Test7B
+//│ ║  l.691: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── • Test7F
-//│ ║  l.720: 	  method Mth7A = 0
+//│ ║  l.726: 	  method Mth7A = 0
 //│ ╙──       	         ^^^^^^^^^
 //│ Defined class Test7G
+
+
+
+
+class Test8A
+    method F: int
+    method F = 1
+//│ Defined class Test8A
+//│ Declared Test8A.F: Test8A -> int
+//│ Defined Test8A.F: Test8A -> 1
+
+:e
+class Test8B: Test8A
+    method F: 1
+//│ ╔══[ERROR] Overriding method Test8A.F without an overriding definition is not allowed.
+//│ ║  l.766: 	    method F: 1
+//│ ║         	           ^
+//│ ╟── Note: method definition inherited from
+//│ ║  l.759: 	    method F = 1
+//│ ╙──       	           ^^^^^
+//│ Defined class Test8B
+//│ Declared Test8B.F: Test8B -> 1
+
+class Test8C[A]
+    method F: A
+    method F = error
+//│ Defined class Test8C
+//│ Declared Test8C.F: Test8C['A] -> 'A
+//│ Defined Test8C.F: Test8C['A] -> nothing
+
+// Allow syntactically identitcal declarations for documentation
+class Test8D: Test8C[int]
+    method F: int
+//│ Defined class Test8D
+//│ Declared Test8D.F: Test8D -> int

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -683,7 +683,7 @@ trait Test7B
 
 :e
 class Test7C: Test7A & Test7B
-//│ ╔══[ERROR] A method definition must be given when inheriting multiple method definitions
+//│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
 //│ ║  l.685: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
@@ -703,7 +703,7 @@ class Test7D: Test7A & Test7B
 :e // TODO: suppress?
 class Test7E: Test7C
   method Mth7A = 0
-//│ ╔══[ERROR] A method definition must be given when inheriting multiple method definitions
+//│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
 //│ ║  l.685: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
@@ -723,7 +723,7 @@ trait Test7F
 
 :e
 class Test7G: Test7C & Test7F
-//│ ╔══[ERROR] A method definition must be given when inheriting multiple method definitions
+//│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
 //│ ║  l.685: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
@@ -733,7 +733,7 @@ class Test7G: Test7C & Test7F
 //│ ╟── • Test7B
 //│ ║  l.676: 	  method Mth7A = 43
 //│ ╙──       	         ^^^^^^^^^^
-//│ ╔══[ERROR] A method definition must be given when inheriting multiple method definitions
+//│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
 //│ ║  l.725: 	class Test7G: Test7C & Test7F
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -785,3 +785,31 @@ class Test8D: Test8C[int]
     method F: int
 //│ Defined class Test8D
 //│ Declared Test8D.F: Test8D -> int
+
+
+
+
+class Test9A[A]: { x: A }
+    method Mth9A = this.x
+//│ Defined class Test9A
+//│ Defined Test9A.Mth9A: Test9A['A] -> 'A
+
+class Test9B: Test9A[int]
+//│ Defined class Test9B
+
+:e
+:NoJS
+error.(Test9B.Mth9A): nothing
+//│ ╔══[ERROR] Type mismatch in type ascription:
+//│ ║  l.802: 	error.(Test9B.Mth9A): nothing
+//│ ║         	^^^^^^^^^^^^^^^^^^^^
+//│ ╟── expression of type `int` does not match type `nothing`
+//│ ║  l.797: 	class Test9B: Test9A[int]
+//│ ║         	                     ^^^
+//│ ╟── but it flows into field selection with expected type `nothing`
+//│ ║  l.802: 	error.(Test9B.Mth9A): nothing
+//│ ║         	^^^^^^^^^^^^^^^^^^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.802: 	error.(Test9B.Mth9A): nothing
+//│ ╙──       	                      ^^^^^^^
+//│ res: nothing

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -716,9 +716,12 @@ class Test7E: Test7C
 //│ Defined class Test7E
 //│ Defined Test7E.Mth7A: (Test7E & test7A & test7B) -> 0
 
-:e
 trait Test7F
   method Mth7A = 0
+//│ Defined trait Test7F
+//│ Defined Test7F.Mth7A: test7F -> 0
+
+:e
 class Test7G: Test7C & Test7F
 //│ ╔══[ERROR] A method definition must be given when inheriting multiple method definitions
 //│ ║  l.685: 	class Test7C: Test7A & Test7B
@@ -731,15 +734,13 @@ class Test7G: Test7C & Test7F
 //│ ║  l.676: 	  method Mth7A = 43
 //│ ╙──       	         ^^^^^^^^^^
 //│ ╔══[ERROR] A method definition must be given when inheriting multiple method definitions
-//│ ║  l.722: 	class Test7G: Test7C & Test7F
+//│ ║  l.725: 	class Test7G: Test7C & Test7F
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
 //│ ╟── • Test7C
 //│ ║  l.685: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── • Test7F
-//│ ║  l.721: 	  method Mth7A = 0
+//│ ║  l.720: 	  method Mth7A = 0
 //│ ╙──       	         ^^^^^^^^^
-//│ Defined trait Test7F
-//│ Defined Test7F.Mth7A: test7F -> 0
 //│ Defined class Test7G

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -41,8 +41,11 @@ class bar[A, B]: Foo[A] & { Y: B; z: int }
 //│ ╔══[ERROR] Method names must start with a capital letter
 //│ ║  l.31: 	    method identity z = z
 //│ ╙──      	           ^^^^^^^^
-//│ ╔══[ERROR] Method 'bar.identity' is already defined.
+//│ ╔══[ERROR] Method 'bar.identity' is already defined
 //│ ║  l.31: 	    method identity z = z
+//│ ║        	           ^^^^^^^^
+//│ ╟── at
+//│ ║  l.30: 	    method identity z = z
 //│ ╙──      	           ^^^^^^^^
 //│ Defined class bar
 //│ Defined bar.identity: (Bar[?] with {Y: 'B, bar#A: 'A -> 'A, bar#B: 'B -> 'B, x: 'A, z: int}) -> 'a -> 'a
@@ -68,14 +71,14 @@ class NoMoreImplicitCall
 
 i.Fun
 //│ ╔══[ERROR] Implicit call to method Fun is forbidden because it is ambiguous.
-//│ ║  l.69: 	i.Fun
+//│ ║  l.72: 	i.Fun
 //│ ║        	^^^^^
 //│ ╟── Unrelated methods named Fun are defined by:
 //│ ╟── • class ImplicitCall
-//│ ║  l.54: 	class ImplicitCall[A]: { x: A }
+//│ ║  l.57: 	class ImplicitCall[A]: { x: A }
 //│ ║        	      ^^^^^^^^^^^^
 //│ ╟── • class NoMoreImplicitCall
-//│ ║  l.64: 	class NoMoreImplicitCall
+//│ ║  l.67: 	class NoMoreImplicitCall
 //│ ╙──      	      ^^^^^^^^^^^^^^^^^^
 //│ res: error
 
@@ -91,22 +94,22 @@ class BadThis: { x: int; y: int }
     method Sum = this this.x this.y
     method Funny = this 42 42
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.91: 	    method Sum = this this.x this.y
+//│ ║  l.94: 	    method Sum = this this.x this.y
 //│ ║        	                 ^^^^^^^^^^^
 //│ ╟── expression of type `BadThis` does not match type `?a -> ?b`
-//│ ║  l.90: 	class BadThis: { x: int; y: int }
+//│ ║  l.93: 	class BadThis: { x: int; y: int }
 //│ ║        	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `?c -> ?b`
-//│ ║  l.91: 	    method Sum = this this.x this.y
+//│ ║  l.94: 	    method Sum = this this.x this.y
 //│ ╙──      	                 ^^^^
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.92: 	    method Funny = this 42 42
+//│ ║  l.95: 	    method Funny = this 42 42
 //│ ║        	                   ^^^^^^^
 //│ ╟── expression of type `BadThis` does not match type `42 -> ?a`
-//│ ║  l.90: 	class BadThis: { x: int; y: int }
+//│ ║  l.93: 	class BadThis: { x: int; y: int }
 //│ ║        	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `42 -> ?a`
-//│ ║  l.92: 	    method Funny = this 42 42
+//│ ║  l.95: 	    method Funny = this 42 42
 //│ ╙──      	                   ^^^^
 //│ Defined class BadThis
 //│ Defined BadThis.Sum: BadThis -> error
@@ -118,10 +121,10 @@ class BadThis: { x: int; y: int }
 class BadSelf[A]: { x: A }
     method F = this.x 42
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.119: 	    method F = this.x 42
+//│ ║  l.122: 	    method F = this.x 42
 //│ ║         	               ^^^^^^^^^
 //│ ╟── expression of type `A` is not a function
-//│ ║  l.119: 	    method F = this.x 42
+//│ ║  l.122: 	    method F = this.x 42
 //│ ╙──       	               ^^^^^^
 //│ Defined class BadSelf
 //│ Defined BadSelf.F: BadSelf['A] -> error
@@ -142,11 +145,11 @@ class Simple2[A]: { a: A }
 class Simple3[A, B]: Simple2[A]
     method Get: B
 //│ ╔══[ERROR] Type mismatch in method declaration:
-//│ ║  l.143: 	    method Get: B
+//│ ║  l.146: 	    method Get: B
 //│ ║         	           ^^^^^^
 //│ ╟── expression of type `B` does not match type `A`
-//│ ╟── Note: constraint arises from method declaration:
-//│ ║  l.138: 	    method Get: A
+//│ ╟── Note: constraint arises from inherited method declaration:
+//│ ║  l.141: 	    method Get: A
 //│ ╙──       	           ^^^^^^
 //│ Defined class Simple3
 //│ Declared Simple3.Get: Simple3['A, 'B] -> 'B
@@ -165,53 +168,53 @@ class BadPair[A, B]: AbstractPair[A, B]
     method Test f = f this.x this.x
     method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.165: 	    method Test f = f this.x this.x
+//│ ║  l.168: 	    method Test f = f this.x this.x
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `A` does not match type `B`
-//│ ║  l.165: 	    method Test f = f this.x this.x
+//│ ║  l.168: 	    method Test f = f this.x this.x
 //│ ╙──       	                             ^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.166: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.169: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `C` does not match type `D`
-//│ ║  l.166: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.169: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into function of type `?a -> ?b`
-//│ ║  l.166: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.169: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── which does not match type `(B -> D) -> AbstractPair[C, D]`
 //│ ╟── Note: constraint arises from record type:
-//│ ║  l.157: 	class AbstractPair[A, B]: { x: A; y: B }
+//│ ║  l.160: 	class AbstractPair[A, B]: { x: A; y: B }
 //│ ║         	                          ^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.159: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ╙──       	                                              ^^^^^^^^^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.166: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.169: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `C` does not match type `D`
 //│ ╟── but it flows into application of type `?a`
-//│ ║  l.166: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.169: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── which does not match type `AbstractPair[C, D]`
 //│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.159: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ╙──       	                                              ^^^^^^^^^^^^^^^^^^
 //│ Defined class BadPair
 //│ Defined BadPair.Test: BadPair['A, 'B] -> ('A -> 'A -> 'a) -> 'a
-//│ Defined BadPair.Map: BadPair['A, 'B] -> ('A -> ('A0 & 'B0 & 'a)) -> anything -> (BadPair['A0, 'B0] with {x: 'a, y: 'a})
+//│ Defined BadPair.Map: BadPair['A, 'B] -> ('A -> ('a & 'B0 & 'A0)) -> anything -> (BadPair['A0, 'B0] with {x: 'a, y: 'a})
 
 bp = BadPair { x = 42; y = true }
 bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
 //│ bp: BadPair['A .. 42 | 'A, 'B .. 'B | true] with {x: 42, y: true}
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.205: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
+//│ ║  l.208: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `42` does not match type `bool`
-//│ ║  l.204: 	bp = BadPair { x = 42; y = true }
+//│ ║  l.207: 	bp = BadPair { x = 42; y = true }
 //│ ║         	                   ^^
 //│ ╟── Note: constraint arises from argument:
-//│ ║  l.205: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
+//│ ║  l.208: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
 //│ ╙──       	                                         ^
 //│ res: 42 | error
 
@@ -221,9 +224,9 @@ BadPair.(BadPair.Map)
 //│ BadPair: BadPair['A .. 42 | 'A, 'B .. 0 | 'B] with {x: 42, y: 0}
 //│ res: BadPair['A, 'B] -> ('A -> ('a & 'B0 & 'A0)) -> anything -> (BadPair['A0, 'B0] with {x: 'a, y: 'a})
 //│ ╔══[ERROR] Class BadPair has no method BadPair.Map
-//│ ║  l.220: 	BadPair.(BadPair.Map)
+//│ ║  l.223: 	BadPair.(BadPair.Map)
 //│ ╙──       	^^^^^^^^^^^^^^^^^^^^^
-//│ res: (42 -> ('B & 'A & 'a)) -> anything -> (BadPair['A, 'B] with {x: 'a, y: 'a})
+//│ res: (42 -> ('A & 'B & 'a)) -> anything -> (BadPair['A, 'B] with {x: 'a, y: 'a})
 
 
 class ClassA
@@ -235,19 +238,22 @@ class ClassA
 class ClassB: ClassA
     method MtdA = 43
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.236: 	    method MtdA = 43
+//│ ║  l.239: 	    method MtdA = 43
+//│ ║         	           ^^^^^^^^^
+//│ ╟── Note: method definition inherited from
+//│ ║  l.233: 	    method MtdA = 42
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.236: 	    method MtdA = 43
+//│ ║  l.239: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `43` does not match type `42`
-//│ ║  l.236: 	    method MtdA = 43
+//│ ║  l.239: 	    method MtdA = 43
 //│ ║         	                  ^^
 //│ ╟── but it flows into method definition with expected type `42`
-//│ ║  l.236: 	    method MtdA = 43
+//│ ║  l.239: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.230: 	    method MtdA = 42
+//│ ║  l.233: 	    method MtdA = 42
 //│ ╙──       	                  ^^
 //│ Defined class ClassB
 //│ Defined ClassB.MtdA: ClassB -> 43
@@ -257,34 +263,22 @@ class ClassC: ClassA
     method MtdA: int
     method MtdA = 43
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.257: 	    method MtdA: int
+//│ ║  l.263: 	    method MtdA: int
+//│ ║         	           ^^^^^^^^^
+//│ ╟── Note: method definition inherited from
+//│ ║  l.233: 	    method MtdA = 42
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method declaration:
-//│ ║  l.257: 	    method MtdA: int
+//│ ║  l.263: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `int` does not match type `42`
-//│ ║  l.257: 	    method MtdA: int
+//│ ║  l.263: 	    method MtdA: int
 //│ ║         	                 ^^^
 //│ ╟── but it flows into method declaration with expected type `42`
-//│ ║  l.257: 	    method MtdA: int
+//│ ║  l.263: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.230: 	    method MtdA = 42
-//│ ╙──       	                  ^^
-//│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.258: 	    method MtdA = 43
-//│ ╙──       	           ^^^^^^^^^
-//│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.258: 	    method MtdA = 43
-//│ ║         	           ^^^^^^^^^
-//│ ╟── expression of type `43` does not match type `42`
-//│ ║  l.258: 	    method MtdA = 43
-//│ ║         	                  ^^
-//│ ╟── but it flows into method definition with expected type `42`
-//│ ║  l.258: 	    method MtdA = 43
-//│ ║         	           ^^^^^^^^^
-//│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.230: 	    method MtdA = 42
+//│ ║  l.233: 	    method MtdA = 42
 //│ ╙──       	                  ^^
 //│ Defined class ClassC
 //│ Declared ClassC.MtdA: ClassC -> int
@@ -293,25 +287,48 @@ class ClassC: ClassA
 :e
 class ClassD: ClassA
     method MtdA: int
-class ClassE: ClassD
-    method MtdA = 43
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.295: 	    method MtdA: int
+//│ ║  l.289: 	    method MtdA: int
+//│ ║         	           ^^^^^^^^^
+//│ ╟── Note: method definition inherited from
+//│ ║  l.233: 	    method MtdA = 42
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method declaration:
-//│ ║  l.295: 	    method MtdA: int
+//│ ║  l.289: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `int` does not match type `42`
-//│ ║  l.295: 	    method MtdA: int
+//│ ║  l.289: 	    method MtdA: int
 //│ ║         	                 ^^^
 //│ ╟── but it flows into method declaration with expected type `42`
-//│ ║  l.295: 	    method MtdA: int
+//│ ║  l.289: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.230: 	    method MtdA = 42
+//│ ║  l.233: 	    method MtdA = 42
 //│ ╙──       	                  ^^
 //│ Defined class ClassD
 //│ Declared ClassD.MtdA: ClassD -> int
+
+// TODO: remove repeated overriding errors?
+class ClassE: ClassD
+    method MtdA = 43
+//│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
+//│ ║  l.313: 	    method MtdA = 43
+//│ ║         	           ^^^^^^^^^
+//│ ╟── Note: method definition inherited from
+//│ ║  l.233: 	    method MtdA = 42
+//│ ╙──       	           ^^^^^^^^^
+//│ ╔══[ERROR] Type mismatch in method definition:
+//│ ║  l.313: 	    method MtdA = 43
+//│ ║         	           ^^^^^^^^^
+//│ ╟── expression of type `43` does not match type `42`
+//│ ║  l.313: 	    method MtdA = 43
+//│ ║         	                  ^^
+//│ ╟── but it flows into method definition with expected type `42`
+//│ ║  l.313: 	    method MtdA = 43
+//│ ║         	           ^^^^^^^^^
+//│ ╟── Note: constraint arises from integer literal:
+//│ ║  l.233: 	    method MtdA = 42
+//│ ╙──       	                  ^^
 //│ Defined class ClassE
 //│ Defined ClassE.MtdA: ClassE -> 43
 
@@ -327,19 +344,19 @@ trait Trait2A[B]
 class Class2B: Class2A[int] & Trait2A[string]
     method MtdA = "ok"
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.328: 	    method MtdA = "ok"
+//│ ║  l.345: 	    method MtdA = "ok"
 //│ ║         	           ^^^^^^^^^^^
 //│ ╟── expression of type `"ok"` does not match type `int`
-//│ ║  l.328: 	    method MtdA = "ok"
+//│ ║  l.345: 	    method MtdA = "ok"
 //│ ║         	                  ^^^^
 //│ ╟── but it flows into method definition with expected type `int`
-//│ ║  l.328: 	    method MtdA = "ok"
+//│ ║  l.345: 	    method MtdA = "ok"
 //│ ║         	           ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.327: 	class Class2B: Class2A[int] & Trait2A[string]
+//│ ║  l.344: 	class Class2B: Class2A[int] & Trait2A[string]
 //│ ║         	                       ^^^
-//│ ╟── from method declaration:
-//│ ║  l.324: 	    method MtdA: A
+//│ ╟── from inherited method declaration:
+//│ ║  l.341: 	    method MtdA: A
 //│ ╙──       	           ^^^^^^^
 //│ Defined class Class2A
 //│ Declared Class2A.MtdA: Class2A['A] -> 'A
@@ -350,14 +367,13 @@ class Class2B: Class2A[int] & Trait2A[string]
 
 
 :e
-:ns // TODO: investigate weird type of `Class3B.MtdA` without `:ns`
 class Class3A[A]
     method MtdA: A
 type Type3A = Class3A[string]
 class Class3B: Type3A
     method MtdA = 1
 //│ ╔══[ERROR] cannot inherit from a type alias
-//│ ║  l.357: 	class Class3B: Type3A
+//│ ║  l.373: 	class Class3B: Type3A
 //│ ╙──       	      ^^^^^^^^^^^^^^^
 //│ Defined class Class3A
 //│ Declared Class3A.MtdA: Class3A['A] -> 'A
@@ -367,7 +383,7 @@ class Class3B: Type3A
 :e
 Oops.M
 //│ ╔══[ERROR] Method M not found
-//│ ║  l.368: 	Oops.M
+//│ ║  l.384: 	Oops.M
 //│ ╙──       	^^^^^^
 //│ res: error
 
@@ -381,17 +397,17 @@ class Test4A
 :e
 class Test4B: Test4A
     method Mth4A: int
-//│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.377: 	    method Mth4A = true
+//│ ╔══[ERROR] Type mismatch in inherited method definition:
+//│ ║  l.393: 	    method Mth4A = true
 //│ ║         	           ^^^^^^^^^^^^
 //│ ╟── expression of type `true` does not match type `int`
-//│ ║  l.377: 	    method Mth4A = true
+//│ ║  l.393: 	    method Mth4A = true
 //│ ║         	                   ^^^^
-//│ ╟── but it flows into method definition with expected type `int`
-//│ ║  l.377: 	    method Mth4A = true
+//│ ╟── but it flows into inherited method definition with expected type `int`
+//│ ║  l.393: 	    method Mth4A = true
 //│ ║         	           ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.383: 	    method Mth4A: int
+//│ ║  l.399: 	    method Mth4A: int
 //│ ╙──       	                  ^^^
 //│ Defined class Test4B
 //│ Declared Test4B.Mth4A: Test4B -> int
@@ -409,16 +425,16 @@ class Test5A
 class Test5B: Test5A
     method Mth5A = 43
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.410: 	    method Mth5A = 43
+//│ ║  l.426: 	    method Mth5A = 43
 //│ ║         	           ^^^^^^^^^^
 //│ ╟── expression of type `43` does not match type `42`
-//│ ║  l.410: 	    method Mth5A = 43
+//│ ║  l.426: 	    method Mth5A = 43
 //│ ║         	                   ^^
 //│ ╟── but it flows into method definition with expected type `42`
-//│ ║  l.410: 	    method Mth5A = 43
+//│ ║  l.426: 	    method Mth5A = 43
 //│ ║         	           ^^^^^^^^^^
-//│ ╟── Note: constraint arises from method declaration:
-//│ ║  l.408: 	    method Mth5A: 42
+//│ ╟── Note: constraint arises from inherited method declaration:
+//│ ║  l.424: 	    method Mth5A: 42
 //│ ╙──       	           ^^^^^
 //│ Defined class Test5A
 //│ Declared Test5A.Mth5A: Test5A -> 42
@@ -442,45 +458,45 @@ class Test6C: Test6A[int] & Test6B
 :e
 Test6A
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
-//│ ║  l.443: 	Test6A
+//│ ║  l.459: 	Test6A
 //│ ║         	^^^^^^
 //│ ╟── Note that class Test6A is abstract:
-//│ ║  l.429: 	class Test6A[A]
+//│ ║  l.445: 	class Test6A[A]
 //│ ║         	      ^^^^^^^^
-//│ ╟── Hint: method Mth6B is abstract
-//│ ║  l.431: 	    method Mth6B[B]: (A -> B) -> B
-//│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Hint: method Mth6A is abstract
-//│ ║  l.430: 	    method Mth6A: A
-//│ ╙──       	           ^^^^^^^^
+//│ ║  l.446: 	    method Mth6A: A
+//│ ║         	           ^^^^^^^^
+//│ ╟── Hint: method Mth6B is abstract
+//│ ║  l.447: 	    method Mth6B[B]: (A -> B) -> B
+//│ ╙──       	           ^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error
 
 :e
 Test6B
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
-//│ ║  l.459: 	Test6B
+//│ ║  l.475: 	Test6B
 //│ ║         	^^^^^^
 //│ ╟── Note that trait Test6B is abstract:
-//│ ║  l.432: 	trait Test6B
+//│ ║  l.448: 	trait Test6B
 //│ ║         	      ^^^^^^
 //│ ╟── Hint: method Mth6A is abstract
-//│ ║  l.433: 	    method Mth6A: bool
+//│ ║  l.449: 	    method Mth6A: bool
 //│ ╙──       	           ^^^^^^^^^^^
 //│ res: error
 
 :e
 Test6C
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
-//│ ║  l.472: 	Test6C
+//│ ║  l.488: 	Test6C
 //│ ║         	^^^^^^
 //│ ╟── Note that class Test6C is abstract:
-//│ ║  l.434: 	class Test6C: Test6A[int] & Test6B
+//│ ║  l.450: 	class Test6C: Test6A[int] & Test6B
 //│ ║         	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Hint: method Mth6B is abstract
-//│ ║  l.431: 	    method Mth6B[B]: (A -> B) -> B
+//│ ║  l.447: 	    method Mth6B[B]: (A -> B) -> B
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Hint: method Mth6A is abstract
-//│ ║  l.434: 	class Test6C: Test6A[int] & Test6B
+//│ ║  l.450: 	class Test6C: Test6A[int] & Test6B
 //│ ╙──       	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error
 
@@ -493,24 +509,24 @@ class Dup[A, A]: { x: A }
         B]: (A -> B) -> B
     method MthDup f = f this.x
 //│ ╔══[ERROR] Multiple declarations of type parameter A in class definition
-//│ ║  l.491: 	class Dup[A, A]: { x: A }
+//│ ║  l.507: 	class Dup[A, A]: { x: A }
 //│ ║         	      ^^^^^^^^^^^^^^^^^^^
 //│ ╟── Declared at
-//│ ║  l.491: 	class Dup[A, A]: { x: A }
+//│ ║  l.507: 	class Dup[A, A]: { x: A }
 //│ ║         	          ^
 //│ ╟── Declared at
-//│ ║  l.491: 	class Dup[A, A]: { x: A }
+//│ ║  l.507: 	class Dup[A, A]: { x: A }
 //│ ╙──       	             ^
 //│ ╔══[ERROR] Multiple declarations of type parameter B in method declaration
-//│ ║  l.492: 	    method MthDup[B, C, // random comment
+//│ ║  l.508: 	    method MthDup[B, C, // random comment
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.493: 	        B]: (A -> B) -> B
+//│ ║  l.509: 	        B]: (A -> B) -> B
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Declared at
-//│ ║  l.492: 	    method MthDup[B, C, // random comment
+//│ ║  l.508: 	    method MthDup[B, C, // random comment
 //│ ║         	                  ^
 //│ ╟── Declared at
-//│ ║  l.493: 	        B]: (A -> B) -> B
+//│ ║  l.509: 	        B]: (A -> B) -> B
 //│ ╙──       	        ^
 //│ Defined class Dup
 //│ Declared Dup.MthDup: Dup['A | 'A0 .. 'A & 'A0, 'A | 'A0 .. 'A & 'A0] -> ('A0 -> 'B) -> 'B
@@ -529,19 +545,19 @@ t : Dup[bool, int]
 :stats
 t : Dup[int, bool]
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.530: 	t : Dup[int, bool]
+//│ ║  l.546: 	t : Dup[int, bool]
 //│ ║         	^
 //│ ╟── expression of type `42` does not match type `bool`
-//│ ║  l.519: 	t = Dup { x = 42 }
+//│ ║  l.535: 	t = Dup { x = 42 }
 //│ ║         	              ^^
 //│ ╟── but it flows into reference with expected type `Dup[int, bool]`
-//│ ║  l.530: 	t : Dup[int, bool]
+//│ ║  l.546: 	t : Dup[int, bool]
 //│ ║         	^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.530: 	t : Dup[int, bool]
+//│ ║  l.546: 	t : Dup[int, bool]
 //│ ║         	             ^^^^
 //│ ╟── from record type:
-//│ ║  l.491: 	class Dup[A, A]: { x: A }
+//│ ║  l.507: 	class Dup[A, A]: { x: A }
 //│ ╙──       	                 ^^^^^^^^
 //│ res: Dup[bool | int .. nothing, bool | int .. nothing]
 //│ constrain calls  : 58
@@ -567,19 +583,19 @@ t.MthDup id
 :e
 class A
   method Yes = B { x = 1 }
-  method Nope = Yes.F
+  method Nope = this.Yes.F1
 class B: { x: int }
-  method F: int
-  method F = 1
-//│ ╔══[ERROR] identifier not found: Yes
-//│ ║  l.570: 	  method Nope = Yes.F
-//│ ╙──       	                ^^^
+  method F1: int
+  method F1 = 1
+//│ ╔══[ERROR] Method F1 not found
+//│ ║  l.586: 	  method Nope = this.Yes.F1
+//│ ╙──       	                ^^^^^^^^^^^
 //│ Defined class A
 //│ Defined A.Yes: A -> (B & {x: 1})
 //│ Defined A.Nope: A -> error
 //│ Defined class B
-//│ Declared B.F: B -> int
-//│ Defined B.F: B -> 1
+//│ Declared B.F1: B -> int
+//│ Defined B.F1: B -> 1
 
 
 trait D
@@ -589,19 +605,22 @@ trait E
 class H: D & E
   method G = 2
 //│ ╔══[ERROR] Overriding method D.G without explicit declaration is not allowed.
-//│ ║  l.590: 	  method G = 2
+//│ ║  l.606: 	  method G = 2
+//│ ║         	         ^^^^^
+//│ ╟── Note: method definition inherited from
+//│ ║  l.602: 	  method G = 1
 //│ ╙──       	         ^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.590: 	  method G = 2
+//│ ║  l.606: 	  method G = 2
 //│ ║         	         ^^^^^
 //│ ╟── expression of type `2` does not match type `1`
-//│ ║  l.590: 	  method G = 2
+//│ ║  l.606: 	  method G = 2
 //│ ║         	             ^
 //│ ╟── but it flows into method definition with expected type `1`
-//│ ║  l.590: 	  method G = 2
+//│ ║  l.606: 	  method G = 2
 //│ ║         	         ^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.586: 	  method G = 1
+//│ ║  l.602: 	  method G = 1
 //│ ╙──       	             ^
 //│ Defined trait D
 //│ Defined D.G: d -> 1
@@ -628,17 +647,17 @@ trait D2
 trait E2
   method G2: bool
 class H2: D2 & E2
-//│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.627: 	  method G2 = 1
+//│ ╔══[ERROR] Type mismatch in inherited method definition:
+//│ ║  l.646: 	  method G2 = 1
 //│ ║         	         ^^^^^^
 //│ ╟── expression of type `1` does not match type `bool`
-//│ ║  l.627: 	  method G2 = 1
+//│ ║  l.646: 	  method G2 = 1
 //│ ║         	              ^
-//│ ╟── but it flows into method definition with expected type `bool`
-//│ ║  l.627: 	  method G2 = 1
+//│ ╟── but it flows into inherited method definition with expected type `bool`
+//│ ║  l.646: 	  method G2 = 1
 //│ ║         	         ^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.629: 	  method G2: bool
+//│ ║  l.648: 	  method G2: bool
 //│ ╙──       	             ^^^^
 //│ Defined trait D2
 //│ Defined D2.G2: d2 -> 1

--- a/shared/src/test/diff/mlscript/MethodAndMatches.mls
+++ b/shared/src/test/diff/mlscript/MethodAndMatches.mls
@@ -62,6 +62,9 @@ def bar0 = foo
 //│ ╟── Note: constraint arises from record type:
 //│ ║  l.3: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                             ^^^^^^^^^^
+//│ ╟── from method definition:
+//│ ║  l.5: 	  method M2 = Derived1 { x = add this.x 1 }
+//│ ║       	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from reference:
 //│ ║  l.21: 	  | Derived1 -> b.M2
 //│ ║        	                ^
@@ -88,10 +91,10 @@ def bar1 = foo
 //│   <:  bar1:
 //│ (Derived1 | Derived2['a, 'b]) -> int -> (Derived1 | Derived2['a0, 'b0])
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.86: 	def bar1 = foo
+//│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `int` does not match type `{c: ?a, d: ?b}`
-//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ║        	                        ^^^
 //│ ╟── Note: constraint arises from record type:
 //│ ║  l.6: 	class Derived2[C, D]: Base1[{ c: C; d: D }]
@@ -100,29 +103,29 @@ def bar1 = foo
 //│ ║  l.22: 	  | Base1 -> b.M1 x
 //│ ╙──      	                  ^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.86: 	def bar1 = foo
+//│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `Base1[?A]` does not match type `Derived1 | Derived2[?a, ?b]`
 //│ ║  l.2: 	  method M1: A -> Base1[A]
 //│ ║       	                  ^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.86: 	def bar1 = foo
+//│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from union type:
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.86: 	def bar1 = foo
+//│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `int` does not match type `{c: ?a, d: ?b}`
-//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ║        	                        ^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.86: 	def bar1 = foo
+//│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from record type:
@@ -132,48 +135,48 @@ def bar1 = foo
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.86: 	def bar1 = foo
+//│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `Base1[?A]` does not match type `Derived1 | Derived2[?a, ?b]`
 //│ ║  l.2: 	  method M1: A -> Base1[A]
 //│ ║       	                  ^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.86: 	def bar1 = foo
+//│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from union type:
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.86: 	def bar1 = foo
+//│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `Base1[?A]` does not match type `Derived1 | Derived2[?a, ?b]`
 //│ ║  l.2: 	  method M1: A -> Base1[A]
 //│ ║       	                  ^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.86: 	def bar1 = foo
+//│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from union type:
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.86: 	def bar1 = foo
+//│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `{c: ?a, d: ?b}` does not match type `int`
 //│ ║  l.6: 	class Derived2[C, D]: Base1[{ c: C; d: D }]
 //│ ║       	                            ^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.86: 	def bar1 = foo
+//│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from type reference:
@@ -183,16 +186,16 @@ def bar1 = foo
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.86: 	def bar1 = foo
+//│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `{c: ?a, d: ?b}` does not match type `int`
 //│ ║  l.6: 	class Derived2[C, D]: Base1[{ c: C; d: D }]
 //│ ║       	                            ^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.86: 	def bar1 = foo
+//│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from type reference:
@@ -202,23 +205,23 @@ def bar1 = foo
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.86: 	def bar1 = foo
+//│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `Base1[?A]` does not match type `Derived1 | Derived2[?a, ?b]`
 //│ ║  l.2: 	  method M1: A -> Base1[A]
 //│ ║       	                  ^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.86: 	def bar1 = foo
+//│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from union type:
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│     = [Function: foo]
 
@@ -241,23 +244,26 @@ def bar2 = foo
 //│   <:  bar2:
 //│ Base1['a] -> 'a -> Base1['a]
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.239: 	def bar2 = foo
+//│ ║  l.242: 	def bar2 = foo
 //│ ║         	           ^^^
 //│ ╟── expression of type `int` does not match type `'a`
 //│ ║  l.3: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                      ^^^
 //│ ╟── Note: constraint arises from type variable:
-//│ ║  l.226: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║  l.229: 	def bar2: Base1['a] -> 'a -> Base1['a]
 //│ ╙──       	                ^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.239: 	def bar2 = foo
+//│ ║  l.242: 	def bar2 = foo
 //│ ║         	           ^^^
 //│ ╟── expression of type `'a` does not match type `int`
-//│ ║  l.226: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║  l.229: 	def bar2: Base1['a] -> 'a -> Base1['a]
 //│ ║         	                ^^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.3: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                      ^^^
+//│ ╟── from method definition:
+//│ ║  l.5: 	  method M2 = Derived1 { x = add this.x 1 }
+//│ ║       	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from reference:
 //│ ║  l.21: 	  | Derived1 -> b.M2
 //│ ║        	                ^
@@ -265,14 +271,17 @@ def bar2 = foo
 //│ ║  l.20: 	def foo b x = case b of {
 //│ ╙──      	                   ^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.239: 	def bar2 = foo
+//│ ║  l.242: 	def bar2 = foo
 //│ ║         	           ^^^
 //│ ╟── expression of type `Base1['a] & ~?a | Derived1` does not match type `{x: int}`
-//│ ║  l.226: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║  l.229: 	def bar2: Base1['a] -> 'a -> Base1['a]
 //│ ║         	          ^^^^^^^^^
 //│ ╟── Note: constraint arises from record type:
 //│ ║  l.3: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                             ^^^^^^^^^^
+//│ ╟── from method definition:
+//│ ║  l.5: 	  method M2 = Derived1 { x = add this.x 1 }
+//│ ║       	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from reference:
 //│ ║  l.21: 	  | Derived1 -> b.M2
 //│ ║        	                ^

--- a/shared/src/test/diff/mlscript/MethodAndMatches.mls
+++ b/shared/src/test/diff/mlscript/MethodAndMatches.mls
@@ -62,9 +62,6 @@ def bar0 = foo
 //│ ╟── Note: constraint arises from record type:
 //│ ║  l.3: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                             ^^^^^^^^^^
-//│ ╟── from method definition:
-//│ ║  l.4: 	  method M1 y = Derived1 { x = add this.x y }
-//│ ║       	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from reference:
 //│ ║  l.21: 	  | Derived1 -> b.M2
 //│ ║        	                ^
@@ -91,10 +88,10 @@ def bar1 = foo
 //│   <:  bar1:
 //│ (Derived1 | Derived2['a, 'b]) -> int -> (Derived1 | Derived2['a0, 'b0])
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.89: 	def bar1 = foo
+//│ ║  l.86: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `int` does not match type `{c: ?a, d: ?b}`
-//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ║        	                        ^^^
 //│ ╟── Note: constraint arises from record type:
 //│ ║  l.6: 	class Derived2[C, D]: Base1[{ c: C; d: D }]
@@ -103,29 +100,29 @@ def bar1 = foo
 //│ ║  l.22: 	  | Base1 -> b.M1 x
 //│ ╙──      	                  ^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.89: 	def bar1 = foo
+//│ ║  l.86: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `Base1[?A]` does not match type `Derived1 | Derived2[?a, ?b]`
 //│ ║  l.2: 	  method M1: A -> Base1[A]
 //│ ║       	                  ^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.89: 	def bar1 = foo
+//│ ║  l.86: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from union type:
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.89: 	def bar1 = foo
+//│ ║  l.86: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `int` does not match type `{c: ?a, d: ?b}`
-//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ║        	                        ^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.89: 	def bar1 = foo
+//│ ║  l.86: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from record type:
@@ -135,48 +132,48 @@ def bar1 = foo
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.89: 	def bar1 = foo
+//│ ║  l.86: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `Base1[?A]` does not match type `Derived1 | Derived2[?a, ?b]`
 //│ ║  l.2: 	  method M1: A -> Base1[A]
 //│ ║       	                  ^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.89: 	def bar1 = foo
+//│ ║  l.86: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from union type:
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.89: 	def bar1 = foo
+//│ ║  l.86: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `Base1[?A]` does not match type `Derived1 | Derived2[?a, ?b]`
 //│ ║  l.2: 	  method M1: A -> Base1[A]
 //│ ║       	                  ^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.89: 	def bar1 = foo
+//│ ║  l.86: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from union type:
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.89: 	def bar1 = foo
+//│ ║  l.86: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `{c: ?a, d: ?b}` does not match type `int`
 //│ ║  l.6: 	class Derived2[C, D]: Base1[{ c: C; d: D }]
 //│ ║       	                            ^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.89: 	def bar1 = foo
+//│ ║  l.86: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from type reference:
@@ -186,16 +183,16 @@ def bar1 = foo
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.89: 	def bar1 = foo
+//│ ║  l.86: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `{c: ?a, d: ?b}` does not match type `int`
 //│ ║  l.6: 	class Derived2[C, D]: Base1[{ c: C; d: D }]
 //│ ║       	                            ^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.89: 	def bar1 = foo
+//│ ║  l.86: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from type reference:
@@ -205,23 +202,23 @@ def bar1 = foo
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.89: 	def bar1 = foo
+//│ ║  l.86: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── expression of type `Base1[?A]` does not match type `Derived1 | Derived2[?a, ?b]`
 //│ ║  l.2: 	  method M1: A -> Base1[A]
 //│ ║       	                  ^^^^^^^^
 //│ ╟── but it flows into reference of type `?c -> ?d -> (?e | ?f)`
-//│ ║  l.89: 	def bar1 = foo
+//│ ║  l.86: 	def bar1 = foo
 //│ ║        	           ^^^
 //│ ╟── which does not match type `Type1[int] -> int -> Type1[int]`
 //│ ╟── Note: constraint arises from union type:
 //│ ║  l.9: 	type Type1[A] = Derived1 | Derived2['a, 'b]
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.74: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│     = [Function: foo]
 
@@ -244,26 +241,23 @@ def bar2 = foo
 //│   <:  bar2:
 //│ Base1['a] -> 'a -> Base1['a]
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.242: 	def bar2 = foo
+//│ ║  l.239: 	def bar2 = foo
 //│ ║         	           ^^^
 //│ ╟── expression of type `int` does not match type `'a`
 //│ ║  l.3: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                      ^^^
 //│ ╟── Note: constraint arises from type variable:
-//│ ║  l.229: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║  l.226: 	def bar2: Base1['a] -> 'a -> Base1['a]
 //│ ╙──       	                ^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.242: 	def bar2 = foo
+//│ ║  l.239: 	def bar2 = foo
 //│ ║         	           ^^^
 //│ ╟── expression of type `'a` does not match type `int`
-//│ ║  l.229: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║  l.226: 	def bar2: Base1['a] -> 'a -> Base1['a]
 //│ ║         	                ^^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.3: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                      ^^^
-//│ ╟── from method definition:
-//│ ║  l.4: 	  method M1 y = Derived1 { x = add this.x y }
-//│ ║       	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from reference:
 //│ ║  l.21: 	  | Derived1 -> b.M2
 //│ ║        	                ^
@@ -271,17 +265,14 @@ def bar2 = foo
 //│ ║  l.20: 	def foo b x = case b of {
 //│ ╙──      	                   ^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.242: 	def bar2 = foo
+//│ ║  l.239: 	def bar2 = foo
 //│ ║         	           ^^^
 //│ ╟── expression of type `Base1['a] & ~?a | Derived1` does not match type `{x: int}`
-//│ ║  l.229: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║  l.226: 	def bar2: Base1['a] -> 'a -> Base1['a]
 //│ ║         	          ^^^^^^^^^
 //│ ╟── Note: constraint arises from record type:
 //│ ║  l.3: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                             ^^^^^^^^^^
-//│ ╟── from method definition:
-//│ ║  l.4: 	  method M1 y = Derived1 { x = add this.x y }
-//│ ║       	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from reference:
 //│ ║  l.21: 	  | Derived1 -> b.M2
 //│ ║        	                ^

--- a/shared/src/test/diff/mlscript/Methods.mls
+++ b/shared/src/test/diff/mlscript/Methods.mls
@@ -400,3 +400,23 @@ class Test6B: { a: Test6A; b: Test6A }
 
 class Test6C: Test6B
 //│ Defined class Test6C
+
+
+
+
+trait Test7A
+    method Mth7A: int
+    method Mth7A = 0
+//│ Defined trait Test7A
+//│ Declared Test7A.Mth7A: test7A -> int
+//│ Defined Test7A.Mth7A: test7A -> 0
+
+trait Test7B
+    method Mth7A: int
+//│ Defined trait Test7B
+//│ Declared Test7B.Mth7A: test7B -> int
+
+class Test7C: Test7A & Test7B
+    method Mth7A = 42
+//│ Defined class Test7C
+//│ Defined Test7C.Mth7A: (Test7C & test7A & test7B) -> 42

--- a/shared/src/test/diff/mlscript/Methods.mls
+++ b/shared/src/test/diff/mlscript/Methods.mls
@@ -256,7 +256,7 @@ class Class3C: Class2C
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.230: 	class Class2C: Class2B[int, bool]
 //│ ║         	                            ^^^^
-//│ ╟── from method declaration:
+//│ ╟── from inherited method declaration:
 //│ ║  l.229: 	    method MtdB: B
 //│ ╙──       	           ^^^^^^^
 //│ Defined class Class3C
@@ -359,3 +359,44 @@ Ber
 //│ res: error
 //│    = [Function: res]
 
+
+
+
+class Test5A[A]: { a: A }
+    method Mth5A[B]: (A -> B) -> B
+//│ Defined class Test5A
+//│ Declared Test5A.Mth5A: Test5A['A] -> ('A -> 'B) -> 'B
+
+
+trait Test5B: { tag: int }
+    method Mth5B = this.tag
+//│ Defined trait Test5B
+//│ Defined Test5B.Mth5B: ({tag: int} & test5B) -> int
+
+
+class Test5C[A]: Test5A[A] & Test5B
+    method Mth5A f = case this.Mth5B of { 0 -> f this.a | _ -> f this.a }
+//│ Defined class Test5C
+//│ Defined Test5C.Mth5A: (Test5C['A] & test5B) -> ('A -> 'a) -> 'a
+
+
+class Test5D: Test5A[int] & Test5B
+    method Mth5A f = case this.Mth5B of { 0 -> f this.a | _ -> f this.Mth5B }
+//│ Defined class Test5D
+//│ Defined Test5D.Mth5A: (Test5D & test5B) -> (int -> 'a) -> 'a
+
+
+
+
+class Test6A: { a: int }
+    method Add (that: Test6A) = Test6A { a = this.a + that.a }
+//│ Defined class Test6A
+//│ Defined Test6A.Add: Test6A -> Test6A -> Test6A
+
+class Test6B: { a: Test6A; b: Test6A }
+    method Add (that: Test6B) = Test6B { a = this.a.(Test6A.Add) that.a; b = this.b.(Test6A.Add) that.b }
+//│ Defined class Test6B
+//│ Defined Test6B.Add: (Test6B with {a: Test6A, b: Test6A}) -> (Test6B with {a: Test6A, b: Test6A}) -> (Test6B with {a: Test6A, b: Test6A})
+
+class Test6C: Test6B
+//│ Defined class Test6C

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -283,7 +283,7 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite {
                 val ttd = ctx.tyDefs(tn)
                 (ttd.mthDecls ++ ttd.mthDefs).foreach { case MethodDef(_, _, Var(mn), _, rhs) =>
                   rhs.fold(_ => ctx.getMthDefn(tn, mn), _ => ctx.getMth(S(tn), mn)).foreach(res => 
-                    output(s"${rhs.fold(_ => "Defined", _ => "Declared")} ${tn}.${mn}: ${getType(res).show}"))
+                    output(s"${rhs.fold(_ => "Defined", _ => "Declared")} ${tn}.${mn}: ${getType(res.toPT).show}"))
                 }
               }
             )

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -281,13 +281,19 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite {
                 val tn = td.nme.name
                 output(s"Defined " + td.kind.str + " " + tn)
                 val ttd = ctx.tyDefs(tn)
-                (ttd.mthDecls ++ ttd.mthDefs).foreach { case MethodDef(_, _, Var(mn), _, rhs) =>
-                  rhs.fold(_ => ctx.getMthDefn(tn, mn), _ => ctx.getMth(S(tn), mn)).foreach(res => 
-                    output(s"${rhs.fold(_ => "Defined", _ => "Declared")} ${tn}.${mn}: ${getType(res.toPT).show}"))
+                (ttd.mthDecls ++ ttd.mthDefs).foreach {
+                  case MethodDef(_, _, Var(mn), _, rhs) =>
+                    rhs.fold(
+                      _ => ctx.getMthDefn(tn, mn).map(md => ttd.wrapMethod(md)(md.prov)),
+                      _ => ctx.getMth(S(tn), mn)
+                    ).foreach(res => output(s"${rhs.fold(
+                      _ => "Defined",
+                      _ => "Declared"
+                    )} ${tn}.${mn}: ${getType(res.toPT).show}"))
                 }
               }
             )
-
+            
             var results: (Str, Bool) \/ Opt[Ls[(Bool, Str)]] = if (!allowTypeErrors &&
                 file.ext =:= "mls" && !mode.noGeneration && !noJavaScript) {
               backend(p) map { testCode =>

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -278,13 +278,12 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite {
               if (ctx.tyDefs.contains(td.nme.name)
                   && !oldCtx.tyDefs.contains(td.nme.name)) {
                   // ^ it may not end up being defined if there's an error
-                output(s"Defined " + td.kind.str + " " + td.nme.name)
-                val ttd = ctx.tyDefs(td.nme.name)
-                (ttd.mthDecls ++ ttd.mthDefs).foreach { case MethodDef(_, _, nme, _, rhs) =>
-                  val fullName = td.nme.name + "." + nme.name
-                  val mthTyOpt = ctx.getMth(rhs.fold(_ => td.nme.name + "#" + nme.name, _ => fullName))
-                  mthTyOpt.map(res => 
-                    output(s"${rhs.fold(_ => "Defined", _ => "Declared")} ${fullName}: ${getType(res).show}"))
+                val tn = td.nme.name
+                output(s"Defined " + td.kind.str + " " + tn)
+                val ttd = ctx.tyDefs(tn)
+                (ttd.mthDecls ++ ttd.mthDefs).foreach { case MethodDef(_, _, Var(mn), _, rhs) =>
+                  rhs.fold(_ => ctx.getMthDefn(tn, mn), _ => ctx.getMth(S(tn), mn)).foreach(res => 
+                    output(s"${rhs.fold(_ => "Defined", _ => "Declared")} ${tn}.${mn}: ${getType(res).show}"))
                 }
               }
             )

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -282,7 +282,7 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite {
                 val ttd = ctx.tyDefs(td.nme.name)
                 (ttd.mthDecls ++ ttd.mthDefs).foreach { case MethodDef(_, _, nme, _, rhs) =>
                   val fullName = td.nme.name + "." + nme.name
-                  val mthTyOpt = ctx.mthenv.get(rhs.fold(_ => td.nme.name + "#" + nme.name, _ => fullName))
+                  val mthTyOpt = ctx.getMth(rhs.fold(_ => td.nme.name + "#" + nme.name, _ => fullName))
                   mthTyOpt.map(res => 
                     output(s"${rhs.fold(_ => "Defined", _ => "Declared")} ${fullName}: ${getType(res).show}"))
                 }

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -250,20 +250,20 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite {
               if (mode.dbg) output(s" where: ${wty.showBounds}")
               if (mode.noSimplification) typer.expandType(wty, true)
               else {
-                val cty = typer.canonicalizeType(wty)
+                val cty = typer.canonicalizeType(wty)(ctx)
                 if (mode.dbg) output(s"Canon: ${cty}")
                 if (mode.dbg) output(s" where: ${cty.showBounds}")
-                val sim = typer.simplifyType(cty)
+                val sim = typer.simplifyType(cty)(ctx)
                 if (mode.dbg) output(s"Type after simplification: ${sim}")
                 if (mode.dbg) output(s" where: ${sim.showBounds}")
                 // val exp = typer.expandType(sim)
                 
                 // TODO: would be better toa void having to do a second pass,
                 // but would require more work:
-                val reca = typer.canonicalizeType(sim)
+                val reca = typer.canonicalizeType(sim)(ctx)
                 if (mode.dbg) output(s"Recanon: ${reca}")
                 if (mode.dbg) output(s" where: ${reca.showBounds}")
-                val resim = typer.simplifyType(reca)
+                val resim = typer.simplifyType(reca)(ctx)
                 if (mode.dbg) output(s"Resimplified: ${resim}")
                 if (mode.dbg) output(s" where: ${resim.showBounds}")
                 val recons = typer.reconstructClassTypes(resim, true, ctx)
@@ -283,7 +283,7 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite {
                 (ttd.mthDecls ++ ttd.mthDefs).foreach { case MethodDef(_, _, nme, tps, rhs) =>
                   val fullName = td.nme.name + "." + nme.name
                   val bodyTy = rhs.fold(_ => ctx.mthDefs, _ => ctx.mthDecls)(td.nme.name)(nme.name)
-                  val mthTy = typer.wrapMethod(ttd.nme.name, bodyTy)(bodyTy.prov, ctx)
+                  val mthTy = ttd.wrapMethod(bodyTy)(bodyTy.prov)
                   val res = getType(mthTy.instantiate(0))
                   output(s"${rhs.fold(_ => "Defined", _ => "Declared")} ${fullName}: ${res.show}")
                 }

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -280,12 +280,11 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite {
                   // ^ it may not end up being defined if there's an error
                 output(s"Defined " + td.kind.str + " " + td.nme.name)
                 val ttd = ctx.tyDefs(td.nme.name)
-                (ttd.mthDecls ++ ttd.mthDefs).foreach { case MethodDef(_, _, nme, tps, rhs) =>
+                (ttd.mthDecls ++ ttd.mthDefs).foreach { case MethodDef(_, _, nme, _, rhs) =>
                   val fullName = td.nme.name + "." + nme.name
-                  val bodyTy = rhs.fold(_ => ctx.mthDefs, _ => ctx.mthDecls)(td.nme.name)(nme.name)
-                  val mthTy = ttd.wrapMethod(bodyTy)(bodyTy.prov)
-                  val res = getType(mthTy.instantiate(0))
-                  output(s"${rhs.fold(_ => "Defined", _ => "Declared")} ${fullName}: ${res.show}")
+                  val mthTyOpt = ctx.mthenv.get(rhs.fold(_ => td.nme.name + "#" + nme.name, _ => fullName))
+                  mthTyOpt.map(res => 
+                    output(s"${rhs.fold(_ => "Defined", _ => "Declared")} ${fullName}: ${getType(res).show}"))
                 }
               }
             )


### PR DESCRIPTION
The code for method typing is refactored to remove the use of mutable maps for storing method signatures and minimize messy substitutions of signatures. Below is an overview of the major changes:

**Refactor TypeDef and TypeRef**:
- `TypeDef` now stores the typed type of its body instead of the syntactic type.
- In order to type the body of a type definition before the `TypeDef` is added to the `Ctx`, `typeType` now takes an additional optional parameter `newDefsInfo` with the kind and number of type paramerters of the new definitions.
- The auxilliary `typeType2` also returns the list of `TypeVariables` used to instantiate implicit `TypeVar`s in the body, which are instantiated by substitution when a `TypeRef` is expanded.
- `TypeRef` now takes a `TypeName` as the base instead of a `TypeDef`, and no longer stores a `Ctx`, instead requiring a `Ctx` argument to retrieve the definition for expansion.
- `TypeRef.expand` no longer takes a `Raise` argument as it only performs substitution instead of typing the body every time. This eliminated much of the error swallowing.
- Caveat: `SimpleType.<:<` also needs to take a `Ctx` argument, which is problematic for normal forms as they implement `<:<` with `toType` and `SimpleType.<:<`, but `toType` would never produce a `TypeRef`. An "empty" `Ctx` is pass to `SimpleType.<:<` for now.

**Refactor method typing**:
- Removed mutable maps in context used for storing method signatures.
- Moved method bindings to a separate environment. Beside the actual binding, the inferred type is also stored with key delimited by `#`. This is only used for printing in `DiffTests`.
- Instead of looking up the signatures of inherited methods and substituting type variables for the type arguments, `typeMethod` now recursively traverse the type definition body, and collect inherited method signatures by typing them with the proper arguments applied.

New subclasses of `PolymorphicType`:
- `MethodType`: stores the parents of the method in addition. `&` intersects the bodies of two inherited methods and concatenate their parents; `+` overwrites a binding with the new signature with the same parent, or concatenate the parents if the call is ambiguous.
- `AbstractConstructor`: stores the set of abstract methods for printing when a constructor call of an abstract type is attempted. This is needed since it is no longer possible to look up the list of all declared and defined methods after the `TypeDef` is processed from the mutable maps.

**Miscellaneous improvements**:
- `checkRegular` no longer expands `TypeRef`s with parameter tags, which eliminates duplicate errors.
- A polymorphism issue for methods was accidentally identified and fixed by the refactoring in `MethodAndMatches.mls`