### PR TITLE
Refactor `MethodType`

### DIFF
--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -37,12 +37,9 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
         baseClasses.iterator.filterNot(traversed).flatMap(v =>
           ctx.tyDefs.get(v.name).fold(Set.empty[Var])(_.allBaseClasses(ctx)(traversed + v)))
     val (tparams: List[TypeName], targs: List[TypeVariable]) = tparamsargs.unzip
-    def wrapMethod(pt: PolymorphicType, prov: TypeProvenance): MethodType = {
-      val thisTy = TypeRef(nme, targs)(prov)
-      MethodType(pt.level, S(FunctionType(singleTup(thisTy), pt.body)(prov)), nme)(prov)
-    }
-    def wrapMethod(mt: MethodType): MethodType =
-      if (mt.body.nonEmpty) wrapMethod(mt.toPT, mt.prov) else mt.copy(parents = nme :: Nil)
+    def thisTy(implicit prov: TypeProvenance): TypeRef = TypeRef(nme, targs)(prov)
+    def wrapMethod(pt: PolymorphicType, prov: TypeProvenance): MethodType =
+      MethodType(pt.level, S((thisTy(prov), pt.body)), nme)(prov)
   }
   
   private case class MethodDefs(
@@ -68,9 +65,13 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
               TypeProvenance(tn.toLoc, "inherited method declaration")))
         }
       )
-    private def addParent(prt: TypeName): MethodDefs =
-      copy(decls = decls.view.mapValues(mt => mt.copy(parents = prt :: mt.parents)).toMap)
-    def propagate(top: Bool = true)(implicit raise: Raise): MethodDefs =
+    private def addParent(prt: TypeName)(implicit ctx: Ctx): MethodDefs = {
+      val td = ctx.tyDefs(prt.name)
+      def addThis(mt: MethodType): MethodType = mt.copy(body = mt.body.map(b => b.copy(_1 = td.thisTy(mt.prov))))
+      def add(mt: MethodType): MethodType = mt.copy(parents = prt :: mt.parents)
+      copy(decls = decls.view.mapValues(addThis).mapValues(add).toMap, defns = defns.view.mapValues(addThis).toMap)
+    }
+    def propagate(top: Bool = true)(implicit ctx: Ctx, raise: Raise): MethodDefs =
       parents.map(_.propagate(false)).reduceOption(_.&(_)(tn, defns.keySet)).map(_.addParent(tn))
         .foldRight(if (top) MethodDefs(tn, Nil, Map.empty, Map.empty) else copy(parents = Nil))((mds1, mds2) =>
           mds2.copy(decls = mds1.decls ++ mds2.decls, defns = mds1.defns ++ mds2.defns))
@@ -513,8 +514,8 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
               val bodyTy = subst(rhs.fold(
                 term => ctx.getMthDefn(prt.name, nme.name)
                   .fold(typeLetRhs(rec, nme.name, term)(thisCtx, raise, targsMap2))(mt =>
-                    subst(mt.toPT, td2.targs.lazyZip(tr.targs).toMap) match {
-                      // Try to wnwrap one layer of prov, which would have been wrapped by the original call to `go`,
+                    subst(mt.bodyPT, td2.targs.lazyZip(tr.targs).toMap) match {
+                      // Try to wnwrap one layer of prov, which would have been wrapped by `MethodType.bodyPT`,
                       // and will otherwise mask the more precise new prov that contains "inherited"
                       case PolymorphicType(level, ProvType(underlying)) =>
                         PolymorphicType(level, underlying)
@@ -531,7 +532,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
                 if (top) thisCtx.addMth(S(td.nme.name), nme.name, mthTy)
                 thisCtx.addMth(N, nme.name, mthTy)
               }
-              nme.name -> MethodType(thisCtx.lvl, S(ProvType(bodyTy.body)(prov)), td2.nme)(prov)
+              nme.name -> mthTy
           }
           MethodDefs(td2.nme, filterTR(tr.expand).map(rec(_)(thisCtx)),
             td2.mthDecls.iterator.map(go).toMap, td2.mthDefs.iterator.map(go).toMap)
@@ -548,7 +549,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
         val rigidtargs = td.targs.map(freshenAbove(ctx.lvl, _, true))
         val targsMap = td.targs.lazyZip(rigidtargs).toMap[SimpleType, SimpleType]
         def ss(mt: MethodType, bmt: MethodType)(implicit prov: TypeProvenance) =
-          constrain(subst(mt.toPT, targsMap).instantiate, subst(bmt.toPT, targsMap).rigidify)
+          constrain(subst(mt.bodyPT, targsMap).instantiate, subst(bmt.bodyPT, targsMap).rigidify)
         def registerImplicit(mn: Str, mthTy: MethodType) = ctx.getMth(N, mn) match {
           // If the currently registered method belongs to one of the base classes of this class,
           // then we don't need to do anything.
@@ -582,16 +583,14 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
           println(s">> Checking subsumption (against inferred type) for inferred type of $mn : $mt")
         }
         declsInherit.foreach { case mn -> mt =>
-          val mthTy = td.wrapMethod(mt)
-          ctx.addMth(S(tn.name), mn, mthTy)
+          ctx.addMth(S(tn.name), mn, mt)
         }
         defnsInherit.foreach { case mn -> mt => 
           println(s">> Checking subsumption for inferred type of $mn : $mt")
           (if (decls.isDefinedAt(mn) && !defns.isDefinedAt(mn)) decls.get(mn) else N).orElse(declsInherit.get(mn))
             .foreach(ss(mt, _)(mt.prov))
-          val mthTy = td.wrapMethod(mt)
           if (!declsInherit.get(mn).exists(decl => decl.single && decl.parents.last === mt.parents.last))
-            ctx.addMth(S(tn.name), mn, mthTy)
+            ctx.addMth(S(tn.name), mn, mt)
         }
         decls.foreach { case mn -> mt =>
           println(s">> Checking subsumption for declared type of $mn : $mt")
@@ -607,9 +606,8 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
               S(defn)
             case (N, N) => N
           }).foreach(ss(mt, _)(mt.prov))
-          val mthTy = td.wrapMethod(mt)
-          ctx.addMth(S(tn.name), mn, mthTy)
-          registerImplicit(mn, mthTy)
+          ctx.addMth(S(tn.name), mn, mt)
+          registerImplicit(mn, mt)
         }
         defns.foreach { case mn -> mt => 
           implicit val prov: TypeProvenance = mt.prov
@@ -622,15 +620,14 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
             case (S(decl), N) => S(decl)
             case (N, N) => N
           }).foreach(ss(mt, _))
-          val mthTy = td.wrapMethod(mt)
           if (!decls.isDefinedAt(mn)) {
             // If the class declares that method explicitly,
             //   the declared signature is used so we don't have to do anything
             // If the class does not declare that method explicitly (it could be inherited),
             //   we still want to make the method available using its inferred signature
             //   both for implicit method calls and for explicit ones
-            ctx.addMth(S(tn.name), mn, mthTy)
-            registerImplicit(mn, mthTy)
+            ctx.addMth(S(tn.name), mn, mt)
+            registerImplicit(mn, mt)
           }
           ctx.addMthDefn(tn.name, mn, mt)
         }

--- a/shared/src/main/scala/mlscript/TyperDatatypes.scala
+++ b/shared/src/main/scala/mlscript/TyperDatatypes.scala
@@ -39,32 +39,39 @@ abstract class TyperDatatypes extends TyperHelpers { self: Typer =>
     def rigidify(implicit lvl: Int): SimpleType = freshenAbove(level, body, rigidify = true)
   }
   
-  // single: whether the method declaration comes from a single class, and not the intersection of multiple inherited declarations
-  class MethodType(val level: Int, val body: Opt[SimpleType], val parents: List[TypeName], val single: Bool)
+  /** body._1: implicit `this` parameter
+   *  body._2: actual body of the method
+   *  single: whether the method declaration comes from a single class, and not the intersection of multiple inherited declarations
+   */
+  class MethodType(val level: Int, val body: Opt[(SimpleType, SimpleType)], val parents: List[TypeName], val single: Bool)
       (val prov: TypeProvenance) {
     def &(that: MethodType): MethodType = {
       require(this.level === that.level)
-      MethodType(level, mergeOptions(this.body, that.body)(_ & _), (this.parents ::: that.parents).distinct, false)(prov)
+      MethodType(level, mergeOptions(this.body, that.body)((b1, b2) => (b1._1 & b2._1, b1._2 & b2._2)),
+        (this.parents ::: that.parents).distinct, false)(prov)
     }
     def +(that: MethodType): MethodType =
       if (this.parents === that.parents) that
       else MethodType(0, N, (this.parents ::: that.parents).distinct)(prov)
-    val toPT: PolymorphicType = body.fold(PolymorphicType(0, errType))(PolymorphicType(level, _))
+    val toPT: PolymorphicType =
+      body.fold(PolymorphicType(0, errType))(b => PolymorphicType(level, FunctionType(singleTup(b._1), b._2)(prov)))
+    val bodyPT: PolymorphicType =
+      body.fold(PolymorphicType(0, errType))(b => PolymorphicType(level, ProvType(b._2)(prov)))
     def instantiate(implicit lvl: Int): SimpleType = toPT.instantiate
     def rigidify(implicit lvl: Int): SimpleType = toPT.rigidify
-    def copy(level: Int = this.level, body: Opt[SimpleType] = this.body, parents: List[TypeName] = this.parents): MethodType =
+    def copy(level: Int = this.level, body: Opt[(SimpleType, SimpleType)] = this.body, parents: List[TypeName] = this.parents): MethodType =
       MethodType(level, body, parents, this.single)(prov)
     override def toString: Str = s"MethodType($level,$body,$parents,$single)"
   }
   object MethodType {
-    def apply(level: Int, body: Opt[SimpleType], parent: TypeName)(prov: TypeProvenance): MethodType =
+    def apply(level: Int, body: Opt[(SimpleType, SimpleType)], parent: TypeName)(prov: TypeProvenance): MethodType =
       MethodType(level, body, parent :: Nil, true)(prov)
-    def apply(level: Int, body: Opt[SimpleType], parents: List[TypeName])(prov: TypeProvenance): MethodType =
+    def apply(level: Int, body: Opt[(SimpleType, SimpleType)], parents: List[TypeName])(prov: TypeProvenance): MethodType =
       MethodType(level, body, parents, true)(prov)
-    private def apply(level: Int, body: Opt[SimpleType], parents: List[TypeName], single: Bool)
+    private def apply(level: Int, body: Opt[(SimpleType, SimpleType)], parents: List[TypeName], single: Bool)
         (implicit prov: TypeProvenance): MethodType =
       new MethodType(level, body, parents, single)(prov)
-    def unapply(mt: MethodType): S[(Int, Opt[SimpleType], List[TypeName])] = S((mt.level, mt.body, mt.parents))
+    def unapply(mt: MethodType): S[(Int, Opt[(SimpleType, SimpleType)], List[TypeName])] = S((mt.level, mt.body, mt.parents))
   }
   
   /** A type without universally quantified type variables. */

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -619,14 +619,14 @@ t : Dup[int, bool]
 :stats
 t.MthDup (fun x -> mul 2 x)
 //│ res: int
-//│ constrain calls  : 100
+//│ constrain calls  : 98
 //│ annoying  calls  : 36
 //│ subtyping calls  : 57
 
 :stats
 t.MthDup id
 //│ res: 42
-//│ constrain calls  : 85
+//│ constrain calls  : 83
 //│ annoying  calls  : 32
 //│ subtyping calls  : 68
 

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -287,7 +287,7 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite with org.scalatest.Pa
                 (ttd.mthDecls ++ ttd.mthDefs).foreach {
                   case MethodDef(_, _, Var(mn), _, rhs) =>
                     rhs.fold(
-                      _ => ctx.getMthDefn(tn, mn).map(md => ttd.wrapMethod(md)),
+                      _ => ctx.getMthDefn(tn, mn),
                       _ => ctx.getMth(S(tn), mn)
                     ).foreach(res => output(s"${rhs.fold(
                       _ => "Defined",  // the method has been defined


### PR DESCRIPTION
In the past, method body types were wrapped in a `FunctionType` with the implicit `this` parameter after type checking is completed. This resulted in some ambiguity as the `MethodType`s within `Typer.processTypeDefs.typeMethods` are not wrapped, while the ones registered to the `Ctx` are wrapped, but with no way to distinguish them.

This PR moves the wrapping logic to `MethodType`, requiring a pair of the `this` parameter and and the actual body type, and wrapping them in `toPT`. A new `bodyPT` val stores the unwrapped body type.

~~Idk why but somehow saved 4 constrain calls~~