### PR TITLE
Fix locations, type provenances, and error messages for mutable fields

### DIFF
--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -969,16 +969,17 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
         val vl = typeTerm(rhs)
         con(vl, fieldType, UnitType.withProv(prov))
       case Assign(s @ Subs(a, i), rhs) => 
-        val a_ty = typeTerm(a)
         val i_ty = typeTerm(i)
         con(i_ty, IntType, TopType)
+        val a_ty = typeTerm(a)
         val sprov = tp(s.toLoc, "assigned array element")
         val elemType = freshVar(sprov)
-        val vl = typeTerm(rhs)
         val arr_ty =
             // Note: this proxy does not seem to make any difference:
             mkProxy(a_ty, tp(a.toCoveringLoc, "receiver"))
         con(arr_ty, ArrayType(FieldType(Some(elemType), elemType)(sprov))(prov), UnitType.withProv(prov))
+        val vl = typeTerm(rhs)
+        con(vl, elemType, UnitType.withProv(prov))
       case Assign(lhs, rhs) =>
         err(msg"Illegal assignment" -> prov.loco
           :: msg"cannot assign to ${lhs.describe}" -> lhs.toLoc :: Nil)

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -133,16 +133,17 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
     override def toString: Str = "[NO PROV]"
   }
   def noProv: TypeProvenance = NoProv
+  def noTyProv: TypeProvenance = TypeProvenance(N, "type", isType = true)
   
-  val TopType: ExtrType = ExtrType(false)(noProv)
-  val BotType: ExtrType = ExtrType(true)(noProv)
-  val UnitType: ClassTag = ClassTag(Var("unit"), Set.empty)(noProv)
-  val BoolType: ClassTag = ClassTag(Var("bool"), Set.empty)(noProv)
-  val TrueType: ClassTag = ClassTag(Var("true"), Set.single(Var("bool")))(noProv)
-  val FalseType: ClassTag = ClassTag(Var("false"), Set.single(Var("bool")))(noProv)
-  val IntType: ClassTag = ClassTag(Var("int"), Set.single(Var("number")))(noProv)
-  val DecType: ClassTag = ClassTag(Var("number"), Set.empty)(noProv)
-  val StrType: ClassTag = ClassTag(Var("string"), Set.empty)(noProv)
+  val TopType: ExtrType = ExtrType(false)(noTyProv)
+  val BotType: ExtrType = ExtrType(true)(noTyProv)
+  val UnitType: ClassTag = ClassTag(Var("unit"), Set.empty)(noTyProv)
+  val BoolType: ClassTag = ClassTag(Var("bool"), Set.empty)(noTyProv)
+  val TrueType: ClassTag = ClassTag(Var("true"), Set.single(Var("bool")))(noTyProv)
+  val FalseType: ClassTag = ClassTag(Var("false"), Set.single(Var("bool")))(noTyProv)
+  val IntType: ClassTag = ClassTag(Var("int"), Set.single(Var("number")))(noTyProv)
+  val DecType: ClassTag = ClassTag(Var("number"), Set.empty)(noTyProv)
+  val StrType: ClassTag = ClassTag(Var("string"), Set.empty)(noTyProv)
   
   val ErrTypeId: SimpleTerm = Var("error")
   
@@ -163,12 +164,14 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
     TypeDef(Cls, TypeName("error"), Nil, Nil, TopType, Nil, Nil, Set.empty, N) ::
     TypeDef(Cls, TypeName("unit"), Nil, Nil, TopType, Nil, Nil, Set.empty, N) ::
     {
-      val tv = freshVar(noProv)(1)
-      TypeDef(Als, TypeName("Array"), List(TypeName("A") -> tv), Nil, ArrayType(FieldType(None, tv)(noProv))(noProv), Nil, Nil, Set.empty, N)
+      val tv = freshVar(noTyProv)(1)
+      TypeDef(Als, TypeName("Array"), List(TypeName("A") -> tv), Nil,
+        ArrayType(FieldType(None, tv)(noTyProv))(noTyProv), Nil, Nil, Set.empty, N)
     } ::
     {
-      val tv = freshVar(noProv)(1)
-      TypeDef(Als, TypeName("MutArray"), List(TypeName("A") -> tv), Nil, ArrayType(FieldType(Some(tv), tv)(noProv))(noProv), Nil, Nil, Set.empty, N)
+      val tv = freshVar(noTyProv)(1)
+      TypeDef(Als, TypeName("MutArray"), List(TypeName("A") -> tv), Nil,
+        ArrayType(FieldType(Some(tv), tv)(noTyProv))(noTyProv), Nil, Nil, Set.empty, N)
     } ::
     Nil
   val primitiveTypes: Set[Str] =
@@ -404,7 +407,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
                 case _ =>
                   val fields = fieldsOf(td.bodyTy, true)
                   val tparamTags = td.tparamsargs.map { case (tp, tv) =>
-                    tparamField(td.nme, tp) -> FieldType(Some(tv), tv)(prov) }
+                    tparamField(td.nme, tp) -> FieldType(Some(tv), tv)(tv.prov) }
                   val ctor = k match {
                     case Cls =>
                       val nomTag = clsNameToNomTag(td)(originProv(td.nme.toLoc, "class", td.nme.name), ctx)
@@ -414,8 +417,10 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
                           val fv = freshVar(noProv,
                             S(f._1.name.drop(f._1.name.indexOf('#') + 1)) // strip any "...#" prefix
                           )(1).tap(_.upperBounds ::= f._2.ub)
-                          // ? not sure if we can do this
-                          f._1 -> (if (f._2.lb.isDefined) FieldType(Some(fv), fv)(prov) else fv.toUpper)
+                          f._1 -> (
+                            if (f._2.lb.isDefined) FieldType(Some(fv), fv)(f._2.prov)
+                            else fv.toUpper(f._2.prov)
+                          )
                         }).toList
                       PolymorphicType(0, FunctionType(
                         singleTup(RecordType.mk(fieldsRefined.filterNot(_._1.name.isCapitalized))(noProv)),
@@ -676,7 +681,9 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
       case Bounds(lb, ub) => TypeBounds(rec(lb), rec(ub))(tyTp(ty.toLoc,
         if (lb === Bot && ub === Top) "type wildcard" else "type bounds"))
       case Tuple(fields) =>
-        TupleType(fields.mapValues(f => FieldType(f.in.map(rec), rec(f.out))(tyTp(ty.toLoc, "tuple field"))))(tyTp(ty.toLoc, "tuple type"))
+        TupleType(fields.mapValues(f =>
+            FieldType(f.in.map(rec), rec(f.out))(tp(f.toLoc, "tuple field"))
+          ))(tyTp(ty.toLoc, "tuple type"))
       case Inter(lhs, rhs) => (if (simplify) rec(lhs) & (rec(rhs), _: TypeProvenance)
           else ComposedType(false, rec(lhs), rec(rhs)) _
         )(tyTp(ty.toLoc, "intersection type"))
@@ -694,12 +701,15 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
         RecordType.mk(fs.map { nt =>
             if (nt._1.name.isCapitalized)
               err(msg"Field identifiers must start with a small letter", nt._1.toLoc)(raise)
-            nt._1 -> FieldType(nt._2.in.map(rec), rec(nt._2.out))(prov)
+            nt._1 -> FieldType(nt._2.in.map(rec), rec(nt._2.out))(
+              tp(App(nt._1, Var("").withLocOf(nt._2)).toCoveringLoc,
+                (if (nt._2.in.isDefined) "mutable " else "") + "record field"))
           })(prov)
       case Function(lhs, rhs) => FunctionType(rec(lhs), rec(rhs))(tyTp(ty.toLoc, "function type"))
       case WithExtension(b, r) => WithType(rec(b),
         RecordType(
-            r.fields.mapValues(f => FieldType(f.in.map(rec), rec(f.out))(tyTp(ty.toLoc, "extension field")))
+            r.fields.map { case (n, f) => n -> FieldType(f.in.map(rec), rec(f.out))(
+              tyTp(App(n, Var("").withLocOf(f)).toCoveringLoc, "extension field")) }
           )(tyTp(r.toLoc, "extension record")))(tyTp(ty.toLoc, "extension type"))
       case Literal(lit) => ClassTag(lit, lit.baseClasses)(tyTp(ty.toLoc, "literal type"))
       case tn @ TypeName(name) =>
@@ -907,7 +917,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
         typeTerm(lhs) | (typeTerm(rhs), prov)
       case App(App(Var("&"), lhs), rhs) =>
         typeTerm(lhs) & (typeTerm(rhs), prov)
-      case Rcd(fs) => // TODO rm: no longer used?
+      case Rcd(fs) =>
         val prov = tp(term.toLoc, "record literal")
         fs.groupMap(_._1.name)(_._1).foreach { case s -> fieldNames if fieldNames.size > 1 => err(
             msg"Multiple declarations of field name ${s} in ${prov.desc}" -> term.toLoc
@@ -918,22 +928,24 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
           if (n.name.isCapitalized)
             err(msg"Field identifiers must start with a small letter", term.toLoc)(raise)
           val tym = typeTerm(t)
+          val fprov = tp(App(n, t).toLoc, (if (mut) "mutable " else "") + "record field")
           if (mut) {
             val res = freshVar(prov)
             val rs = con(tym, res, res)
-            (n, FieldType(Some(rs), rs)(prov))
-          } else (n, tym.toUpper(prov))
+            (n, FieldType(Some(rs), rs)(fprov))
+          } else (n, tym.toUpper(fprov))
         })(prov)
       case tup: Tup if funkyTuples =>
         typeTerms(tup :: Nil, false, Nil)
       case Tup(fs) =>
-        TupleType(fs.map{ case (n, (t, mut)) =>
+        TupleType(fs.map { case (n, (t, mut)) =>
           val tym = typeTerm(t)
+          val fprov = tp(t.toLoc, "tuple field")
           if (mut) {
-            val res = freshVar(prov)
+            val res = freshVar(tym.prov)
             val rs = con(tym, res, res)
-            (n, FieldType(Some(rs), rs)(prov))
-          } else (n, tym.toUpper)
+            (n, FieldType(Some(rs), rs)(fprov))
+          } else (n, tym.toUpper(fprov))
         })(fs match {
           case Nil | ((N, _) :: Nil) => noProv
           case _ => tp(term.toLoc, "tuple literal")
@@ -941,33 +953,40 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
       case Subs(a, i) =>
         val t_a = typeTerm(a)
         val t_i = typeTerm(i)
-        val res = freshVar(prov)
-        con(t_a, ArrayType(res.toUpper)(prov), t_a)
-        con(t_i, IntType, t_i)
-        res
-      case Assign(s @ Sel(r, f), rhs) => 
+        con(t_i, IntType, TopType)
+        val elemType = freshVar(prov)
+        con(t_a, ArrayType(elemType.toUpper(tp(i.toLoc, "array element")))(prov), elemType)
+      case Assign(s @ Sel(r, f), rhs) =>
         val o_ty = typeTerm(r)
-        val res = freshVar(prov)
+        val sprov = tp(s.toLoc, "assigned selection")
+        val fieldType = freshVar(sprov)
+        val obj_ty =
+          // Note: this proxy does not seem to make any difference:
+          mkProxy(o_ty, tp(r.toCoveringLoc, "receiver"))
+        con(obj_ty, RecordType.mk((f, FieldType(Some(fieldType), fieldType)(
+          tp(f.toLoc, "assigned field")
+        )) :: Nil)(sprov), fieldType)
         val vl = typeTerm(rhs)
-        val obj_ty = mkProxy(o_ty, tp(r.toCoveringLoc, "receiver"))
-        val rf = con(obj_ty, RecordType.mk((f, FieldType(Some(res), res)(prov)) :: Nil)(prov), res)
-        con(vl, rf, vl)
-        UnitType
+        con(vl, fieldType, UnitType.withProv(prov))
       case Assign(s @ Subs(a, i), rhs) => 
         val a_ty = typeTerm(a)
-        val res = freshVar(prov)
+        val i_ty = typeTerm(i)
+        con(i_ty, IntType, TopType)
+        val sprov = tp(s.toLoc, "assigned array element")
+        val elemType = freshVar(sprov)
         val vl = typeTerm(rhs)
-        val arr_ty = mkProxy(a_ty, tp(a.toCoveringLoc, "receiver"))
-        con(arr_ty, ArrayType(FieldType(Some(res), res)(prov))(prov), res)
-        con(vl, IntType, vl)
-        UnitType
-      case Assign(_, rhs) => 
-        err(msg"Cannot not assign to non-field", term.toLoc)(raise)
+        val arr_ty =
+            // Note: this proxy does not seem to make any difference:
+            mkProxy(a_ty, tp(a.toCoveringLoc, "receiver"))
+        con(arr_ty, ArrayType(FieldType(Some(elemType), elemType)(sprov))(prov), UnitType.withProv(prov))
+      case Assign(lhs, rhs) =>
+        err(msg"Illegal assignment" -> prov.loco
+          :: msg"cannot assign to ${lhs.describe}" -> lhs.toLoc :: Nil)
       case Bra(false, trm: Blk) => typeTerm(trm)
       case Bra(rcd, trm @ (_: Tup | _: Blk)) if funkyTuples => typeTerms(trm :: Nil, rcd, Nil)
       case Bra(_, trm) => typeTerm(trm)
       case Blk((s: Term) :: Nil) => typeTerm(s)
-      case Blk(Nil) => UnitType
+      case Blk(Nil) => UnitType.withProv(prov)
       case pat if ctx.inPattern =>
         err(msg"Unsupported pattern shape${
           if (dbg) " ("+pat.getClass.toString+")" else ""}:", pat.toLoc)(raise)
@@ -1008,7 +1027,9 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
           val o_ty = typeTerm(obj)
           val res = freshVar(prov)
           val obj_ty = mkProxy(o_ty, tp(obj.toCoveringLoc, "receiver"))
-          con(obj_ty, RecordType.mk((fieldName, res.toUpper) :: Nil)(prov), res)
+          val rcd_ty = RecordType.mk(
+            fieldName -> res.toUpper(tp(fieldName.toLoc, "field selector")) :: Nil)(prov)
+          con(obj_ty, rcd_ty, res)
         }
         def mthCallOrSel(obj: Term, fieldName: Var) = 
           (fieldName.name match {
@@ -1190,14 +1211,14 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
       if (rcd) {
         val fs = fields.reverseIterator.zipWithIndex.map {
           case ((S(n), t), i) =>
-            n -> t.toUpper
+            n -> t.toUpper(noProv)
           case ((N, t), i) =>
             // err("Missing name for record field", t.prov.loco)
             warn("Missing name for record field", t.prov.loco)
-            (Var("_" + (i + 1)), t.toUpper)
+            (Var("_" + (i + 1)), t.toUpper(noProv))
         }.toList
         RecordType.mk(fs)(prov)
-      } else TupleType(fields.reverseIterator.mapValues(_.toUpper).toList)(prov)
+      } else TupleType(fields.reverseIterator.mapValues(_.toUpper(noProv)).toList)(prov)
   }
   
   

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -969,15 +969,15 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
         val vl = typeTerm(rhs)
         con(vl, fieldType, UnitType.withProv(prov))
       case Assign(s @ Subs(a, i), rhs) => 
-        val i_ty = typeTerm(i)
-        con(i_ty, IntType, TopType)
         val a_ty = typeTerm(a)
         val sprov = tp(s.toLoc, "assigned array element")
         val elemType = freshVar(sprov)
         val arr_ty =
             // Note: this proxy does not seem to make any difference:
             mkProxy(a_ty, tp(a.toCoveringLoc, "receiver"))
-        con(arr_ty, ArrayType(FieldType(Some(elemType), elemType)(sprov))(prov), UnitType.withProv(prov))
+        con(arr_ty, ArrayType(FieldType(Some(elemType), elemType)(sprov))(prov), elemType)
+        val i_ty = typeTerm(i)
+        con(i_ty, IntType, TopType)
         val vl = typeTerm(rhs)
         con(vl, elemType, UnitType.withProv(prov))
       case Assign(lhs, rhs) =>

--- a/shared/src/main/scala/mlscript/TyperHelpers.scala
+++ b/shared/src/main/scala/mlscript/TyperHelpers.scala
@@ -197,8 +197,8 @@ abstract class TyperHelpers { self: Typer =>
       }
     }
     
-    def toUpper(implicit prov: TypeProvenance): FieldType = FieldType(None, this)(prov)
-    def toLower(implicit prov: TypeProvenance): FieldType = FieldType(Some(this), TopType)(prov)
+    def toUpper(prov: TypeProvenance): FieldType = FieldType(None, this)(prov)
+    def toLower(prov: TypeProvenance): FieldType = FieldType(Some(this), TopType)(prov)
     
     def | (that: SimpleType, prov: TypeProvenance = noProv, swapped: Bool = false): SimpleType = (this, that) match {
       case (TopType, _) => TopType

--- a/shared/src/main/scala/mlscript/helpers.scala
+++ b/shared/src/main/scala/mlscript/helpers.scala
@@ -201,7 +201,7 @@ trait TermImpl extends StatementImpl { self: Term =>
     case Test(l, r) => "'is' test"
     case With(t, fs) =>  "`with` extension"
     case CaseOf(scrut, cases) =>  "`case` expression" 
-    case Subs(arr, idx) => "array subscript"
+    case Subs(arr, idx) => "array access"
     case Assign(lhs, rhs) => "assignment"
   }
   
@@ -288,6 +288,11 @@ trait SimpleTermImpl extends Ordered[SimpleTerm] { self: SimpleTerm =>
     case Var(name) => name
     case lit: Lit => lit.toString
   }
+}
+
+trait FieldImpl extends Located { self: Field =>
+  def children: List[Located] =
+    self.in.toList ::: self.out :: Nil
 }
 
 trait Located {

--- a/shared/src/main/scala/mlscript/syntax.scala
+++ b/shared/src/main/scala/mlscript/syntax.scala
@@ -92,7 +92,7 @@ final case class Rem(base: Type, names: Ls[Var])         extends Type
 final case class Bounds(lb: Type, ub: Type)              extends Type
 final case class WithExtension(base: Type, rcd: Record)  extends Type
 
-final case class Field(in: Option[Type], out: Type)
+final case class Field(in: Option[Type], out: Type) extends FieldImpl
 
 sealed abstract class NullaryType                        extends Type
 

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -619,7 +619,7 @@ t : Dup[int, bool]
 :stats
 t.MthDup (fun x -> mul 2 x)
 //│ res: int
-//│ constrain calls  : 96
+//│ constrain calls  : 101
 //│ annoying  calls  : 30
 //│ subtyping calls  : 50
 

--- a/shared/src/test/diff/mlscript/ExprProb.mls
+++ b/shared/src/test/diff/mlscript/ExprProb.mls
@@ -61,7 +61,7 @@ rec def eval1 k e = case e of {
   }
 //│ eval1: ('a -> int) -> ((Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit as 'b) -> int
 //│      = [Function: eval1]
-//│ constrain calls  : 81
+//│ constrain calls  : 83
 //│ annoying  calls  : 0
 //│ subtyping calls  : 1310
 
@@ -110,7 +110,7 @@ def eval1_ty_ugly = eval1
 //│   <:  eval1_ty_ugly:
 //│ ('a -> int) -> ('a & 'b & ~{val: int} & ~add | 'a & 'b & ~add & ~lit | 'a & 'b & ~{Add#E :> nothing} & ~lit | 'a & 'b & ~{lhs: anything} & ~lit | 'a & 'b & ~{rhs: anything} & ~lit | (Add['d .. 'e] with {lhs: 'c, rhs: 'c}) & 'b | Lit & 'b as 'c) -> int
 //│              = [Function: eval1]
-//│ constrain calls  : 76
+//│ constrain calls  : 81
 //│ annoying  calls  : 36
 //│ subtyping calls  : 13850
 
@@ -130,7 +130,7 @@ def eval1_ty = eval1
 //│   <:  eval1_ty:
 //│ ('a -> int) -> ('a & 'b & ~add & ~lit | (Add['d .. 'e] with {lhs: 'c, rhs: 'c}) & 'b | Lit & 'b as 'c) -> int
 //│         = [Function: eval1]
-//│ constrain calls  : 76
+//│ constrain calls  : 81
 //│ annoying  calls  : 36
 //│ subtyping calls  : 2678
 
@@ -172,7 +172,7 @@ def eval1_ty = eval1
 //│   <:  eval1_ty:
 //│ ('a -> int) -> ('a & ~add & ~lit | (Add['c .. 'd] with {lhs: 'b, rhs: 'b}) | Lit as 'b) -> int
 //│         = [Function: eval1]
-//│ constrain calls  : 80
+//│ constrain calls  : 85
 //│ annoying  calls  : 38
 //│ subtyping calls  : 2210
 
@@ -197,7 +197,7 @@ rec def prettier1 k ev e = case e of {
   }
 //│ prettier1: ('a -> string) -> ('b -> int) -> ((Add[?] with {lhs: (Add[?] with {lhs: 'c, rhs: 'c}) | Lit | 'a & ~add & ~lit as 'c, rhs: (Add[?] with {lhs: 'd, rhs: 'd}) | Lit | 'a & ~add & ~lit as 'd}) & 'b | Lit | 'a & ~add & ~lit) -> string
 //│          = [Function: prettier1]
-//│ constrain calls  : 164
+//│ constrain calls  : 167
 //│ annoying  calls  : 0
 //│ subtyping calls  : 2881
 
@@ -217,9 +217,9 @@ prettier1 done (eval1 done) e1
 //│    = '123'
 //│ res: string
 //│    = '123'
-//│ constrain calls  : 667
+//│ constrain calls  : 686
 //│ annoying  calls  : 240
-//│ subtyping calls  : 855
+//│ subtyping calls  : 859
 
 e1 = add (lit 1) (add (lit 2) (lit 3))
 eval1 done e1
@@ -263,7 +263,7 @@ rec def prettier2 k ev = prettier1 (fun x -> case x of {
   }) ev
 //│ prettier2: ('a -> string) -> ('b -> int) -> ((Add[?] with {lhs: 'd & ((Add[?] with {lhs: 'e, rhs: 'e}) | Lit | (Nega[?] with {arg: 'c}) | 'a & ~add & ~lit & ~nega as 'e), rhs: (Add[?] with {lhs: 'f, rhs: 'f}) | Lit | (Nega[?] with {arg: 'c}) | 'a & ~add & ~lit & ~nega as 'f}) & 'b | Lit | (Nega[?] with {arg: 'c}) | 'a & ~add & ~lit & ~nega as 'c) -> string
 //│          = [Function: prettier2]
-//│ constrain calls  : 174
+//│ constrain calls  : 181
 //│ annoying  calls  : 0
 //│ subtyping calls  : 54430
 
@@ -273,7 +273,7 @@ rec def prettier2 k ev = prettier1 (fun x -> case x of {
 eval2 done e1
 //│ res: int
 //│    = 6
-//│ constrain calls  : 185
+//│ constrain calls  : 197
 //│ annoying  calls  : 60
 //│ subtyping calls  : 149
 
@@ -288,7 +288,7 @@ e2 = add (lit 1) (nega e1)
 eval2 done e2
 //│ res: int
 //│    = -5
-//│ constrain calls  : 268
+//│ constrain calls  : 280
 //│ annoying  calls  : 103
 //│ subtyping calls  : 214
 
@@ -300,7 +300,7 @@ d2 = nega (add (lit 1) (nega (lit 1)))
 eval2 done d2
 //│ res: int
 //│    = 0
-//│ constrain calls  : 174
+//│ constrain calls  : 178
 //│ annoying  calls  : 71
 //│ subtyping calls  : 98
 
@@ -313,7 +313,7 @@ prettier2 done
 prettier2 done (eval1 done)
 //│ res: ((Add[?] with {lhs: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit as 'b, rhs: (Add[?] with {lhs: 'c, rhs: 'c}) | Lit as 'c}) | Lit | (Nega[?] with {arg: 'a}) as 'a) -> string
 //│    = [Function (anonymous)]
-//│ constrain calls  : 76
+//│ constrain calls  : 77
 //│ annoying  calls  : 0
 //│ subtyping calls  : 8695
 
@@ -327,9 +327,9 @@ prettier2 done (eval2 done) d2
 //│    = '1-123'
 //│ res: string
 //│    = '-1'
-//│ constrain calls  : 1012
+//│ constrain calls  : 1039
 //│ annoying  calls  : 335
-//│ subtyping calls  : 127595
+//│ subtyping calls  : 127607
 
 
 
@@ -415,9 +415,9 @@ prettier2 done (eval1 done) e2
 //│ res: error | string
 //│ Runtime error:
 //│   Error: non-exhaustive case expression
-//│ constrain calls  : 529
+//│ constrain calls  : 543
 //│ annoying  calls  : 198
-//│ subtyping calls  : 586
+//│ subtyping calls  : 594
 
 :e
 :stats
@@ -441,7 +441,7 @@ prettier2 done eval2
 //│ ╙──       	            ^^^^
 //│ res: (Lit | (Nega[?] with {arg: 'a}) as 'a) -> string | error
 //│    = [Function (anonymous)]
-//│ constrain calls  : 55
+//│ constrain calls  : 56
 //│ annoying  calls  : 0
 //│ subtyping calls  : 408
 
@@ -482,7 +482,7 @@ prettier2 done eval2 e1
 //│ ╙──       	                                ^
 //│ res: error | string
 //│    = '123'
-//│ constrain calls  : 221
+//│ constrain calls  : 222
 //│ annoying  calls  : 62
 //│ subtyping calls  : 266
 
@@ -523,7 +523,7 @@ prettier2 done eval2 e2
 //│ ╙──       	                                ^
 //│ res: error | string
 //│    = '1-123'
-//│ constrain calls  : 314
+//│ constrain calls  : 315
 //│ annoying  calls  : 107
 //│ subtyping calls  : 480
 
@@ -561,7 +561,7 @@ prettier2 done eval2 d2
 //│ ╙──       	                                       ^^^^^
 //│ res: error | string
 //│    = '-1-1'
-//│ constrain calls  : 221
+//│ constrain calls  : 222
 //│ annoying  calls  : 73
 //│ subtyping calls  : 225
 
@@ -602,7 +602,7 @@ prettier2 done eval1 e2
 //│ ╙──       	                                ^
 //│ res: error | string
 //│    = '1-123'
-//│ constrain calls  : 311
+//│ constrain calls  : 312
 //│ annoying  calls  : 107
 //│ subtyping calls  : 478
 

--- a/shared/src/test/diff/mlscript/Mut.mls
+++ b/shared/src/test/diff/mlscript/Mut.mls
@@ -14,8 +14,18 @@ muta1 : Array[int]
 
 :e
 a1: MutArray[int]
-//│ ╔══[ERROR] type mismatch in type ascription
-//│ ╙── array of `???` is not mutable
+//│ ╔══[ERROR] Type mismatch in type ascription:
+//│ ║  l.16: 	a1: MutArray[int]
+//│ ║        	^^
+//│ ╟── type `Array[int]` does not match type `MutArray[int .. int]`
+//│ ║  l.9: 	def a1: Array[int]
+//│ ║       	        ^^^^^^^^^^
+//│ ╟── but it flows into reference with expected type `MutArray[int .. int]`
+//│ ║  l.16: 	a1: MutArray[int]
+//│ ║        	^^
+//│ ╟── Note: constraint arises from applied type reference:
+//│ ║  l.16: 	a1: MutArray[int]
+//│ ╙──      	    ^^^^^^^^^^^^^
 //│ res: MutArray[int .. int]
 
 a2 = A {x=3}
@@ -33,11 +43,63 @@ rc1.x <- 3
 :e
 rc1.x <- true
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.34: 	rc1.x <- true
+//│ ║  l.44: 	rc1.x <- true
 //│ ║        	^^^^^^^^^^^^^
 //│ ╟── reference of type `true` does not match type `int`
-//│ ║  l.34: 	rc1.x <- true
-//│ ╙──      	         ^^^^
+//│ ║  l.44: 	rc1.x <- true
+//│ ║        	         ^^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.34: 	def rc1 : { mut x : int}
+//│ ║        	                    ^^^
+//│ ╟── from assigned selection:
+//│ ║  l.44: 	rc1.x <- true
+//│ ╙──      	^^^^^
+
+
+immrcd = { x = 1: int }
+immtpl = (1: int,)
+//│ immrcd: {x: int}
+//│ immtpl: (int,)
+
+immrcd.x
+immtpl._1
+immtpl[0]
+//│ res: int
+//│ res: int
+//│ res: int
+
+:e
+immrcd.x <- 0
+immtpl._1 <- 0
+immtpl[0] <- 0
+//│ ╔══[ERROR] Type mismatch in assignment:
+//│ ║  l.72: 	immrcd.x <- 0
+//│ ║        	^^^^^^^^^^^^^
+//│ ╟── record field of type `int` is not mutable
+//│ ║  l.59: 	immrcd = { x = 1: int }
+//│ ║        	           ^^^^^
+//│ ╟── but it flows into assigned field with expected type `?a`
+//│ ║  l.72: 	immrcd.x <- 0
+//│ ╙──      	       ^
+//│ ╔══[ERROR] Type mismatch in assignment:
+//│ ║  l.73: 	immtpl._1 <- 0
+//│ ║        	^^^^^^^^^^^^^^
+//│ ╟── tuple field of type `int` is not mutable
+//│ ║  l.60: 	immtpl = (1: int,)
+//│ ║        	          ^
+//│ ╟── but it flows into assigned field with expected type `?a`
+//│ ║  l.73: 	immtpl._1 <- 0
+//│ ╙──      	       ^^
+//│ ╔══[ERROR] Type mismatch in assignment:
+//│ ║  l.74: 	immtpl[0] <- 0
+//│ ║        	^^^^^^^^^^^^^^
+//│ ╟── tuple field of type `int` is not mutable
+//│ ║  l.60: 	immtpl = (1: int,)
+//│ ║        	          ^
+//│ ╟── but it flows into assigned array element with expected type `?a`
+//│ ║  l.74: 	immtpl[0] <- 0
+//│ ╙──      	^^^^^^^^^
+
 
 //FIXME
 rc2 = {mut x = 1}
@@ -72,26 +134,28 @@ t1.x <- 4
 t1.y <- true
 t2.x <- 3
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.72: 	t1.y <- true
-//│ ║        	^^^^^^^^^^^^
-//│ ╟── type `{x: int .. int, y: bool} & t` does not have field 'y'
-//│ ║  l.60: 	def t1 : T & {mut x : int; y : bool}
-//│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{y: ?a .. ?a}`
-//│ ║  l.72: 	t1.y <- true
-//│ ╙──      	^^
+//│ ║  l.134: 	t1.y <- true
+//│ ║         	^^^^^^^^^^^^
+//│ ╟── record field of type `bool` is not mutable
+//│ ║  l.122: 	def t1 : T & {mut x : int; y : bool}
+//│ ║         	                           ^^^^^^^^
+//│ ╟── but it flows into assigned field with expected type `?a`
+//│ ║  l.134: 	t1.y <- true
+//│ ╙──       	   ^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.73: 	t2.x <- 3
-//│ ║        	^^^^^^^^^
-//│ ╟── record literal of type `{x: 2}` does not match type `{x: ?a .. ?a} | ~t`
-//│ ║  l.62: 	t2 = T {x = 2}
-//│ ║        	       ^^^^^^^
-//│ ╟── but it flows into reference with expected type `{x: ?a .. ?a} | ~t`
-//│ ║  l.73: 	t2.x <- 3
-//│ ╙──      	^^
+//│ ║  l.135: 	t2.x <- 3
+//│ ║         	^^^^^^^^^
+//│ ╟── record field of type `2` is not mutable
+//│ ║  l.124: 	t2 = T {x = 2}
+//│ ║         	        ^^^^^
+//│ ╟── but it flows into assigned field with expected type `?a`
+//│ ║  l.135: 	t2.x <- 3
+//│ ╙──       	   ^
 
 class B: { mut x: int; y: bool }
+  method Foo = this.x
 //│ Defined class B
+//│ Defined B.Foo: B -> int
 
 def b1 : B
 b1 = B { mut x = 2; y = true }
@@ -102,42 +166,63 @@ b2 = B { mut x = 1; y = false}
 //│ B
 //│ b2: B with {x: int & 'x .. 1 | 'x, y: false}
 
-b2: B
-//│ res: B
+b1.Foo
+//│ res: int
+
+:e
+b1.Foo <- 0
+//│ ╔══[ERROR] Type mismatch in assignment:
+//│ ║  l.172: 	b1.Foo <- 0
+//│ ║         	^^^^^^^^^^^
+//│ ╟── type `B` does not have field 'Foo'
+//│ ║  l.160: 	def b1 : B
+//│ ║         	         ^
+//│ ╟── but it flows into reference with expected type `{Foo = ?a}`
+//│ ║  l.172: 	b1.Foo <- 0
+//│ ║         	^^
+//│ ╟── Note: constraint arises from assigned selection:
+//│ ║  l.172: 	b1.Foo <- 0
+//│ ╙──       	^^^^^^
 
 :e
 b3 = B {x = 6; y = false}
-//│ ╔══[ERROR] type mismatch in application
-//│ ║  l.93: 	class B: { mut x: int; y: bool }
-//│ ║        	      ^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── field `x` is not mutable
-//│ ║  l.109: 	b3 = B {x = 6; y = false}
-//│ ╙──       	       ^^^^^^^^^^^^^^^^^^
+//│ ╔══[ERROR] Type mismatch in application:
+//│ ║  l.176: 	b3 = B {x = 6; y = false}
+//│ ║         	     ^^^^^^^^^^^^^^^^^^^^
+//│ ╟── record field of type `6` is not mutable
+//│ ║  l.176: 	b3 = B {x = 6; y = false}
+//│ ╙──       	        ^^^^^
 //│ b3: (B with {x: int & 'x .. 6 | 'x, y: false}) | error
 
 :e
 b2.y <- b1.y
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.119: 	b2.y <- b1.y
+//│ ║  l.186: 	b2.y <- b1.y
 //│ ║         	^^^^^^^^^^^^
-//│ ╟── application of type `B with {x: ?x .. ?x, y: ?y}` does not have field 'y'
-//│ ║  l.98: 	b2 = B { mut x = 1; y = false}
-//│ ║        	     ^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{y: ?a .. ?a}`
-//│ ║  l.119: 	b2.y <- b1.y
-//│ ╙──       	^^
+//│ ╟── record field of type `?y` is not mutable
+//│ ║  l.155: 	class B: { mut x: int; y: bool }
+//│ ║         	                       ^^^^^^^
+//│ ╟── but it flows into assigned field with expected type `?a`
+//│ ║  l.186: 	b2.y <- b1.y
+//│ ╙──       	   ^
 
 :e
 b2.x <- b1.y
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.131: 	b2.x <- b1.y
+//│ ║  l.198: 	b2.x <- b1.y
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── type `bool` does not match type `int`
-//│ ║  l.93: 	class B: { mut x: int; y: bool }
-//│ ║        	                          ^^^^
+//│ ║  l.155: 	class B: { mut x: int; y: bool }
+//│ ║         	                          ^^^^
 //│ ╟── but it flows into field selection with expected type `int`
-//│ ║  l.131: 	b2.x <- b1.y
-//│ ╙──       	        ^^^^
+//│ ║  l.198: 	b2.x <- b1.y
+//│ ║         	        ^^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.155: 	class B: { mut x: int; y: bool }
+//│ ║         	                  ^^^
+//│ ╟── from assigned selection:
+//│ ║  l.198: 	b2.x <- b1.y
+//│ ╙──       	^^^^
 
 b2.x <- b1.x
 b1.x <- a2.x
@@ -155,13 +240,13 @@ h b1 2
 :e
 h {mut x = 4} 2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.156: 	h {mut x = 4} 2
+//│ ║  l.229: 	h {mut x = 4} 2
 //│ ║         	^^^^^^^^^^^^^
 //│ ╟── record literal of type `{x: ?a .. ?a}` is not an instance of type B
-//│ ║  l.156: 	h {mut x = 4} 2
+//│ ║  l.229: 	h {mut x = 4} 2
 //│ ║         	  ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.145: 	def h : B -> int -> int
+//│ ║  l.218: 	def h : B -> int -> int
 //│ ╙──       	        ^
 //│ res: error | int
 
@@ -193,12 +278,15 @@ k1._1 <- k1._1 + 1
 
 :e
 k1._2 <- 233
-//│ ╔══[ERROR] type mismatch in assignment
-//│ ║  l.195: 	k1._2 <- 233
+//│ ╔══[ERROR] Type mismatch in assignment:
+//│ ║  l.268: 	k1._2 <- 233
 //│ ║         	^^^^^^^^^^^^
-//│ ╟── field `_2` is not mutable
-//│ ║  l.190: 	k1 = (mut 233, "hello", mut true)
-//│ ╙──       	     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── tuple field of type `"hello"` is not mutable
+//│ ║  l.263: 	k1 = (mut 233, "hello", mut true)
+//│ ║         	               ^^^^^^^
+//│ ╟── but it flows into assigned field with expected type `?a`
+//│ ║  l.268: 	k1._2 <- 233
+//│ ╙──       	   ^^
 
 muta1[0] <- 1
 
@@ -215,12 +303,18 @@ amf mt3
 
 :e
 amf mt4
-//│ ╔══[ERROR] type mismatch in application
-//│ ║  l.171: 	def mt4: (mut bool, bool, bool)
+//│ ╔══[ERROR] Type mismatch in application:
+//│ ║  l.293: 	amf mt4
+//│ ║         	^^^^^^^
+//│ ╟── type `(bool .. bool, bool, bool,)` does not match type `MutArray[?a .. ?a]`
+//│ ║  l.244: 	def mt4: (mut bool, bool, bool)
 //│ ║         	         ^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── array of `???` is not mutable
-//│ ║  l.171: 	def mt4: (mut bool, bool, bool)
-//│ ╙──       	         ^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── but it flows into reference with expected type `MutArray[?a .. ?a]`
+//│ ║  l.293: 	amf mt4
+//│ ║         	    ^^^
+//│ ╟── Note: constraint arises from applied type reference:
+//│ ║  l.286: 	def amf : MutArray['a] -> 'a
+//│ ╙──       	          ^^^^^^^^^^^^
 //│ res: bool | error
 
 :e
@@ -228,19 +322,26 @@ muta1[1] <- false
 a1[0] <- 1
 mt1[0] <- mt2._1
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.227: 	muta1[1] <- false
-//│ ║         	^^^^^^^^^^^^^^^^^
-//│ ╟── reference of type `false` does not match type `int`
-//│ ║  l.227: 	muta1[1] <- false
-//│ ╙──       	            ^^^^^
-//│ ╔══[ERROR] type mismatch in assignment
-//│ ╙── array of `???` is not mutable
+//│ ║  l.310: 	a1[0] <- 1
+//│ ║         	^^^^^^^^^^
+//│ ╟── type `Array[int]` does not match type `MutArray[?a .. ?a]`
+//│ ║  l.9: 	def a1: Array[int]
+//│ ║       	        ^^^^^^^^^^
+//│ ╟── but it flows into reference with expected type `MutArray[?a .. ?a]`
+//│ ║  l.310: 	a1[0] <- 1
+//│ ╙──       	^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.229: 	mt1[0] <- mt2._1
+//│ ║  l.311: 	mt1[0] <- mt2._1
 //│ ║         	^^^^^^^^^^^^^^^^
 //│ ╟── type `int` does not match type `bool`
-//│ ║  l.168: 	def mt1: (mut int, mut bool)
-//│ ╙──       	              ^^^
+//│ ║  l.241: 	def mt1: (mut int, mut bool)
+//│ ║         	              ^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.241: 	def mt1: (mut int, mut bool)
+//│ ║         	                       ^^^^
+//│ ╟── from assigned array element:
+//│ ║  l.311: 	mt1[0] <- mt2._1
+//│ ╙──       	^^^^^^
 
 mt1._1 <- mt2._1
 mt1._1 <- mt1._1 * 2
@@ -255,40 +356,69 @@ mt1._1 <- (b1.t <- 4)
 (mt1._1 <- b1.t) <- 4
 b1.x <- 1 + 2 <- 4
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.252: 	mt1._1 <- mt1._2
+//│ ║  l.341: 	mt1._1 <- mt1._2
 //│ ║         	^^^^^^^^^^^^^^^^
 //│ ╟── type `bool` does not match type `int`
-//│ ║  l.168: 	def mt1: (mut int, mut bool)
+//│ ║  l.241: 	def mt1: (mut int, mut bool)
 //│ ║         	                       ^^^^
 //│ ╟── but it flows into field selection with expected type `int`
-//│ ║  l.252: 	mt1._1 <- mt1._2
-//│ ╙──       	          ^^^^^^
+//│ ║  l.341: 	mt1._1 <- mt1._2
+//│ ║         	          ^^^^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.241: 	def mt1: (mut int, mut bool)
+//│ ║         	              ^^^
+//│ ╟── from assigned selection:
+//│ ║  l.341: 	mt1._1 <- mt1._2
+//│ ╙──       	^^^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.253: 	mt1._2 <- 1
+//│ ║  l.342: 	mt1._2 <- 1
 //│ ║         	^^^^^^^^^^^
 //│ ╟── integer literal of type `1` does not match type `bool`
-//│ ║  l.253: 	mt1._2 <- 1
-//│ ╙──       	          ^
+//│ ║  l.342: 	mt1._2 <- 1
+//│ ║         	          ^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.241: 	def mt1: (mut int, mut bool)
+//│ ║         	                       ^^^^
+//│ ╟── from assigned selection:
+//│ ║  l.342: 	mt1._2 <- 1
+//│ ╙──       	^^^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.254: 	mt1._1 <- (b1.t <- 4)
+//│ ║  l.343: 	mt1._1 <- (b1.t <- 4)
 //│ ║         	           ^^^^^^^^^
 //│ ╟── type `B` does not have field 't'
-//│ ║  l.96: 	def b1 : B
-//│ ║        	         ^
+//│ ║  l.160: 	def b1 : B
+//│ ║         	         ^
 //│ ╟── but it flows into reference with expected type `{t: ?a .. ?a}`
-//│ ║  l.254: 	mt1._1 <- (b1.t <- 4)
-//│ ╙──       	           ^^
+//│ ║  l.343: 	mt1._1 <- (b1.t <- 4)
+//│ ║         	           ^^
+//│ ╟── Note: constraint arises from assigned selection:
+//│ ║  l.343: 	mt1._1 <- (b1.t <- 4)
+//│ ╙──       	           ^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.254: 	mt1._1 <- (b1.t <- 4)
+//│ ║  l.343: 	mt1._1 <- (b1.t <- 4)
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
-//│ ╙── expression of type `unit` does not match type `int`
-//│ ╔══[ERROR] Cannot not assign to non-field
-//│ ║  l.255: 	(mt1._1 <- b1.t) <- 4
-//│ ╙──       	^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── assignment of type `unit` does not match type `int`
+//│ ║  l.343: 	mt1._1 <- (b1.t <- 4)
+//│ ║         	           ^^^^^^^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.241: 	def mt1: (mut int, mut bool)
+//│ ║         	              ^^^
+//│ ╟── from assigned selection:
+//│ ║  l.343: 	mt1._1 <- (b1.t <- 4)
+//│ ╙──       	^^^^^^
+//│ ╔══[ERROR] Illegal assignment
+//│ ║  l.344: 	(mt1._1 <- b1.t) <- 4
+//│ ║         	^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── cannot assign to assignment
+//│ ║  l.344: 	(mt1._1 <- b1.t) <- 4
+//│ ╙──       	^^^^^^^^^^^^^^^^
 //│ res: error
-//│ ╔══[ERROR] Cannot not assign to non-field
-//│ ║  l.256: 	b1.x <- 1 + 2 <- 4
-//│ ╙──       	            ^^^^^^
+//│ ╔══[ERROR] Illegal assignment
+//│ ║  l.345: 	b1.x <- 1 + 2 <- 4
+//│ ║         	            ^^^^^^
+//│ ╟── cannot assign to integer literal
+//│ ║  l.345: 	b1.x <- 1 + 2 <- 4
+//│ ╙──       	            ^
 
 def f : {mut _1 : int} -> int -> unit
 def g : (mut int, bool) -> int -> unit
@@ -304,25 +434,22 @@ f mt1 1
 
 :e
 f mt2
-//│ ╔══[ERROR] type mismatch in application
-//│ ║  l.293: 	def f : {mut _1 : int} -> int -> unit
-//│ ║         	        ^^^^^^^^^^^^^^
-//│ ╟── field `_1` is not mutable
-//│ ║  l.169: 	def mt2: (int, int)
-//│ ╙──       	         ^^^^^^^^^^
+//│ ╔══[ERROR] Type mismatch in application:
+//│ ║  l.424: 	f mt2
+//│ ║         	^^^^^
+//│ ╟── tuple field of type `int` is not mutable
+//│ ║  l.242: 	def mt2: (int, int)
+//│ ╙──       	          ^^^
 //│ res: int -> unit | error
 
 :e
 g (1, true) 2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.316: 	g (1, true) 2
+//│ ║  l.434: 	g (1, true) 2
 //│ ║         	^^^^^^^^^^^
-//│ ╟── tuple literal of type `(1, true,)` does not match type `(int .. int, bool,)`
-//│ ║  l.316: 	g (1, true) 2
-//│ ║         	  ^^^^^^^^^
-//│ ╟── Note: constraint arises from tuple type:
-//│ ║  l.294: 	def g : (mut int, bool) -> int -> unit
-//│ ╙──       	        ^^^^^^^^^^^^^^^
+//│ ╟── tuple field of type `1` is not mutable
+//│ ║  l.434: 	g (1, true) 2
+//│ ╙──       	   ^
 //│ res: error | unit
 
 w1 = 3 with {mut x = 4}
@@ -350,12 +477,15 @@ st2._1 <- 8
 
 :e
 st1._1 <- 9
-//│ ╔══[ERROR] type mismatch in assignment
-//│ ║  l.352: 	st1._1 <- 9
+//│ ╔══[ERROR] Type mismatch in assignment:
+//│ ║  l.467: 	st1._1 <- 9
 //│ ║         	^^^^^^^^^^^
-//│ ╟── field `_1` is not mutable
-//│ ║  l.335: 	def st1 : (int, )
-//│ ╙──       	          ^^^^^^^
+//│ ╟── tuple field of type `int` is not mutable
+//│ ║  l.450: 	def st1 : (int, )
+//│ ║         	           ^^^
+//│ ╟── but it flows into assigned field with expected type `?a`
+//│ ║  l.467: 	st1._1 <- 9
+//│ ╙──       	    ^^
 
 def am1 : Array[(mut int)]
 //│ am1: Array[(int .. int,)]
@@ -371,21 +501,64 @@ foreach am1 (fun y -> y._1 <- 2)
 :e
 (1,2,3)[0] <- true
 (1,2,3)._1 <- "hello"
-//│ ╔══[ERROR] type mismatch in assignment
-//│ ║  l.372: 	(1,2,3)[0] <- true
-//│ ║         	^^^^^^^
-//│ ╟── array of `???` is not mutable
-//│ ║  l.372: 	(1,2,3)[0] <- true
+//│ ╔══[ERROR] Type mismatch in assignment:
+//│ ║  l.490: 	(1,2,3)[0] <- true
+//│ ║         	^^^^^^^^^^^^^^^^^^
+//│ ╟── tuple literal of type `(1, 2, 3,)` does not match type `MutArray[?a .. ?a]`
+//│ ║  l.490: 	(1,2,3)[0] <- true
 //│ ╙──       	^^^^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.372: 	(1,2,3)[0] <- true
-//│ ║         	^^^^^^^^^^^^^^^^^^
-//│ ╟── reference of type `true` does not match type `int`
-//│ ║  l.372: 	(1,2,3)[0] <- true
-//│ ╙──       	              ^^^^
-//│ ╔══[ERROR] type mismatch in assignment
-//│ ║  l.373: 	(1,2,3)._1 <- "hello"
+//│ ║  l.491: 	(1,2,3)._1 <- "hello"
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── field `_1` is not mutable
-//│ ║  l.373: 	(1,2,3)._1 <- "hello"
-//│ ╙──       	^^^^^^^
+//│ ╟── tuple field of type `1` is not mutable
+//│ ║  l.491: 	(1,2,3)._1 <- "hello"
+//│ ║         	 ^
+//│ ╟── but it flows into assigned field with expected type `?a`
+//│ ║  l.491: 	(1,2,3)._1 <- "hello"
+//│ ╙──       	        ^^
+
+:e
+(0,)["oops"]
+(mut 0,)["oops"] <- 1
+//│ ╔══[ERROR] Type mismatch in array access:
+//│ ║  l.509: 	(0,)["oops"]
+//│ ║         	^^^^^^^^^^^^
+//│ ╟── string literal of type `"oops"` does not match type `int`
+//│ ║  l.509: 	(0,)["oops"]
+//│ ╙──       	     ^^^^^^
+//│ res: 0
+//│ ╔══[ERROR] Type mismatch in assignment:
+//│ ║  l.510: 	(mut 0,)["oops"] <- 1
+//│ ║         	^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── string literal of type `"oops"` does not match type `int`
+//│ ║  l.510: 	(mut 0,)["oops"] <- 1
+//│ ╙──       	         ^^^^^^
+
+oops = "oops"
+arr = (mut 0,)
+//│ oops: "oops"
+//│ arr: ('a .. 0 | 'a,)
+
+:e
+arr[oops]
+arr[oops] <- 1
+//│ ╔══[ERROR] Type mismatch in array access:
+//│ ║  l.531: 	arr[oops]
+//│ ║         	^^^^^^^^^
+//│ ╟── string literal of type `"oops"` does not match type `int`
+//│ ║  l.525: 	oops = "oops"
+//│ ║         	       ^^^^^^
+//│ ╟── but it flows into reference with expected type `int`
+//│ ║  l.531: 	arr[oops]
+//│ ╙──       	    ^^^^
+//│ res: 0
+//│ ╔══[ERROR] Type mismatch in assignment:
+//│ ║  l.532: 	arr[oops] <- 1
+//│ ║         	^^^^^^^^^^^^^^
+//│ ╟── string literal of type `"oops"` does not match type `int`
+//│ ║  l.525: 	oops = "oops"
+//│ ║         	       ^^^^^^
+//│ ╟── but it flows into reference with expected type `int`
+//│ ║  l.532: 	arr[oops] <- 1
+//│ ╙──       	    ^^^^
+

--- a/shared/src/test/diff/mlscript/Mut.mls
+++ b/shared/src/test/diff/mlscript/Mut.mls
@@ -6,6 +6,23 @@ class A: { x: int }
 def muta1: MutArray[int]
 //│ muta1: MutArray[int .. int]
 
+muta1[2] <- 233
+
+:e
+muta1[1] <- false
+//│ ╔══[ERROR] Type mismatch in assignment:
+//│ ║  l.12: 	muta1[1] <- false
+//│ ║        	^^^^^^^^^^^^^^^^^
+//│ ╟── reference of type `false` does not match type `int`
+//│ ║  l.12: 	muta1[1] <- false
+//│ ║        	            ^^^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.6: 	def muta1: MutArray[int]
+//│ ║       	                    ^^^
+//│ ╟── from assigned array element:
+//│ ║  l.12: 	muta1[1] <- false
+//│ ╙──      	^^^^^^^^
+
 def a1: Array[int]
 //│ a1: Array[int]
 
@@ -15,16 +32,16 @@ muta1 : Array[int]
 :e
 a1: MutArray[int]
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.16: 	a1: MutArray[int]
+//│ ║  l.33: 	a1: MutArray[int]
 //│ ║        	^^
 //│ ╟── type `Array[int]` does not match type `MutArray[int .. int]`
-//│ ║  l.9: 	def a1: Array[int]
-//│ ║       	        ^^^^^^^^^^
+//│ ║  l.26: 	def a1: Array[int]
+//│ ║        	        ^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `MutArray[int .. int]`
-//│ ║  l.16: 	a1: MutArray[int]
+//│ ║  l.33: 	a1: MutArray[int]
 //│ ║        	^^
 //│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.16: 	a1: MutArray[int]
+//│ ║  l.33: 	a1: MutArray[int]
 //│ ╙──      	    ^^^^^^^^^^^^^
 //│ res: MutArray[int .. int]
 
@@ -43,16 +60,16 @@ rc1.x <- 3
 :e
 rc1.x <- true
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.44: 	rc1.x <- true
+//│ ║  l.61: 	rc1.x <- true
 //│ ║        	^^^^^^^^^^^^^
 //│ ╟── reference of type `true` does not match type `int`
-//│ ║  l.44: 	rc1.x <- true
+//│ ║  l.61: 	rc1.x <- true
 //│ ║        	         ^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.34: 	def rc1 : { mut x : int}
+//│ ║  l.51: 	def rc1 : { mut x : int}
 //│ ║        	                    ^^^
 //│ ╟── from assigned selection:
-//│ ║  l.44: 	rc1.x <- true
+//│ ║  l.61: 	rc1.x <- true
 //│ ╙──      	^^^^^
 
 
@@ -73,31 +90,31 @@ immrcd.x <- 0
 immtpl._1 <- 0
 immtpl[0] <- 0
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.72: 	immrcd.x <- 0
+//│ ║  l.89: 	immrcd.x <- 0
 //│ ║        	^^^^^^^^^^^^^
 //│ ╟── record field of type `int` is not mutable
-//│ ║  l.59: 	immrcd = { x = 1: int }
+//│ ║  l.76: 	immrcd = { x = 1: int }
 //│ ║        	           ^^^^^
 //│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.72: 	immrcd.x <- 0
+//│ ║  l.89: 	immrcd.x <- 0
 //│ ╙──      	       ^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.73: 	immtpl._1 <- 0
+//│ ║  l.90: 	immtpl._1 <- 0
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── tuple field of type `int` is not mutable
-//│ ║  l.60: 	immtpl = (1: int,)
+//│ ║  l.77: 	immtpl = (1: int,)
 //│ ║        	          ^
 //│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.73: 	immtpl._1 <- 0
+//│ ║  l.90: 	immtpl._1 <- 0
 //│ ╙──      	       ^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.74: 	immtpl[0] <- 0
+//│ ║  l.91: 	immtpl[0] <- 0
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── tuple field of type `int` is not mutable
-//│ ║  l.60: 	immtpl = (1: int,)
+//│ ║  l.77: 	immtpl = (1: int,)
 //│ ║        	          ^
 //│ ╟── but it flows into assigned array element with expected type `?a`
-//│ ║  l.74: 	immtpl[0] <- 0
+//│ ║  l.91: 	immtpl[0] <- 0
 //│ ╙──      	^^^^^^^^^
 
 
@@ -134,22 +151,22 @@ t1.x <- 4
 t1.y <- true
 t2.x <- 3
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.134: 	t1.y <- true
+//│ ║  l.151: 	t1.y <- true
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── record field of type `bool` is not mutable
-//│ ║  l.122: 	def t1 : T & {mut x : int; y : bool}
+//│ ║  l.139: 	def t1 : T & {mut x : int; y : bool}
 //│ ║         	                           ^^^^^^^^
 //│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.134: 	t1.y <- true
+//│ ║  l.151: 	t1.y <- true
 //│ ╙──       	   ^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.135: 	t2.x <- 3
+//│ ║  l.152: 	t2.x <- 3
 //│ ║         	^^^^^^^^^
 //│ ╟── record field of type `2` is not mutable
-//│ ║  l.124: 	t2 = T {x = 2}
+//│ ║  l.141: 	t2 = T {x = 2}
 //│ ║         	        ^^^^^
 //│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.135: 	t2.x <- 3
+//│ ║  l.152: 	t2.x <- 3
 //│ ╙──       	   ^
 
 class B: { mut x: int; y: bool }
@@ -172,56 +189,56 @@ b1.Foo
 :e
 b1.Foo <- 0
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.172: 	b1.Foo <- 0
+//│ ║  l.190: 	b1.Foo <- 0
 //│ ║         	^^^^^^^^^^^
 //│ ╟── type `B` does not have field 'Foo'
-//│ ║  l.160: 	def b1 : B
+//│ ║  l.177: 	def b1 : B
 //│ ║         	         ^
 //│ ╟── but it flows into reference with expected type `{Foo = ?a}`
-//│ ║  l.172: 	b1.Foo <- 0
+//│ ║  l.190: 	b1.Foo <- 0
 //│ ║         	^^
 //│ ╟── Note: constraint arises from assigned selection:
-//│ ║  l.172: 	b1.Foo <- 0
+//│ ║  l.190: 	b1.Foo <- 0
 //│ ╙──       	^^^^^^
 
 :e
 b3 = B {x = 6; y = false}
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.176: 	b3 = B {x = 6; y = false}
+//│ ║  l.205: 	b3 = B {x = 6; y = false}
 //│ ║         	     ^^^^^^^^^^^^^^^^^^^^
 //│ ╟── record field of type `6` is not mutable
-//│ ║  l.176: 	b3 = B {x = 6; y = false}
+//│ ║  l.205: 	b3 = B {x = 6; y = false}
 //│ ╙──       	        ^^^^^
 //│ b3: (B with {x: int & 'x .. 6 | 'x, y: false}) | error
 
 :e
 b2.y <- b1.y
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.186: 	b2.y <- b1.y
+//│ ║  l.215: 	b2.y <- b1.y
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── record field of type `?y` is not mutable
-//│ ║  l.155: 	class B: { mut x: int; y: bool }
+//│ ║  l.172: 	class B: { mut x: int; y: bool }
 //│ ║         	                       ^^^^^^^
 //│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.186: 	b2.y <- b1.y
+//│ ║  l.215: 	b2.y <- b1.y
 //│ ╙──       	   ^
 
 :e
 b2.x <- b1.y
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.198: 	b2.x <- b1.y
+//│ ║  l.227: 	b2.x <- b1.y
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── type `bool` does not match type `int`
-//│ ║  l.155: 	class B: { mut x: int; y: bool }
+//│ ║  l.172: 	class B: { mut x: int; y: bool }
 //│ ║         	                          ^^^^
 //│ ╟── but it flows into field selection with expected type `int`
-//│ ║  l.198: 	b2.x <- b1.y
+//│ ║  l.227: 	b2.x <- b1.y
 //│ ║         	        ^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.155: 	class B: { mut x: int; y: bool }
+//│ ║  l.172: 	class B: { mut x: int; y: bool }
 //│ ║         	                  ^^^
 //│ ╟── from assigned selection:
-//│ ║  l.198: 	b2.x <- b1.y
+//│ ║  l.227: 	b2.x <- b1.y
 //│ ╙──       	^^^^
 
 b2.x <- b1.x
@@ -240,13 +257,13 @@ h b1 2
 :e
 h {mut x = 4} 2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.229: 	h {mut x = 4} 2
+//│ ║  l.258: 	h {mut x = 4} 2
 //│ ║         	^^^^^^^^^^^^^
 //│ ╟── record literal of type `{x: ?a .. ?a}` is not an instance of type B
-//│ ║  l.229: 	h {mut x = 4} 2
+//│ ║  l.258: 	h {mut x = 4} 2
 //│ ║         	  ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.218: 	def h : B -> int -> int
+//│ ║  l.247: 	def h : B -> int -> int
 //│ ╙──       	        ^
 //│ res: error | int
 
@@ -279,13 +296,13 @@ k1._1 <- k1._1 + 1
 :e
 k1._2 <- 233
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.268: 	k1._2 <- 233
+//│ ║  l.297: 	k1._2 <- 233
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── tuple field of type `"hello"` is not mutable
-//│ ║  l.263: 	k1 = (mut 233, "hello", mut true)
+//│ ║  l.292: 	k1 = (mut 233, "hello", mut true)
 //│ ║         	               ^^^^^^^
 //│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.268: 	k1._2 <- 233
+//│ ║  l.297: 	k1._2 <- 233
 //│ ╙──       	   ^^
 
 muta1[0] <- 1
@@ -304,43 +321,57 @@ amf mt3
 :e
 amf mt4
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.293: 	amf mt4
+//│ ║  l.322: 	amf mt4
 //│ ║         	^^^^^^^
 //│ ╟── type `(bool .. bool, bool, bool,)` does not match type `MutArray[?a .. ?a]`
-//│ ║  l.244: 	def mt4: (mut bool, bool, bool)
+//│ ║  l.273: 	def mt4: (mut bool, bool, bool)
 //│ ║         	         ^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `MutArray[?a .. ?a]`
-//│ ║  l.293: 	amf mt4
+//│ ║  l.322: 	amf mt4
 //│ ║         	    ^^^
 //│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.286: 	def amf : MutArray['a] -> 'a
+//│ ║  l.315: 	def amf : MutArray['a] -> 'a
 //│ ╙──       	          ^^^^^^^^^^^^
 //│ res: bool | error
 
 :e
-muta1[1] <- false
 a1[0] <- 1
 mt1[0] <- mt2._1
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.310: 	a1[0] <- 1
+//│ ║  l.338: 	a1[0] <- 1
 //│ ║         	^^^^^^^^^^
 //│ ╟── type `Array[int]` does not match type `MutArray[?a .. ?a]`
-//│ ║  l.9: 	def a1: Array[int]
-//│ ║       	        ^^^^^^^^^^
+//│ ║  l.26: 	def a1: Array[int]
+//│ ║        	        ^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `MutArray[?a .. ?a]`
-//│ ║  l.310: 	a1[0] <- 1
+//│ ║  l.338: 	a1[0] <- 1
 //│ ╙──       	^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.311: 	mt1[0] <- mt2._1
+//│ ║  l.339: 	mt1[0] <- mt2._1
 //│ ║         	^^^^^^^^^^^^^^^^
 //│ ╟── type `int` does not match type `bool`
-//│ ║  l.241: 	def mt1: (mut int, mut bool)
+//│ ║  l.270: 	def mt1: (mut int, mut bool)
 //│ ║         	              ^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.241: 	def mt1: (mut int, mut bool)
+//│ ║  l.270: 	def mt1: (mut int, mut bool)
 //│ ║         	                       ^^^^
 //│ ╟── from assigned array element:
-//│ ║  l.311: 	mt1[0] <- mt2._1
+//│ ║  l.339: 	mt1[0] <- mt2._1
+//│ ╙──       	^^^^^^
+//│ ╔══[ERROR] Type mismatch in assignment:
+//│ ║  l.339: 	mt1[0] <- mt2._1
+//│ ║         	^^^^^^^^^^^^^^^^
+//│ ╟── type `int` does not match type `bool`
+//│ ║  l.271: 	def mt2: (int, int)
+//│ ║         	          ^^^
+//│ ╟── but it flows into field selection with expected type `bool`
+//│ ║  l.339: 	mt1[0] <- mt2._1
+//│ ║         	          ^^^^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.270: 	def mt1: (mut int, mut bool)
+//│ ║         	                       ^^^^
+//│ ╟── from assigned array element:
+//│ ║  l.339: 	mt1[0] <- mt2._1
 //│ ╙──       	^^^^^^
 
 mt1._1 <- mt2._1
@@ -356,68 +387,68 @@ mt1._1 <- (b1.t <- 4)
 (mt1._1 <- b1.t) <- 4
 b1.x <- 1 + 2 <- 4
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.341: 	mt1._1 <- mt1._2
+//│ ║  l.384: 	mt1._1 <- mt1._2
 //│ ║         	^^^^^^^^^^^^^^^^
 //│ ╟── type `bool` does not match type `int`
-//│ ║  l.241: 	def mt1: (mut int, mut bool)
+//│ ║  l.270: 	def mt1: (mut int, mut bool)
 //│ ║         	                       ^^^^
 //│ ╟── but it flows into field selection with expected type `int`
-//│ ║  l.341: 	mt1._1 <- mt1._2
+//│ ║  l.384: 	mt1._1 <- mt1._2
 //│ ║         	          ^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.241: 	def mt1: (mut int, mut bool)
+//│ ║  l.270: 	def mt1: (mut int, mut bool)
 //│ ║         	              ^^^
 //│ ╟── from assigned selection:
-//│ ║  l.341: 	mt1._1 <- mt1._2
+//│ ║  l.384: 	mt1._1 <- mt1._2
 //│ ╙──       	^^^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.342: 	mt1._2 <- 1
+//│ ║  l.385: 	mt1._2 <- 1
 //│ ║         	^^^^^^^^^^^
 //│ ╟── integer literal of type `1` does not match type `bool`
-//│ ║  l.342: 	mt1._2 <- 1
+//│ ║  l.385: 	mt1._2 <- 1
 //│ ║         	          ^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.241: 	def mt1: (mut int, mut bool)
+//│ ║  l.270: 	def mt1: (mut int, mut bool)
 //│ ║         	                       ^^^^
 //│ ╟── from assigned selection:
-//│ ║  l.342: 	mt1._2 <- 1
+//│ ║  l.385: 	mt1._2 <- 1
 //│ ╙──       	^^^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.343: 	mt1._1 <- (b1.t <- 4)
+//│ ║  l.386: 	mt1._1 <- (b1.t <- 4)
 //│ ║         	           ^^^^^^^^^
 //│ ╟── type `B` does not have field 't'
-//│ ║  l.160: 	def b1 : B
+//│ ║  l.177: 	def b1 : B
 //│ ║         	         ^
 //│ ╟── but it flows into reference with expected type `{t: ?a .. ?a}`
-//│ ║  l.343: 	mt1._1 <- (b1.t <- 4)
+//│ ║  l.386: 	mt1._1 <- (b1.t <- 4)
 //│ ║         	           ^^
 //│ ╟── Note: constraint arises from assigned selection:
-//│ ║  l.343: 	mt1._1 <- (b1.t <- 4)
+//│ ║  l.386: 	mt1._1 <- (b1.t <- 4)
 //│ ╙──       	           ^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.343: 	mt1._1 <- (b1.t <- 4)
+//│ ║  l.386: 	mt1._1 <- (b1.t <- 4)
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── assignment of type `unit` does not match type `int`
-//│ ║  l.343: 	mt1._1 <- (b1.t <- 4)
+//│ ║  l.386: 	mt1._1 <- (b1.t <- 4)
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.241: 	def mt1: (mut int, mut bool)
+//│ ║  l.270: 	def mt1: (mut int, mut bool)
 //│ ║         	              ^^^
 //│ ╟── from assigned selection:
-//│ ║  l.343: 	mt1._1 <- (b1.t <- 4)
+//│ ║  l.386: 	mt1._1 <- (b1.t <- 4)
 //│ ╙──       	^^^^^^
 //│ ╔══[ERROR] Illegal assignment
-//│ ║  l.344: 	(mt1._1 <- b1.t) <- 4
+//│ ║  l.387: 	(mt1._1 <- b1.t) <- 4
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── cannot assign to assignment
-//│ ║  l.344: 	(mt1._1 <- b1.t) <- 4
+//│ ║  l.387: 	(mt1._1 <- b1.t) <- 4
 //│ ╙──       	^^^^^^^^^^^^^^^^
 //│ res: error
 //│ ╔══[ERROR] Illegal assignment
-//│ ║  l.345: 	b1.x <- 1 + 2 <- 4
+//│ ║  l.388: 	b1.x <- 1 + 2 <- 4
 //│ ║         	            ^^^^^^
 //│ ╟── cannot assign to integer literal
-//│ ║  l.345: 	b1.x <- 1 + 2 <- 4
+//│ ║  l.388: 	b1.x <- 1 + 2 <- 4
 //│ ╙──       	            ^
 
 def f : {mut _1 : int} -> int -> unit
@@ -435,20 +466,20 @@ f mt1 1
 :e
 f mt2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.424: 	f mt2
+//│ ║  l.467: 	f mt2
 //│ ║         	^^^^^
 //│ ╟── tuple field of type `int` is not mutable
-//│ ║  l.242: 	def mt2: (int, int)
+//│ ║  l.271: 	def mt2: (int, int)
 //│ ╙──       	          ^^^
 //│ res: int -> unit | error
 
 :e
 g (1, true) 2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.434: 	g (1, true) 2
+//│ ║  l.477: 	g (1, true) 2
 //│ ║         	^^^^^^^^^^^
 //│ ╟── tuple field of type `1` is not mutable
-//│ ║  l.434: 	g (1, true) 2
+//│ ║  l.477: 	g (1, true) 2
 //│ ╙──       	   ^
 //│ res: error | unit
 
@@ -478,13 +509,13 @@ st2._1 <- 8
 :e
 st1._1 <- 9
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.467: 	st1._1 <- 9
+//│ ║  l.510: 	st1._1 <- 9
 //│ ║         	^^^^^^^^^^^
 //│ ╟── tuple field of type `int` is not mutable
-//│ ║  l.450: 	def st1 : (int, )
+//│ ║  l.493: 	def st1 : (int, )
 //│ ║         	           ^^^
 //│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.467: 	st1._1 <- 9
+//│ ║  l.510: 	st1._1 <- 9
 //│ ╙──       	    ^^
 
 def am1 : Array[(mut int)]
@@ -502,36 +533,36 @@ foreach am1 (fun y -> y._1 <- 2)
 (1,2,3)[0] <- true
 (1,2,3)._1 <- "hello"
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.490: 	(1,2,3)[0] <- true
+//│ ║  l.533: 	(1,2,3)[0] <- true
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── tuple literal of type `(1, 2, 3,)` does not match type `MutArray[?a .. ?a]`
-//│ ║  l.490: 	(1,2,3)[0] <- true
+//│ ║  l.533: 	(1,2,3)[0] <- true
 //│ ╙──       	^^^^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.491: 	(1,2,3)._1 <- "hello"
+//│ ║  l.534: 	(1,2,3)._1 <- "hello"
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── tuple field of type `1` is not mutable
-//│ ║  l.491: 	(1,2,3)._1 <- "hello"
+//│ ║  l.534: 	(1,2,3)._1 <- "hello"
 //│ ║         	 ^
 //│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.491: 	(1,2,3)._1 <- "hello"
+//│ ║  l.534: 	(1,2,3)._1 <- "hello"
 //│ ╙──       	        ^^
 
 :e
 (0,)["oops"]
 (mut 0,)["oops"] <- 1
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.509: 	(0,)["oops"]
+//│ ║  l.552: 	(0,)["oops"]
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` does not match type `int`
-//│ ║  l.509: 	(0,)["oops"]
+//│ ║  l.552: 	(0,)["oops"]
 //│ ╙──       	     ^^^^^^
 //│ res: 0
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.510: 	(mut 0,)["oops"] <- 1
+//│ ║  l.553: 	(mut 0,)["oops"] <- 1
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` does not match type `int`
-//│ ║  l.510: 	(mut 0,)["oops"] <- 1
+//│ ║  l.553: 	(mut 0,)["oops"] <- 1
 //│ ╙──       	         ^^^^^^
 
 oops = "oops"
@@ -543,22 +574,22 @@ arr = (mut 0,)
 arr[oops]
 arr[oops] <- 1
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.531: 	arr[oops]
+//│ ║  l.574: 	arr[oops]
 //│ ║         	^^^^^^^^^
 //│ ╟── string literal of type `"oops"` does not match type `int`
-//│ ║  l.525: 	oops = "oops"
+//│ ║  l.568: 	oops = "oops"
 //│ ║         	       ^^^^^^
 //│ ╟── but it flows into reference with expected type `int`
-//│ ║  l.531: 	arr[oops]
+//│ ║  l.574: 	arr[oops]
 //│ ╙──       	    ^^^^
 //│ res: 0
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.532: 	arr[oops] <- 1
+//│ ║  l.575: 	arr[oops] <- 1
 //│ ║         	^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` does not match type `int`
-//│ ║  l.525: 	oops = "oops"
+//│ ║  l.568: 	oops = "oops"
 //│ ║         	       ^^^^^^
 //│ ╟── but it flows into reference with expected type `int`
-//│ ║  l.532: 	arr[oops] <- 1
+//│ ║  l.575: 	arr[oops] <- 1
 //│ ╙──       	    ^^^^
 

--- a/shared/src/test/diff/mlscript/Mut.mls
+++ b/shared/src/test/diff/mlscript/Mut.mls
@@ -125,13 +125,45 @@ rc2.x <- "hello"
 //│ rc2: {x: 'a .. 1 | 'a}
 
 def g r = (fun x -> r) (r.x <- 3)
-//│ g: ({x: 3 | 'a .. 'a} & 'b) -> 'b
-
 g rc1
-//│ res: {x: int .. int}
-
 g rc2
+//│ g: ({x: 3 | 'a .. 'a} & 'b) -> 'b
+//│ res: {x: int .. int}
 //│ res: {x: 'a .. 1 | 3 | 'a}
+
+:e 
+g {x = 3}
+//│ ╔══[ERROR] Type mismatch in application:
+//│ ║  l.135: 	g {x = 3}
+//│ ║         	^^^^^^^^^
+//│ ╟── record field of type `3` is not mutable
+//│ ║  l.135: 	g {x = 3}
+//│ ╙──       	   ^^^^^
+//│ res: error | {x: 3}
+
+def ga r = (fun x -> r) (r[1] <- 6)
+ga muta1
+//│ ga: (MutArray[6 | 'a .. 'a] & 'b) -> 'b
+//│ res: MutArray[int .. int]
+
+:e
+ga a1
+//│ ╔══[ERROR] Type mismatch in application:
+//│ ║  l.150: 	ga a1
+//│ ║         	^^^^^
+//│ ╟── type `Array[int]` does not match type `MutArray[?a .. ?a]`
+//│ ║  l.26: 	def a1: Array[int]
+//│ ║        	        ^^^^^^^^^^
+//│ ╟── but it flows into reference with expected type `MutArray[?b .. ?b]`
+//│ ║  l.150: 	ga a1
+//│ ║         	   ^^
+//│ ╟── Note: constraint arises from assignment:
+//│ ║  l.144: 	def ga r = (fun x -> r) (r[1] <- 6)
+//│ ║         	                         ^^^^^^^^^
+//│ ╟── from reference:
+//│ ║  l.144: 	def ga r = (fun x -> r) (r[1] <- 6)
+//│ ╙──       	                         ^
+//│ res: Array[int] | error
 
 trait T
 //│ Defined trait T
@@ -151,22 +183,22 @@ t1.x <- 4
 t1.y <- true
 t2.x <- 3
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.151: 	t1.y <- true
+//│ ║  l.183: 	t1.y <- true
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── record field of type `bool` is not mutable
-//│ ║  l.139: 	def t1 : T & {mut x : int; y : bool}
+//│ ║  l.171: 	def t1 : T & {mut x : int; y : bool}
 //│ ║         	                           ^^^^^^^^
 //│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.151: 	t1.y <- true
+//│ ║  l.183: 	t1.y <- true
 //│ ╙──       	   ^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.152: 	t2.x <- 3
+//│ ║  l.184: 	t2.x <- 3
 //│ ║         	^^^^^^^^^
 //│ ╟── record field of type `2` is not mutable
-//│ ║  l.141: 	t2 = T {x = 2}
+//│ ║  l.173: 	t2 = T {x = 2}
 //│ ║         	        ^^^^^
 //│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.152: 	t2.x <- 3
+//│ ║  l.184: 	t2.x <- 3
 //│ ╙──       	   ^
 
 class B: { mut x: int; y: bool }
@@ -189,56 +221,56 @@ b1.Foo
 :e
 b1.Foo <- 0
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.190: 	b1.Foo <- 0
+//│ ║  l.222: 	b1.Foo <- 0
 //│ ║         	^^^^^^^^^^^
 //│ ╟── type `B` does not have field 'Foo'
-//│ ║  l.177: 	def b1 : B
+//│ ║  l.209: 	def b1 : B
 //│ ║         	         ^
 //│ ╟── but it flows into reference with expected type `{Foo = ?a}`
-//│ ║  l.190: 	b1.Foo <- 0
+//│ ║  l.222: 	b1.Foo <- 0
 //│ ║         	^^
 //│ ╟── Note: constraint arises from assigned selection:
-//│ ║  l.190: 	b1.Foo <- 0
+//│ ║  l.222: 	b1.Foo <- 0
 //│ ╙──       	^^^^^^
 
 :e
 b3 = B {x = 6; y = false}
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.205: 	b3 = B {x = 6; y = false}
+//│ ║  l.237: 	b3 = B {x = 6; y = false}
 //│ ║         	     ^^^^^^^^^^^^^^^^^^^^
 //│ ╟── record field of type `6` is not mutable
-//│ ║  l.205: 	b3 = B {x = 6; y = false}
+//│ ║  l.237: 	b3 = B {x = 6; y = false}
 //│ ╙──       	        ^^^^^
 //│ b3: (B with {x: int & 'x .. 6 | 'x, y: false}) | error
 
 :e
 b2.y <- b1.y
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.215: 	b2.y <- b1.y
+//│ ║  l.247: 	b2.y <- b1.y
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── record field of type `?y` is not mutable
-//│ ║  l.172: 	class B: { mut x: int; y: bool }
+//│ ║  l.204: 	class B: { mut x: int; y: bool }
 //│ ║         	                       ^^^^^^^
 //│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.215: 	b2.y <- b1.y
+//│ ║  l.247: 	b2.y <- b1.y
 //│ ╙──       	   ^
 
 :e
 b2.x <- b1.y
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.227: 	b2.x <- b1.y
+//│ ║  l.259: 	b2.x <- b1.y
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── type `bool` does not match type `int`
-//│ ║  l.172: 	class B: { mut x: int; y: bool }
+//│ ║  l.204: 	class B: { mut x: int; y: bool }
 //│ ║         	                          ^^^^
 //│ ╟── but it flows into field selection with expected type `int`
-//│ ║  l.227: 	b2.x <- b1.y
+//│ ║  l.259: 	b2.x <- b1.y
 //│ ║         	        ^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.172: 	class B: { mut x: int; y: bool }
+//│ ║  l.204: 	class B: { mut x: int; y: bool }
 //│ ║         	                  ^^^
 //│ ╟── from assigned selection:
-//│ ║  l.227: 	b2.x <- b1.y
+//│ ║  l.259: 	b2.x <- b1.y
 //│ ╙──       	^^^^
 
 b2.x <- b1.x
@@ -257,13 +289,13 @@ h b1 2
 :e
 h {mut x = 4} 2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.258: 	h {mut x = 4} 2
+//│ ║  l.290: 	h {mut x = 4} 2
 //│ ║         	^^^^^^^^^^^^^
 //│ ╟── record literal of type `{x: ?a .. ?a}` is not an instance of type B
-//│ ║  l.258: 	h {mut x = 4} 2
+//│ ║  l.290: 	h {mut x = 4} 2
 //│ ║         	  ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.247: 	def h : B -> int -> int
+//│ ║  l.279: 	def h : B -> int -> int
 //│ ╙──       	        ^
 //│ res: error | int
 
@@ -284,9 +316,8 @@ mt1 : (int, bool)
 //│ res: (int, bool,)
 
 def emt: (mut int)
-//│ emt: (int .. int,)
-
 emt._1
+//│ emt: (int .. int,)
 //│ res: int
 
 k1 = (mut 233, "hello", mut true)
@@ -296,16 +327,14 @@ k1._1 <- k1._1 + 1
 :e
 k1._2 <- 233
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.297: 	k1._2 <- 233
+//│ ║  l.328: 	k1._2 <- 233
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── tuple field of type `"hello"` is not mutable
-//│ ║  l.292: 	k1 = (mut 233, "hello", mut true)
+//│ ║  l.323: 	k1 = (mut 233, "hello", mut true)
 //│ ║         	               ^^^^^^^
 //│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.297: 	k1._2 <- 233
+//│ ║  l.328: 	k1._2 <- 233
 //│ ╙──       	   ^^
-
-muta1[0] <- 1
 
 mt1 = (mut 3, mut false)
 //│ ('a .. 3 | 'a, 'b .. false | 'b,)
@@ -321,58 +350,68 @@ amf mt3
 :e
 amf mt4
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.322: 	amf mt4
+//│ ║  l.351: 	amf mt4
 //│ ║         	^^^^^^^
 //│ ╟── type `(bool .. bool, bool, bool,)` does not match type `MutArray[?a .. ?a]`
-//│ ║  l.273: 	def mt4: (mut bool, bool, bool)
+//│ ║  l.305: 	def mt4: (mut bool, bool, bool)
 //│ ║         	         ^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `MutArray[?a .. ?a]`
-//│ ║  l.322: 	amf mt4
+//│ ║  l.351: 	amf mt4
 //│ ║         	    ^^^
 //│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.315: 	def amf : MutArray['a] -> 'a
+//│ ║  l.344: 	def amf : MutArray['a] -> 'a
 //│ ╙──       	          ^^^^^^^^^^^^
 //│ res: bool | error
 
 :e
 a1[0] <- 1
 mt1[0] <- mt2._1
+mt4[3] <- true
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.338: 	a1[0] <- 1
+//│ ║  l.367: 	a1[0] <- 1
 //│ ║         	^^^^^^^^^^
 //│ ╟── type `Array[int]` does not match type `MutArray[?a .. ?a]`
 //│ ║  l.26: 	def a1: Array[int]
 //│ ║        	        ^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `MutArray[?a .. ?a]`
-//│ ║  l.338: 	a1[0] <- 1
+//│ ║  l.367: 	a1[0] <- 1
 //│ ╙──       	^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.339: 	mt1[0] <- mt2._1
+//│ ║  l.368: 	mt1[0] <- mt2._1
 //│ ║         	^^^^^^^^^^^^^^^^
 //│ ╟── type `int` does not match type `bool`
-//│ ║  l.270: 	def mt1: (mut int, mut bool)
+//│ ║  l.302: 	def mt1: (mut int, mut bool)
 //│ ║         	              ^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.270: 	def mt1: (mut int, mut bool)
+//│ ║  l.302: 	def mt1: (mut int, mut bool)
 //│ ║         	                       ^^^^
 //│ ╟── from assigned array element:
-//│ ║  l.339: 	mt1[0] <- mt2._1
+//│ ║  l.368: 	mt1[0] <- mt2._1
 //│ ╙──       	^^^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.339: 	mt1[0] <- mt2._1
+//│ ║  l.368: 	mt1[0] <- mt2._1
 //│ ║         	^^^^^^^^^^^^^^^^
 //│ ╟── type `int` does not match type `bool`
-//│ ║  l.271: 	def mt2: (int, int)
+//│ ║  l.303: 	def mt2: (int, int)
 //│ ║         	          ^^^
 //│ ╟── but it flows into field selection with expected type `bool`
-//│ ║  l.339: 	mt1[0] <- mt2._1
+//│ ║  l.368: 	mt1[0] <- mt2._1
 //│ ║         	          ^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.270: 	def mt1: (mut int, mut bool)
+//│ ║  l.302: 	def mt1: (mut int, mut bool)
 //│ ║         	                       ^^^^
 //│ ╟── from assigned array element:
-//│ ║  l.339: 	mt1[0] <- mt2._1
+//│ ║  l.368: 	mt1[0] <- mt2._1
 //│ ╙──       	^^^^^^
+//│ ╔══[ERROR] Type mismatch in assignment:
+//│ ║  l.369: 	mt4[3] <- true
+//│ ║         	^^^^^^^^^^^^^^
+//│ ╟── type `(bool .. bool, bool, bool,)` does not match type `MutArray[?a .. ?a]`
+//│ ║  l.305: 	def mt4: (mut bool, bool, bool)
+//│ ║         	         ^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── but it flows into reference with expected type `MutArray[?a .. ?a]`
+//│ ║  l.369: 	mt4[3] <- true
+//│ ╙──       	^^^
 
 mt1._1 <- mt2._1
 mt1._1 <- mt1._1 * 2
@@ -387,68 +426,68 @@ mt1._1 <- (b1.t <- 4)
 (mt1._1 <- b1.t) <- 4
 b1.x <- 1 + 2 <- 4
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.384: 	mt1._1 <- mt1._2
+//│ ║  l.423: 	mt1._1 <- mt1._2
 //│ ║         	^^^^^^^^^^^^^^^^
 //│ ╟── type `bool` does not match type `int`
-//│ ║  l.270: 	def mt1: (mut int, mut bool)
+//│ ║  l.302: 	def mt1: (mut int, mut bool)
 //│ ║         	                       ^^^^
 //│ ╟── but it flows into field selection with expected type `int`
-//│ ║  l.384: 	mt1._1 <- mt1._2
+//│ ║  l.423: 	mt1._1 <- mt1._2
 //│ ║         	          ^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.270: 	def mt1: (mut int, mut bool)
+//│ ║  l.302: 	def mt1: (mut int, mut bool)
 //│ ║         	              ^^^
 //│ ╟── from assigned selection:
-//│ ║  l.384: 	mt1._1 <- mt1._2
+//│ ║  l.423: 	mt1._1 <- mt1._2
 //│ ╙──       	^^^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.385: 	mt1._2 <- 1
+//│ ║  l.424: 	mt1._2 <- 1
 //│ ║         	^^^^^^^^^^^
 //│ ╟── integer literal of type `1` does not match type `bool`
-//│ ║  l.385: 	mt1._2 <- 1
+//│ ║  l.424: 	mt1._2 <- 1
 //│ ║         	          ^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.270: 	def mt1: (mut int, mut bool)
+//│ ║  l.302: 	def mt1: (mut int, mut bool)
 //│ ║         	                       ^^^^
 //│ ╟── from assigned selection:
-//│ ║  l.385: 	mt1._2 <- 1
+//│ ║  l.424: 	mt1._2 <- 1
 //│ ╙──       	^^^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.386: 	mt1._1 <- (b1.t <- 4)
+//│ ║  l.425: 	mt1._1 <- (b1.t <- 4)
 //│ ║         	           ^^^^^^^^^
 //│ ╟── type `B` does not have field 't'
-//│ ║  l.177: 	def b1 : B
+//│ ║  l.209: 	def b1 : B
 //│ ║         	         ^
 //│ ╟── but it flows into reference with expected type `{t: ?a .. ?a}`
-//│ ║  l.386: 	mt1._1 <- (b1.t <- 4)
+//│ ║  l.425: 	mt1._1 <- (b1.t <- 4)
 //│ ║         	           ^^
 //│ ╟── Note: constraint arises from assigned selection:
-//│ ║  l.386: 	mt1._1 <- (b1.t <- 4)
+//│ ║  l.425: 	mt1._1 <- (b1.t <- 4)
 //│ ╙──       	           ^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.386: 	mt1._1 <- (b1.t <- 4)
+//│ ║  l.425: 	mt1._1 <- (b1.t <- 4)
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── assignment of type `unit` does not match type `int`
-//│ ║  l.386: 	mt1._1 <- (b1.t <- 4)
+//│ ║  l.425: 	mt1._1 <- (b1.t <- 4)
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.270: 	def mt1: (mut int, mut bool)
+//│ ║  l.302: 	def mt1: (mut int, mut bool)
 //│ ║         	              ^^^
 //│ ╟── from assigned selection:
-//│ ║  l.386: 	mt1._1 <- (b1.t <- 4)
+//│ ║  l.425: 	mt1._1 <- (b1.t <- 4)
 //│ ╙──       	^^^^^^
 //│ ╔══[ERROR] Illegal assignment
-//│ ║  l.387: 	(mt1._1 <- b1.t) <- 4
+//│ ║  l.426: 	(mt1._1 <- b1.t) <- 4
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── cannot assign to assignment
-//│ ║  l.387: 	(mt1._1 <- b1.t) <- 4
+//│ ║  l.426: 	(mt1._1 <- b1.t) <- 4
 //│ ╙──       	^^^^^^^^^^^^^^^^
 //│ res: error
 //│ ╔══[ERROR] Illegal assignment
-//│ ║  l.388: 	b1.x <- 1 + 2 <- 4
+//│ ║  l.427: 	b1.x <- 1 + 2 <- 4
 //│ ║         	            ^^^^^^
 //│ ╟── cannot assign to integer literal
-//│ ║  l.388: 	b1.x <- 1 + 2 <- 4
+//│ ║  l.427: 	b1.x <- 1 + 2 <- 4
 //│ ╙──       	            ^
 
 def f : {mut _1 : int} -> int -> unit
@@ -466,20 +505,20 @@ f mt1 1
 :e
 f mt2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.467: 	f mt2
+//│ ║  l.506: 	f mt2
 //│ ║         	^^^^^
 //│ ╟── tuple field of type `int` is not mutable
-//│ ║  l.271: 	def mt2: (int, int)
+//│ ║  l.303: 	def mt2: (int, int)
 //│ ╙──       	          ^^^
 //│ res: int -> unit | error
 
 :e
 g (1, true) 2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.477: 	g (1, true) 2
+//│ ║  l.516: 	g (1, true) 2
 //│ ║         	^^^^^^^^^^^
 //│ ╟── tuple field of type `1` is not mutable
-//│ ║  l.477: 	g (1, true) 2
+//│ ║  l.516: 	g (1, true) 2
 //│ ╙──       	   ^
 //│ res: error | unit
 
@@ -509,13 +548,13 @@ st2._1 <- 8
 :e
 st1._1 <- 9
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.510: 	st1._1 <- 9
+//│ ║  l.549: 	st1._1 <- 9
 //│ ║         	^^^^^^^^^^^
 //│ ╟── tuple field of type `int` is not mutable
-//│ ║  l.493: 	def st1 : (int, )
+//│ ║  l.532: 	def st1 : (int, )
 //│ ║         	           ^^^
 //│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.510: 	st1._1 <- 9
+//│ ║  l.549: 	st1._1 <- 9
 //│ ╙──       	    ^^
 
 def am1 : Array[(mut int)]
@@ -533,36 +572,36 @@ foreach am1 (fun y -> y._1 <- 2)
 (1,2,3)[0] <- true
 (1,2,3)._1 <- "hello"
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.533: 	(1,2,3)[0] <- true
+//│ ║  l.572: 	(1,2,3)[0] <- true
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── tuple literal of type `(1, 2, 3,)` does not match type `MutArray[?a .. ?a]`
-//│ ║  l.533: 	(1,2,3)[0] <- true
+//│ ║  l.572: 	(1,2,3)[0] <- true
 //│ ╙──       	^^^^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.534: 	(1,2,3)._1 <- "hello"
+//│ ║  l.573: 	(1,2,3)._1 <- "hello"
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── tuple field of type `1` is not mutable
-//│ ║  l.534: 	(1,2,3)._1 <- "hello"
+//│ ║  l.573: 	(1,2,3)._1 <- "hello"
 //│ ║         	 ^
 //│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.534: 	(1,2,3)._1 <- "hello"
+//│ ║  l.573: 	(1,2,3)._1 <- "hello"
 //│ ╙──       	        ^^
 
 :e
 (0,)["oops"]
 (mut 0,)["oops"] <- 1
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.552: 	(0,)["oops"]
+//│ ║  l.591: 	(0,)["oops"]
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` does not match type `int`
-//│ ║  l.552: 	(0,)["oops"]
+//│ ║  l.591: 	(0,)["oops"]
 //│ ╙──       	     ^^^^^^
 //│ res: 0
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.553: 	(mut 0,)["oops"] <- 1
+//│ ║  l.592: 	(mut 0,)["oops"] <- 1
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` does not match type `int`
-//│ ║  l.553: 	(mut 0,)["oops"] <- 1
+//│ ║  l.592: 	(mut 0,)["oops"] <- 1
 //│ ╙──       	         ^^^^^^
 
 oops = "oops"
@@ -574,22 +613,22 @@ arr = (mut 0,)
 arr[oops]
 arr[oops] <- 1
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.574: 	arr[oops]
+//│ ║  l.613: 	arr[oops]
 //│ ║         	^^^^^^^^^
 //│ ╟── string literal of type `"oops"` does not match type `int`
-//│ ║  l.568: 	oops = "oops"
+//│ ║  l.607: 	oops = "oops"
 //│ ║         	       ^^^^^^
 //│ ╟── but it flows into reference with expected type `int`
-//│ ║  l.574: 	arr[oops]
+//│ ║  l.613: 	arr[oops]
 //│ ╙──       	    ^^^^
 //│ res: 0
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.575: 	arr[oops] <- 1
+//│ ║  l.614: 	arr[oops] <- 1
 //│ ║         	^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` does not match type `int`
-//│ ║  l.568: 	oops = "oops"
+//│ ║  l.607: 	oops = "oops"
 //│ ║         	       ^^^^^^
 //│ ╟── but it flows into reference with expected type `int`
-//│ ║  l.575: 	arr[oops] <- 1
+//│ ║  l.614: 	arr[oops] <- 1
 //│ ╙──       	    ^^^^
 

--- a/shared/src/test/diff/mlscript/ProvFlows.mls
+++ b/shared/src/test/diff/mlscript/ProvFlows.mls
@@ -26,7 +26,7 @@ succ x3
 //│ ║  l.3: 	def succ: int -> int
 //│ ║       	          ^^^
 //│ ╟── ========= Additional explanations below =========
-//│ ╟── [info] flowing from expression of type `false`
+//│ ╟── [info] flowing from type `false`
 //│ ╟── [info] flowing from reference of type `false`
 //│ ║  l.7: 	x1 = false
 //│ ║       	     ^^^^^
@@ -68,7 +68,7 @@ f3 true
 //│ ║  l.51: 	f3 y3 = f2 y3
 //│ ║        	           ^^
 //│ ╟── ========= Additional explanations below =========
-//│ ╟── [info] flowing from expression of type `true`
+//│ ╟── [info] flowing from type `true`
 //│ ╟── [info] flowing from reference of type `true`
 //│ ║  l.57: 	f3 true
 //│ ║        	   ^^^^
@@ -117,7 +117,7 @@ f3 x3
 //│ ║  l.51: 	f3 y3 = f2 y3
 //│ ║        	           ^^
 //│ ╟── ========= Additional explanations below =========
-//│ ╟── [info] flowing from expression of type `false`
+//│ ╟── [info] flowing from type `false`
 //│ ╟── [info] flowing from reference of type `false`
 //│ ║  l.7: 	x1 = false
 //│ ║       	     ^^^^^
@@ -182,7 +182,7 @@ h3 f3 x3
 //│ ║  l.162: 	h3 f x = h2 f x
 //│ ║         	              ^
 //│ ╟── ========= Additional explanations below =========
-//│ ╟── [info] flowing from expression of type `false`
+//│ ╟── [info] flowing from type `false`
 //│ ╟── [info] flowing from reference of type `false`
 //│ ║  l.7: 	x1 = false
 //│ ║       	     ^^^^^
@@ -255,7 +255,7 @@ h3 f3 x3
 //│ ║  l.244: 	(fun x -> succ x) false
 //│ ║         	               ^
 //│ ╟── ========= Additional explanations below =========
-//│ ╟── [info] flowing from expression of type `false`
+//│ ╟── [info] flowing from type `false`
 //│ ╟── [info] flowing from reference of type `false`
 //│ ║  l.244: 	(fun x -> succ x) false
 //│ ║         	                  ^^^^^
@@ -295,7 +295,8 @@ rec def x = add x
 //│ ╟── [info] flowing into reference of type `int`
 //│ ║  l.278: 	rec def x = add x
 //│ ║         	                ^
-//│ ╙── [info] flowing into expression of type `int`
+//│ ╟── [info] flowing into type `int`
+//│ ╙── [info] flowing into type `int`
 //│ x: int -> int
 
 
@@ -305,13 +306,13 @@ def foo: int | string
 :ex
 succ foo
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.306: 	succ foo
+//│ ║  l.307: 	succ foo
 //│ ║         	^^^^^^^^
 //│ ╟── type `string` does not match type `int`
-//│ ║  l.302: 	def foo: int | string
+//│ ║  l.303: 	def foo: int | string
 //│ ║         	               ^^^^^^
 //│ ╟── but it flows into reference with expected type `int`
-//│ ║  l.306: 	succ foo
+//│ ║  l.307: 	succ foo
 //│ ║         	     ^^^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.3: 	def succ: int -> int
@@ -319,13 +320,13 @@ succ foo
 //│ ╟── ========= Additional explanations below =========
 //│ ╟── [info] flowing from expression of type `string`
 //│ ╟── [info] flowing from type `string`
-//│ ║  l.302: 	def foo: int | string
+//│ ║  l.303: 	def foo: int | string
 //│ ║         	               ^^^^^^
 //│ ╟── [info] flowing from type `int | string`
-//│ ║  l.302: 	def foo: int | string
+//│ ║  l.303: 	def foo: int | string
 //│ ║         	         ^^^^^^^^^^^^
 //│ ╟── [info] flowing from reference of type `int | string`
-//│ ║  l.306: 	succ foo
+//│ ║  l.307: 	succ foo
 //│ ║         	     ^^^
 //│ ╟── [info] flowing into type `int`
 //│ ║  l.3: 	def succ: int -> int
@@ -358,59 +359,59 @@ ty00 = ty11
 //│   <:  ty00:
 //│ (A & 'a | B & 'b) -> ('a, 'b,)
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.356: 	ty00 = ty11
+//│ ║  l.357: 	ty00 = ty11
 //│ ║         	^^^^^^^^^^^
 //│ ╟── type `B & 'b` is not an instance of type 'a
-//│ ║  l.343: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
+//│ ║  l.344: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
 //│ ║         	                    ^^^^^^
 //│ ╟── Note: constraint arises from type variable:
-//│ ║  l.343: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
+//│ ║  l.344: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
 //│ ║         	                                ^^
 //│ ╟── ========= Additional explanations below =========
 //│ ╟── [info] flowing from expression of type `B & 'b`
 //│ ╟── [info] flowing from type `B & 'b`
-//│ ║  l.343: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
+//│ ║  l.344: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
 //│ ║         	                    ^^^^^^
 //│ ╟── [info] flowing from type `B & 'b`
-//│ ║  l.343: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
+//│ ║  l.344: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
 //│ ║         	          ^^^^^^^^^^^^^^^^^
 //│ ╟── [info] flowing from type `B & 'b`
-//│ ║  l.346: 	def ty11: ('a & A | 'a & B) -> ('a, 'a)
+//│ ║  l.347: 	def ty11: ('a & A | 'a & B) -> ('a, 'a)
 //│ ║         	          ^^^^^^^^^^^^^^^^^
 //│ ╟── [info] flowing from expression of type `?a`
 //│ ╟── [info] flowing from type `?a0`
-//│ ║  l.346: 	def ty11: ('a & A | 'a & B) -> ('a, 'a)
+//│ ║  l.347: 	def ty11: ('a & A | 'a & B) -> ('a, 'a)
 //│ ║         	                                ^^
 //│ ╟── [info] flowing into type `'a`
-//│ ║  l.343: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
+//│ ║  l.344: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
 //│ ║         	                                ^^
 //│ ╙── [info] flowing into expression of type `'a`
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.356: 	ty00 = ty11
+//│ ║  l.357: 	ty00 = ty11
 //│ ║         	^^^^^^^^^^^
 //│ ╟── type `A & 'a` is not an instance of type 'b
-//│ ║  l.343: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
+//│ ║  l.344: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
 //│ ║         	           ^^^^^^
 //│ ╟── Note: constraint arises from type variable:
-//│ ║  l.343: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
+//│ ║  l.344: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
 //│ ║         	                                    ^^
 //│ ╟── ========= Additional explanations below =========
 //│ ╟── [info] flowing from expression of type `A & 'a`
 //│ ╟── [info] flowing from type `A & 'a`
-//│ ║  l.343: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
+//│ ║  l.344: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
 //│ ║         	           ^^^^^^
 //│ ╟── [info] flowing from type `A & 'a`
-//│ ║  l.343: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
+//│ ║  l.344: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
 //│ ║         	          ^^^^^^^^^^^^^^^^^
 //│ ╟── [info] flowing from type `A & 'a`
-//│ ║  l.346: 	def ty11: ('a & A | 'a & B) -> ('a, 'a)
+//│ ║  l.347: 	def ty11: ('a & A | 'a & B) -> ('a, 'a)
 //│ ║         	          ^^^^^^^^^^^^^^^^^
 //│ ╟── [info] flowing from expression of type `?a`
 //│ ╟── [info] flowing from type `?a0`
-//│ ║  l.346: 	def ty11: ('a & A | 'a & B) -> ('a, 'a)
+//│ ║  l.347: 	def ty11: ('a & A | 'a & B) -> ('a, 'a)
 //│ ║         	                                    ^^
 //│ ╟── [info] flowing into type `'b`
-//│ ║  l.343: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
+//│ ║  l.344: 	def ty00: ('a & A | 'b & B) -> ('a, 'b)
 //│ ║         	                                    ^^
 //│ ╙── [info] flowing into expression of type `'b`
 

--- a/shared/src/test/diff/mlscript/Tony.mls
+++ b/shared/src/test/diff/mlscript/Tony.mls
@@ -19,7 +19,7 @@ def arg = if true then Some{value = 42} with {payload = 23} else None {}
 flatMap3 (fun x -> add x.value x.payload) arg
 //│ res: int | None
 //│    = 65
-//│ constrain calls  : 97
+//│ constrain calls  : 100
 //│ annoying  calls  : 23
 //│ subtyping calls  : 46
 

--- a/shared/src/test/diff/mlscript/Trio.mls
+++ b/shared/src/test/diff/mlscript/Trio.mls
@@ -80,7 +80,7 @@ foo arg
 //│ res: error | int | string | {l: bool, r: nothing}
 //│ Runtime error:
 //│   ReferenceError: arg is not defined
-//│ constrain calls  : 53
+//│ constrain calls  : 54
 //│ annoying  calls  : 40
 //│ subtyping calls  : 131
 
@@ -90,7 +90,7 @@ foo (arg with { payload = 1 })
 //│ res: int | string | {l: bool, r: 1}
 //│ Runtime error:
 //│   ReferenceError: arg is not defined
-//│ constrain calls  : 48
+//│ constrain calls  : 50
 //│ annoying  calls  : 38
 //│ subtyping calls  : 96
 

--- a/shared/src/test/diff/mlscript/TupleArray.mls
+++ b/shared/src/test/diff/mlscript/TupleArray.mls
@@ -123,15 +123,15 @@ f(1,2,3) : 1 | 2 | 3
 
 :e
 (arr[0])[1][2]
-//│ ╔══[ERROR] Type mismatch in array subscript:
+//│ ╔══[ERROR] Type mismatch in array access:
 //│ ║  l.125: 	(arr[0])[1][2]
-//│ ║         	^^^^^^^^^^
+//│ ║         	^^^^^^^^^^^
 //│ ╟── type `int` does not match type `Array[?a]`
 //│ ║  l.35: 	def arr: Array[int]
 //│ ║        	               ^^^
-//│ ╟── but it flows into array subscript with expected type `Array[?a]`
+//│ ╟── but it flows into array access with expected type `Array[?a]`
 //│ ║  l.125: 	(arr[0])[1][2]
-//│ ╙──       	 ^^^^^
+//│ ╙──       	 ^^^^^^
 //│ res: nothing
 //│ Code generation crashed:
 //│   (arr[0])[1][2] (of class mlscript.Subs)

--- a/shared/src/test/diff/mlscript/Wildcards.mls
+++ b/shared/src/test/diff/mlscript/Wildcards.mls
@@ -59,7 +59,7 @@ add 1 : Als1[?]
 //│ ╔══[ERROR] Type mismatch in type ascription:
 //│ ║  l.58: 	add 1 : Als1[?]
 //│ ║        	^^^^^
-//│ ╟── expression of type `int` does not match type `nothing`
+//│ ╟── type `int` does not match type `nothing`
 //│ ╟── Note: constraint arises from type wildcard:
 //│ ║  l.58: 	add 1 : Als1[?]
 //│ ╙──      	             ^

--- a/shared/src/test/diff/mlscript/Yicong.mls
+++ b/shared/src/test/diff/mlscript/Yicong.mls
@@ -533,52 +533,52 @@ true[false]
 4["hello"]
 ge[2]
 //│ ge: int -> int
-//│ ╔══[ERROR] Type mismatch in array subscript:
+//│ ╔══[ERROR] Type mismatch in array access:
 //│ ║  l.531: 	ta3[ge 3][ge (1+2)]
-//│ ║         	^^^^^^^^^^^^^^^^^^
+//│ ║         	^^^^^^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"hello"` does not match type `Array[?a]`
 //│ ║  l.518: 	ta3 = ((1,2,3), "hello", false)
 //│ ║         	                ^^^^^^^
-//│ ╟── but it flows into array subscript with expected type `Array[?b]`
+//│ ╟── but it flows into array access with expected type `Array[?b]`
 //│ ║  l.531: 	ta3[ge 3][ge (1+2)]
-//│ ╙──       	^^^^^^^^
-//│ res: 1 | 2 | 3
-//│ ╔══[ERROR] Type mismatch in array subscript:
+//│ ╙──       	^^^^^^^^^
+//│ res: 1 | 2 | 3 | error
+//│ ╔══[ERROR] Type mismatch in array access:
 //│ ║  l.532: 	true[false]
-//│ ║         	^^^^^^^^^^
-//│ ╟── reference of type `true` does not match type `Array[?a]`
-//│ ║  l.532: 	true[false]
-//│ ╙──       	^^^^
-//│ ╔══[ERROR] Type mismatch in array subscript:
-//│ ║  l.532: 	true[false]
-//│ ║         	^^^^^^^^^^
+//│ ║         	^^^^^^^^^^^
 //│ ╟── reference of type `false` does not match type `int`
 //│ ║  l.532: 	true[false]
 //│ ╙──       	     ^^^^^
-//│ res: nothing
-//│ ╔══[ERROR] Type mismatch in array subscript:
+//│ ╔══[ERROR] Type mismatch in array access:
+//│ ║  l.532: 	true[false]
+//│ ║         	^^^^^^^^^^^
+//│ ╟── reference of type `true` does not match type `Array[?a]`
+//│ ║  l.532: 	true[false]
+//│ ╙──       	^^^^
+//│ res: error
+//│ ╔══[ERROR] Type mismatch in array access:
 //│ ║  l.533: 	4["hello"]
-//│ ║         	^^^^^^^^^
-//│ ╟── integer literal of type `4` does not match type `Array[?a]`
-//│ ║  l.533: 	4["hello"]
-//│ ╙──       	^
-//│ ╔══[ERROR] Type mismatch in array subscript:
-//│ ║  l.533: 	4["hello"]
-//│ ║         	^^^^^^^^^
+//│ ║         	^^^^^^^^^^
 //│ ╟── string literal of type `"hello"` does not match type `int`
 //│ ║  l.533: 	4["hello"]
 //│ ╙──       	  ^^^^^^^
-//│ res: nothing
-//│ ╔══[ERROR] Type mismatch in array subscript:
+//│ ╔══[ERROR] Type mismatch in array access:
+//│ ║  l.533: 	4["hello"]
+//│ ║         	^^^^^^^^^^
+//│ ╟── integer literal of type `4` does not match type `Array[?a]`
+//│ ║  l.533: 	4["hello"]
+//│ ╙──       	^
+//│ res: error
+//│ ╔══[ERROR] Type mismatch in array access:
 //│ ║  l.534: 	ge[2]
-//│ ║         	^^^^
+//│ ║         	^^^^^
 //│ ╟── function of type `?a -> ?b` does not match type `Array[?c]`
 //│ ║  l.530: 	def ge x = x + 1
 //│ ║         	       ^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `Array[?c]`
 //│ ║  l.534: 	ge[2]
 //│ ╙──       	^^
-//│ res: nothing
+//│ res: error
 
 def mkarr: 'a -> Array['a]
 def mkarr x = (x,x,x,x,x)
@@ -596,23 +596,23 @@ mkarr (1,true,"hi")[0]
 :e 
 mkarr 3 [  1]
 mk1[2  ]
-//│ ╔══[ERROR] Type mismatch in array subscript:
+//│ ╔══[ERROR] Type mismatch in array access:
 //│ ║  l.597: 	mkarr 3 [  1]
-//│ ║         	      ^^^^^^
+//│ ║         	      ^^^^^^^
 //│ ╟── integer literal of type `3` does not match type `Array[?a]`
 //│ ║  l.597: 	mkarr 3 [  1]
 //│ ╙──       	      ^
-//│ res: Array[nothing]
-//│ ╔══[ERROR] Type mismatch in array subscript:
+//│ res: Array[error]
+//│ ╔══[ERROR] Type mismatch in array access:
 //│ ║  l.598: 	mk1[2  ]
-//│ ║         	^^^^^
+//│ ║         	^^^^^^^^
 //│ ╟── integer literal of type `6` does not match type `Array[?a]`
 //│ ║  l.585: 	mk1 = (mkarr 6)[ 0]
 //│ ║         	             ^
 //│ ╟── but it flows into reference with expected type `Array[?a]`
 //│ ║  l.598: 	mk1[2  ]
 //│ ╙──       	^^^
-//│ res: nothing
+//│ res: error
 
 def s1 a = (a[1] + a[2], a[(1,2)._2])
 def s2 a = (a[1][0])._2 + (a[2])._1
@@ -643,13 +643,13 @@ dup ara[1]._1 arb[10][8]._2 + 1
 
 :e
 (1,2,3)._1[1]
-//│ ╔══[ERROR] Type mismatch in array subscript:
+//│ ╔══[ERROR] Type mismatch in array access:
 //│ ║  l.645: 	(1,2,3)._1[1]
-//│ ║         	^^^^^^^^^^^^
+//│ ║         	^^^^^^^^^^^^^
 //│ ╟── integer literal of type `1` does not match type `Array[?a]`
 //│ ║  l.645: 	(1,2,3)._1[1]
 //│ ║         	 ^
 //│ ╟── but it flows into field selection with expected type `Array[?a]`
 //│ ║  l.645: 	(1,2,3)._1[1]
 //│ ╙──       	^^^^^^^^^^
-//│ res: nothing
+//│ res: error


### PR DESCRIPTION
@Meowcolm024 Here, I made many fixes to your branch regarding the rather tricky error reporting mechanism.

Most of the type provenance information you were passing along was wrong. But I don't blame you, because this system is a bit like black magic if you don't know all the details 😛 

Make sure to review the diff to validate the changes.

Also, you should really merge the changes from the main `mlscript` branch more regularly. The longer you wait, the more it risks diverging, and the more painful the merge conflict resolution will be!