### PR TITLE
Handle "origin" type provenances

### DIFF
--- a/shared/src/main/scala/mlscript/ConstraintSolver.scala
+++ b/shared/src/main/scala/mlscript/ConstraintSolver.scala
@@ -406,7 +406,7 @@ class ConstraintSolver extends NormalForms { self: Typer =>
       
       val originProvList = cctx.flatMap{ subCtx =>
         subCtx.iterator.flatMap { case (l,r) => 
-          //we only one origin prov for each subCtx
+          // We only keep one origin prov for each subCtx.
           val considered = List(l optionIf (_.prov.isOrigin), r optionIf (_.prov.isOrigin)).flatten
           considered
         }.nextOption()

--- a/shared/src/main/scala/mlscript/ConstraintSolver.scala
+++ b/shared/src/main/scala/mlscript/ConstraintSolver.scala
@@ -382,7 +382,7 @@ class ConstraintSolver extends NormalForms { self: Typer =>
       
       val tighestLocatedRHS = cctx.flatMap { subCtx =>
         subCtx.flatMap { case (l, r) =>
-          val considered =  (r, r.prov) :: Nil
+          val considered = (r, r.prov) :: Nil
           considered.filter { case (_, p) =>
             p.loco =/= prov.loco && (p.loco match {
               case Some(loco) =>

--- a/shared/src/main/scala/mlscript/ConstraintSolver.scala
+++ b/shared/src/main/scala/mlscript/ConstraintSolver.scala
@@ -416,7 +416,7 @@ class ConstraintSolver extends NormalForms { self: Typer =>
       val originProvHints = originProvList.map { l => 
         val msgHead = if (first) msg"Note: " else msg""
           first = false
-          msg"${msgHead}Type ${l.prov.desc} is defined at: " -> l.prov.loco 
+          msg"${msgHead}${l.prov.desc.capitalize} is defined at: " -> l.prov.loco 
       }
 
       val msgs: Ls[Message -> Opt[Loc]] = List(

--- a/shared/src/main/scala/mlscript/ConstraintSolver.scala
+++ b/shared/src/main/scala/mlscript/ConstraintSolver.scala
@@ -488,14 +488,14 @@ class ConstraintSolver extends NormalForms { self: Typer =>
     }
   
   
-  def err(msg: Message, loco: Opt[Loc])(implicit raise: Raise, prov: TypeProvenance): SimpleType = {
+  def err(msg: Message, loco: Opt[Loc])(implicit raise: Raise): SimpleType = {
     err(msg -> loco :: Nil)
   }
-  def err(msgs: List[Message -> Opt[Loc]])(implicit raise: Raise, prov: TypeProvenance): SimpleType = {
+  def err(msgs: List[Message -> Opt[Loc]])(implicit raise: Raise): SimpleType = {
     raise(TypeError(msgs))
     errType
   }
-  def errType(implicit prov: TypeProvenance): SimpleType = ClassTag(ErrTypeId, Set.empty)(prov)
+  def errType: SimpleType = ClassTag(ErrTypeId, Set.empty)(noProv)
   
   def warn(msg: Message, loco: Opt[Loc])(implicit raise: Raise): Unit =
     warn(msg -> loco :: Nil)

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -428,7 +428,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
                   expandType(tr, true).show
                 }, but is defined as ${
                   expandType(TypeRef(defn, td.targs)(noProv), true).show
-                }", td.toLoc)(raise, noProv)
+                }", td.toLoc)(raise)
                 false
               } else true
           }
@@ -564,7 +564,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
         def overrideError(mn: Str, mt: MethodType, mt2: MethodType) = {
           mt2.parents.foreach(parent => 
             err(msg"Overriding method ${parent}.${mn} without explicit declaration is not allowed." -> mt.prov.loco ::
-              msg"Note: method definition inherited from" -> mt2.prov.loco :: Nil)(raise, noProv))
+              msg"Note: method definition inherited from" -> mt2.prov.loco :: Nil)(raise))
           println(s">> Checking subsumption (against inferred type) for inferred type of $mn : $mt")
         }
         declsInherit.foreach { case mn -> mt =>
@@ -588,7 +588,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
             case (S(decl), S(defn)) =>
               if (mt.body =/= decl.body && !defns.isDefinedAt(mn)) defn.parents.foreach(parent => 
                 err(msg"Overriding method ${parent}.${mn} without an overriding definition is not allowed." -> mt.prov.loco ::
-                  msg"Note: method definition inherited from" -> defn.prov.loco :: Nil)(raise, noProv))
+                  msg"Note: method definition inherited from" -> defn.prov.loco :: Nil)(raise))
               S(decl)
             case (S(decl), N) => S(decl)
             case (N, S(defn)) =>
@@ -645,7 +645,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
     val typeType = ()
     def typeNamed(loc: Opt[Loc], name: Str): (() => ST) \/ (TypeDefKind, Int) =
       newDefsInfo.get(name).orElse(ctx.tyDefs.get(name).map(td => (td.kind, td.tparamsargs.size))).toRight(() =>
-        err("type identifier not found: " + name, loc)(raise, tp(loc, "missing type")))
+        err("type identifier not found: " + name, loc)(raise))
     val localVars = mutable.Map.empty[TypeVar, TypeVariable]
     def rec(ty: Type)(implicit ctx: Ctx, recVars: Map[TypeVar, TypeVariable]): SimpleType = ty match {
       case Top => ExtrType(false)(tp(ty.toLoc, "top type"))
@@ -668,12 +668,12 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
         val prov = tp(ty.toLoc, "record type")
         fs.groupMap(_._1.name)(_._1).foreach { case s -> fieldNames if fieldNames.size > 1 => err(
             msg"Multiple declarations of field name ${s} in ${prov.desc}" -> ty.toLoc
-              :: fieldNames.map(tp => msg"Declared at" -> tp.toLoc))(raise, prov)
+              :: fieldNames.map(tp => msg"Declared at" -> tp.toLoc))(raise)
           case _ =>
         }
         RecordType.mk(fs.map { nt =>
           if (nt._1.name.head.isUpper)
-            err(msg"Field identifiers must start with a small letter", nt._1.toLoc)(raise, prov)
+            err(msg"Field identifiers must start with a small letter", nt._1.toLoc)(raise)
           nt._1 -> rec(nt._2)
         })(prov)
       case Function(lhs, rhs) => FunctionType(rec(lhs), rec(rhs))(tp(ty.toLoc, "function type"))
@@ -687,7 +687,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
           typeNamed(tyLoc, name) match {
             case R((_, tpnum)) =>
               if (tpnum =/= 0) {
-                err(msg"Type $name takes parameters", tyLoc)(raise, tpr)
+                err(msg"Type $name takes parameters", tyLoc)(raise)
               } else TypeRef(tn, Nil)(tpr)
             case L(e) =>
               if (name.isEmpty || !name.head.isLower) e()
@@ -696,7 +696,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
                   case Cls => clsNameToNomTag(td)(tp(tyLoc, "class tag"), ctx)
                   case Trt => trtNameToNomTag(td)(tp(tyLoc, "trait tag"), ctx)
                   case Als => err(
-                    msg"Type alias ${name.capitalize} cannot be used as a type tag", tyLoc)(raise, tpr)
+                    msg"Type alias ${name.capitalize} cannot be used as a type tag", tyLoc)(raise)
                 }
                 case _ => e()
               }
@@ -713,7 +713,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
           case R((_, tpnum)) =>
             val realTargs = if (targs.size === tpnum) targs.map(rec) else {
               err(msg"Wrong number of type arguments – expected ${tpnum.toString}, found ${
-                  targs.size.toString}", ty.toLoc)(raise, prov)
+                  targs.size.toString}", ty.toLoc)(raise)
               (targs.iterator.map(rec) ++ Iterator.continually(freshVar(noProv))).take(tpnum).toList
             }
             TypeRef(base, realTargs)(prov)
@@ -740,7 +740,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
     case Def(false, Var("_"), L(rhs)) => typeStatement(rhs, allowPure)
     case Def(isrec, nme, L(rhs)) => // TODO reject R(..)
       if (nme.name === "_")
-        err(msg"Illegal definition name: ${nme.name}", nme.toLoc)(raise, noProv)
+        err(msg"Illegal definition name: ${nme.name}", nme.toLoc)(raise)
       val ty_sch = typeLetRhs(isrec, nme.name, rhs)
       ctx += nme.name -> ty_sch
       R(nme.name -> ty_sch :: Nil)
@@ -767,7 +767,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
       }
       L(PolymorphicType(0, ty))
     case _ =>
-      err(msg"Illegal position for this ${s.describe} statement.", s.toLoc)(raise, noProv)
+      err(msg"Illegal position for this ${s.describe} statement.", s.toLoc)(raise)
       R(Nil)
   }
   
@@ -797,7 +797,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
     def unapply(v: Var)(implicit raise: Raise): S[Str] = S {
       if (reservedNames(v.name))
         err(s"Illegal use of ${if (v.name.head.isLetter) "keyword" else "operator"}: " + v.name,
-          v.toLoc)(raise, ttp(v))
+          v.toLoc)(raise)
       v.name
     }
   }
@@ -884,12 +884,12 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
         val prov = tp(term.toLoc, "record literal")
         fs.groupMap(_._1.name)(_._1).foreach { case s -> fieldNames if fieldNames.size > 1 => err(
             msg"Multiple declarations of field name ${s} in ${prov.desc}" -> term.toLoc
-              :: fieldNames.map(tp => msg"Declared at" -> tp.toLoc))(raise, prov)
+              :: fieldNames.map(tp => msg"Declared at" -> tp.toLoc))(raise)
           case _ =>
         }
         RecordType.mk(fs.map { case (n, t) => 
           if (n.name.head.isUpper)
-            err(msg"Field identifiers must start with a small letter", term.toLoc)(raise, prov)
+            err(msg"Field identifiers must start with a small letter", term.toLoc)(raise)
           (n, typeTerm(t))
         })(prov)
       case tup: Tup if funkyTuples =>
@@ -906,7 +906,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
       case Blk(Nil) => UnitType
       case pat if ctx.inPattern =>
         err(msg"Unsupported pattern shape${
-          if (dbg) " ("+pat.getClass.toString+")" else ""}:", pat.toLoc)(raise, ttp(pat))
+          if (dbg) " ("+pat.getClass.toString+")" else ""}:", pat.toLoc)(raise)
       case Lam(pat, body) =>
         val newBindings = mutable.Map.empty[Str, TypeVariable]
         val newCtx = ctx.nest
@@ -1034,12 +1034,12 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
           val tpr = tp(pat.toLoc, "type pattern")
           ctx.tyDefs.get(nme) match {
             case None =>
-              err("type identifier not found: " + nme, pat.toLoc)(raise, tpr)
+              err("type identifier not found: " + nme, pat.toLoc)(raise)
               val e = ClassTag(ErrTypeId, Set.empty)(tpr)
               return ((e -> e) :: Nil) -> e
             case Some(td) =>
               td.kind match {
-                case Als => err(msg"can only match on classes and traits", pat.toLoc)(raise, tpr)
+                case Als => err(msg"can only match on classes and traits", pat.toLoc)(raise)
                 case Cls => clsNameToNomTag(td)(tp(pat.toLoc, "class pattern"), ctx)
                 case Trt => trtNameToNomTag(td)(tp(pat.toLoc, "trait pattern"), ctx)
               }

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -121,13 +121,13 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
     TypeProvenance(trm.toLoc, if (desc === "") trm.describe else desc)
   def originProv(loco: Opt[Loc], desc: Str): TypeProvenance = {
     // TODO make a new sort of provenance for where types and type varianles are defined
-    // tp(loco, desc)
+    tp(loco, desc,true)
     // ^ This yields unnatural errors like:
       //│ ╟── expression of type `B` is not a function
       //│ ║  l.6: 	    method Map[B]: B -> A
       //│ ║       	               ^
     // So we should keep the info but not shadow the more relevant later provenances
-    noProv
+    //noProv
   }
   
   val noProv: TypeProvenance = tp(N, "expression")

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -127,7 +127,6 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
       //│ ║  l.6: 	    method Map[B]: B -> A
       //│ ║       	               ^
     // So we should keep the info but not shadow the more relevant later provenances
-    //noProv
   }
   
   val noProv: TypeProvenance = tp(N, "expression")

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -121,7 +121,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
     TypeProvenance(trm.toLoc, if (desc === "") trm.describe else desc)
   def originProv(loco: Opt[Loc], desc: Str): TypeProvenance = {
     // TODO make a new sort of provenance for where types and type varianles are defined
-    tp(loco, desc,true)
+    tp(loco, desc, true)
     // ^ This yields unnatural errors like:
       //│ ╟── expression of type `B` is not a function
       //│ ║  l.6: 	    method Map[B]: B -> A

--- a/shared/src/main/scala/mlscript/TyperDatatypes.scala
+++ b/shared/src/main/scala/mlscript/TyperDatatypes.scala
@@ -14,7 +14,7 @@ abstract class TyperDatatypes extends TyperHelpers { self: Typer =>
   
   case class TypeProvenance(loco: Opt[Loc], desc: Str, isOrigin: Bool = false) {
     def & (that: TypeProvenance): TypeProvenance = this // arbitrary; maybe should do better
-    override def toString: Str = (if(isOrigin) "o: " else "") + "‹"+loco.fold(desc)(desc+":"+_)+"›"
+    override def toString: Str = (if (isOrigin) "o: " else "") + "‹"+loco.fold(desc)(desc+":"+_)+"›"
   }
 
   sealed abstract class TypeInfo

--- a/shared/src/main/scala/mlscript/TyperDatatypes.scala
+++ b/shared/src/main/scala/mlscript/TyperDatatypes.scala
@@ -12,9 +12,9 @@ abstract class TyperDatatypes extends TyperHelpers { self: Typer =>
   
   // The data types used for type inference:
   
-  case class TypeProvenance(loco: Opt[Loc], desc: Str) {
+  case class TypeProvenance(loco: Opt[Loc], desc: Str, isOrigin: Bool = false) {
     def & (that: TypeProvenance): TypeProvenance = this // arbitrary; maybe should do better
-    override def toString: Str = "‹"+loco.fold(desc)(desc+":"+_)+"›"
+    override def toString: Str = (if(isOrigin) "o: " else "") + "‹"+loco.fold(desc)(desc+":"+_)+"›"
   }
 
   sealed abstract class TypeInfo

--- a/shared/src/test/diff/mlscript/BadInherit.mls
+++ b/shared/src/test/diff/mlscript/BadInherit.mls
@@ -212,7 +212,10 @@ E{}: int
 //│ ╔══[ERROR] Type mismatch in type ascription:
 //│ ║  l.210: 	E{}: 1
 //│ ║         	^^^
-//│ ╙── expression of type `E` does not match type `1`
+//│ ╟── expression of type `E` does not match type `1`
+//│ ╟── Note: Type class is defined at: 
+//│ ║  l.206: 	class E: 1
+//│ ╙──       	      ^
 //│ res: 1
 //│ Runtime error:
 //│   ReferenceError: E is not defined
@@ -222,7 +225,10 @@ E{}: int
 //│ ╟── expression of type `E` does not match type `int`
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.211: 	E{}: int
-//│ ╙──       	     ^^^
+//│ ║         	     ^^^
+//│ ╟── Note: Type class is defined at: 
+//│ ║  l.206: 	class E: 1
+//│ ╙──       	      ^
 //│ res: int
 //│ Runtime error:
 //│   ReferenceError: E is not defined

--- a/shared/src/test/diff/mlscript/BadInherit.mls
+++ b/shared/src/test/diff/mlscript/BadInherit.mls
@@ -213,7 +213,7 @@ E{}: int
 //│ ║  l.210: 	E{}: 1
 //│ ║         	^^^
 //│ ╟── expression of type `E` does not match type `1`
-//│ ╟── Note: Type class is defined at: 
+//│ ╟── Note: Class is defined at: 
 //│ ║  l.206: 	class E: 1
 //│ ╙──       	      ^
 //│ res: 1
@@ -226,7 +226,7 @@ E{}: int
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.211: 	E{}: int
 //│ ║         	     ^^^
-//│ ╟── Note: Type class is defined at: 
+//│ ╟── Note: Class is defined at: 
 //│ ║  l.206: 	class E: 1
 //│ ╙──       	      ^
 //│ res: int
@@ -238,10 +238,10 @@ E{}: int
 class F: nothing
 F{}
 //│ ╔══[ERROR] cannot inherit from a type alias
-//│ ║  l.232: 	class F: nothing
+//│ ║  l.238: 	class F: nothing
 //│ ╙──       	      ^^^^^^^^^^
 //│ ╔══[ERROR] identifier not found: F
-//│ ║  l.233: 	F{}
+//│ ║  l.239: 	F{}
 //│ ╙──       	^
 //│ res: error
 //│ Code generation met an error:
@@ -265,7 +265,7 @@ true : Bool
 :e
 class Weird: {} | {}
 //│ ╔══[ERROR] cannot inherit from a type union
-//│ ║  l.260: 	class Weird: {} | {}
+//│ ║  l.266: 	class Weird: {} | {}
 //│ ╙──       	      ^^^^^^^^^^^^^^
 //│ Code generation met an error:
 //│   unable to derive from type Union(Record(List()),Record(List()))
@@ -276,7 +276,7 @@ class A
 type Id[T] = T
 class B: Id[A]
 //│ ╔══[ERROR] cannot inherit from a type alias
-//│ ║  l.271: 	class B: Id[A]
+//│ ║  l.277: 	class B: Id[A]
 //│ ╙──       	      ^^^^^^^^
 //│ Defined class A
 //│ Defined type alias Id
@@ -286,7 +286,7 @@ class B: Id[A]
 class Class3A
 class Class3B: Class3A & 'a
 //│ ╔══[ERROR] cannot inherit from a type variable
-//│ ║  l.281: 	class Class3B: Class3A & 'a
+//│ ║  l.287: 	class Class3B: Class3A & 'a
 //│ ╙──       	      ^^^^^^^^^^^^^^^^^^^^^
 //│ Defined class Class3A
 //│ Code generation met an error:

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -9,9 +9,14 @@ class Bar[A]: Foo[A]
 //│ ║  l.7: 	    rec method Map f = f Map (fun x -> Map)
 //│ ║       	               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `B` is not a function
+//│ ║  l.6: 	    method Map[B]: B -> A
+//│ ║       	               ^
 //│ ╟── Note: constraint arises from application:
 //│ ║  l.7: 	    rec method Map f = f Map (fun x -> Map)
-//│ ╙──     	                       ^^^^^
+//│ ║       	                       ^^^^^
+//│ ╟── Note: Type method type parameter is defined at: 
+//│ ║  l.6: 	    method Map[B]: B -> A
+//│ ╙──     	               ^
 //│ Defined class Foo
 //│ Declared Foo.Map: Foo['A] -> ('A -> anything) -> 'A
 //│ Defined class Bar
@@ -125,7 +130,10 @@ class BadSelf[A]: { x: A }
 //│ ║         	               ^^^^^^^^^
 //│ ╟── expression of type `A` is not a function
 //│ ║  l.122: 	    method F = this.x 42
-//│ ╙──       	               ^^^^^^
+//│ ║         	               ^^^^^^
+//│ ╟── Note: Type class type parameter is defined at: 
+//│ ║  l.121: 	class BadSelf[A]: { x: A }
+//│ ╙──       	              ^
 //│ Defined class BadSelf
 //│ Defined BadSelf.F: BadSelf['A] -> error
 
@@ -148,9 +156,15 @@ class Simple3[A, B]: Simple2[A]
 //│ ║  l.146: 	    method Get: B
 //│ ║         	           ^^^^^^
 //│ ╟── expression of type `B` does not match type `A`
-//│ ╟── Note: constraint arises from inherited method declaration:
+//│ ╟── Note: constraint arises from class type parameter:
+//│ ║  l.145: 	class Simple3[A, B]: Simple2[A]
+//│ ║         	              ^
+//│ ╟── from inherited method declaration:
 //│ ║  l.141: 	    method Get: A
-//│ ╙──       	           ^^^^^^
+//│ ║         	           ^^^^^^
+//│ ╟── Note: Type class type parameter is defined at: 
+//│ ║  l.145: 	class Simple3[A, B]: Simple2[A]
+//│ ╙──       	                 ^
 //│ Defined class Simple3
 //│ Declared Simple3.Get: Simple3['A, 'B] -> 'B
 
@@ -172,7 +186,13 @@ class BadPair[A, B]: AbstractPair[A, B]
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `A` does not match type `B`
 //│ ║  l.168: 	    method Test f = f this.x this.x
-//│ ╙──       	                             ^^^^^^
+//│ ║         	                             ^^^^^^
+//│ ╟── Note: constraint arises from class type parameter:
+//│ ║  l.167: 	class BadPair[A, B]: AbstractPair[A, B]
+//│ ║         	                 ^
+//│ ╟── Note: Type class type parameter is defined at: 
+//│ ║  l.167: 	class BadPair[A, B]: AbstractPair[A, B]
+//│ ╙──       	              ^
 //│ ╔══[ERROR] Type mismatch in method definition:
 //│ ║  l.169: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -183,23 +203,37 @@ class BadPair[A, B]: AbstractPair[A, B]
 //│ ║  l.169: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── which does not match type `(B -> D) -> AbstractPair[C, D]`
-//│ ╟── Note: constraint arises from record type:
+//│ ╟── Note: constraint arises from method type parameter:
+//│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║         	                  ^
+//│ ╟── from record type:
 //│ ║  l.160: 	class AbstractPair[A, B]: { x: A; y: B }
 //│ ║         	                          ^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
 //│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
-//│ ╙──       	                                              ^^^^^^^^^^^^^^^^^^
+//│ ║         	                                              ^^^^^^^^^^^^^^^^^^
+//│ ╟── Note: Type method type parameter is defined at: 
+//│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ╙──       	               ^
 //│ ╔══[ERROR] Type mismatch in method definition:
 //│ ║  l.169: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `C` does not match type `D`
+//│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║         	               ^
 //│ ╟── but it flows into application of type `?a`
 //│ ║  l.169: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── which does not match type `AbstractPair[C, D]`
-//│ ╟── Note: constraint arises from applied type reference:
+//│ ╟── Note: constraint arises from method type parameter:
 //│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
-//│ ╙──       	                                              ^^^^^^^^^^^^^^^^^^
+//│ ║         	                  ^
+//│ ╟── from applied type reference:
+//│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║         	                                              ^^^^^^^^^^^^^^^^^^
+//│ ╟── Note: Type method type parameter is defined at: 
+//│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ╙──       	               ^
 //│ Defined class BadPair
 //│ Defined BadPair.Test: BadPair['A, 'B] -> ('A -> 'A -> 'a) -> 'a
 //│ Defined BadPair.Map: BadPair['A, 'B] -> ('A -> ('a & 'B0 & 'A0)) -> anything -> (BadPair['A0, 'B0] with {x: 'a, y: 'a})
@@ -215,7 +249,10 @@ bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
 //│ ║         	                   ^^
 //│ ╟── Note: constraint arises from argument:
 //│ ║  l.208: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
-//│ ╙──       	                                         ^
+//│ ║         	                                         ^
+//│ ╟── Note: Type class type parameter is defined at: 
+//│ ║  l.167: 	class BadPair[A, B]: AbstractPair[A, B]
+//│ ╙──       	              ^
 //│ res: 42 | error
 
 BadPair = BadPair { x = 42; y = 0 }

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -14,7 +14,7 @@ class Bar[A]: Foo[A]
 //│ ╟── Note: constraint arises from application:
 //│ ║  l.7: 	    rec method Map f = f Map (fun x -> Map)
 //│ ║       	                       ^^^^^
-//│ ╟── Note: Type method type parameter is defined at: 
+//│ ╟── Note: Method type parameter is defined at: 
 //│ ║  l.6: 	    method Map[B]: B -> A
 //│ ╙──     	               ^
 //│ Defined class Foo
@@ -35,22 +35,22 @@ class bar[A, B]: Foo[A] & { Y: B; z: int }
     method identity z = z
     method identity z = z
 //│ ╔══[ERROR] Type names must start with a capital letter
-//│ ║  l.29: 	class bar[A, B]: Foo[A] & { Y: B; z: int }
+//│ ║  l.34: 	class bar[A, B]: Foo[A] & { Y: B; z: int }
 //│ ╙──      	      ^^^
 //│ ╔══[ERROR] Field identifiers must start with a small letter
-//│ ║  l.29: 	class bar[A, B]: Foo[A] & { Y: B; z: int }
+//│ ║  l.34: 	class bar[A, B]: Foo[A] & { Y: B; z: int }
 //│ ╙──      	                            ^
 //│ ╔══[ERROR] Method names must start with a capital letter
-//│ ║  l.30: 	    method identity z = z
+//│ ║  l.35: 	    method identity z = z
 //│ ╙──      	           ^^^^^^^^
 //│ ╔══[ERROR] Method names must start with a capital letter
-//│ ║  l.31: 	    method identity z = z
+//│ ║  l.36: 	    method identity z = z
 //│ ╙──      	           ^^^^^^^^
 //│ ╔══[ERROR] Method 'bar.identity' is already defined
-//│ ║  l.31: 	    method identity z = z
+//│ ║  l.36: 	    method identity z = z
 //│ ║        	           ^^^^^^^^
 //│ ╟── at
-//│ ║  l.30: 	    method identity z = z
+//│ ║  l.35: 	    method identity z = z
 //│ ╙──      	           ^^^^^^^^
 //│ Defined class bar
 //│ Defined bar.identity: (Bar[?] with {Y: 'B, bar#A: 'A -> 'A, bar#B: 'B -> 'B, x: 'A, z: int}) -> 'a -> 'a
@@ -76,14 +76,14 @@ class NoMoreImplicitCall
 
 i.Fun
 //│ ╔══[ERROR] Implicit call to method Fun is forbidden because it is ambiguous.
-//│ ║  l.72: 	i.Fun
+//│ ║  l.77: 	i.Fun
 //│ ║        	^^^^^
 //│ ╟── Unrelated methods named Fun are defined by:
 //│ ╟── • class ImplicitCall
-//│ ║  l.57: 	class ImplicitCall[A]: { x: A }
+//│ ║  l.62: 	class ImplicitCall[A]: { x: A }
 //│ ║        	      ^^^^^^^^^^^^
 //│ ╟── • class NoMoreImplicitCall
-//│ ║  l.67: 	class NoMoreImplicitCall
+//│ ║  l.72: 	class NoMoreImplicitCall
 //│ ╙──      	      ^^^^^^^^^^^^^^^^^^
 //│ res: error
 
@@ -99,23 +99,23 @@ class BadThis: { x: int; y: int }
     method Sum = this this.x this.y
     method Funny = this 42 42
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.94: 	    method Sum = this this.x this.y
+//│ ║  l.99: 	    method Sum = this this.x this.y
 //│ ║        	                 ^^^^^^^^^^^
 //│ ╟── expression of type `BadThis` does not match type `?a -> ?b`
-//│ ║  l.93: 	class BadThis: { x: int; y: int }
+//│ ║  l.98: 	class BadThis: { x: int; y: int }
 //│ ║        	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `?c -> ?b`
-//│ ║  l.94: 	    method Sum = this this.x this.y
+//│ ║  l.99: 	    method Sum = this this.x this.y
 //│ ╙──      	                 ^^^^
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.95: 	    method Funny = this 42 42
-//│ ║        	                   ^^^^^^^
+//│ ║  l.100: 	    method Funny = this 42 42
+//│ ║         	                   ^^^^^^^
 //│ ╟── expression of type `BadThis` does not match type `42 -> ?a`
-//│ ║  l.93: 	class BadThis: { x: int; y: int }
+//│ ║  l.98: 	class BadThis: { x: int; y: int }
 //│ ║        	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `42 -> ?a`
-//│ ║  l.95: 	    method Funny = this 42 42
-//│ ╙──      	                   ^^^^
+//│ ║  l.100: 	    method Funny = this 42 42
+//│ ╙──       	                   ^^^^
 //│ Defined class BadThis
 //│ Defined BadThis.Sum: BadThis -> error
 //│ Defined BadThis.Funny: BadThis -> error
@@ -126,13 +126,13 @@ class BadThis: { x: int; y: int }
 class BadSelf[A]: { x: A }
     method F = this.x 42
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.122: 	    method F = this.x 42
+//│ ║  l.127: 	    method F = this.x 42
 //│ ║         	               ^^^^^^^^^
 //│ ╟── expression of type `A` is not a function
-//│ ║  l.122: 	    method F = this.x 42
+//│ ║  l.127: 	    method F = this.x 42
 //│ ║         	               ^^^^^^
-//│ ╟── Note: Type class type parameter is defined at: 
-//│ ║  l.121: 	class BadSelf[A]: { x: A }
+//│ ╟── Note: Class type parameter is defined at: 
+//│ ║  l.126: 	class BadSelf[A]: { x: A }
 //│ ╙──       	              ^
 //│ Defined class BadSelf
 //│ Defined BadSelf.F: BadSelf['A] -> error
@@ -153,17 +153,17 @@ class Simple2[A]: { a: A }
 class Simple3[A, B]: Simple2[A]
     method Get: B
 //│ ╔══[ERROR] Type mismatch in method declaration:
-//│ ║  l.146: 	    method Get: B
+//│ ║  l.154: 	    method Get: B
 //│ ║         	           ^^^^^^
 //│ ╟── expression of type `B` does not match type `A`
 //│ ╟── Note: constraint arises from class type parameter:
-//│ ║  l.145: 	class Simple3[A, B]: Simple2[A]
+//│ ║  l.153: 	class Simple3[A, B]: Simple2[A]
 //│ ║         	              ^
 //│ ╟── from inherited method declaration:
-//│ ║  l.141: 	    method Get: A
+//│ ║  l.149: 	    method Get: A
 //│ ║         	           ^^^^^^
-//│ ╟── Note: Type class type parameter is defined at: 
-//│ ║  l.145: 	class Simple3[A, B]: Simple2[A]
+//│ ╟── Note: Class type parameter is defined at: 
+//│ ║  l.153: 	class Simple3[A, B]: Simple2[A]
 //│ ╙──       	                 ^
 //│ Defined class Simple3
 //│ Declared Simple3.Get: Simple3['A, 'B] -> 'B
@@ -182,57 +182,57 @@ class BadPair[A, B]: AbstractPair[A, B]
     method Test f = f this.x this.x
     method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.168: 	    method Test f = f this.x this.x
+//│ ║  l.182: 	    method Test f = f this.x this.x
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `A` does not match type `B`
-//│ ║  l.168: 	    method Test f = f this.x this.x
+//│ ║  l.182: 	    method Test f = f this.x this.x
 //│ ║         	                             ^^^^^^
 //│ ╟── Note: constraint arises from class type parameter:
-//│ ║  l.167: 	class BadPair[A, B]: AbstractPair[A, B]
+//│ ║  l.181: 	class BadPair[A, B]: AbstractPair[A, B]
 //│ ║         	                 ^
-//│ ╟── Note: Type class type parameter is defined at: 
-//│ ║  l.167: 	class BadPair[A, B]: AbstractPair[A, B]
+//│ ╟── Note: Class type parameter is defined at: 
+//│ ║  l.181: 	class BadPair[A, B]: AbstractPair[A, B]
 //│ ╙──       	              ^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.169: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.183: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `C` does not match type `D`
-//│ ║  l.169: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.183: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into function of type `?a -> ?b`
-//│ ║  l.169: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.183: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── which does not match type `(B -> D) -> AbstractPair[C, D]`
 //│ ╟── Note: constraint arises from method type parameter:
-//│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║  l.176: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ║         	                  ^
 //│ ╟── from record type:
-//│ ║  l.160: 	class AbstractPair[A, B]: { x: A; y: B }
+//│ ║  l.174: 	class AbstractPair[A, B]: { x: A; y: B }
 //│ ║         	                          ^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║  l.176: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ║         	                                              ^^^^^^^^^^^^^^^^^^
-//│ ╟── Note: Type method type parameter is defined at: 
-//│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ╟── Note: Method type parameter is defined at: 
+//│ ║  l.176: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ╙──       	               ^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.169: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.183: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `C` does not match type `D`
-//│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║  l.176: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ║         	               ^
 //│ ╟── but it flows into application of type `?a`
-//│ ║  l.169: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.183: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── which does not match type `AbstractPair[C, D]`
 //│ ╟── Note: constraint arises from method type parameter:
-//│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║  l.176: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ║         	                  ^
 //│ ╟── from applied type reference:
-//│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║  l.176: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ║         	                                              ^^^^^^^^^^^^^^^^^^
-//│ ╟── Note: Type method type parameter is defined at: 
-//│ ║  l.162: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ╟── Note: Method type parameter is defined at: 
+//│ ║  l.176: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ╙──       	               ^
 //│ Defined class BadPair
 //│ Defined BadPair.Test: BadPair['A, 'B] -> ('A -> 'A -> 'a) -> 'a
@@ -242,16 +242,16 @@ bp = BadPair { x = 42; y = true }
 bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
 //│ bp: BadPair['A .. 42 | 'A, 'B .. 'B | true] with {x: 42, y: true}
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.208: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
+//│ ║  l.242: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `42` does not match type `bool`
-//│ ║  l.207: 	bp = BadPair { x = 42; y = true }
+//│ ║  l.241: 	bp = BadPair { x = 42; y = true }
 //│ ║         	                   ^^
 //│ ╟── Note: constraint arises from argument:
-//│ ║  l.208: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
+//│ ║  l.242: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
 //│ ║         	                                         ^
-//│ ╟── Note: Type class type parameter is defined at: 
-//│ ║  l.167: 	class BadPair[A, B]: AbstractPair[A, B]
+//│ ╟── Note: Class type parameter is defined at: 
+//│ ║  l.181: 	class BadPair[A, B]: AbstractPair[A, B]
 //│ ╙──       	              ^
 //│ res: 42 | error
 
@@ -261,7 +261,7 @@ BadPair.(BadPair.Map)
 //│ BadPair: BadPair['A .. 42 | 'A, 'B .. 0 | 'B] with {x: 42, y: 0}
 //│ res: BadPair['A, 'B] -> ('A -> ('a & 'B0 & 'A0)) -> anything -> (BadPair['A0, 'B0] with {x: 'a, y: 'a})
 //│ ╔══[ERROR] Class BadPair has no method BadPair.Map
-//│ ║  l.223: 	BadPair.(BadPair.Map)
+//│ ║  l.260: 	BadPair.(BadPair.Map)
 //│ ╙──       	^^^^^^^^^^^^^^^^^^^^^
 //│ res: (42 -> ('A & 'B & 'a)) -> anything -> (BadPair['A, 'B] with {x: 'a, y: 'a})
 
@@ -275,22 +275,22 @@ class ClassA
 class ClassB: ClassA
     method MtdA = 43
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.239: 	    method MtdA = 43
+//│ ║  l.276: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.233: 	    method MtdA = 42
+//│ ║  l.270: 	    method MtdA = 42
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.239: 	    method MtdA = 43
+//│ ║  l.276: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `43` does not match type `42`
-//│ ║  l.239: 	    method MtdA = 43
+//│ ║  l.276: 	    method MtdA = 43
 //│ ║         	                  ^^
 //│ ╟── but it flows into method definition with expected type `42`
-//│ ║  l.239: 	    method MtdA = 43
+//│ ║  l.276: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.233: 	    method MtdA = 42
+//│ ║  l.270: 	    method MtdA = 42
 //│ ╙──       	                  ^^
 //│ Defined class ClassB
 //│ Defined ClassB.MtdA: ClassB -> 43
@@ -300,22 +300,22 @@ class ClassC: ClassA
     method MtdA: int
     method MtdA = 43
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.263: 	    method MtdA: int
+//│ ║  l.300: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.233: 	    method MtdA = 42
+//│ ║  l.270: 	    method MtdA = 42
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method declaration:
-//│ ║  l.263: 	    method MtdA: int
+//│ ║  l.300: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `int` does not match type `42`
-//│ ║  l.263: 	    method MtdA: int
+//│ ║  l.300: 	    method MtdA: int
 //│ ║         	                 ^^^
 //│ ╟── but it flows into method declaration with expected type `42`
-//│ ║  l.263: 	    method MtdA: int
+//│ ║  l.300: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.233: 	    method MtdA = 42
+//│ ║  l.270: 	    method MtdA = 42
 //│ ╙──       	                  ^^
 //│ Defined class ClassC
 //│ Declared ClassC.MtdA: ClassC -> int
@@ -325,22 +325,22 @@ class ClassC: ClassA
 class ClassD: ClassA
     method MtdA: int
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.289: 	    method MtdA: int
+//│ ║  l.326: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.233: 	    method MtdA = 42
+//│ ║  l.270: 	    method MtdA = 42
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method declaration:
-//│ ║  l.289: 	    method MtdA: int
+//│ ║  l.326: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `int` does not match type `42`
-//│ ║  l.289: 	    method MtdA: int
+//│ ║  l.326: 	    method MtdA: int
 //│ ║         	                 ^^^
 //│ ╟── but it flows into method declaration with expected type `42`
-//│ ║  l.289: 	    method MtdA: int
+//│ ║  l.326: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.233: 	    method MtdA = 42
+//│ ║  l.270: 	    method MtdA = 42
 //│ ╙──       	                  ^^
 //│ Defined class ClassD
 //│ Declared ClassD.MtdA: ClassD -> int
@@ -349,22 +349,22 @@ class ClassD: ClassA
 class ClassE: ClassD
     method MtdA = 43
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.313: 	    method MtdA = 43
+//│ ║  l.350: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.233: 	    method MtdA = 42
+//│ ║  l.270: 	    method MtdA = 42
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.313: 	    method MtdA = 43
+//│ ║  l.350: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── expression of type `43` does not match type `42`
-//│ ║  l.313: 	    method MtdA = 43
+//│ ║  l.350: 	    method MtdA = 43
 //│ ║         	                  ^^
 //│ ╟── but it flows into method definition with expected type `42`
-//│ ║  l.313: 	    method MtdA = 43
+//│ ║  l.350: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.233: 	    method MtdA = 42
+//│ ║  l.270: 	    method MtdA = 42
 //│ ╙──       	                  ^^
 //│ Defined class ClassE
 //│ Defined ClassE.MtdA: ClassE -> 43
@@ -381,19 +381,19 @@ trait Trait2A[B]
 class Class2B: Class2A[int] & Trait2A[string]
     method MtdA = "ok"
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.345: 	    method MtdA = "ok"
+//│ ║  l.382: 	    method MtdA = "ok"
 //│ ║         	           ^^^^^^^^^^^
 //│ ╟── expression of type `"ok"` does not match type `int`
-//│ ║  l.345: 	    method MtdA = "ok"
+//│ ║  l.382: 	    method MtdA = "ok"
 //│ ║         	                  ^^^^
 //│ ╟── but it flows into method definition with expected type `int`
-//│ ║  l.345: 	    method MtdA = "ok"
+//│ ║  l.382: 	    method MtdA = "ok"
 //│ ║         	           ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.344: 	class Class2B: Class2A[int] & Trait2A[string]
+//│ ║  l.381: 	class Class2B: Class2A[int] & Trait2A[string]
 //│ ║         	                       ^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.341: 	    method MtdA: A
+//│ ║  l.378: 	    method MtdA: A
 //│ ╙──       	           ^^^^^^^
 //│ Defined class Class2A
 //│ Declared Class2A.MtdA: Class2A['A] -> 'A
@@ -410,7 +410,7 @@ type Type3A = Class3A[string]
 class Class3B: Type3A
     method MtdA = 1
 //│ ╔══[ERROR] cannot inherit from a type alias
-//│ ║  l.373: 	class Class3B: Type3A
+//│ ║  l.410: 	class Class3B: Type3A
 //│ ╙──       	      ^^^^^^^^^^^^^^^
 //│ Defined class Class3A
 //│ Declared Class3A.MtdA: Class3A['A] -> 'A
@@ -420,7 +420,7 @@ class Class3B: Type3A
 :e
 Oops.M
 //│ ╔══[ERROR] Method M not found
-//│ ║  l.384: 	Oops.M
+//│ ║  l.421: 	Oops.M
 //│ ╙──       	^^^^^^
 //│ res: error
 
@@ -435,22 +435,22 @@ class Test4A
 class Test4B: Test4A
     method Mth4A: int
 //│ ╔══[ERROR] Type mismatch in inherited method definition:
-//│ ║  l.393: 	    method Mth4A = true
+//│ ║  l.430: 	    method Mth4A = true
 //│ ║         	           ^^^^^^^^^^^^
 //│ ╟── expression of type `true` does not match type `int`
-//│ ║  l.393: 	    method Mth4A = true
+//│ ║  l.430: 	    method Mth4A = true
 //│ ║         	                   ^^^^
 //│ ╟── but it flows into inherited method definition with expected type `int`
-//│ ║  l.393: 	    method Mth4A = true
+//│ ║  l.430: 	    method Mth4A = true
 //│ ║         	           ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.399: 	    method Mth4A: int
+//│ ║  l.436: 	    method Mth4A: int
 //│ ╙──       	                  ^^^
 //│ ╔══[ERROR] Overriding method Test4A.Mth4A without an overriding definition is not allowed.
-//│ ║  l.399: 	    method Mth4A: int
+//│ ║  l.436: 	    method Mth4A: int
 //│ ║         	           ^^^^^^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.393: 	    method Mth4A = true
+//│ ║  l.430: 	    method Mth4A = true
 //│ ╙──       	           ^^^^^^^^^^^^
 //│ Defined class Test4B
 //│ Declared Test4B.Mth4A: Test4B -> int
@@ -468,16 +468,16 @@ class Test5A
 class Test5B: Test5A
     method Mth5A = 43
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.432: 	    method Mth5A = 43
+//│ ║  l.469: 	    method Mth5A = 43
 //│ ║         	           ^^^^^^^^^^
 //│ ╟── expression of type `43` does not match type `42`
-//│ ║  l.432: 	    method Mth5A = 43
+//│ ║  l.469: 	    method Mth5A = 43
 //│ ║         	                   ^^
 //│ ╟── but it flows into method definition with expected type `42`
-//│ ║  l.432: 	    method Mth5A = 43
+//│ ║  l.469: 	    method Mth5A = 43
 //│ ║         	           ^^^^^^^^^^
 //│ ╟── Note: constraint arises from inherited method declaration:
-//│ ║  l.430: 	    method Mth5A: 42
+//│ ║  l.467: 	    method Mth5A: 42
 //│ ╙──       	           ^^^^^
 //│ Defined class Test5A
 //│ Declared Test5A.Mth5A: Test5A -> 42
@@ -501,45 +501,45 @@ class Test6C: Test6A[int] & Test6B
 :e
 Test6A
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
-//│ ║  l.465: 	Test6A
+//│ ║  l.502: 	Test6A
 //│ ║         	^^^^^^
 //│ ╟── Note that class Test6A is abstract:
-//│ ║  l.451: 	class Test6A[A]
+//│ ║  l.488: 	class Test6A[A]
 //│ ║         	      ^^^^^^^^
 //│ ╟── Hint: method Mth6A is abstract
-//│ ║  l.452: 	    method Mth6A: A
+//│ ║  l.489: 	    method Mth6A: A
 //│ ║         	           ^^^^^^^^
 //│ ╟── Hint: method Mth6B is abstract
-//│ ║  l.453: 	    method Mth6B[B]: (A -> B) -> B
+//│ ║  l.490: 	    method Mth6B[B]: (A -> B) -> B
 //│ ╙──       	           ^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error
 
 :e
 Test6B
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
-//│ ║  l.481: 	Test6B
+//│ ║  l.518: 	Test6B
 //│ ║         	^^^^^^
 //│ ╟── Note that trait Test6B is abstract:
-//│ ║  l.454: 	trait Test6B
+//│ ║  l.491: 	trait Test6B
 //│ ║         	      ^^^^^^
 //│ ╟── Hint: method Mth6A is abstract
-//│ ║  l.455: 	    method Mth6A: bool
+//│ ║  l.492: 	    method Mth6A: bool
 //│ ╙──       	           ^^^^^^^^^^^
 //│ res: error
 
 :e
 Test6C
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
-//│ ║  l.494: 	Test6C
+//│ ║  l.531: 	Test6C
 //│ ║         	^^^^^^
 //│ ╟── Note that class Test6C is abstract:
-//│ ║  l.456: 	class Test6C: Test6A[int] & Test6B
+//│ ║  l.493: 	class Test6C: Test6A[int] & Test6B
 //│ ║         	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Hint: method Mth6B is abstract
-//│ ║  l.453: 	    method Mth6B[B]: (A -> B) -> B
+//│ ║  l.490: 	    method Mth6B[B]: (A -> B) -> B
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Hint: method Mth6A is abstract
-//│ ║  l.456: 	class Test6C: Test6A[int] & Test6B
+//│ ║  l.493: 	class Test6C: Test6A[int] & Test6B
 //│ ╙──       	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error
 
@@ -552,24 +552,24 @@ class Dup[A, A]: { x: A }
         B]: (A -> B) -> B
     method MthDup f = f this.x
 //│ ╔══[ERROR] Multiple declarations of type parameter A in class definition
-//│ ║  l.513: 	class Dup[A, A]: { x: A }
+//│ ║  l.550: 	class Dup[A, A]: { x: A }
 //│ ║         	      ^^^^^^^^^^^^^^^^^^^
 //│ ╟── Declared at
-//│ ║  l.513: 	class Dup[A, A]: { x: A }
+//│ ║  l.550: 	class Dup[A, A]: { x: A }
 //│ ║         	          ^
 //│ ╟── Declared at
-//│ ║  l.513: 	class Dup[A, A]: { x: A }
+//│ ║  l.550: 	class Dup[A, A]: { x: A }
 //│ ╙──       	             ^
 //│ ╔══[ERROR] Multiple declarations of type parameter B in method declaration
-//│ ║  l.514: 	    method MthDup[B, C, // random comment
+//│ ║  l.551: 	    method MthDup[B, C, // random comment
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.515: 	        B]: (A -> B) -> B
+//│ ║  l.552: 	        B]: (A -> B) -> B
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Declared at
-//│ ║  l.514: 	    method MthDup[B, C, // random comment
+//│ ║  l.551: 	    method MthDup[B, C, // random comment
 //│ ║         	                  ^
 //│ ╟── Declared at
-//│ ║  l.515: 	        B]: (A -> B) -> B
+//│ ║  l.552: 	        B]: (A -> B) -> B
 //│ ╙──       	        ^
 //│ Defined class Dup
 //│ Declared Dup.MthDup: Dup['A | 'A0 .. 'A & 'A0, 'A | 'A0 .. 'A & 'A0] -> ('A0 -> 'B) -> 'B
@@ -588,19 +588,19 @@ t : Dup[bool, int]
 :stats
 t : Dup[int, bool]
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.552: 	t : Dup[int, bool]
+//│ ║  l.589: 	t : Dup[int, bool]
 //│ ║         	^
 //│ ╟── expression of type `42` does not match type `bool`
-//│ ║  l.541: 	t = Dup { x = 42 }
+//│ ║  l.578: 	t = Dup { x = 42 }
 //│ ║         	              ^^
 //│ ╟── but it flows into reference with expected type `Dup[int, bool]`
-//│ ║  l.552: 	t : Dup[int, bool]
+//│ ║  l.589: 	t : Dup[int, bool]
 //│ ║         	^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.552: 	t : Dup[int, bool]
+//│ ║  l.589: 	t : Dup[int, bool]
 //│ ║         	             ^^^^
 //│ ╟── from record type:
-//│ ║  l.513: 	class Dup[A, A]: { x: A }
+//│ ║  l.550: 	class Dup[A, A]: { x: A }
 //│ ╙──       	                 ^^^^^^^^
 //│ res: Dup[bool | int .. nothing, bool | int .. nothing]
 //│ constrain calls  : 58
@@ -631,7 +631,7 @@ class B: { x: int }
   method F1: int
   method F1 = 1
 //│ ╔══[ERROR] Method F1 not found
-//│ ║  l.592: 	  method Nope = this.Yes.F1
+//│ ║  l.629: 	  method Nope = this.Yes.F1
 //│ ╙──       	                ^^^^^^^^^^^
 //│ Defined class A
 //│ Defined A.Yes: A -> (B & {x: 1})
@@ -648,22 +648,22 @@ trait E
 class H: D & E
   method G = 2
 //│ ╔══[ERROR] Overriding method D.G without explicit declaration is not allowed.
-//│ ║  l.612: 	  method G = 2
+//│ ║  l.649: 	  method G = 2
 //│ ║         	         ^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.608: 	  method G = 1
+//│ ║  l.645: 	  method G = 1
 //│ ╙──       	         ^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.612: 	  method G = 2
+//│ ║  l.649: 	  method G = 2
 //│ ║         	         ^^^^^
 //│ ╟── expression of type `2` does not match type `1`
-//│ ║  l.612: 	  method G = 2
+//│ ║  l.649: 	  method G = 2
 //│ ║         	             ^
 //│ ╟── but it flows into method definition with expected type `1`
-//│ ║  l.612: 	  method G = 2
+//│ ║  l.649: 	  method G = 2
 //│ ║         	         ^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.608: 	  method G = 1
+//│ ║  l.645: 	  method G = 1
 //│ ╙──       	             ^
 //│ Defined trait D
 //│ Defined D.G: d -> 1
@@ -691,16 +691,16 @@ trait E2
   method G2: bool
 class H2: D2 & E2
 //│ ╔══[ERROR] Type mismatch in inherited method definition:
-//│ ║  l.652: 	  method G2 = 1
+//│ ║  l.689: 	  method G2 = 1
 //│ ║         	         ^^^^^^
 //│ ╟── expression of type `1` does not match type `bool`
-//│ ║  l.652: 	  method G2 = 1
+//│ ║  l.689: 	  method G2 = 1
 //│ ║         	              ^
 //│ ╟── but it flows into inherited method definition with expected type `bool`
-//│ ║  l.652: 	  method G2 = 1
+//│ ║  l.689: 	  method G2 = 1
 //│ ║         	         ^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.654: 	  method G2: bool
+//│ ║  l.691: 	  method G2: bool
 //│ ╙──       	             ^^^^
 //│ Defined trait D2
 //│ Defined D2.G2: d2 -> 1
@@ -727,14 +727,14 @@ trait Test7B
 :e
 class Test7C: Test7A & Test7B
 //│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
-//│ ║  l.691: 	class Test7C: Test7A & Test7B
+//│ ║  l.728: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
 //│ ╟── • Test7A
-//│ ║  l.679: 	  method Mth7A = 42
+//│ ║  l.716: 	  method Mth7A = 42
 //│ ║         	         ^^^^^^^^^^
 //│ ╟── • Test7B
-//│ ║  l.682: 	  method Mth7A = 43
+//│ ║  l.719: 	  method Mth7A = 43
 //│ ╙──       	         ^^^^^^^^^^
 //│ Defined class Test7C
 
@@ -747,14 +747,14 @@ class Test7D: Test7A & Test7B
 class Test7E: Test7C
   method Mth7A = 0
 //│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
-//│ ║  l.691: 	class Test7C: Test7A & Test7B
+//│ ║  l.728: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
 //│ ╟── • Test7A
-//│ ║  l.679: 	  method Mth7A = 42
+//│ ║  l.716: 	  method Mth7A = 42
 //│ ║         	         ^^^^^^^^^^
 //│ ╟── • Test7B
-//│ ║  l.682: 	  method Mth7A = 43
+//│ ║  l.719: 	  method Mth7A = 43
 //│ ╙──       	         ^^^^^^^^^^
 //│ Defined class Test7E
 //│ Defined Test7E.Mth7A: (Test7E & test7A & test7B) -> 0
@@ -767,24 +767,24 @@ trait Test7F
 :e
 class Test7G: Test7C & Test7F
 //│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
-//│ ║  l.691: 	class Test7C: Test7A & Test7B
+//│ ║  l.728: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
 //│ ╟── • Test7A
-//│ ║  l.679: 	  method Mth7A = 42
+//│ ║  l.716: 	  method Mth7A = 42
 //│ ║         	         ^^^^^^^^^^
 //│ ╟── • Test7B
-//│ ║  l.682: 	  method Mth7A = 43
+//│ ║  l.719: 	  method Mth7A = 43
 //│ ╙──       	         ^^^^^^^^^^
 //│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
-//│ ║  l.731: 	class Test7G: Test7C & Test7F
+//│ ║  l.768: 	class Test7G: Test7C & Test7F
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
 //│ ╟── • Test7C
-//│ ║  l.691: 	class Test7C: Test7A & Test7B
+//│ ║  l.728: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── • Test7F
-//│ ║  l.726: 	  method Mth7A = 0
+//│ ║  l.763: 	  method Mth7A = 0
 //│ ╙──       	         ^^^^^^^^^
 //│ Defined class Test7G
 
@@ -802,10 +802,10 @@ class Test8A
 class Test8B: Test8A
     method F: 1
 //│ ╔══[ERROR] Overriding method Test8A.F without an overriding definition is not allowed.
-//│ ║  l.766: 	    method F: 1
+//│ ║  l.803: 	    method F: 1
 //│ ║         	           ^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.759: 	    method F = 1
+//│ ║  l.796: 	    method F = 1
 //│ ╙──       	           ^^^^^
 //│ Defined class Test8B
 //│ Declared Test8B.F: Test8B -> 1
@@ -838,15 +838,15 @@ class Test9B: Test9A[int]
 :NoJS
 error.(Test9B.Mth9A): nothing
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.802: 	error.(Test9B.Mth9A): nothing
+//│ ║  l.839: 	error.(Test9B.Mth9A): nothing
 //│ ║         	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── expression of type `int` does not match type `nothing`
-//│ ║  l.797: 	class Test9B: Test9A[int]
+//│ ║  l.834: 	class Test9B: Test9A[int]
 //│ ║         	                     ^^^
 //│ ╟── but it flows into field selection with expected type `nothing`
-//│ ║  l.802: 	error.(Test9B.Mth9A): nothing
+//│ ║  l.839: 	error.(Test9B.Mth9A): nothing
 //│ ║         	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.802: 	error.(Test9B.Mth9A): nothing
+//│ ║  l.839: 	error.(Test9B.Mth9A): nothing
 //│ ╙──       	                      ^^^^^^^
 //│ res: nothing

--- a/shared/src/test/diff/mlscript/BadTraits.mls
+++ b/shared/src/test/diff/mlscript/BadTraits.mls
@@ -39,7 +39,7 @@ T a
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.7: 	trait T: A & B
 //│ ║       	             ^
-//│ ╟── Note: Type class is defined at: 
+//│ ╟── Note: Class is defined at: 
 //│ ║  l.1: 	class A
 //│ ╙──     	      ^
 //│ res: A & t | error
@@ -52,15 +52,15 @@ T A
 //│ res = ((x) => new A(x));
 //│ // End of generated code
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.47: 	T A
+//│ ║  l.50: 	T A
 //│ ║        	^^^
 //│ ╟── expression of type `anything -> A` does not match type `A`
-//│ ║  l.47: 	T A
+//│ ║  l.50: 	T A
 //│ ║        	  ^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.7: 	trait T: A & B
 //│ ║       	         ^
-//│ ╟── Note: Type class constructor is defined at: 
+//│ ╟── Note: Class constructor is defined at: 
 //│ ║  l.1: 	class A
 //│ ╙──     	      ^
 //│ res: anything -> A & t | error
@@ -69,15 +69,15 @@ T A
 :e
 T (B {})
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.64: 	T (B {})
+//│ ║  l.70: 	T (B {})
 //│ ║        	^^^^^^^
 //│ ╟── expression of type `B` does not match type `A`
-//│ ║  l.64: 	T (B {})
+//│ ║  l.70: 	T (B {})
 //│ ║        	   ^^^^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.7: 	trait T: A & B
 //│ ║       	         ^
-//│ ╟── Note: Type class is defined at: 
+//│ ╟── Note: Class is defined at: 
 //│ ║  l.2: 	class B
 //│ ╙──     	      ^
 //│ res: B & t | error
@@ -108,13 +108,13 @@ t: Als
 :e
 class D0: T
 //│ ╔══[ERROR] class D0 cannot inherit from class B as it already inherits from class A
-//│ ║  l.100: 	class D0: T
+//│ ║  l.109: 	class D0: T
 //│ ╙──       	      ^^^^^
 
 :e
 class D1: B & T
 //│ ╔══[ERROR] class D1 cannot inherit from class A as it already inherits from class B
-//│ ║  l.106: 	class D1: B & T
+//│ ║  l.115: 	class D1: B & T
 //│ ╙──       	      ^^^^^^^^^
 
 
@@ -132,13 +132,13 @@ t = s: s
 :e
 t.x
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.124: 	t.x
+//│ ║  l.133: 	t.x
 //│ ║         	^^^
 //│ ╟── expression of type `s` does not have field 'x'
-//│ ║  l.119: 	t = s: s
+//│ ║  l.128: 	t = s: s
 //│ ║         	       ^
 //│ ╟── but it flows into reference with expected type `{x: ?a}`
-//│ ║  l.124: 	t.x
+//│ ║  l.133: 	t.x
 //│ ╙──       	^
 //│ res: error
 //│    = 1

--- a/shared/src/test/diff/mlscript/BadTraits.mls
+++ b/shared/src/test/diff/mlscript/BadTraits.mls
@@ -38,7 +38,10 @@ T a
 //│ ║        	  ^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.7: 	trait T: A & B
-//│ ╙──     	             ^
+//│ ║       	             ^
+//│ ╟── Note: Type class is defined at: 
+//│ ║  l.1: 	class A
+//│ ╙──     	      ^
 //│ res: A & t | error
 //│    = A {}
 
@@ -56,7 +59,10 @@ T A
 //│ ║        	  ^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.7: 	trait T: A & B
-//│ ╙──     	         ^
+//│ ║       	         ^
+//│ ╟── Note: Type class constructor is defined at: 
+//│ ║  l.1: 	class A
+//│ ╙──     	      ^
 //│ res: anything -> A & t | error
 //│    = [Function: res]
 
@@ -70,7 +76,10 @@ T (B {})
 //│ ║        	   ^^^^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.7: 	trait T: A & B
-//│ ╙──     	         ^
+//│ ║       	         ^
+//│ ╟── Note: Type class is defined at: 
+//│ ║  l.2: 	class B
+//│ ╙──     	      ^
 //│ res: B & t | error
 //│    = B {}
 

--- a/shared/src/test/diff/mlscript/InheritSimple.mls
+++ b/shared/src/test/diff/mlscript/InheritSimple.mls
@@ -24,7 +24,7 @@ c.name
 //│ ╟── but it flows into reference with expected type `{name: ?a}`
 //│ ║  l.17: 	c.name
 //│ ║        	^
-//│ ╟── Note: Type class is defined at: 
+//│ ╟── Note: Class is defined at: 
 //│ ║  l.5: 	class Child: Parent
 //│ ╙──     	      ^^^^^
 //│ res: error

--- a/shared/src/test/diff/mlscript/InheritSimple.mls
+++ b/shared/src/test/diff/mlscript/InheritSimple.mls
@@ -23,7 +23,10 @@ c.name
 //│ ║        	        ^^^^^^^
 //│ ╟── but it flows into reference with expected type `{name: ?a}`
 //│ ║  l.17: 	c.name
-//│ ╙──      	^
+//│ ║        	^
+//│ ╟── Note: Type class is defined at: 
+//│ ║  l.5: 	class Child: Parent
+//│ ╙──     	      ^^^^^
 //│ res: error
 //│    = undefined
 

--- a/shared/src/test/diff/mlscript/Lists.mls
+++ b/shared/src/test/diff/mlscript/Lists.mls
@@ -74,7 +74,10 @@ res.tail.head
 //│ ║        	          ^^^^^^
 //│ ╟── but it flows into reference with expected type `{tail: ?a}`
 //│ ║  l.68: 	res.tail.head
-//│ ╙──      	^^^
+//│ ║        	^^^
+//│ ╟── Note: Type class is defined at: 
+//│ ║  l.2: 	class Nil: {}
+//│ ╙──     	      ^^^
 //│ res: error
 //│ Runtime error:
 //│   TypeError: Cannot read properties of undefined (reading 'head')

--- a/shared/src/test/diff/mlscript/Lists.mls
+++ b/shared/src/test/diff/mlscript/Lists.mls
@@ -75,7 +75,7 @@ res.tail.head
 //│ ╟── but it flows into reference with expected type `{tail: ?a}`
 //│ ║  l.68: 	res.tail.head
 //│ ║        	^^^
-//│ ╟── Note: Type class is defined at: 
+//│ ╟── Note: Class is defined at: 
 //│ ║  l.2: 	class Nil: {}
 //│ ╙──     	      ^^^
 //│ res: error
@@ -105,13 +105,13 @@ res.head
 :e
 Cons 1 res
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.103: 	Cons 1 res
+//│ ║  l.106: 	Cons 1 res
 //│ ║         	^^^^^^^^^^
 //│ ╟── expression of type `2` does not match type `Nil | Cons[?A]`
-//│ ║  l.94: 	Cons 2 Nil
+//│ ║  l.97: 	Cons 2 Nil
 //│ ║        	     ^
 //│ ╟── but it flows into reference with expected type `List[?A0]`
-//│ ║  l.103: 	Cons 1 res
+//│ ║  l.106: 	Cons 1 res
 //│ ║         	       ^^^
 //│ ╟── Note: constraint arises from union type:
 //│ ║  l.4: 	type List[A] = Nil | Cons[A]
@@ -120,7 +120,7 @@ Cons 1 res
 //│ ║  l.3: 	class Cons[A]: { head: A; tail: List[A] }
 //│ ║       	                                ^^^^^^^
 //│ ╟── from reference:
-//│ ║  l.85: 	def Cons head tail = originalCons { head; tail } with { head; tail }
+//│ ║  l.88: 	def Cons head tail = originalCons { head; tail } with { head; tail }
 //│ ╙──      	                                          ^^^^
 //│ res: (Cons['A .. 1 | 'A] with {head: 1, tail: 2}) | error
 //│    = Cons { head: 1, tail: 2 }

--- a/shared/src/test/diff/mlscript/Match2.mls
+++ b/shared/src/test/diff/mlscript/Match2.mls
@@ -44,7 +44,7 @@ bar Test
 //│ ╟── Note: constraint arises from reference:
 //│ ║  l.29: 	def bar x = case x of
 //│ ║        	                 ^
-//│ ╟── Note: Type class constructor is defined at: 
+//│ ╟── Note: Class constructor is defined at: 
 //│ ║  l.2: 	class Test: { value: int }
 //│ ╙──     	      ^^^^
 //│ res: error
@@ -54,10 +54,10 @@ bar Test
 :e
 bar "ops"
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.52: 	bar "ops"
+//│ ║  l.55: 	bar "ops"
 //│ ║        	^^^^^^^^^
 //│ ╟── expression of type `"ops"` does not match type `Test & ?a | Toast & ?b`
-//│ ║  l.52: 	bar "ops"
+//│ ║  l.55: 	bar "ops"
 //│ ║        	    ^^^^^
 //│ ╟── Note: constraint arises from reference:
 //│ ║  l.29: 	def bar x = case x of
@@ -77,13 +77,13 @@ def baz x = case x of
 :e
 baz "oops"
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.75: 	baz "oops"
+//│ ║  l.78: 	baz "oops"
 //│ ║        	^^^^^^^^^^
 //│ ╟── expression of type `"oops"` does not match type `Test & ?a | Toast & ?b`
-//│ ║  l.75: 	baz "oops"
+//│ ║  l.78: 	baz "oops"
 //│ ║        	    ^^^^^^
 //│ ╟── Note: constraint arises from reference:
-//│ ║  l.67: 	def baz x = case x of
+//│ ║  l.70: 	def baz x = case x of
 //│ ╙──      	                 ^
 //│ res: error
 //│ Runtime error:

--- a/shared/src/test/diff/mlscript/Match2.mls
+++ b/shared/src/test/diff/mlscript/Match2.mls
@@ -43,7 +43,10 @@ bar Test
 //│ ║        	    ^^^^
 //│ ╟── Note: constraint arises from reference:
 //│ ║  l.29: 	def bar x = case x of
-//│ ╙──      	                 ^
+//│ ║        	                 ^
+//│ ╟── Note: Type class constructor is defined at: 
+//│ ║  l.2: 	class Test: { value: int }
+//│ ╙──     	      ^^^^
 //│ res: error
 //│ Runtime error:
 //│   Error: non-exhaustive case expression

--- a/shared/src/test/diff/mlscript/MethodAndMatches.mls
+++ b/shared/src/test/diff/mlscript/MethodAndMatches.mls
@@ -136,7 +136,10 @@ def bar1 = foo
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
 //│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
-//│ ╙──      	                               ^^^^^^^^^^
+//│ ║        	                               ^^^^^^^^^^
+//│ ╟── Note: Type class type parameter is defined at: 
+//│ ║  l.1: 	class Base1[A]
+//│ ╙──     	            ^
 //│ ╔══[ERROR] Type mismatch in def definition:
 //│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
@@ -187,7 +190,10 @@ def bar1 = foo
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
 //│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
-//│ ╙──      	                               ^^^^^^^^^^
+//│ ║        	                               ^^^^^^^^^^
+//│ ╟── Note: Type class type parameter is defined at: 
+//│ ║  l.1: 	class Base1[A]
+//│ ╙──     	            ^
 //│ ╔══[ERROR] Type mismatch in def definition:
 //│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^
@@ -206,7 +212,10 @@ def bar1 = foo
 //│ ║       	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
 //│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
-//│ ╙──      	                               ^^^^^^^^^^
+//│ ║        	                               ^^^^^^^^^^
+//│ ╟── Note: Type class type parameter is defined at: 
+//│ ║  l.1: 	class Base1[A]
+//│ ╙──     	            ^
 //│ ╔══[ERROR] Type mismatch in def definition:
 //│ ║  l.89: 	def bar1 = foo
 //│ ║        	           ^^^

--- a/shared/src/test/diff/mlscript/MethodAndMatches.mls
+++ b/shared/src/test/diff/mlscript/MethodAndMatches.mls
@@ -137,7 +137,7 @@ def bar1 = foo
 //│ ╟── from applied type reference:
 //│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ║        	                               ^^^^^^^^^^
-//│ ╟── Note: Type class type parameter is defined at: 
+//│ ╟── Note: Class type parameter is defined at: 
 //│ ║  l.1: 	class Base1[A]
 //│ ╙──     	            ^
 //│ ╔══[ERROR] Type mismatch in def definition:
@@ -191,7 +191,7 @@ def bar1 = foo
 //│ ╟── from applied type reference:
 //│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ║        	                               ^^^^^^^^^^
-//│ ╟── Note: Type class type parameter is defined at: 
+//│ ╟── Note: Class type parameter is defined at: 
 //│ ║  l.1: 	class Base1[A]
 //│ ╙──     	            ^
 //│ ╔══[ERROR] Type mismatch in def definition:
@@ -213,7 +213,7 @@ def bar1 = foo
 //│ ╟── from applied type reference:
 //│ ║  l.77: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ║        	                               ^^^^^^^^^^
-//│ ╟── Note: Type class type parameter is defined at: 
+//│ ╟── Note: Class type parameter is defined at: 
 //│ ║  l.1: 	class Base1[A]
 //│ ╙──     	            ^
 //│ ╔══[ERROR] Type mismatch in def definition:
@@ -253,19 +253,19 @@ def bar2 = foo
 //│   <:  bar2:
 //│ Base1['a] -> 'a -> Base1['a]
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.242: 	def bar2 = foo
+//│ ║  l.251: 	def bar2 = foo
 //│ ║         	           ^^^
 //│ ╟── expression of type `int` does not match type `'a`
 //│ ║  l.3: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                      ^^^
 //│ ╟── Note: constraint arises from type variable:
-//│ ║  l.229: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║  l.238: 	def bar2: Base1['a] -> 'a -> Base1['a]
 //│ ╙──       	                ^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.242: 	def bar2 = foo
+//│ ║  l.251: 	def bar2 = foo
 //│ ║         	           ^^^
 //│ ╟── expression of type `'a` does not match type `int`
-//│ ║  l.229: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║  l.238: 	def bar2: Base1['a] -> 'a -> Base1['a]
 //│ ║         	                ^^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.3: 	class Derived1: Base1[int] & { x: int }
@@ -280,10 +280,10 @@ def bar2 = foo
 //│ ║  l.20: 	def foo b x = case b of {
 //│ ╙──      	                   ^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.242: 	def bar2 = foo
+//│ ║  l.251: 	def bar2 = foo
 //│ ║         	           ^^^
 //│ ╟── expression of type `Base1['a] & ~?a | Derived1` does not match type `{x: int}`
-//│ ║  l.229: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║  l.238: 	def bar2: Base1['a] -> 'a -> Base1['a]
 //│ ║         	          ^^^^^^^^^
 //│ ╟── Note: constraint arises from record type:
 //│ ║  l.3: 	class Derived1: Base1[int] & { x: int }

--- a/shared/src/test/diff/mlscript/SimpleMethods.mls
+++ b/shared/src/test/diff/mlscript/SimpleMethods.mls
@@ -8,7 +8,10 @@ class C0
 //│ ║       	                         ^^^
 //│ ╟── expression of type `A` does not match type `int`
 //│ ║  l.4: 	  method Foo0[A](a: A) = a + 1
-//│ ╙──     	                         ^
+//│ ║       	                         ^
+//│ ╟── Note: Type method type parameter is defined at: 
+//│ ║  l.4: 	  method Foo0[A](a: A) = a + 1
+//│ ╙──     	              ^
 //│ Defined class C0
 //│ Defined C0.Foo0: C0 -> anything -> (error | int)
 //│ Defined C0.Foo1: C0 -> 'A -> {a: 'A}
@@ -60,7 +63,10 @@ class C5[A]
 //│ ║        	                   ^^^
 //│ ╟── expression of type `A` does not match type `int`
 //│ ║  l.57: 	  method F(x: A) = x + 1
-//│ ╙──      	                   ^
+//│ ║        	                   ^
+//│ ╟── Note: Type class type parameter is defined at: 
+//│ ║  l.56: 	class C5[A]
+//│ ╙──      	         ^
 //│ Defined class C5
 //│ Defined C5.F: C5['A] -> 'A -> (error | int)
 

--- a/shared/src/test/diff/mlscript/SimpleMethods.mls
+++ b/shared/src/test/diff/mlscript/SimpleMethods.mls
@@ -9,7 +9,7 @@ class C0
 //│ ╟── expression of type `A` does not match type `int`
 //│ ║  l.4: 	  method Foo0[A](a: A) = a + 1
 //│ ║       	                         ^
-//│ ╟── Note: Type method type parameter is defined at: 
+//│ ╟── Note: Method type parameter is defined at: 
 //│ ║  l.4: 	  method Foo0[A](a: A) = a + 1
 //│ ╙──     	              ^
 //│ Defined class C0
@@ -59,13 +59,13 @@ class C4: C3
 class C5[A]
   method F(x: A) = x + 1
 //│ ╔══[ERROR] Type mismatch in operator application:
-//│ ║  l.57: 	  method F(x: A) = x + 1
+//│ ║  l.60: 	  method F(x: A) = x + 1
 //│ ║        	                   ^^^
 //│ ╟── expression of type `A` does not match type `int`
-//│ ║  l.57: 	  method F(x: A) = x + 1
+//│ ║  l.60: 	  method F(x: A) = x + 1
 //│ ║        	                   ^
-//│ ╟── Note: Type class type parameter is defined at: 
-//│ ║  l.56: 	class C5[A]
+//│ ╟── Note: Class type parameter is defined at: 
+//│ ║  l.59: 	class C5[A]
 //│ ╙──      	         ^
 //│ Defined class C5
 //│ Defined C5.F: C5['A] -> 'A -> (error | int)
@@ -84,7 +84,7 @@ class Hey
     rec method A = B
     rec method B = 1
 //│ ╔══[ERROR] identifier not found: B
-//│ ║  l.78: 	    rec method A = B
+//│ ║  l.84: 	    rec method A = B
 //│ ╙──      	                   ^
 //│ Defined class Hey
 //│ Defined Hey.A: Hey -> error

--- a/shared/src/test/diff/mlscript/Wildcards.mls
+++ b/shared/src/test/diff/mlscript/Wildcards.mls
@@ -41,7 +41,7 @@ E{} : E[?]
 //│ ╟── Note: constraint arises from type wildcard:
 //│ ║  l.32: 	E{} : E[?]
 //│ ║        	        ^
-//│ ╟── Note: Type class type parameter is defined at: 
+//│ ╟── Note: Class type parameter is defined at: 
 //│ ║  l.28: 	class E[A]
 //│ ╙──      	        ^
 //│ res: E[?]
@@ -62,18 +62,18 @@ type Als1[A] = int -> A
 :e
 add 1 : Als1[?]
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.60: 	add 1 : Als1[?]
+//│ ║  l.63: 	add 1 : Als1[?]
 //│ ║        	^^^^^
 //│ ╟── expression of type `int` does not match type `nothing`
 //│ ╟── but it flows into application of type `?a`
-//│ ║  l.60: 	add 1 : Als1[?]
+//│ ║  l.63: 	add 1 : Als1[?]
 //│ ║        	^^^^^
 //│ ╟── which does not match type `Als1[?]`
 //│ ╟── Note: constraint arises from type wildcard:
-//│ ║  l.60: 	add 1 : Als1[?]
+//│ ║  l.63: 	add 1 : Als1[?]
 //│ ║        	             ^
 //│ ╟── from function type:
-//│ ║  l.56: 	type Als1[A] = int -> A
+//│ ║  l.59: 	type Als1[A] = int -> A
 //│ ╙──      	               ^^^^^^^^
 //│ res: int -> anything
 //│    = [Function (anonymous)]
@@ -93,10 +93,10 @@ type Als2[A] = A -> int
 :e
 add 1 : Als2[?]
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.91: 	add 1 : Als2[?]
+//│ ║  l.94: 	add 1 : Als2[?]
 //│ ║        	^^^^^
 //│ ╟── expression of type `anything` does not match type `int`
-//│ ║  l.91: 	add 1 : Als2[?]
+//│ ║  l.94: 	add 1 : Als2[?]
 //│ ╙──      	             ^
 //│ res: nothing -> int
 //│    = [Function (anonymous)]
@@ -122,13 +122,13 @@ q = 1
 :e
 q + 1
 //│ ╔══[ERROR] Type mismatch in operator application:
-//│ ║  l.120: 	q + 1
+//│ ║  l.123: 	q + 1
 //│ ║         	^^^
 //│ ╟── expression of type `anything` does not match type `int`
-//│ ║  l.110: 	def q: ?
+//│ ║  l.113: 	def q: ?
 //│ ║         	       ^
 //│ ╟── but it flows into reference with expected type `int`
-//│ ║  l.120: 	q + 1
+//│ ║  l.123: 	q + 1
 //│ ╙──       	^
 //│ res: error | int
 //│    = 2
@@ -136,13 +136,13 @@ q + 1
 :e
 q q
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.134: 	q q
+//│ ║  l.137: 	q q
 //│ ║         	^^^
 //│ ╟── expression of type `anything` is not a function
-//│ ║  l.110: 	def q: ?
+//│ ║  l.113: 	def q: ?
 //│ ║         	       ^
 //│ ╟── but it flows into reference with expected type `anything -> ?a`
-//│ ║  l.134: 	q q
+//│ ║  l.137: 	q q
 //│ ╙──       	^
 //│ res: error
 //│ Runtime error:

--- a/shared/src/test/diff/mlscript/Wildcards.mls
+++ b/shared/src/test/diff/mlscript/Wildcards.mls
@@ -40,6 +40,9 @@ E{} : E[?]
 //│ ╟── which does not match type `E[?]`
 //│ ╟── Note: constraint arises from type wildcard:
 //│ ║  l.32: 	E{} : E[?]
+//│ ║        	        ^
+//│ ╟── Note: Type class type parameter is defined at: 
+//│ ║  l.28: 	class E[A]
 //│ ╙──      	        ^
 //│ res: E[?]
 //│    = E {}


### PR DESCRIPTION
Add a boolean isOrigin to type provenances to reflect whether a provenance is an origin prov or not.
When using the toString method of a type provenance we prepend "o:" in front of an origin prov.
When we report an error, we add a note at the end of the error to explain where the type is defined when there is an origin prov.
We also modified the selection of lhs prov so that the one printed for the error is not an origin prov.

#66 