### PR TITLE
Simplify and constrain with variance info

### DIFF
--- a/shared/src/main/scala/mlscript/ConstraintSolver.scala
+++ b/shared/src/main/scala/mlscript/ConstraintSolver.scala
@@ -385,10 +385,6 @@ class ConstraintSolver extends NormalForms { self: Typer =>
               val td = ctx.tyDefs(tr1.defn.name)
               val tvv = td.getVariancesOrDefault
               td.tparamsargs.unzip._2.lazyZip(tr1.targs).lazyZip(tr2.targs).foreach { (tv, targ1, targ2) =>
-                // TODO use variance info
-                // rec(targ1, targ2, false)
-                // rec(targ2, targ1, false)
-                // val v = td.tvarVariances
                 val v = tvv(tv)
                 if (!v.isContravariant) rec(targ1, targ2, false)
                 if (!v.isCovariant) rec(targ2, targ1, false)

--- a/shared/src/main/scala/mlscript/ConstraintSolver.scala
+++ b/shared/src/main/scala/mlscript/ConstraintSolver.scala
@@ -382,10 +382,16 @@ class ConstraintSolver extends NormalForms { self: Typer =>
           case (tr1: TypeRef, tr2: TypeRef) if tr1.defn.name =/= "Array" =>
             if (tr1.defn === tr2.defn) {
               assert(tr1.targs.sizeCompare(tr2.targs) === 0)
-              tr1.targs.lazyZip(tr2.targs).foreach { (targ1, targ2) =>
+              val td = ctx.tyDefs(tr1.defn.name)
+              val tvv = td.getVariancesOrDefault
+              td.tparamsargs.unzip._2.lazyZip(tr1.targs).lazyZip(tr2.targs).foreach { (tv, targ1, targ2) =>
                 // TODO use variance info
-                rec(targ1, targ2, false)
-                rec(targ2, targ1, false)
+                // rec(targ1, targ2, false)
+                // rec(targ2, targ1, false)
+                // val v = td.tvarVariances
+                val v = tvv(tv)
+                if (!v.isContravariant) rec(targ1, targ2, false)
+                if (!v.isCovariant) rec(targ2, targ1, false)
               }
             } else {
               (tr1.mkTag, tr2.mkTag) match {
@@ -587,12 +593,11 @@ class ConstraintSolver extends NormalForms { self: Typer =>
       case p @ ProxyType(und) => extrude(und, lvl, pol)
       case _: ClassTag | _: TraitTag => ty
       case tr @ TypeRef(d, ts) =>
-        /* Note: we could try to preserve TypeRef-s through extrusion,
-            but in the absence of variance analysis it's a bit wasteful
-            to always extrude in both directions: */
-        // TypeRef(d, ts.map(t =>
-        //   TypeBounds(extrude(t, lvl, pol), extrude(t, lvl, pol))(noProv)))(tr.prov, tr.ctx) // FIXME pol...
-        extrude(tr.expand, lvl, pol).withProvOf(tr)
+        TypeRef(d, tr.mapTargs(S(pol)) {
+          case (N, targ) =>
+            TypeBounds(extrude(targ, lvl, false), extrude(targ, lvl, true))(noProv)
+          case (S(pol), targ) => extrude(targ, lvl, pol)
+        })(tr.prov)
     }
   
   

--- a/shared/src/main/scala/mlscript/TypeDefs.scala
+++ b/shared/src/main/scala/mlscript/TypeDefs.scala
@@ -43,6 +43,8 @@ class TypeDefs extends ConstraintSolver { self: Typer =>
     val (tparams: List[TypeName], targs: List[TypeVariable]) = tparamsargs.unzip
     val thisTv: TypeVariable = freshVar(noProv, S("this"), Nil, TypeRef(nme, targs)(noProv) :: Nil)(1)
     var tvarVariances: Opt[VarianceStore] = N
+    def getVariancesOrDefault: collection.Map[TV, VarianceInfo] =
+      tvarVariances.getOrElse(Map.empty[TV, VarianceInfo].withDefaultValue(VarianceInfo.in))
   }
   
   /** Represent a set of methods belonging to some owner type.

--- a/shared/src/main/scala/mlscript/TypeSimplifier.scala
+++ b/shared/src/main/scala/mlscript/TypeSimplifier.scala
@@ -58,6 +58,7 @@ trait TypeSimplifier { self: Typer =>
       case tr @ TypeRef(defn, targs) if builtinTypes.contains(defn) => process(tr.expand, parent)
       
       case RecordType(fields) => RecordType.mk(fields.flatMap { case (v @ Var(fnme), fty) =>
+        // * We make a pass to transform the LB and UB of variant type parameter fields into their exterma
         val prefix = fnme.takeWhile(_ =/= '#')
         val postfix = fnme.drop(prefix.length + 1)
         lazy val default = fty.update(process(_ , N), process(_ , N))

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -799,7 +799,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool)
   
   
   /** Convert an inferred SimpleType into the immutable Type representation. */
-  def expandType(st: SimpleType, stopAtTyVars: Bool = false): Type = {
+  def expandType(st: SimpleType, stopAtTyVars: Bool = false)(implicit ctx: Ctx): Type = {
     val expandType = ()
     
     import Set.{empty => semp}
@@ -850,7 +850,13 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool)
           case lit: Lit => Literal(lit)
         }
         case TypeRef(td, Nil) => td
-        case TypeRef(td, targs) => AppliedType(td, targs.map(go))
+        case tr @ TypeRef(td, targs) => AppliedType(td, targs.map(go))
+        // case tr @ TypeRef(td, targs) => AppliedType(td, tr.mapTargs(S(true)) {
+        //   // case (N, _) | (S(true), TopType) | (S(false), BotType) => Bounds(Bot, Top)
+        //   case (N, TypeBounds(BotType, TopType)) | (S(true), TypeBounds(_, TopType)) | (S(false), TypeBounds(BotType, _)) => Bounds(Bot, Top)
+        //   // case (N, _) | (S(true), TypeBounds(BotType, _)) | (S(false), TypeBounds(_, TopType)) => Bounds(Bot, Top)
+        //   case (_, ty) => go(ty)
+        // })
         case TypeBounds(lb, ub) => Bounds(go(lb), go(ub))
         case Without(base, names) => Rem(go(base), names.toList)
     }

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -850,13 +850,18 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool)
           case lit: Lit => Literal(lit)
         }
         case TypeRef(td, Nil) => td
-        case tr @ TypeRef(td, targs) => AppliedType(td, targs.map(go))
-        // case tr @ TypeRef(td, targs) => AppliedType(td, tr.mapTargs(S(true)) {
-        //   // case (N, _) | (S(true), TopType) | (S(false), BotType) => Bounds(Bot, Top)
-        //   case (N, TypeBounds(BotType, TopType)) | (S(true), TypeBounds(_, TopType)) | (S(false), TypeBounds(BotType, _)) => Bounds(Bot, Top)
-        //   // case (N, _) | (S(true), TypeBounds(BotType, _)) | (S(false), TypeBounds(_, TopType)) => Bounds(Bot, Top)
-        //   case (_, ty) => go(ty)
-        // })
+        // case tr @ TypeRef(td, targs) => AppliedType(td, targs.map(go))
+        case tr @ TypeRef(td, targs) => 
+          println(s"> " + targs)
+          AppliedType(td, tr.mapTargs(S(true)) {
+          // case ta @ ((N, _) | (S(true), TopType) | (S(false), BotType)) => 
+          case ta @ ((S(true), TopType) | (S(false), BotType)) => 
+            println(s"> " + ta)
+            Bounds(Bot, Top)
+          // case (N, TypeBounds(BotType, TopType)) | (S(true), TypeBounds(_, TopType)) | (S(false), TypeBounds(BotType, _)) => Bounds(Bot, Top)
+          // case (N, _) | (S(true), TypeBounds(BotType, _)) | (S(false), TypeBounds(_, TopType)) => Bounds(Bot, Top)
+          case (_, ty) => go(ty)
+        })
         case TypeBounds(lb, ub) => Bounds(go(lb), go(ub))
         case Without(base, names) => Rem(go(base), names.toList)
     }

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -120,14 +120,14 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool)
       val tv = freshVar(noTyProv)(1)
       val tyDef = TypeDef(Als, TypeName("Array"), List(TypeName("A") -> tv), Nil,
         ArrayType(FieldType(None, tv)(noTyProv))(noTyProv), Nil, Nil, Set.empty, N)
-      tyDef.tvarVariances += tv -> VarianceInfo.co
+      tyDef.tvarVariances = S(MutMap(tv -> VarianceInfo.co))
       tyDef
     } ::
     {
       val tv = freshVar(noTyProv)(1)
       val tyDef = TypeDef(Als, TypeName("MutArray"), List(TypeName("A") -> tv), Nil,
         ArrayType(FieldType(Some(tv), tv)(noTyProv))(noTyProv), Nil, Nil, Set.empty, N)
-      tyDef.tvarVariances += tv -> VarianceInfo.in
+      tyDef.tvarVariances = S(MutMap(tv -> VarianceInfo.in))
       tyDef
     } ::
     Nil

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -850,16 +850,8 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool)
           case lit: Lit => Literal(lit)
         }
         case TypeRef(td, Nil) => td
-        // case tr @ TypeRef(td, targs) => AppliedType(td, targs.map(go))
-        case tr @ TypeRef(td, targs) => 
-          println(s"> " + targs)
-          AppliedType(td, tr.mapTargs(S(true)) {
-          // case ta @ ((N, _) | (S(true), TopType) | (S(false), BotType)) => 
-          case ta @ ((S(true), TopType) | (S(false), BotType)) => 
-            println(s"> " + ta)
-            Bounds(Bot, Top)
-          // case (N, TypeBounds(BotType, TopType)) | (S(true), TypeBounds(_, TopType)) | (S(false), TypeBounds(BotType, _)) => Bounds(Bot, Top)
-          // case (N, _) | (S(true), TypeBounds(BotType, _)) | (S(false), TypeBounds(_, TopType)) => Bounds(Bot, Top)
+        case tr @ TypeRef(td, targs) => AppliedType(td, tr.mapTargs(S(true)) {
+          case ta @ ((S(true), TopType) | (S(false), BotType)) => Bounds(Bot, Top)
           case (_, ty) => go(ty)
         })
         case TypeBounds(lb, ub) => Bounds(go(lb), go(ub))

--- a/shared/src/main/scala/mlscript/TyperDatatypes.scala
+++ b/shared/src/main/scala/mlscript/TyperDatatypes.scala
@@ -232,6 +232,19 @@ abstract class TyperDatatypes extends TyperHelpers { self: Typer =>
       tag = S(res)
       res
     }
+    def mapTargs[R](pol: Opt[Bool])(f: (Opt[Bool], ST) => R)(implicit ctx: Ctx): Ls[R] = {
+      val td = ctx.tyDefs(defn.name)
+      td.tvarVariances.fold(targs.map(f(N, _))) { tvv =>
+        assert(td.tparamsargs.sizeCompare(targs) === 0)
+        (td.tparamsargs lazyZip targs).map { case ((_, tv), ta) =>
+          tvv(tv) match {
+            case VarianceInfo(true, true) =>
+              f(S(true), TypeBounds(BotType, TopType)(noProv))
+            case VarianceInfo(co, contra) =>
+              f(if (co) pol else if (contra) pol.map(!_) else N, ta)
+          }
+      }}
+    }
     override def toString = showProvOver(false) {
       val displayName =
         if (primitiveTypes.contains(defn.name)) defn.name.capitalize else defn.name
@@ -307,16 +320,16 @@ abstract class TyperDatatypes extends TyperHelpers { self: Typer =>
     lazy val asTypeVar = new TypeVar(L(uid), nameHint)
     def compare(that: TV): Int = this.uid compare that.uid
     
-    def isRecursive_$ : Bool = (lbRecOccs_$, ubRecOccs_$) match {
+    def isRecursive_$(implicit ctx: Ctx) : Bool = (lbRecOccs_$, ubRecOccs_$) match {
       case (S(N | S(true)), _) | (_, S(N | S(false))) => true
       case _ => false
     } 
     /** None: not recursive in this bound; Some(Some(pol)): polarly-recursive; Some(None): nonpolarly-recursive.
       * Note that if we have something like 'a :> Bot <: 'a -> Top, 'a is not truly recursive
       *   and its bounds can actually be inlined. */
-    private final def lbRecOccs_$: Opt[Opt[Bool]] =
+    private final def lbRecOccs_$(implicit ctx: Ctx): Opt[Opt[Bool]] =
       TupleType(lowerBounds.map(N -> _.toUpper(noProv)))(noProv).getVarsPol(S(true)).get(this)
-    private final def ubRecOccs_$: Opt[Opt[Bool]] =
+    private final def ubRecOccs_$(implicit ctx: Ctx): Opt[Opt[Bool]] =
       TupleType(upperBounds.map(N -> _.toUpper(noProv)))(noProv).getVarsPol(S(false)).get(this)
     
     override def toString: String = showProvOver(false)(nameHint.getOrElse("α") + uid + "'" * level)

--- a/shared/src/main/scala/mlscript/TyperDatatypes.scala
+++ b/shared/src/main/scala/mlscript/TyperDatatypes.scala
@@ -244,7 +244,8 @@ abstract class TyperDatatypes extends TyperHelpers { self: Typer =>
         (td.tparamsargs lazyZip targs).map { case ((_, tv), ta) =>
           tvv(tv) match {
             case VarianceInfo(true, true) =>
-              f(S(true), TypeBounds(BotType, TopType)(noProv))
+              // f(S(true), TypeBounds(BotType, TopType)(noProv))
+              f(N, TypeBounds(BotType, TopType)(noProv))
             case VarianceInfo(co, contra) =>
               f(if (co) pol else if (contra) pol.map(!_) else N, ta)
           }

--- a/shared/src/main/scala/mlscript/TyperDatatypes.scala
+++ b/shared/src/main/scala/mlscript/TyperDatatypes.scala
@@ -214,10 +214,8 @@ abstract class TyperDatatypes extends TyperHelpers { self: Typer =>
       require(targs.size === td.tparamsargs.size)
       lazy val tparamTags =
         if (paramTags) RecordType.mk(td.tparamsargs.map { case (tp, tv) =>
-            // val tvv = td.tvarVariances.getOrElse(Map.empty[TV, VarianceInfo].withDefaultValue(VarianceInfo.in))
             val tvv = td.getVariancesOrDefault
             tparamField(defn, tp) -> FieldType(
-              // if (tvv(tv).isCovariant) N else Some(tv),
               Some(if (tvv(tv).isCovariant) BotType else tv),
               if (tvv(tv).isContravariant) TopType else tv)(prov)
           }.toList)(noProv)
@@ -244,7 +242,6 @@ abstract class TyperDatatypes extends TyperHelpers { self: Typer =>
         (td.tparamsargs lazyZip targs).map { case ((_, tv), ta) =>
           tvv(tv) match {
             case VarianceInfo(true, true) =>
-              // f(S(true), TypeBounds(BotType, TopType)(noProv))
               f(N, TypeBounds(BotType, TopType)(noProv))
             case VarianceInfo(co, contra) =>
               f(if (co) pol else if (contra) pol.map(!_) else N, ta)
@@ -312,7 +309,6 @@ abstract class TyperDatatypes extends TyperHelpers { self: Typer =>
     def update(lb: SimpleType => SimpleType, ub: SimpleType => SimpleType): FieldType =
       FieldType(this.lb.map(lb), ub(this.ub))(prov)
     override def toString =
-      // lb.filterNot(_ === BotType).fold(s"$ub")(lb => s"mut $lb..$ub")
       lb.fold(s"$ub")(lb => s"mut ${if (lb === BotType) "" else lb}..$ub")
   }
   

--- a/shared/src/main/scala/mlscript/TyperHelpers.scala
+++ b/shared/src/main/scala/mlscript/TyperHelpers.scala
@@ -307,9 +307,7 @@ abstract class TyperHelpers { Typer: Typer =>
       case ProvType(underlying) => ProvType(f(pol, underlying))(prov)
       case WithType(bse, rcd) => WithType(f(pol, bse), RecordType(rcd.fields.mapValues(_.update(f(pol.map(!_), _), f(pol, _))))(rcd.prov))(prov)
       case ProxyType(underlying) => f(pol, underlying) // TODO different?
-      case tr @ TypeRef(defn, targs) =>
-        // TypeRef(defn, targs.map(f(N, _)))(prov)
-        TypeRef(defn, tr.mapTargs(pol)(f))(prov)
+      case tr @ TypeRef(defn, targs) => TypeRef(defn, tr.mapTargs(pol)(f))(prov)
       case _: TypeVariable | _: ObjectTag | _: ExtrType => this
     }
     

--- a/shared/src/test/diff/analysis/Variance.mls
+++ b/shared/src/test/diff/analysis/Variance.mls
@@ -28,7 +28,7 @@ class Z[X, R]
 //│ Defined class E[=G]
 //│ Declared E.Id: E['G] -> 'G -> 'G
 //│ Defined class Z[=X, ±R]
-//│ Declared Z.Phantom: Z['X, anything] -> C['X]
+//│ Declared Z.Phantom: Z['X, ?] -> C['X]
 //│ ╔══[WARNING] Type definition Z has bivariant type parameters:
 //│ ║  l.24: 	class Z[X, R]
 //│ ║        	      ^

--- a/shared/src/test/diff/analysis/Variance.mls
+++ b/shared/src/test/diff/analysis/Variance.mls
@@ -37,32 +37,8 @@ class Z[X, R]
 //│ ╙──      	           ^
 
 
-:dv
 class C0[A]
   method M0 (x: A) = x
-//│ VARIANCE ANALYSIS
-//│ ⬤ ITERATION 1
-//│ | class C0  ± A73'
-//│ | | upd[+] ⊤
-//│ | | upd[+] (A73' -> [α76'])
-//│ | | | upd[-] (A73',)
-//│ | | | | upd[-] A73'
-//│ | | | | | UPDATE C0.A73' from ± to -
-//│ | | | upd[+] [α76']
-//│ | | | | upd[+] α76'
-//│ | | | | | UPDATE C0.α76' from ± to +
-//│ | | | | | upd[+] A73'
-//│ | | | | | | UPDATE C0.A73' from - to =
-//│ ⬤ ITERATION 2
-//│ | class C0  = A73'  + α76'
-//│ | | upd[+] ⊤
-//│ | | upd[+] (A73' -> [α76'])
-//│ | | | upd[-] (A73',)
-//│ | | | | upd[-] A73'
-//│ | | | upd[+] [α76']
-//│ | | | | upd[+] α76'
-//│ | | | | | upd[+] A73'
-//│ DONE
 //│ Defined class C0[=A]
 //│ Defined C0.M0: C0['A] -> 'A -> 'A
 
@@ -75,13 +51,13 @@ class C1[A]
   method M1 (x: A) = x
   method M1: nothing -> anything
 //│ Defined class C1[±A]
-//│ Declared C1.M1: C1['A] -> nothing -> anything
-//│ Defined C1.M1: C1['A] -> 'A -> 'A
+//│ Declared C1.M1: C1[?] -> nothing -> anything
+//│ Defined C1.M1: C1[?] -> 'A -> 'A
 //│ ╔══[WARNING] Type definition C1 has bivariant type parameters:
-//│ ║  l.74: 	class C1[A]
+//│ ║  l.50: 	class C1[A]
 //│ ║        	      ^^
 //│ ╟── A is irrelevant and may be removed
-//│ ║  l.74: 	class C1[A]
+//│ ║  l.50: 	class C1[A]
 //│ ╙──      	         ^
 
 

--- a/shared/src/test/diff/analysis/Variance.mls
+++ b/shared/src/test/diff/analysis/Variance.mls
@@ -28,7 +28,7 @@ class Z[X, R]
 //│ Defined class E[=G]
 //│ Declared E.Id: E['G] -> 'G -> 'G
 //│ Defined class Z[=X, ±R]
-//│ Declared Z.Phantom: Z['X, 'R] -> C['X]
+//│ Declared Z.Phantom: Z['X, anything] -> C['X]
 //│ ╔══[WARNING] Type definition Z has bivariant type parameters:
 //│ ║  l.24: 	class Z[X, R]
 //│ ║        	      ^

--- a/shared/src/test/diff/basics/Datatypes.fun
+++ b/shared/src/test/diff/basics/Datatypes.fun
@@ -125,7 +125,7 @@ data type List a of
 //│ ╟── a is irrelevant and may be removed
 //│ ║  l.110: 	data type List a of
 //│ ╙──       	               ^
-//│ Nil: Nil[anything]
+//│ Nil: Nil[?]
 //│ Cons: (head: 'a,) -> (tail: List['a],) -> Cons['a]
 
 // TODO interpret as free type variable?
@@ -157,7 +157,7 @@ Cons
 Cons 1
 Cons 2 Nil
 Cons 1 (Cons 2 Nil)
-//│ res: Nil[anything]
+//│ res: Nil[?]
 //│ res: (head: 'a,) -> (tail: List['a],) -> Cons['a]
 //│ res: (tail: List['a],) -> Cons[1 | 'a]
 //│ res: Cons[2]

--- a/shared/src/test/diff/basics/Datatypes.fun
+++ b/shared/src/test/diff/basics/Datatypes.fun
@@ -205,7 +205,7 @@ Cons 1 2
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.204: 	Cons 1 2
 //│ ║         	^^^^^^^^
-//│ ╟── integer literal of type `2` does not match type `Cons[?a] | Nil[anything]`
+//│ ╟── integer literal of type `2` does not match type `Cons[?a] | Nil[?]`
 //│ ║  l.204: 	Cons 1 2
 //│ ║         	       ^
 //│ ╟── Note: constraint arises from union type:

--- a/shared/src/test/diff/basics/Datatypes.fun
+++ b/shared/src/test/diff/basics/Datatypes.fun
@@ -125,7 +125,7 @@ data type List a of
 //│ ╟── a is irrelevant and may be removed
 //│ ║  l.110: 	data type List a of
 //│ ╙──       	               ^
-//│ Nil: Nil['a]
+//│ Nil: Nil[anything]
 //│ Cons: (head: 'a,) -> (tail: List['a],) -> Cons['a]
 
 // TODO interpret as free type variable?
@@ -157,17 +157,11 @@ Cons
 Cons 1
 Cons 2 Nil
 Cons 1 (Cons 2 Nil)
-//│ res: Nil['a]
+//│ res: Nil[anything]
 //│ res: (head: 'a,) -> (tail: List['a],) -> Cons['a]
-//│ res: (tail: List['a],) -> Cons['a]
-//│   where
-//│     'a :> 1
-//│ res: Cons['a]
-//│   where
-//│     'a :> 2
-//│ res: Cons['a]
-//│   where
-//│     'a :> 1 | 2
+//│ res: (tail: List['a],) -> Cons[1 | 'a]
+//│ res: Cons[2]
+//│ res: Cons[1 | 2]
 
 (Cons 3 Nil).head
 succ (Cons 3 Nil).head
@@ -179,20 +173,20 @@ not (Cons false Nil).head
 :e
 not (Cons 42 Nil).head
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.180: 	not (Cons 42 Nil).head
+//│ ║  l.174: 	not (Cons 42 Nil).head
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── integer literal of type `42` does not match type `bool`
-//│ ║  l.180: 	not (Cons 42 Nil).head
+//│ ║  l.174: 	not (Cons 42 Nil).head
 //│ ║         	          ^^
 //│ ╟── but it flows into field selection with expected type `bool`
-//│ ║  l.180: 	not (Cons 42 Nil).head
+//│ ║  l.174: 	not (Cons 42 Nil).head
 //│ ╙──       	                 ^^^^^
 //│ res: bool | error
 
 :e
 (Cons 4).head
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.193: 	(Cons 4).head
+//│ ║  l.187: 	(Cons 4).head
 //│ ║         	        ^^^^^
 //│ ╟── type `(tail: List[?a],) -> Cons[?a]` does not have field 'head'
 //│ ║  l.110: 	data type List a of
@@ -202,17 +196,17 @@ not (Cons 42 Nil).head
 //│ ║  l.112: 	  Cons (head: a) (tail: List a)
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into receiver with expected type `{head: ?head}`
-//│ ║  l.193: 	(Cons 4).head
+//│ ║  l.187: 	(Cons 4).head
 //│ ╙──       	^^^^^^^^
 //│ res: error
 
 :e
 Cons 1 2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.210: 	Cons 1 2
+//│ ║  l.204: 	Cons 1 2
 //│ ║         	^^^^^^^^
-//│ ╟── integer literal of type `2` does not match type `Cons[?a] | Nil[?a]`
-//│ ║  l.210: 	Cons 1 2
+//│ ╟── integer literal of type `2` does not match type `Cons[?a] | Nil[anything]`
+//│ ║  l.204: 	Cons 1 2
 //│ ║         	       ^
 //│ ╟── Note: constraint arises from union type:
 //│ ║  l.110: 	data type List a of
@@ -220,15 +214,13 @@ Cons 1 2
 //│ ╟── from tuple type:
 //│ ║  l.112: 	  Cons (head: a) (tail: List a)
 //│ ╙──       	                        ^^^^^^
-//│ res: Cons['a] | error
-//│   where
-//│     'a :> 1
+//│ res: Cons[1] | error
 
 // TODO Allow method/field defintions in the same file (lose the let?):
 :e
 let List.head = () // ...
 //│ ╔══[ERROR] Unsupported pattern shape
-//│ ║  l.229: 	let List.head = () // ...
+//│ ║  l.221: 	let List.head = () // ...
 //│ ╙──       	        ^^^^^
 //│ <error>: ()
 

--- a/shared/src/test/diff/basics/Either.fun
+++ b/shared/src/test/diff/basics/Either.fun
@@ -25,8 +25,8 @@ data type Either l r of
 //│ ╟── l is irrelevant and may be removed
 //│ ║  l.4: 	data type Either l r of
 //│ ╙──     	                 ^
-//│ Left: 'a -> Left['a, 'b]
-//│ Right: 'a -> Right['b, 'a]
+//│ Left: 'a -> Left['a, anything]
+//│ Right: 'a -> Right[anything, 'a]
 
 :e
 data type Either2 (l: _) (r: _) of
@@ -53,21 +53,14 @@ data type Either2 (l: _) (r: _) of
 let l = Left 1
 let r = Right "ok"
 let e = if _ then l else r
-//│ l: Left['a, 'b]
-//│   where
-//│     'a :> 1
-//│ r: Right['a, 'b]
-//│   where
-//│     'b :> "ok"
-//│ e: Left['a, 'b] | Right['c, 'd]
-//│   where
-//│     'd :> "ok"
-//│     'a :> 1
+//│ l: Left[1, anything]
+//│ r: Right[anything, "ok"]
+//│ e: Left[1, anything] | Right[anything, "ok"]
 
 :e // TODO
 e as Either Int String
 //│ ╔══[ERROR] Unsupported pattern shape:
-//│ ║  l.68: 	e as Either Int String
+//│ ║  l.61: 	e as Either Int String
 //│ ╙──      	     ^^^^^^^^^^^^^^^^^
 //│ res: error
 
@@ -78,7 +71,7 @@ e as Either Int String
 :e
 e as Either
 //│ ╔══[ERROR] identifier not found: Either
-//│ ║  l.79: 	e as Either
+//│ ║  l.72: 	e as Either
 //│ ╙──      	     ^^^^^^
 //│ res: error
 

--- a/shared/src/test/diff/basics/Either.fun
+++ b/shared/src/test/diff/basics/Either.fun
@@ -25,8 +25,8 @@ data type Either l r of
 //│ ╟── l is irrelevant and may be removed
 //│ ║  l.4: 	data type Either l r of
 //│ ╙──     	                 ^
-//│ Left: 'a -> Left['a, anything]
-//│ Right: 'a -> Right[anything, 'a]
+//│ Left: 'a -> Left['a, ?]
+//│ Right: 'a -> Right[?, 'a]
 
 :e
 data type Either2 (l: _) (r: _) of
@@ -53,9 +53,9 @@ data type Either2 (l: _) (r: _) of
 let l = Left 1
 let r = Right "ok"
 let e = if _ then l else r
-//│ l: Left[1, anything]
-//│ r: Right[anything, "ok"]
-//│ e: Left[1, anything] | Right[anything, "ok"]
+//│ l: Left[1, ?]
+//│ r: Right[?, "ok"]
+//│ e: Left[1, ?] | Right[?, "ok"]
 
 :e // TODO
 e as Either Int String

--- a/shared/src/test/diff/basics/ExplicitDatatypes.fun
+++ b/shared/src/test/diff/basics/ExplicitDatatypes.fun
@@ -10,10 +10,7 @@ let Either l r = Left l | Right r // TODO actual type parameters
 //│ Either: 'a -> 'b -> (Left['a] | Right['b])
 
 Either 1 2
-//│ res: Left['a] | Right['b]
-//│   where
-//│     'b :> 2
-//│     'a :> 1
+//│ res: Left[1] | Right[2]
 
 res.v
 //│ res: 1 | 2

--- a/shared/src/test/diff/codegen/Classes.mls
+++ b/shared/src/test/diff/codegen/Classes.mls
@@ -146,6 +146,48 @@ MyBox.Map mb (fun x -> x * 3)
 
 
 
+// Note that there is currently an inconsistency with wildcards:
+//  The type simplifier uses `?` to denote a class type argument wildcard,
+//    meaning there are no constraints on the corresponding class parameter in that type application,
+//    while user-written `?` in type signatures is handled like a definition-wide existential,
+//    which is NOT the same:
+
+def f0 (x: Box['_]) = 42
+//│ f0: Box[?] -> 42
+//│   = [Function: f0]
+
+f0(Box{})
+//│ res: 42
+//│    = 42
+
+// i.e., def f: exists T. Box[T] -> int
+def f: Box[?] -> int
+//│ f: Box[nothing] -> int
+//│  = <missing implementation>
+
+:e
+f(Box{})
+//│ ╔══[ERROR] Type mismatch in application:
+//│ ║  l.169: 	f(Box{})
+//│ ║         	^^^^^^^^
+//│ ╟── record literal of type `anything` does not match type `nothing`
+//│ ║  l.169: 	f(Box{})
+//│ ║         	     ^^
+//│ ╟── Note: constraint arises from type wildcard:
+//│ ║  l.164: 	def f: Box[?] -> int
+//│ ╙──       	           ^
+//│ res: error | int
+//│    = <no result>
+//│      f is not implemented
+
+f = f0
+//│ Box[?] -> 42
+//│   <:  f:
+//│ Box[nothing] -> int
+//│  = [Function: f0]
+
+
+
 //  Some simplification tests:
 
 :NoJS

--- a/shared/src/test/diff/codegen/Classes.mls
+++ b/shared/src/test/diff/codegen/Classes.mls
@@ -11,7 +11,7 @@ class Box[T]: { inner: T }
   method Get = this.inner
 //│ Defined class Box[+T]
 //│ Declared Box.Map: Box['T] -> ('T -> 'a) -> Box['a]
-//│ Defined Box.Map: Box['T] -> ('T -> ('inner & 'T0)) -> (Box['T0] with {inner: 'inner})
+//│ Defined Box.Map: Box['T] -> ('T -> 'inner) -> Box['inner]
 //│ Defined Box.Get: Box['T] -> 'T
 //│ // Prelude
 //│ class Box {
@@ -35,7 +35,7 @@ def Box value = Box { inner = value }
 //│ };
 //│ res = Box1;
 //│ // End of generated code
-//│ Box: ('inner & 'T) -> (Box['T] with {inner: 'inner})
+//│ Box: 'inner -> Box['inner]
 //│    = [Function: Box1]
 
 :js
@@ -48,13 +48,9 @@ def box2 = box1.Map (fun x -> add x 1)
 //│ globalThis.box2 = box1.Map((x) => add(x)(1));
 //│ res = box2;
 //│ // End of generated code
-//│ box1: Box['T] & {inner: 1}
-//│   where
-//│     'T :> 1
+//│ box1: Box[1]
 //│     = Box { inner: 1 }
-//│ box2: Box['a]
-//│   where
-//│     'a :> int
+//│ box2: Box[int]
 //│     = Box { inner: 2 }
 
 :js
@@ -71,7 +67,7 @@ class MyBox: Box[int] & { info: string }
   method Inc = MyBox { inner = this.inner + 1; info = this.info }
 def MyBox inner info = MyBox { inner; info }
 //│ Defined class MyBox
-//│ Defined MyBox.Map: MyBox -> (int -> ('inner & 'T)) -> (Box['T] with {info: string, inner: 'inner})
+//│ Defined MyBox.Map: MyBox -> (int -> 'inner) -> (Box['inner] with {info: string})
 //│ Defined MyBox.Inc: MyBox -> MyBox
 //│ // Prelude
 //│ class MyBox extends Box {
@@ -121,15 +117,13 @@ mb2.Get
 //│ // Query 5
 //│ res = mb2.Get;
 //│ // End of generated code
-//│ mb: MyBox & {info: "hello", inner: 1}
+//│ mb: MyBox with {info: "hello", inner: 1}
 //│   = MyBox { inner: 1, info: 'hello' }
 //│ mb: MyBox
 //│   = MyBox { inner: 2, info: 'hello' }
 //│ res: int
 //│    = 2
-//│ mb2: Box['a]
-//│   where
-//│     'a :> int
+//│ mb2: Box[int]
 //│    = Box { inner: 6, info: 'hello' }
 //│ res: int
 //│    = 6
@@ -143,14 +137,10 @@ MyBox.Map mb (fun x -> x * 3)
 //│ // Query 2
 //│ res = MyBox1.Map(mb1)((x) => x * 3);
 //│ // End of generated code
-//│ res: Box['T] & {info: string, inner: int}
-//│   where
-//│     'T :> int
+//│ res: Box[int] with {info: string}
 //│ Runtime error:
 //│   TypeError: mb1.MyBox.Map is not a function
-//│ res: Box['T] & {info: string, inner: int}
-//│   where
-//│     'T :> int
+//│ res: Box[int] with {info: string}
 //│ Runtime error:
 //│   TypeError: MyBox1.Map is not a function
 
@@ -170,10 +160,10 @@ error : Box[int] & ~box
 //│ res: nothing
 
 error : Box[?] | Box[?] & {x: '_}
-//│ res: Box[?]
+//│ res: Box[anything]
 
 error : ((Box[?] | Box[?] & {x: 'a -> int}) & 'a) -> 'a
-//│ res: (Box[?] & 'a) -> 'a
+//│ res: (Box[nothing] & 'a) -> 'a
 
 error: "" | string
 //│ res: string

--- a/shared/src/test/diff/codegen/Classes.mls
+++ b/shared/src/test/diff/codegen/Classes.mls
@@ -67,7 +67,7 @@ class MyBox: Box[int] & { info: string }
   method Inc = MyBox { inner = this.inner + 1; info = this.info }
 def MyBox inner info = MyBox { inner; info }
 //│ Defined class MyBox
-//│ Defined MyBox.Map: MyBox -> (int -> 'inner) -> (Box['inner] with {info: string})
+//│ Defined MyBox.Map: MyBox -> (int -> 'inner) -> (Box['inner] & {info: string})
 //│ Defined MyBox.Inc: MyBox -> MyBox
 //│ // Prelude
 //│ class MyBox extends Box {
@@ -117,7 +117,7 @@ mb2.Get
 //│ // Query 5
 //│ res = mb2.Get;
 //│ // End of generated code
-//│ mb: MyBox with {info: "hello", inner: 1}
+//│ mb: MyBox & {info: "hello", inner: 1}
 //│   = MyBox { inner: 1, info: 'hello' }
 //│ mb: MyBox
 //│   = MyBox { inner: 2, info: 'hello' }
@@ -137,10 +137,10 @@ MyBox.Map mb (fun x -> x * 3)
 //│ // Query 2
 //│ res = MyBox1.Map(mb1)((x) => x * 3);
 //│ // End of generated code
-//│ res: Box[int] with {info: string}
+//│ res: Box[int] & {info: string}
 //│ Runtime error:
 //│   TypeError: mb1.MyBox.Map is not a function
-//│ res: Box[int] with {info: string}
+//│ res: Box[int] & {info: string}
 //│ Runtime error:
 //│   TypeError: MyBox1.Map is not a function
 

--- a/shared/src/test/diff/codegen/Classes.mls
+++ b/shared/src/test/diff/codegen/Classes.mls
@@ -160,7 +160,7 @@ error : Box[int] & ~box
 //│ res: nothing
 
 error : Box[?] | Box[?] & {x: '_}
-//│ res: Box[anything]
+//│ res: Box[?]
 
 error : ((Box[?] | Box[?] & {x: 'a -> int}) & 'a) -> 'a
 //│ res: (Box[nothing] & 'a) -> 'a

--- a/shared/src/test/diff/mlscript/ADTs.mls
+++ b/shared/src/test/diff/mlscript/ADTs.mls
@@ -26,7 +26,7 @@ rec def evalStub2 e = case e of {
   }
 //│ evalStub2: 'a -> int
 //│   where
-//│     'a <: Lit | (Nega[nothing] with {arg: 'a})
+//│     'a <: Lit | Nega[anything] & {arg: 'a}
 //│          = [Function: evalStub2]
 
 rec def eval e = case e of {
@@ -36,7 +36,7 @@ rec def eval e = case e of {
   }
 //│ eval: 'a -> int
 //│   where
-//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit | (Nega[nothing] with {arg: 'a})
+//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit | Nega[anything] & {arg: 'a}
 //│     = [Function: eval]
 
 def ex = add (lit 2) (lit 2)
@@ -102,10 +102,10 @@ eval exp
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+2: 	eval exp
 //│ ║        	^^^^^^^^
-//│ ╟── type `Array[Automata] -> Array[Binding]` does not match type `Add[?] & ?a | Lit & ?b | Nega[?] & ?c`
+//│ ╟── type `Array[Automata] -> Array[Binding]` does not match type `Add[anything] & ?a | Lit & ?b | Nega[anything] & ?c`
 //│ ║  l.+1: 	def exp: Array[Automata] -> Array[Binding]
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `Add[?] & ?d | Lit & ?e | Nega[?] & ?f`
+//│ ╟── but it flows into reference with expected type `Add[anything] & ?d | Lit & ?e | Nega[anything] & ?f`
 //│ ║  l.+2: 	eval exp
 //│ ║        	     ^^^
 //│ ╟── Note: constraint arises from reference:
@@ -118,27 +118,24 @@ eval (e : Lit | Add['e] | Nega[int] as 'e)
 //│ ╔══[ERROR] Type mismatch in type ascription:
 //│ ║  l.+1: 	eval (e : Lit | Add['e] | Nega[int] as 'e)
 //│ ║        	      ^
-//│ ╟── type `int` does not match type `Add[?e] | Lit | Nega[int]`
-//│ ║  l.+1: 	eval (e : Lit | Add['e] | Nega[int] as 'e)
-//│ ║        	                               ^^^
-//│ ╟── Note: constraint arises from union type:
-//│ ║  l.+1: 	eval (e : Lit | Add['e] | Nega[int] as 'e)
-//│ ║        	          ^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── from local type binding:
+//│ ╟── type `Lit` is not an instance of `int`
 //│ ║  l.62: 	def e: Lit | Add['e] | Nega['e] as 'e
-//│ ╙──      	       ^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║        	       ^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.+1: 	eval (e : Lit | Add['e] | Nega[int] as 'e)
+//│ ╙──      	                               ^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	eval (e : Lit | Add['e] | Nega[int] as 'e)
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── type `int` does not match type `Add[?] & ?a | Lit & ?b | Nega[?] & ?c`
+//│ ╟── type `int` does not match type `Add[anything] & ?a | Lit & ?b | Nega[anything] & ?c`
 //│ ║  l.+1: 	eval (e : Lit | Add['e] | Nega[int] as 'e)
 //│ ║        	                               ^^^
-//│ ╟── but it flows into reference with expected type `Add[?] & ?d | Lit & ?e | Nega[?] & ?f`
-//│ ║  l.+1: 	eval (e : Lit | Add['e] | Nega[int] as 'e)
-//│ ║        	      ^
 //│ ╟── Note: constraint arises from reference:
 //│ ║  l.32: 	rec def eval e = case e of {
-//│ ╙──      	                      ^
+//│ ║        	                      ^
+//│ ╟── from field selection:
+//│ ║  l.35: 	  | Nega -> 0 - (eval e.arg)
+//│ ╙──      	                      ^^^^^
 //│ res: error | int
 
 

--- a/shared/src/test/diff/mlscript/ADTs.mls
+++ b/shared/src/test/diff/mlscript/ADTs.mls
@@ -26,7 +26,7 @@ rec def evalStub2 e = case e of {
   }
 //│ evalStub2: 'a -> int
 //│   where
-//│     'a <: Lit | Nega[anything] & {arg: 'a}
+//│     'a <: Lit | Nega[?] & {arg: 'a}
 //│          = [Function: evalStub2]
 
 rec def eval e = case e of {
@@ -36,7 +36,7 @@ rec def eval e = case e of {
   }
 //│ eval: 'a -> int
 //│   where
-//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit | Nega[anything] & {arg: 'a}
+//│     'a <: Add[?] & {lhs: 'a, rhs: 'a} | Lit | Nega[?] & {arg: 'a}
 //│     = [Function: eval]
 
 def ex = add (lit 2) (lit 2)
@@ -102,10 +102,10 @@ eval exp
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+2: 	eval exp
 //│ ║        	^^^^^^^^
-//│ ╟── type `Array[Automata] -> Array[Binding]` does not match type `Add[anything] & ?a | Lit & ?b | Nega[anything] & ?c`
+//│ ╟── type `Array[Automata] -> Array[Binding]` does not match type `Add[?] & ?a | Lit & ?b | Nega[?] & ?c`
 //│ ║  l.+1: 	def exp: Array[Automata] -> Array[Binding]
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `Add[anything] & ?d | Lit & ?e | Nega[anything] & ?f`
+//│ ╟── but it flows into reference with expected type `Add[?] & ?d | Lit & ?e | Nega[?] & ?f`
 //│ ║  l.+2: 	eval exp
 //│ ║        	     ^^^
 //│ ╟── Note: constraint arises from reference:
@@ -127,7 +127,7 @@ eval (e : Lit | Add['e] | Nega[int] as 'e)
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	eval (e : Lit | Add['e] | Nega[int] as 'e)
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── type `int` does not match type `Add[anything] & ?a | Lit & ?b | Nega[anything] & ?c`
+//│ ╟── type `int` does not match type `Add[?] & ?a | Lit & ?b | Nega[?] & ?c`
 //│ ║  l.+1: 	eval (e : Lit | Add['e] | Nega[int] as 'e)
 //│ ║        	                               ^^^
 //│ ╟── Note: constraint arises from reference:

--- a/shared/src/test/diff/mlscript/ADTs.mls
+++ b/shared/src/test/diff/mlscript/ADTs.mls
@@ -12,7 +12,7 @@ def nega arg = Nega { arg }
 //│    = [Function: lit]
 //│ add: ('lhs & 'E) -> ('E & 'rhs) -> (Add['E] with {lhs: 'lhs, rhs: 'rhs})
 //│    = [Function: add]
-//│ nega: ('arg & 'E) -> (Nega['E] with {arg: 'arg})
+//│ nega: 'arg -> Nega['arg]
 //│     = [Function: nega]
 
 rec def evalStub1 e = case e of {
@@ -26,7 +26,7 @@ rec def evalStub2 e = case e of {
   }
 //│ evalStub2: 'a -> int
 //│   where
-//│     'a <: Lit | (Nega[?] with {arg: 'a})
+//│     'a <: Lit | (Nega[nothing] with {arg: 'a})
 //│          = [Function: evalStub2]
 
 rec def eval e = case e of {
@@ -36,13 +36,11 @@ rec def eval e = case e of {
   }
 //│ eval: 'a -> int
 //│   where
-//│     'a <: (Add[?] with {lhs: 'a, rhs: 'a}) | Lit | (Nega[?] with {arg: 'a})
+//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit | (Nega[nothing] with {arg: 'a})
 //│     = [Function: eval]
 
 def ex = add (lit 2) (lit 2)
-//│ ex: Add['E] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 2}}
-//│   where
-//│     'E :> Lit & {val: 2}
+//│ ex: Add[Lit & {val: 2}]
 //│   = Add { lhs: Lit { val: 2 }, rhs: Lit { val: 2 } }
 
 eval ex
@@ -52,29 +50,27 @@ eval ex
 def e: Add['e] as 'e
 //│ e: 'e
 //│   where
-//│     'e := Add['e]
+//│     'e :> Add['e]
 //│  = <missing implementation>
 
 def e: Lit | Add['e] as 'e
 //│ e: 'e
 //│   where
-//│     'e := Add['e] | Lit
+//│     'e :> Add['e] | Lit
 //│  = <missing implementation>
 
 def e: Lit | Add['e] | Nega['e] as 'e
 //│ e: 'e
 //│   where
-//│     'e := Add['e] | Lit | Nega['e]
+//│     'e :> Add['e] | Lit | Nega['e]
 //│  = <missing implementation>
 
 def e = ex
-//│ Add['E] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 2}}
-//│   where
-//│     'E :> Lit & {val: 2}
+//│ Add[Lit & {val: 2}]
 //│   <:  e:
 //│ 'e
 //│   where
-//│     'e := Add['e] | Lit | Nega['e]
+//│     'e :> Add['e] | Lit | Nega['e]
 //│  = Add { lhs: Lit { val: 2 }, rhs: Lit { val: 2 } }
 
 eval e
@@ -129,7 +125,7 @@ eval (e : Lit | Add['e] | Nega[int] as 'e)
 //│ ║  l.+1: 	eval (e : Lit | Add['e] | Nega[int] as 'e)
 //│ ║        	          ^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from local type binding:
-//│ ║  l.64: 	def e: Lit | Add['e] | Nega['e] as 'e
+//│ ║  l.62: 	def e: Lit | Add['e] | Nega['e] as 'e
 //│ ╙──      	       ^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	eval (e : Lit | Add['e] | Nega[int] as 'e)

--- a/shared/src/test/diff/mlscript/Ascribe.mls
+++ b/shared/src/test/diff/mlscript/Ascribe.mls
@@ -31,7 +31,7 @@ class Foo[A]: { field: A }
 //│ Defined class Foo[+A]
 
 def foo(f: Foo['a]) = f.field
-//│ foo: Foo['a] -> 'a
+//│ foo: Foo['field] -> 'field
 //│    = [Function: foo2]
 
 

--- a/shared/src/test/diff/mlscript/BadClasses.mls
+++ b/shared/src/test/diff/mlscript/BadClasses.mls
@@ -12,7 +12,7 @@ class Box[T]: { inner: T }
 //│ ╙──     	                ^^^^
 //│ Defined class Box[+T]
 //│ Defined Box.Get: Box['T] -> 'T
-//│ Defined Box.Get2: Box[anything] -> error
+//│ Defined Box.Get2: Box[?] -> error
 
 
 class Box2[T]: { inner: T }
@@ -27,4 +27,4 @@ class Box2[T]: { inner: T }
 //│ ║  l.18: 	class Box2[T]: { inner: T }
 //│ ╙──      	           ^
 //│ Defined class Box2[+T]
-//│ Defined Box2.Test: Box2[anything] -> (error | int)
+//│ Defined Box2.Test: Box2[?] -> (error | int)

--- a/shared/src/test/diff/mlscript/BadClasses.mls
+++ b/shared/src/test/diff/mlscript/BadClasses.mls
@@ -12,7 +12,7 @@ class Box[T]: { inner: T }
 //│ ╙──     	                ^^^^
 //│ Defined class Box[+T]
 //│ Defined Box.Get: Box['T] -> 'T
-//│ Defined Box.Get2: Box['T] -> error
+//│ Defined Box.Get2: Box[anything] -> error
 
 
 class Box2[T]: { inner: T }
@@ -27,4 +27,4 @@ class Box2[T]: { inner: T }
 //│ ║  l.18: 	class Box2[T]: { inner: T }
 //│ ╙──      	           ^
 //│ Defined class Box2[+T]
-//│ Defined Box2.Test: Box2['T] -> (error | int)
+//│ Defined Box2.Test: Box2[anything] -> (error | int)

--- a/shared/src/test/diff/mlscript/BadInherit.mls
+++ b/shared/src/test/diff/mlscript/BadInherit.mls
@@ -93,34 +93,30 @@ Crazy
 //│      Crazy is not implemented
 
 def c = Crazy({ name = "Bob"; age = 42 })
-//│ c: Crazy['a] & 'a
-//│   where
-//│     'a :> {age: 42, name: "Bob"}
+//│ c: Crazy[{age: 42, name: "Bob"}] with {age: 42, name: "Bob"}
 //│  = <no result>
 //│    Crazy is not implemented
 
 :e
 c: nothing
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.103: 	c: nothing
+//│ ║  l.101: 	c: nothing
 //│ ║         	^
 //│ ╟── record literal of type `{age: 42, name: "Bob"}` does not match type `~Crazy[?a]`
 //│ ║  l.95: 	def c = Crazy({ name = "Bob"; age = 42 })
 //│ ║        	              ^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `~Crazy[?a0]`
-//│ ║  l.103: 	c: nothing
+//│ ║  l.101: 	c: nothing
 //│ ║         	^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.103: 	c: nothing
+//│ ║  l.101: 	c: nothing
 //│ ╙──       	   ^^^^^^^
 //│ res: nothing
 //│    = <no result>
 //│      c and Crazy are not implemented
 
 def d = Crazy(Parent1{name = "Bob"})
-//│ d: Crazy['a] & 'a
-//│   where
-//│     'a :> Parent1 & {name: "Bob"}
+//│ d: nothing
 //│  = <no result>
 //│    Crazy is not implemented
 
@@ -133,17 +129,17 @@ d: nothing
 :e
 class Stupid: Parent1 | Parent2
 //│ ╔══[ERROR] cannot inherit from a type union
-//│ ║  l.134: 	class Stupid: Parent1 | Parent2
+//│ ║  l.130: 	class Stupid: Parent1 | Parent2
 //│ ╙──       	      ^^^^^^^^^^^^^^^^^^^^^^^^^
 :e
 class Stupid: Parent1 -> Parent2
 //│ ╔══[ERROR] cannot inherit from a function type
-//│ ║  l.139: 	class Stupid: Parent1 -> Parent2
+//│ ║  l.135: 	class Stupid: Parent1 -> Parent2
 //│ ╙──       	      ^^^^^^^^^^^^^^^^^^^^^^^^^^
 :e
 class Stupid: ~Parent1
 //│ ╔══[ERROR] cannot inherit from a type negation
-//│ ║  l.144: 	class Stupid: ~Parent1
+//│ ║  l.140: 	class Stupid: ~Parent1
 //│ ╙──       	      ^^^^^^^^^^^^^^^^
 
 :e // TODO don't report several times
@@ -152,13 +148,13 @@ class Cycle1: Cycle2
 class Cycle2: Cycle1
 type Stutter = Cycle1
 //│ ╔══[ERROR] illegal cycle involving type Cycle1
-//│ ║  l.151: 	class Cycle1: Cycle2
+//│ ║  l.147: 	class Cycle1: Cycle2
 //│ ╙──       	      ^^^^^^^^^^^^^^
 //│ ╔══[ERROR] illegal cycle involving type Cycle2
-//│ ║  l.152: 	class Cycle2: Cycle1
+//│ ║  l.148: 	class Cycle2: Cycle1
 //│ ╙──       	      ^^^^^^^^^^^^^^
 //│ ╔══[ERROR] illegal cycle involving type Cycle1
-//│ ║  l.153: 	type Stutter = Cycle1
+//│ ║  l.149: 	type Stutter = Cycle1
 //│ ╙──       	     ^^^^^^^^^^^^^^^^
 //│ Code generation encountered an error:
 //│   cyclic inheritance detected
@@ -167,13 +163,13 @@ type Stutter = Cycle1
 def c = Cycle1 error
 c: Cycle1
 //│ ╔══[ERROR] identifier not found: Cycle1
-//│ ║  l.167: 	def c = Cycle1 error
+//│ ║  l.163: 	def c = Cycle1 error
 //│ ╙──       	        ^^^^^^
 //│ c: error
 //│ Runtime error:
 //│   ReferenceError: Cycle1 is not defined
 //│ ╔══[ERROR] type identifier not found: Cycle1
-//│ ║  l.168: 	c: Cycle1
+//│ ║  l.164: 	c: Cycle1
 //│ ╙──       	   ^^^^^^
 //│ res: error
 //│ Runtime error:
@@ -187,7 +183,7 @@ type N[A] = ~A
 :ge
 class Cycle: N[Cycle]
 //│ ╔══[ERROR] cannot inherit from a type alias
-//│ ║  l.188: 	class Cycle: N[Cycle]
+//│ ║  l.184: 	class Cycle: N[Cycle]
 //│ ╙──       	      ^^^^^^^^^^^^^^^
 //│ Code generation encountered an error:
 //│   cannot inherit from type alias N
@@ -215,37 +211,37 @@ E{}: 1
 E{}: int
 E{} + 1
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.214: 	E{}: 1
+//│ ║  l.210: 	E{}: 1
 //│ ║         	^^^
 //│ ╟── application of type `E` does not match type `1`
 //│ ╟── Note: constraint arises from literal type:
-//│ ║  l.214: 	E{}: 1
+//│ ║  l.210: 	E{}: 1
 //│ ║         	     ^
 //│ ╟── Note: class E is defined at:
-//│ ║  l.210: 	class E: 1
+//│ ║  l.206: 	class E: 1
 //│ ╙──       	      ^
 //│ res: 1
 //│    = E {}
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.215: 	E{}: int
+//│ ║  l.211: 	E{}: int
 //│ ║         	^^^
 //│ ╟── application of type `E` does not match type `int`
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.215: 	E{}: int
+//│ ║  l.211: 	E{}: int
 //│ ║         	     ^^^
 //│ ╟── Note: class E is defined at:
-//│ ║  l.210: 	class E: 1
+//│ ║  l.206: 	class E: 1
 //│ ╙──       	      ^
 //│ res: int
 //│    = E {}
 //│ ╔══[ERROR] Type mismatch in operator application:
-//│ ║  l.216: 	E{} + 1
+//│ ║  l.212: 	E{} + 1
 //│ ║         	^^^^^
 //│ ╟── application of type `E` does not match type `int`
-//│ ║  l.216: 	E{} + 1
+//│ ║  l.212: 	E{} + 1
 //│ ║         	^^^
 //│ ╟── Note: class E is defined at:
-//│ ║  l.210: 	class E: 1
+//│ ║  l.206: 	class E: 1
 //│ ╙──       	      ^
 //│ res: error | int
 //│    = '[object Object]1'
@@ -255,10 +251,10 @@ E{} + 1
 class F: nothing
 F{}
 //│ ╔══[ERROR] cannot inherit from a type alias
-//│ ║  l.255: 	class F: nothing
+//│ ║  l.251: 	class F: nothing
 //│ ╙──       	      ^^^^^^^^^^
 //│ ╔══[ERROR] identifier not found: F
-//│ ║  l.256: 	F{}
+//│ ║  l.252: 	F{}
 //│ ╙──       	^
 //│ res: error
 //│ Code generation encountered an error:
@@ -269,10 +265,10 @@ F{}
 class String
 class Bool
 //│ ╔══[ERROR] Type name 'String' is reserved.
-//│ ║  l.269: 	class String
+//│ ║  l.265: 	class String
 //│ ╙──       	      ^^^^^^
 //│ ╔══[ERROR] Type name 'Bool' is reserved.
-//│ ║  l.270: 	class Bool
+//│ ║  l.266: 	class Bool
 //│ ╙──       	      ^^^^
 //│ Defined class String
 //│ Defined class Bool
@@ -288,7 +284,7 @@ true : Bool
 :e
 class Weird: {} | {}
 //│ ╔══[ERROR] cannot inherit from a type union
-//│ ║  l.289: 	class Weird: {} | {}
+//│ ║  l.285: 	class Weird: {} | {}
 //│ ╙──       	      ^^^^^^^^^^^^^^
 
 
@@ -298,7 +294,7 @@ class A
 type Id[T] = T
 class B: Id[A]
 //│ ╔══[ERROR] cannot inherit from a type alias
-//│ ║  l.299: 	class B: Id[A]
+//│ ║  l.295: 	class B: Id[A]
 //│ ╙──       	      ^^^^^^^^
 //│ Defined class A
 //│ Defined type alias Id[+T]
@@ -310,7 +306,7 @@ class B: Id[A]
 class Class3A
 class Class3B: Class3A & 'a
 //│ ╔══[ERROR] cannot inherit from a type variable
-//│ ║  l.311: 	class Class3B: Class3A & 'a
+//│ ║  l.307: 	class Class3B: Class3A & 'a
 //│ ╙──       	      ^^^^^^^^^^^^^^^^^^^^^
 //│ Defined class Class3A
 

--- a/shared/src/test/diff/mlscript/BadInherit2.mls
+++ b/shared/src/test/diff/mlscript/BadInherit2.mls
@@ -4,11 +4,11 @@
 
 
 trait S0[A]
-  method Foo0: A
+  method Foo0: A -> A
 trait T0[B]: S0[B]
-//│ Defined trait S0[+A]
-//│ Declared S0.Foo0: S0['A] -> 'A
-//│ Defined trait T0[+B]
+//│ Defined trait S0[=A]
+//│ Declared S0.Foo0: S0['A] -> 'A -> 'A
+//│ Defined trait T0[=B]
 
 :e
 class A0: S0[int] & T0[string]
@@ -41,12 +41,12 @@ class A0: S0[int] & T0[string]
 //│ ╟── Hint: method Foo0 is abstract
 //│ ║  l.14: 	class A0: S0[int] & T0[string]
 //│ ╙──      	      ^^^^^^^^^^^^^^^^^^^^^^^^
-//│ res: error
+//│ res: 'A -> ('A | error)
 //│    = undefined
 
 :e
 class A0_2: S0[int] & T0[string]
-  method Foo0 = 1
+  method Foo0 x = 1
 //│ ╔══[ERROR] Type mismatch in type definition:
 //│ ║  l.48: 	class A0_2: S0[int] & T0[string]
 //│ ║        	      ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,97 +66,93 @@ class A0_2: S0[int] & T0[string]
 //│ ║  l.48: 	class A0_2: S0[int] & T0[string]
 //│ ╙──      	               ^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.49: 	  method Foo0 = 1
-//│ ║        	         ^^^^^^^^
+//│ ║  l.49: 	  method Foo0 x = 1
+//│ ║        	         ^^^^^^^^^^
 //│ ╟── integer literal of type `1` does not match type `string`
-//│ ║  l.49: 	  method Foo0 = 1
-//│ ║        	                ^
-//│ ╟── but it flows into method definition with expected type `string`
-//│ ║  l.49: 	  method Foo0 = 1
-//│ ║        	         ^^^^^^^^
+//│ ║  l.49: 	  method Foo0 x = 1
+//│ ║        	                  ^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.48: 	class A0_2: S0[int] & T0[string]
-//│ ║        	                         ^^^^^^
-//│ ╟── from inherited method declaration:
-//│ ║  l.7: 	  method Foo0: A
-//│ ╙──     	         ^^^^^^^
+//│ ╙──      	                         ^^^^^^
 //│ Defined class A0_2
-//│ Defined A0_2.Foo0: A0_2 -> 1
+//│ Defined A0_2.Foo0: A0_2 -> anything -> 1
 
 (A0_2{}).Foo0
-//│ res: nothing
-//│    = 1
+//│ res: ('A & (int | string)) -> 'A
+//│    = [Function: Foo0]
 
 
 // ———
 
 
 trait R1[A]
-  method Foo1: A
-//│ Defined trait R1[+A]
-//│ Declared R1.Foo1: R1['A] -> 'A
+  method Foo1: A -> A
+//│ Defined trait R1[=A]
+//│ Declared R1.Foo1: R1['A] -> 'A -> 'A
 
 trait S1: R1[int]
-  method Foo1 = 1
+  method Foo1 x = 1
 trait T1: R1[string]
-  method Foo1 = "a"
+  method Foo1 x = "a"
 //│ Defined trait S1
-//│ Defined S1.Foo1: S1 -> 1
+//│ Defined S1.Foo1: S1 -> anything -> 1
 //│ Defined trait T1
-//│ Defined T1.Foo1: T1 -> "a"
+//│ Defined T1.Foo1: T1 -> anything -> "a"
 
 :e
 class A1: S1 & T1
 //│ ╔══[ERROR] Type mismatch in type definition:
-//│ ║  l.109: 	class A1: S1 & T1
+//│ ║  l.103: 	class A1: S1 & T1
 //│ ║         	      ^^^^^^^^^^^
 //│ ╟── type `int` is not an instance of `string`
-//│ ║  l.99: 	trait S1: R1[int]
+//│ ║  l.93: 	trait S1: R1[int]
 //│ ║        	             ^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.101: 	trait T1: R1[string]
-//│ ╙──       	             ^^^^^^
+//│ ║  l.95: 	trait T1: R1[string]
+//│ ╙──      	             ^^^^^^
 //│ ╔══[ERROR] Type mismatch in type definition:
-//│ ║  l.109: 	class A1: S1 & T1
+//│ ║  l.103: 	class A1: S1 & T1
 //│ ║         	      ^^^^^^^^^^^
 //│ ╟── type `string` is not an instance of `int`
-//│ ║  l.101: 	trait T1: R1[string]
-//│ ║         	             ^^^^^^
+//│ ║  l.95: 	trait T1: R1[string]
+//│ ║        	             ^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.99: 	trait S1: R1[int]
+//│ ║  l.93: 	trait S1: R1[int]
 //│ ╙──      	             ^^^
 //│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
-//│ ║  l.109: 	class A1: S1 & T1
+//│ ║  l.103: 	class A1: S1 & T1
 //│ ║         	      ^^
 //│ ╟── Definitions of method Foo1 inherited from:
 //│ ╟── • S1
-//│ ║  l.100: 	  method Foo1 = 1
-//│ ║         	         ^^^^^^^^
+//│ ║  l.94: 	  method Foo1 x = 1
+//│ ║        	         ^^^^^^^^^^
 //│ ╟── • T1
-//│ ║  l.102: 	  method Foo1 = "a"
-//│ ╙──       	         ^^^^^^^^^^
+//│ ║  l.96: 	  method Foo1 x = "a"
+//│ ╙──      	         ^^^^^^^^^^^^
 //│ Defined class A1
 
 a1 = A1{}
 //│ a1: A1
-//│   = A1 {}
+//│   = A1 { Foo1: [Function (anonymous)] }
 
 a1.Foo1
-//│ res: nothing
-//│    = 1
+//│ res: ('A & (int | string)) -> 'A
+//│    = [Function (anonymous)]
 
 a1: S1
 a1: R1[int]
 a1: R1[string]
 a1: R1['_]
 //│ res: S1
-//│    = A1 {}
+//│    = A1 { Foo1: [Function (anonymous)] }
 //│ res: R1[int]
-//│    = A1 {}
+//│    = A1 { Foo1: [Function (anonymous)] }
 //│ res: R1[string]
-//│    = A1 {}
-//│ res: R1[nothing]
-//│    = A1 {}
+//│    = A1 { Foo1: [Function (anonymous)] }
+//│ res: R1['_]
+//│   where
+//│     '_ <: int | string
+//│    = A1 { Foo1: [Function (anonymous)] }
 
 :ns
 a1: R1['_]
@@ -164,7 +160,7 @@ a1: R1['_]
 //│   where
 //│     '_ :> int & string
 //│        <: int | string
-//│    = A1 {}
+//│    = A1 { Foo1: [Function (anonymous)] }
 
 
 :e
@@ -172,22 +168,22 @@ a1: R1['_]
 class A1_2: S1 & T1
   method Foo1 = error
 //│ ╔══[ERROR] Type mismatch in type definition:
-//│ ║  l.172: 	class A1_2: S1 & T1
+//│ ║  l.168: 	class A1_2: S1 & T1
 //│ ║         	      ^^^^^^^^^^^^^
 //│ ╟── type `int` is not an instance of `string`
-//│ ║  l.99: 	trait S1: R1[int]
+//│ ║  l.93: 	trait S1: R1[int]
 //│ ║        	             ^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.101: 	trait T1: R1[string]
-//│ ╙──       	             ^^^^^^
+//│ ║  l.95: 	trait T1: R1[string]
+//│ ╙──      	             ^^^^^^
 //│ ╔══[ERROR] Type mismatch in type definition:
-//│ ║  l.172: 	class A1_2: S1 & T1
+//│ ║  l.168: 	class A1_2: S1 & T1
 //│ ║         	      ^^^^^^^^^^^^^
 //│ ╟── type `string` is not an instance of `int`
-//│ ║  l.101: 	trait T1: R1[string]
-//│ ║         	             ^^^^^^
+//│ ║  l.95: 	trait T1: R1[string]
+//│ ║        	             ^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.99: 	trait S1: R1[int]
+//│ ║  l.93: 	trait S1: R1[int]
 //│ ╙──      	             ^^^
 //│ Defined class A1_2
 //│ Defined A1_2.Foo1: A1_2 -> nothing
@@ -208,7 +204,7 @@ class A1_2: S1 & T1
 
 :re
 (A1_2{}).Foo1
-//│ res: nothing
+//│ res: ('A & (int | string)) -> 'A
 //│ Runtime error:
 //│   Error: unexpected runtime error
 

--- a/shared/src/test/diff/mlscript/BadInherit2.mls
+++ b/shared/src/test/diff/mlscript/BadInherit2.mls
@@ -221,3 +221,39 @@ f'
 //│ res: 1
 //│    = 0
 
+
+
+class C0[A]: S0[A]
+  method Foo0 = id
+//│ Defined class C0[=A]
+//│ Defined C0.Foo0: C0['A] -> 'a -> 'a
+
+def s0: S0['a] -> S0['a]
+//│ s0: S0['a] -> S0['a]
+//│   = <missing implementation>
+
+s0 (C0{})
+//│ res: S0['a]
+//│    = <no result>
+//│      s0 is not implemented
+
+def s0: S0[?] -> S0[?]
+//│ s0: S0[?] -> S0[?]
+//│   = <missing implementation>
+
+:e
+s0 (C0{})
+//│ ╔══[ERROR] Type mismatch in application:
+//│ ║  l.245: 	s0 (C0{})
+//│ ║         	^^^^^^^^^
+//│ ╟── type `anything` does not match type `nothing`
+//│ ║  l.240: 	def s0: S0[?] -> S0[?]
+//│ ║         	           ^
+//│ ╟── Note: constraint arises from type wildcard:
+//│ ║  l.240: 	def s0: S0[?] -> S0[?]
+//│ ╙──       	           ^
+//│ res: error | S0[?]
+//│    = <no result>
+//│      s0 is not implemented
+
+

--- a/shared/src/test/diff/mlscript/BadInherit2.mls
+++ b/shared/src/test/diff/mlscript/BadInherit2.mls
@@ -155,9 +155,7 @@ a1: R1['_]
 //│    = A1 {}
 //│ res: R1[string]
 //│    = A1 {}
-//│ res: R1['_]
-//│   where
-//│     '_ <: int | string
+//│ res: R1[nothing]
 //│    = A1 {}
 
 :ns
@@ -174,7 +172,7 @@ a1: R1['_]
 class A1_2: S1 & T1
   method Foo1 = error
 //│ ╔══[ERROR] Type mismatch in type definition:
-//│ ║  l.174: 	class A1_2: S1 & T1
+//│ ║  l.172: 	class A1_2: S1 & T1
 //│ ║         	      ^^^^^^^^^^^^^
 //│ ╟── type `int` is not an instance of `string`
 //│ ║  l.99: 	trait S1: R1[int]
@@ -183,7 +181,7 @@ class A1_2: S1 & T1
 //│ ║  l.101: 	trait T1: R1[string]
 //│ ╙──       	             ^^^^^^
 //│ ╔══[ERROR] Type mismatch in type definition:
-//│ ║  l.174: 	class A1_2: S1 & T1
+//│ ║  l.172: 	class A1_2: S1 & T1
 //│ ║         	      ^^^^^^^^^^^^^
 //│ ╟── type `string` is not an instance of `int`
 //│ ║  l.101: 	trait T1: R1[string]

--- a/shared/src/test/diff/mlscript/BadInherit2Co.mls
+++ b/shared/src/test/diff/mlscript/BadInherit2Co.mls
@@ -1,0 +1,185 @@
+
+
+// ———
+
+
+:e
+trait S00[A]
+  method Foo00: A
+trait T00[B]: S00[B]
+class A00: S00[int] & T00[string]
+//│ ╔══[ERROR] Type mismatch in type definition:
+//│ ║  l.10: 	class A00: S00[int] & T00[string]
+//│ ║        	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── type `int` is not an instance of `string`
+//│ ║  l.10: 	class A00: S00[int] & T00[string]
+//│ ║        	               ^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.10: 	class A00: S00[int] & T00[string]
+//│ ╙──      	                          ^^^^^^
+//│ ╔══[ERROR] Type mismatch in type definition:
+//│ ║  l.10: 	class A00: S00[int] & T00[string]
+//│ ║        	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── type `string` is not an instance of `int`
+//│ ║  l.10: 	class A00: S00[int] & T00[string]
+//│ ║        	                          ^^^^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.10: 	class A00: S00[int] & T00[string]
+//│ ╙──      	               ^^^
+//│ Defined trait S00[+A]
+//│ Declared S00.Foo00: S00['A] -> 'A
+//│ Defined trait T00[+B]
+//│ Defined class A00
+
+// Note: the definition above becomes valid if we split it into two definition groups
+//    so that the variance analysis has a chance of running in between...
+
+trait S0[A]
+  method Foo0: A
+trait T0[B]: S0[B]
+//│ Defined trait S0[+A]
+//│ Declared S0.Foo0: S0['A] -> 'A
+//│ Defined trait T0[+B]
+
+class A0: S0[int] & T0[string]
+//│ Defined class A0
+
+:e
+(A0{}).Foo0
+//│ ╔══[ERROR] Instantiation of an abstract type is forbidden
+//│ ║  l.48: 	(A0{}).Foo0
+//│ ║        	 ^^
+//│ ╟── Note that class A0 is abstract:
+//│ ║  l.44: 	class A0: S0[int] & T0[string]
+//│ ║        	      ^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── Hint: method Foo0 is abstract
+//│ ║  l.44: 	class A0: S0[int] & T0[string]
+//│ ╙──      	      ^^^^^^^^^^^^^^^^^^^^^^^^
+//│ res: error
+//│    = undefined
+
+:e
+class A0_2: S0[int] & T0[string]
+  method Foo0 = 1
+//│ ╔══[ERROR] Type mismatch in method definition:
+//│ ║  l.63: 	  method Foo0 = 1
+//│ ║        	         ^^^^^^^^
+//│ ╟── integer literal of type `1` does not match type `string`
+//│ ║  l.63: 	  method Foo0 = 1
+//│ ║        	                ^
+//│ ╟── but it flows into method definition with expected type `string`
+//│ ║  l.63: 	  method Foo0 = 1
+//│ ║        	         ^^^^^^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.62: 	class A0_2: S0[int] & T0[string]
+//│ ║        	                         ^^^^^^
+//│ ╟── from inherited method declaration:
+//│ ║  l.38: 	  method Foo0: A
+//│ ╙──      	         ^^^^^^^
+//│ Defined class A0_2
+//│ Defined A0_2.Foo0: A0_2 -> 1
+
+(A0_2{}).Foo0
+//│ res: nothing
+//│    = 1
+
+
+// ———
+
+
+trait R1[A]
+  method Foo1: A
+//│ Defined trait R1[+A]
+//│ Declared R1.Foo1: R1['A] -> 'A
+
+trait S1: R1[int]
+  method Foo1 = 1
+trait T1: R1[string]
+  method Foo1 = "a"
+//│ Defined trait S1
+//│ Defined S1.Foo1: S1 -> 1
+//│ Defined trait T1
+//│ Defined T1.Foo1: T1 -> "a"
+
+:e
+class A1: S1 & T1
+//│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
+//│ ║  l.105: 	class A1: S1 & T1
+//│ ║         	      ^^
+//│ ╟── Definitions of method Foo1 inherited from:
+//│ ╟── • S1
+//│ ║  l.96: 	  method Foo1 = 1
+//│ ║        	         ^^^^^^^^
+//│ ╟── • T1
+//│ ║  l.98: 	  method Foo1 = "a"
+//│ ╙──      	         ^^^^^^^^^^
+//│ Defined class A1
+
+a1 = A1{}
+//│ a1: A1
+//│   = A1 {}
+
+a1.Foo1
+//│ res: nothing
+//│    = 1
+
+a1: S1
+a1: R1[int]
+a1: R1[string]
+a1: R1['_]
+//│ res: S1
+//│    = A1 {}
+//│ res: R1[int]
+//│    = A1 {}
+//│ res: R1[string]
+//│    = A1 {}
+//│ res: R1[nothing]
+//│    = A1 {}
+
+:ns
+a1: R1['_]
+//│ res: R1['_]
+//│   where
+//│     '_ :> int & string
+//│    = A1 {}
+
+
+:js
+class A1_2: S1 & T1
+  method Foo1 = error
+//│ Defined class A1_2
+//│ Defined A1_2.Foo1: A1_2 -> nothing
+//│ // Prelude
+//│ function error() {
+//│   throw new Error("unexpected runtime error");
+//│ }
+//│ class A1_2 {
+//│   constructor(fields) {
+//│     S1.implement(this);
+//│     T1.implement(this);
+//│   }
+//│   get Foo1() {
+//│     return error();
+//│   }
+//│ }
+//│ // End of generated code
+
+:re
+(A1_2{}).Foo1
+//│ res: nothing
+//│ Runtime error:
+//│   Error: unexpected runtime error
+
+
+def f = 0
+//│ f: 0
+//│  = 0
+
+def f' = 1
+//│ f': 1
+//│   = 0
+
+f'
+//│ res: 1
+//│    = 0
+

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -565,8 +565,8 @@ class Dup[A, A]: { x: A }
 //│ ║  l.545: 	        B]: (A -> B) -> B
 //│ ╙──       	        ^
 //│ Defined class Dup[±A, +A]
-//│ Declared Dup.MthDup: Dup[anything, 'A] -> ('A -> 'B) -> 'B
-//│ Defined Dup.MthDup: Dup[anything, 'A] -> ('A -> 'a) -> 'a
+//│ Declared Dup.MthDup: Dup[?, 'A] -> ('A -> 'B) -> 'B
+//│ Defined Dup.MthDup: Dup[?, 'A] -> ('A -> 'a) -> 'a
 //│ ╔══[WARNING] Type definition Dup has bivariant type parameters:
 //│ ║  l.543: 	class Dup[A, A]: { x: A }
 //│ ║         	      ^^^
@@ -575,14 +575,14 @@ class Dup[A, A]: { x: A }
 //│ ╙──       	          ^
 
 t = Dup { x = 42 }
-//│ t: Dup[anything, anything] & {x: 42}
+//│ t: Dup[?, anything] & {x: 42}
 
 :stats
 t : Dup[bool, int]
-//│ res: Dup[anything, int]
+//│ res: Dup[?, int]
 //│ constrain calls  : 22
 //│ annoying  calls  : 21
-//│ subtyping calls  : 27
+//│ subtyping calls  : 33
 
 :stats
 t : Dup[int, bool]
@@ -595,10 +595,10 @@ t : Dup[int, bool]
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.588: 	t : Dup[int, bool]
 //│ ╙──       	             ^^^^
-//│ res: Dup[anything, bool]
+//│ res: Dup[?, bool]
 //│ constrain calls  : 33
 //│ annoying  calls  : 23
-//│ subtyping calls  : 26
+//│ subtyping calls  : 32
 
 :stats
 t.MthDup (fun x -> mul 2 x)

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -21,7 +21,7 @@ class Bar[A]: Foo[A]
 //│ Declared Foo.Map: Foo['A] -> ('A -> anything) -> 'A
 //│ Defined class Bar[+A]
 //│ Declared Bar.Map: Bar['A] -> anything -> 'A
-//│ Defined Bar.Map: Bar['A] -> 'Map
+//│ Defined Bar.Map: Bar[anything] -> 'Map
 //│   where
 //│     'Map :> ('Map -> (anything -> 'Map) -> 'a) -> 'a
 
@@ -68,9 +68,7 @@ class ImplicitCall[A]: { x: A }
 
 i = ImplicitCall { x = "stonks" }
 i.Fun
-//│ i: ImplicitCall['A] & {x: "stonks"}
-//│   where
-//│     'A :> "stonks"
+//│ i: ImplicitCall["stonks"]
 //│ res: "stonks"
 
 class NoMoreImplicitCall
@@ -80,14 +78,14 @@ class NoMoreImplicitCall
 
 i.Fun
 //│ ╔══[ERROR] Implicit call to method Fun is forbidden because it is ambiguous.
-//│ ║  l.81: 	i.Fun
+//│ ║  l.79: 	i.Fun
 //│ ║        	^^^^^
 //│ ╟── Unrelated methods named Fun are defined by:
 //│ ╟── • class ImplicitCall
 //│ ║  l.64: 	class ImplicitCall[A]: { x: A }
 //│ ║        	      ^^^^^^^^^^^^
 //│ ╟── • class NoMoreImplicitCall
-//│ ║  l.76: 	class NoMoreImplicitCall
+//│ ║  l.74: 	class NoMoreImplicitCall
 //│ ╙──      	      ^^^^^^^^^^^^^^^^^^
 //│ res: error
 
@@ -103,16 +101,16 @@ class BadThis: { x: int; y: int }
     method Sum = this this.x this.y
     method Funny = this 42 42
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.103: 	    method Sum = this this.x this.y
+//│ ║  l.101: 	    method Sum = this this.x this.y
 //│ ║         	                 ^^^^^^^^^^^
 //│ ╟── reference of type `BadThis & this` is not a function
-//│ ║  l.103: 	    method Sum = this this.x this.y
+//│ ║  l.101: 	    method Sum = this this.x this.y
 //│ ╙──       	                 ^^^^
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.104: 	    method Funny = this 42 42
+//│ ║  l.102: 	    method Funny = this 42 42
 //│ ║         	                   ^^^^^^^
 //│ ╟── reference of type `BadThis & this` is not a function
-//│ ║  l.104: 	    method Funny = this 42 42
+//│ ║  l.102: 	    method Funny = this 42 42
 //│ ╙──       	                   ^^^^
 //│ Defined class BadThis
 //│ Defined BadThis.Sum: BadThis -> error
@@ -124,22 +122,20 @@ class BadThis: { x: int; y: int }
 class BadSelf[A]: { x: A }
     method F = this.x 42
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.125: 	    method F = this.x 42
+//│ ║  l.123: 	    method F = this.x 42
 //│ ║         	               ^^^^^^^^^
 //│ ╟── field selection of type `A` is not a function
-//│ ║  l.125: 	    method F = this.x 42
+//│ ║  l.123: 	    method F = this.x 42
 //│ ║         	               ^^^^^^
 //│ ╟── Note: class type parameter A is defined at:
-//│ ║  l.124: 	class BadSelf[A]: { x: A }
+//│ ║  l.122: 	class BadSelf[A]: { x: A }
 //│ ╙──       	              ^
 //│ Defined class BadSelf[+A]
-//│ Defined BadSelf.F: BadSelf['A] -> error
+//│ Defined BadSelf.F: BadSelf[anything] -> error
 
 c = BadSelf { x = fun x -> x }
 c.F
-//│ c: BadSelf['A] with {x: 'a -> 'a}
-//│   where
-//│     'A :> 'a -> 'a
+//│ c: BadSelf['a -> 'a]
 //│ res: error
 
 
@@ -153,16 +149,16 @@ class Simple2[A]: { a: A }
 class Simple3[A, B]: Simple2[A]
     method Get: B
 //│ ╔══[ERROR] Type mismatch in method declaration:
-//│ ║  l.154: 	    method Get: B
+//│ ║  l.150: 	    method Get: B
 //│ ║         	           ^^^^^^
 //│ ╟── type `B` is not an instance of type A
-//│ ║  l.153: 	class Simple3[A, B]: Simple2[A]
+//│ ║  l.149: 	class Simple3[A, B]: Simple2[A]
 //│ ║         	                 ^
 //│ ╟── Note: constraint arises from class type parameter:
-//│ ║  l.153: 	class Simple3[A, B]: Simple2[A]
+//│ ║  l.149: 	class Simple3[A, B]: Simple2[A]
 //│ ╙──       	              ^
 //│ Defined class Simple3[+A, +B]
-//│ Declared Simple3.Get: Simple3['A, 'B] -> 'B
+//│ Declared Simple3.Get: Simple3[anything, 'B] -> 'B
 
 
 
@@ -178,77 +174,71 @@ class BadPair[A, B]: AbstractPair[A, B]
     method Test f = f this.x this.x
     method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.178: 	    method Test f = f this.x this.x
+//│ ║  l.174: 	    method Test f = f this.x this.x
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── field selection of type `A` is not an instance of type B
-//│ ║  l.178: 	    method Test f = f this.x this.x
+//│ ║  l.174: 	    method Test f = f this.x this.x
 //│ ║         	                             ^^^^^^
 //│ ╟── Note: constraint arises from class type parameter:
-//│ ║  l.177: 	class BadPair[A, B]: AbstractPair[A, B]
+//│ ║  l.173: 	class BadPair[A, B]: AbstractPair[A, B]
 //│ ║         	                 ^
 //│ ╟── Note: class type parameter A is defined at:
-//│ ║  l.177: 	class BadPair[A, B]: AbstractPair[A, B]
+//│ ║  l.173: 	class BadPair[A, B]: AbstractPair[A, B]
 //│ ╙──       	              ^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.179: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.175: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `C` is not an instance of type D
-//│ ║  l.179: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.175: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	                                                    ^^^^^^^^^
 //│ ╟── Note: constraint arises from method type parameter:
-//│ ║  l.172: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║  l.168: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ║         	                  ^
 //│ ╟── Note: method type parameter C is defined at:
-//│ ║  l.172: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║  l.168: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ╙──       	               ^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.179: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.175: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `C` is not an instance of type D
-//│ ║  l.179: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
+//│ ║  l.175: 	    method Map fx fy = BadPair { x = fx this.x; y = fx this.x }
 //│ ║         	                                                    ^^^^^^^^^
 //│ ╟── Note: constraint arises from method type parameter:
-//│ ║  l.172: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║  l.168: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ║         	                  ^
 //│ ╟── Note: method type parameter C is defined at:
-//│ ║  l.172: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
+//│ ║  l.168: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ╙──       	               ^
 //│ Defined class BadPair[+A, +B]
-//│ Defined BadPair.Test: BadPair['A, 'B] -> ('A -> 'A -> 'a) -> 'a
-//│ Defined BadPair.Map: BadPair['A, 'B] -> ('A -> ('y & 'A0 & 'B0)) -> anything -> (BadPair['A0, 'B0] with {x: 'y, y: 'y})
+//│ Defined BadPair.Test: BadPair['A, anything] -> ('A -> 'A -> 'a) -> 'a
+//│ Defined BadPair.Map: BadPair['A, anything] -> ('A -> 'y) -> anything -> BadPair['y, 'y]
 
 bp = BadPair { x = 42; y = true }
 bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
-//│ bp: BadPair['A, 'B] & {x: 42, y: true}
-//│   where
-//│     'B :> true
-//│     'A :> 42
+//│ bp: BadPair[42, true]
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.221: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
+//│ ║  l.217: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── integer literal of type `42` does not match type `bool`
-//│ ║  l.220: 	bp = BadPair { x = 42; y = true }
+//│ ║  l.216: 	bp = BadPair { x = 42; y = true }
 //│ ║         	                   ^^
 //│ ╟── Note: constraint arises from argument:
-//│ ║  l.221: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
+//│ ║  l.217: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
 //│ ║         	                                        ^^^
 //│ ╟── from reference:
-//│ ║  l.221: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
+//│ ║  l.217: 	bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
 //│ ╙──       	                                         ^
 //│ res: 42 | error
 
 BadPair = BadPair { x = 42; y = 0 }
 BadPair.Map
 BadPair.(BadPair.Map)
-//│ BadPair: BadPair['A, 'B] & {x: 42, y: 0}
-//│   where
-//│     'B :> 0
-//│     'A :> 42
-//│ res: BadPair['A, 'B] -> ('A -> ('y & 'A0 & 'B0)) -> anything -> (BadPair['A0, 'B0] with {x: 'y, y: 'y})
+//│ BadPair: BadPair[42, 0]
+//│ res: BadPair['A, anything] -> ('A -> 'y) -> anything -> BadPair['y, 'y]
 //│ ╔══[ERROR] Class BadPair has no method BadPair.Map
-//│ ║  l.242: 	BadPair.(BadPair.Map)
+//│ ║  l.235: 	BadPair.(BadPair.Map)
 //│ ╙──       	^^^^^^^^^^^^^^^^^^^^^
-//│ res: (42 -> ('y & 'A & 'B)) -> anything -> (BadPair['A, 'B] with {x: 'y, y: 'y})
+//│ res: (42 -> 'y) -> anything -> BadPair['y, 'y]
 
 
 class ClassA
@@ -260,25 +250,25 @@ class ClassA
 class ClassB: ClassA
     method MtdA = 43
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.261: 	    method MtdA = 43
+//│ ║  l.251: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.255: 	    method MtdA = 42
+//│ ║  l.245: 	    method MtdA = 42
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.261: 	    method MtdA = 43
+//│ ║  l.251: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── integer literal of type `43` does not match type `42`
-//│ ║  l.261: 	    method MtdA = 43
+//│ ║  l.251: 	    method MtdA = 43
 //│ ║         	                  ^^
 //│ ╟── but it flows into method definition with expected type `42`
-//│ ║  l.261: 	    method MtdA = 43
+//│ ║  l.251: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.255: 	    method MtdA = 42
+//│ ║  l.245: 	    method MtdA = 42
 //│ ║         	                  ^^
 //│ ╟── from inherited method definition:
-//│ ║  l.255: 	    method MtdA = 42
+//│ ║  l.245: 	    method MtdA = 42
 //│ ╙──       	           ^^^^^^^^^
 //│ Defined class ClassB
 //│ Defined ClassB.MtdA: ClassB -> 43
@@ -288,25 +278,25 @@ class ClassC: ClassA
     method MtdA: int
     method MtdA = 43
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.288: 	    method MtdA: int
+//│ ║  l.278: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.255: 	    method MtdA = 42
+//│ ║  l.245: 	    method MtdA = 42
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method declaration:
-//│ ║  l.288: 	    method MtdA: int
+//│ ║  l.278: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── type `int` does not match type `42`
-//│ ║  l.288: 	    method MtdA: int
+//│ ║  l.278: 	    method MtdA: int
 //│ ║         	                 ^^^
 //│ ╟── but it flows into method declaration with expected type `42`
-//│ ║  l.288: 	    method MtdA: int
+//│ ║  l.278: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.255: 	    method MtdA = 42
+//│ ║  l.245: 	    method MtdA = 42
 //│ ║         	                  ^^
 //│ ╟── from inherited method definition:
-//│ ║  l.255: 	    method MtdA = 42
+//│ ║  l.245: 	    method MtdA = 42
 //│ ╙──       	           ^^^^^^^^^
 //│ Defined class ClassC
 //│ Declared ClassC.MtdA: ClassC -> int
@@ -316,25 +306,25 @@ class ClassC: ClassA
 class ClassD: ClassA
     method MtdA: int
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.317: 	    method MtdA: int
+//│ ║  l.307: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.255: 	    method MtdA = 42
+//│ ║  l.245: 	    method MtdA = 42
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method declaration:
-//│ ║  l.317: 	    method MtdA: int
+//│ ║  l.307: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── type `int` does not match type `42`
-//│ ║  l.317: 	    method MtdA: int
+//│ ║  l.307: 	    method MtdA: int
 //│ ║         	                 ^^^
 //│ ╟── but it flows into method declaration with expected type `42`
-//│ ║  l.317: 	    method MtdA: int
+//│ ║  l.307: 	    method MtdA: int
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.255: 	    method MtdA = 42
+//│ ║  l.245: 	    method MtdA = 42
 //│ ║         	                  ^^
 //│ ╟── from inherited method definition:
-//│ ║  l.255: 	    method MtdA = 42
+//│ ║  l.245: 	    method MtdA = 42
 //│ ╙──       	           ^^^^^^^^^
 //│ Defined class ClassD
 //│ Declared ClassD.MtdA: ClassD -> int
@@ -343,25 +333,25 @@ class ClassD: ClassA
 class ClassE: ClassD
     method MtdA = 43
 //│ ╔══[ERROR] Overriding method ClassA.MtdA without explicit declaration is not allowed.
-//│ ║  l.344: 	    method MtdA = 43
+//│ ║  l.334: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.255: 	    method MtdA = 42
+//│ ║  l.245: 	    method MtdA = 42
 //│ ╙──       	           ^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.344: 	    method MtdA = 43
+//│ ║  l.334: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── integer literal of type `43` does not match type `42`
-//│ ║  l.344: 	    method MtdA = 43
+//│ ║  l.334: 	    method MtdA = 43
 //│ ║         	                  ^^
 //│ ╟── but it flows into method definition with expected type `42`
-//│ ║  l.344: 	    method MtdA = 43
+//│ ║  l.334: 	    method MtdA = 43
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.255: 	    method MtdA = 42
+//│ ║  l.245: 	    method MtdA = 42
 //│ ║         	                  ^^
 //│ ╟── from inherited method definition:
-//│ ║  l.255: 	    method MtdA = 42
+//│ ║  l.245: 	    method MtdA = 42
 //│ ╙──       	           ^^^^^^^^^
 //│ Defined class ClassE
 //│ Defined ClassE.MtdA: ClassE -> 43
@@ -378,19 +368,19 @@ trait Trait2A[B]
 class Class2B: Class2A[int] & Trait2A[string]
     method MtdA = "ok"
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.379: 	    method MtdA = "ok"
+//│ ║  l.369: 	    method MtdA = "ok"
 //│ ║         	           ^^^^^^^^^^^
 //│ ╟── string literal of type `"ok"` does not match type `int`
-//│ ║  l.379: 	    method MtdA = "ok"
+//│ ║  l.369: 	    method MtdA = "ok"
 //│ ║         	                  ^^^^
 //│ ╟── but it flows into method definition with expected type `int`
-//│ ║  l.379: 	    method MtdA = "ok"
+//│ ║  l.369: 	    method MtdA = "ok"
 //│ ║         	           ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.378: 	class Class2B: Class2A[int] & Trait2A[string]
+//│ ║  l.368: 	class Class2B: Class2A[int] & Trait2A[string]
 //│ ║         	                       ^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.375: 	    method MtdA: A
+//│ ║  l.365: 	    method MtdA: A
 //│ ╙──       	           ^^^^^^^
 //│ Defined class Class2A[+A]
 //│ Declared Class2A.MtdA: Class2A['A] -> 'A
@@ -407,7 +397,7 @@ type Type3A = Class3A[string]
 class Class3B: Type3A
     method MtdA = 1
 //│ ╔══[ERROR] cannot inherit from a type alias
-//│ ║  l.407: 	class Class3B: Type3A
+//│ ║  l.397: 	class Class3B: Type3A
 //│ ╙──       	      ^^^^^^^^^^^^^^^
 //│ Defined class Class3A[+A]
 //│ Declared Class3A.MtdA: Class3A['A] -> 'A
@@ -417,7 +407,7 @@ class Class3B: Type3A
 :e
 Oops.M
 //│ ╔══[ERROR] Method M not found
-//│ ║  l.418: 	Oops.M
+//│ ║  l.408: 	Oops.M
 //│ ╙──       	^^^^^^
 //│ res: error
 
@@ -432,25 +422,25 @@ class Test4A
 class Test4B: Test4A
     method Mth4A: int
 //│ ╔══[ERROR] Type mismatch in inherited method definition:
-//│ ║  l.427: 	    method Mth4A = true
+//│ ║  l.417: 	    method Mth4A = true
 //│ ║         	           ^^^^^^^^^^^^
 //│ ╟── reference of type `true` does not match type `int`
-//│ ║  l.427: 	    method Mth4A = true
+//│ ║  l.417: 	    method Mth4A = true
 //│ ║         	                   ^^^^
 //│ ╟── but it flows into inherited method definition with expected type `int`
-//│ ║  l.427: 	    method Mth4A = true
+//│ ║  l.417: 	    method Mth4A = true
 //│ ║         	           ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.433: 	    method Mth4A: int
+//│ ║  l.423: 	    method Mth4A: int
 //│ ║         	                  ^^^
 //│ ╟── from method declaration:
-//│ ║  l.433: 	    method Mth4A: int
+//│ ║  l.423: 	    method Mth4A: int
 //│ ╙──       	           ^^^^^^^^^^
 //│ ╔══[ERROR] Overriding method Test4A.Mth4A without an overriding definition is not allowed.
-//│ ║  l.433: 	    method Mth4A: int
+//│ ║  l.423: 	    method Mth4A: int
 //│ ║         	           ^^^^^^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.427: 	    method Mth4A = true
+//│ ║  l.417: 	    method Mth4A = true
 //│ ╙──       	           ^^^^^^^^^^^^
 //│ Defined class Test4B
 //│ Declared Test4B.Mth4A: Test4B -> int
@@ -468,19 +458,19 @@ class Test5A
 class Test5B: Test5A
     method Mth5A = 43
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.469: 	    method Mth5A = 43
+//│ ║  l.459: 	    method Mth5A = 43
 //│ ║         	           ^^^^^^^^^^
 //│ ╟── integer literal of type `43` does not match type `42`
-//│ ║  l.469: 	    method Mth5A = 43
+//│ ║  l.459: 	    method Mth5A = 43
 //│ ║         	                   ^^
 //│ ╟── but it flows into method definition with expected type `42`
-//│ ║  l.469: 	    method Mth5A = 43
+//│ ║  l.459: 	    method Mth5A = 43
 //│ ║         	           ^^^^^^^^^^
 //│ ╟── Note: constraint arises from literal type:
-//│ ║  l.467: 	    method Mth5A: 42
+//│ ║  l.457: 	    method Mth5A: 42
 //│ ║         	                  ^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.467: 	    method Mth5A: 42
+//│ ║  l.457: 	    method Mth5A: 42
 //│ ╙──       	           ^^^^^^^^^
 //│ Defined class Test5A
 //│ Declared Test5A.Mth5A: Test5A -> 42
@@ -504,45 +494,45 @@ class Test6C: Test6A[int] & Test6B
 :e
 Test6A
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
-//│ ║  l.505: 	Test6A
+//│ ║  l.495: 	Test6A
 //│ ║         	^^^^^^
 //│ ╟── Note that class Test6A is abstract:
-//│ ║  l.491: 	class Test6A[A]
+//│ ║  l.481: 	class Test6A[A]
 //│ ║         	      ^^^^^^^^
 //│ ╟── Hint: method Mth6A is abstract
-//│ ║  l.492: 	    method Mth6A: A
+//│ ║  l.482: 	    method Mth6A: A
 //│ ║         	           ^^^^^^^^
 //│ ╟── Hint: method Mth6B is abstract
-//│ ║  l.493: 	    method Mth6B[B]: (A -> B) -> B
+//│ ║  l.483: 	    method Mth6B[B]: (A -> B) -> B
 //│ ╙──       	           ^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error
 
 :e
 Test6B
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
-//│ ║  l.521: 	Test6B
+//│ ║  l.511: 	Test6B
 //│ ║         	^^^^^^
 //│ ╟── Note that trait Test6B is abstract:
-//│ ║  l.494: 	trait Test6B
+//│ ║  l.484: 	trait Test6B
 //│ ║         	      ^^^^^^
 //│ ╟── Hint: method Mth6A is abstract
-//│ ║  l.495: 	    method Mth6A: bool
+//│ ║  l.485: 	    method Mth6A: bool
 //│ ╙──       	           ^^^^^^^^^^^
 //│ res: error
 
 :e
 Test6C
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
-//│ ║  l.534: 	Test6C
+//│ ║  l.524: 	Test6C
 //│ ║         	^^^^^^
 //│ ╟── Note that class Test6C is abstract:
-//│ ║  l.496: 	class Test6C: Test6A[int] & Test6B
+//│ ║  l.486: 	class Test6C: Test6A[int] & Test6B
 //│ ║         	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Hint: method Mth6B is abstract
-//│ ║  l.493: 	    method Mth6B[B]: (A -> B) -> B
+//│ ║  l.483: 	    method Mth6B[B]: (A -> B) -> B
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Hint: method Mth6A is abstract
-//│ ║  l.496: 	class Test6C: Test6A[int] & Test6B
+//│ ║  l.486: 	class Test6C: Test6A[int] & Test6B
 //│ ╙──       	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error
 
@@ -555,41 +545,41 @@ class Dup[A, A]: { x: A }
         B]: (A -> B) -> B
     method MthDup f = f this.x
 //│ ╔══[ERROR] Multiple declarations of type parameter A in class definition
-//│ ║  l.553: 	class Dup[A, A]: { x: A }
+//│ ║  l.543: 	class Dup[A, A]: { x: A }
 //│ ║         	      ^^^^^^^^^^^^^^^^^^^
 //│ ╟── Declared at
-//│ ║  l.553: 	class Dup[A, A]: { x: A }
+//│ ║  l.543: 	class Dup[A, A]: { x: A }
 //│ ║         	          ^
 //│ ╟── Declared at
-//│ ║  l.553: 	class Dup[A, A]: { x: A }
+//│ ║  l.543: 	class Dup[A, A]: { x: A }
 //│ ╙──       	             ^
 //│ ╔══[ERROR] Multiple declarations of type parameter B in method declaration
-//│ ║  l.554: 	    method MthDup[B, C, // random comment
+//│ ║  l.544: 	    method MthDup[B, C, // random comment
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.555: 	        B]: (A -> B) -> B
+//│ ║  l.545: 	        B]: (A -> B) -> B
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Declared at
-//│ ║  l.554: 	    method MthDup[B, C, // random comment
+//│ ║  l.544: 	    method MthDup[B, C, // random comment
 //│ ║         	                  ^
 //│ ╟── Declared at
-//│ ║  l.555: 	        B]: (A -> B) -> B
+//│ ║  l.545: 	        B]: (A -> B) -> B
 //│ ╙──       	        ^
 //│ Defined class Dup[±A, +A]
-//│ Declared Dup.MthDup: Dup['A, 'A0] -> ('A0 -> 'B) -> 'B
-//│ Defined Dup.MthDup: Dup['A, 'A0] -> ('A0 -> 'a) -> 'a
+//│ Declared Dup.MthDup: Dup[anything, 'A] -> ('A -> 'B) -> 'B
+//│ Defined Dup.MthDup: Dup[anything, 'A] -> ('A -> 'a) -> 'a
 //│ ╔══[WARNING] Type definition Dup has bivariant type parameters:
-//│ ║  l.553: 	class Dup[A, A]: { x: A }
+//│ ║  l.543: 	class Dup[A, A]: { x: A }
 //│ ║         	      ^^^
 //│ ╟── A is irrelevant and may be removed
-//│ ║  l.553: 	class Dup[A, A]: { x: A }
+//│ ║  l.543: 	class Dup[A, A]: { x: A }
 //│ ╙──       	          ^
 
 t = Dup { x = 42 }
-//│ t: Dup[in 'A | 'A0 out 'A & (42 | 'A0), in 'A | 'A0 out 'A & (42 | 'A0)] & {x: 42}
+//│ t: Dup[anything, anything] with {x: 42}
 
 :stats
 t : Dup[bool, int]
-//│ res: Dup[bool, int]
+//│ res: Dup[anything, int]
 //│ constrain calls  : 53
 //│ annoying  calls  : 41
 //│ subtyping calls  : 54
@@ -597,15 +587,15 @@ t : Dup[bool, int]
 :stats
 t : Dup[int, bool]
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.598: 	t : Dup[int, bool]
+//│ ║  l.588: 	t : Dup[int, bool]
 //│ ║         	^
 //│ ╟── integer literal of type `42` does not match type `bool`
-//│ ║  l.587: 	t = Dup { x = 42 }
+//│ ║  l.577: 	t = Dup { x = 42 }
 //│ ║         	              ^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.598: 	t : Dup[int, bool]
+//│ ║  l.588: 	t : Dup[int, bool]
 //│ ╙──       	             ^^^^
-//│ res: Dup[int, bool]
+//│ res: Dup[anything, bool]
 //│ constrain calls  : 62
 //│ annoying  calls  : 41
 //│ subtyping calls  : 54
@@ -634,7 +624,7 @@ class B: { x: int }
   method F1: int
   method F1 = 1
 //│ ╔══[ERROR] Method F1 not found
-//│ ║  l.632: 	  method Nope = this.Yes.F1
+//│ ║  l.622: 	  method Nope = this.Yes.F1
 //│ ╙──       	                ^^^^^^^^^^^
 //│ Defined class A
 //│ Defined A.Yes: A -> (B & {x: 1})
@@ -651,25 +641,25 @@ trait E
 class H: D & E
   method G = 2
 //│ ╔══[ERROR] Overriding method D.G without explicit declaration is not allowed.
-//│ ║  l.652: 	  method G = 2
+//│ ║  l.642: 	  method G = 2
 //│ ║         	         ^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.648: 	  method G = 1
+//│ ║  l.638: 	  method G = 1
 //│ ╙──       	         ^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.652: 	  method G = 2
+//│ ║  l.642: 	  method G = 2
 //│ ║         	         ^^^^^
 //│ ╟── integer literal of type `2` does not match type `1`
-//│ ║  l.652: 	  method G = 2
+//│ ║  l.642: 	  method G = 2
 //│ ║         	             ^
 //│ ╟── but it flows into method definition with expected type `1`
-//│ ║  l.652: 	  method G = 2
+//│ ║  l.642: 	  method G = 2
 //│ ║         	         ^^^^^
 //│ ╟── Note: constraint arises from integer literal:
-//│ ║  l.648: 	  method G = 1
+//│ ║  l.638: 	  method G = 1
 //│ ║         	             ^
 //│ ╟── from inherited method definition:
-//│ ║  l.648: 	  method G = 1
+//│ ║  l.638: 	  method G = 1
 //│ ╙──       	         ^^^^^
 //│ Defined trait D
 //│ Defined D.G: D -> 1
@@ -697,19 +687,19 @@ trait E2
   method G2: bool
 class H2: D2 & E2
 //│ ╔══[ERROR] Type mismatch in inherited method definition:
-//│ ║  l.695: 	  method G2 = 1
+//│ ║  l.685: 	  method G2 = 1
 //│ ║         	         ^^^^^^
 //│ ╟── integer literal of type `1` does not match type `bool`
-//│ ║  l.695: 	  method G2 = 1
+//│ ║  l.685: 	  method G2 = 1
 //│ ║         	              ^
 //│ ╟── but it flows into inherited method definition with expected type `bool`
-//│ ║  l.695: 	  method G2 = 1
+//│ ║  l.685: 	  method G2 = 1
 //│ ║         	         ^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.697: 	  method G2: bool
+//│ ║  l.687: 	  method G2: bool
 //│ ║         	             ^^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.697: 	  method G2: bool
+//│ ║  l.687: 	  method G2: bool
 //│ ╙──       	         ^^^^^^^^
 //│ Defined trait D2
 //│ Defined D2.G2: D2 -> 1
@@ -736,14 +726,14 @@ trait Test7B
 :e
 class Test7C: Test7A & Test7B
 //│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
-//│ ║  l.737: 	class Test7C: Test7A & Test7B
+//│ ║  l.727: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
 //│ ╟── • Test7A
-//│ ║  l.725: 	  method Mth7A = 42
+//│ ║  l.715: 	  method Mth7A = 42
 //│ ║         	         ^^^^^^^^^^
 //│ ╟── • Test7B
-//│ ║  l.728: 	  method Mth7A = 43
+//│ ║  l.718: 	  method Mth7A = 43
 //│ ╙──       	         ^^^^^^^^^^
 //│ Defined class Test7C
 
@@ -759,14 +749,14 @@ class Test7D: Test7A & Test7B
 class Test7E: Test7C
   method Mth7A = 0
 //│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
-//│ ║  l.737: 	class Test7C: Test7A & Test7B
+//│ ║  l.727: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
 //│ ╟── • Test7A
-//│ ║  l.725: 	  method Mth7A = 42
+//│ ║  l.715: 	  method Mth7A = 42
 //│ ║         	         ^^^^^^^^^^
 //│ ╟── • Test7B
-//│ ║  l.728: 	  method Mth7A = 43
+//│ ║  l.718: 	  method Mth7A = 43
 //│ ╙──       	         ^^^^^^^^^^
 //│ Defined class Test7E
 //│ Defined Test7E.Mth7A: Test7E -> 0
@@ -779,24 +769,24 @@ trait Test7F
 :e
 class Test7G: Test7C & Test7F
 //│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
-//│ ║  l.737: 	class Test7C: Test7A & Test7B
+//│ ║  l.727: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
 //│ ╟── • Test7A
-//│ ║  l.725: 	  method Mth7A = 42
+//│ ║  l.715: 	  method Mth7A = 42
 //│ ║         	         ^^^^^^^^^^
 //│ ╟── • Test7B
-//│ ║  l.728: 	  method Mth7A = 43
+//│ ║  l.718: 	  method Mth7A = 43
 //│ ╙──       	         ^^^^^^^^^^
 //│ ╔══[ERROR] An overriding method definition must be given when inheriting from multiple method definitions
-//│ ║  l.780: 	class Test7G: Test7C & Test7F
+//│ ║  l.770: 	class Test7G: Test7C & Test7F
 //│ ║         	      ^^^^^^
 //│ ╟── Definitions of method Mth7A inherited from:
 //│ ╟── • Test7C
-//│ ║  l.737: 	class Test7C: Test7A & Test7B
+//│ ║  l.727: 	class Test7C: Test7A & Test7B
 //│ ║         	      ^^^^^^
 //│ ╟── • Test7F
-//│ ║  l.775: 	  method Mth7A = 0
+//│ ║  l.765: 	  method Mth7A = 0
 //│ ╙──       	         ^^^^^^^^^
 //│ Defined class Test7G
 
@@ -814,10 +804,10 @@ class Test8A
 class Test8B: Test8A
     method F: 1
 //│ ╔══[ERROR] Overriding method Test8A.F without an overriding definition is not allowed.
-//│ ║  l.815: 	    method F: 1
+//│ ║  l.805: 	    method F: 1
 //│ ║         	           ^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.808: 	    method F = 1
+//│ ║  l.798: 	    method F = 1
 //│ ╙──       	           ^^^^^
 //│ Defined class Test8B
 //│ Declared Test8B.F: Test8B -> 1
@@ -827,7 +817,7 @@ class Test8C[A]
     method F = error
 //│ Defined class Test8C[+A]
 //│ Declared Test8C.F: Test8C['A] -> 'A
-//│ Defined Test8C.F: Test8C['A] -> nothing
+//│ Defined Test8C.F: Test8C[anything] -> nothing
 
 // We used to allow syntactically identitcal declarations for documentation,
 //  but that's actually a bad idea (and the implementation was broken)
@@ -835,10 +825,10 @@ class Test8C[A]
 class Test8D: Test8C[int]
     method F: int
 //│ ╔══[ERROR] Overriding method Test8C.F without an overriding definition is not allowed.
-//│ ║  l.836: 	    method F: int
+//│ ║  l.826: 	    method F: int
 //│ ║         	           ^^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.827: 	    method F = error
+//│ ║  l.817: 	    method F = error
 //│ ╙──       	           ^^^^^^^^^
 //│ Defined class Test8D
 //│ Declared Test8D.F: Test8D -> int
@@ -855,40 +845,40 @@ class Test9B: Test9A[int]
     method Mth9A : Test9A[int] -> int
     method Mth9A = this.x
 //│ ╔══[ERROR] Overriding method Test9A.Mth9A without explicit declaration is not allowed.
-//│ ║  l.855: 	    method Mth9A : Test9A[int] -> int
+//│ ║  l.845: 	    method Mth9A : Test9A[int] -> int
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.850: 	    method Mth9A = this.x
+//│ ║  l.840: 	    method Mth9A = this.x
 //│ ╙──       	           ^^^^^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method declaration:
-//│ ║  l.855: 	    method Mth9A : Test9A[int] -> int
+//│ ║  l.845: 	    method Mth9A : Test9A[int] -> int
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── type `Test9A[int] -> int` is not an instance of type X
-//│ ║  l.855: 	    method Mth9A : Test9A[int] -> int
+//│ ║  l.845: 	    method Mth9A : Test9A[int] -> int
 //│ ║         	                   ^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into method declaration with expected type `x`
-//│ ║  l.855: 	    method Mth9A : Test9A[int] -> int
+//│ ║  l.845: 	    method Mth9A : Test9A[int] -> int
 //│ ║         	           ^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.850: 	    method Mth9A = this.x
+//│ ║  l.840: 	    method Mth9A = this.x
 //│ ║         	                   ^^^^^^
 //│ ╟── from inherited method definition:
-//│ ║  l.850: 	    method Mth9A = this.x
+//│ ║  l.840: 	    method Mth9A = this.x
 //│ ╙──       	           ^^^^^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.856: 	    method Mth9A = this.x
+//│ ║  l.846: 	    method Mth9A = this.x
 //│ ║         	           ^^^^^^^^^^^^^^
 //│ ╟── type `int` is not a function
-//│ ║  l.854: 	class Test9B: Test9A[int]
+//│ ║  l.844: 	class Test9B: Test9A[int]
 //│ ║         	                     ^^^
 //│ ╟── but it flows into field selection with expected type `Test9A[int] -> int`
-//│ ║  l.856: 	    method Mth9A = this.x
+//│ ║  l.846: 	    method Mth9A = this.x
 //│ ║         	                   ^^^^^^
 //│ ╟── Note: constraint arises from function type:
-//│ ║  l.855: 	    method Mth9A : Test9A[int] -> int
+//│ ║  l.845: 	    method Mth9A : Test9A[int] -> int
 //│ ║         	                   ^^^^^^^^^^^^^^^^^^
 //│ ╟── from method declaration:
-//│ ║  l.855: 	    method Mth9A : Test9A[int] -> int
+//│ ║  l.845: 	    method Mth9A : Test9A[int] -> int
 //│ ╙──       	           ^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ Defined class Test9B
 //│ Declared Test9B.Mth9A: Test9B -> Test9A[int] -> int
@@ -898,15 +888,15 @@ class Test9B: Test9A[int]
 :NoJS
 error.(Test9B.Mth9A): nothing
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.899: 	error.(Test9B.Mth9A): nothing
+//│ ║  l.889: 	error.(Test9B.Mth9A): nothing
 //│ ║         	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── type `Test9A[int] -> int` does not match type `nothing`
-//│ ║  l.855: 	    method Mth9A : Test9A[int] -> int
+//│ ║  l.845: 	    method Mth9A : Test9A[int] -> int
 //│ ║         	                   ^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into field selection with expected type `nothing`
-//│ ║  l.899: 	error.(Test9B.Mth9A): nothing
+//│ ║  l.889: 	error.(Test9B.Mth9A): nothing
 //│ ║         	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.899: 	error.(Test9B.Mth9A): nothing
+//│ ║  l.889: 	error.(Test9B.Mth9A): nothing
 //│ ╙──       	                      ^^^^^^^
 //│ res: nothing

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -575,14 +575,14 @@ class Dup[A, A]: { x: A }
 //│ ╙──       	          ^
 
 t = Dup { x = 42 }
-//│ t: Dup[anything, anything] with {x: 42}
+//│ t: Dup[anything, anything] & {x: 42}
 
 :stats
 t : Dup[bool, int]
 //│ res: Dup[anything, int]
-//│ constrain calls  : 53
-//│ annoying  calls  : 41
-//│ subtyping calls  : 54
+//│ constrain calls  : 22
+//│ annoying  calls  : 21
+//│ subtyping calls  : 27
 
 :stats
 t : Dup[int, bool]
@@ -596,23 +596,23 @@ t : Dup[int, bool]
 //│ ║  l.588: 	t : Dup[int, bool]
 //│ ╙──       	             ^^^^
 //│ res: Dup[anything, bool]
-//│ constrain calls  : 62
-//│ annoying  calls  : 41
-//│ subtyping calls  : 54
+//│ constrain calls  : 33
+//│ annoying  calls  : 23
+//│ subtyping calls  : 26
 
 :stats
 t.MthDup (fun x -> mul 2 x)
 //│ res: int
-//│ constrain calls  : 90
-//│ annoying  calls  : 27
-//│ subtyping calls  : 40
+//│ constrain calls  : 75
+//│ annoying  calls  : 21
+//│ subtyping calls  : 26
 
 :stats
 t.MthDup id
 //│ res: 42
-//│ constrain calls  : 75
-//│ annoying  calls  : 25
-//│ subtyping calls  : 55
+//│ constrain calls  : 60
+//│ annoying  calls  : 19
+//│ subtyping calls  : 23
 
 
 // We don't currently analyze forward method declarations

--- a/shared/src/test/diff/mlscript/BadMethods.mls
+++ b/shared/src/test/diff/mlscript/BadMethods.mls
@@ -21,7 +21,7 @@ class Bar[A]: Foo[A]
 //│ Declared Foo.Map: Foo['A] -> ('A -> anything) -> 'A
 //│ Defined class Bar[+A]
 //│ Declared Bar.Map: Bar['A] -> anything -> 'A
-//│ Defined Bar.Map: Bar[anything] -> 'Map
+//│ Defined Bar.Map: Bar[?] -> 'Map
 //│   where
 //│     'Map :> ('Map -> (anything -> 'Map) -> 'a) -> 'a
 
@@ -131,7 +131,7 @@ class BadSelf[A]: { x: A }
 //│ ║  l.122: 	class BadSelf[A]: { x: A }
 //│ ╙──       	              ^
 //│ Defined class BadSelf[+A]
-//│ Defined BadSelf.F: BadSelf[anything] -> error
+//│ Defined BadSelf.F: BadSelf[?] -> error
 
 c = BadSelf { x = fun x -> x }
 c.F
@@ -158,7 +158,7 @@ class Simple3[A, B]: Simple2[A]
 //│ ║  l.149: 	class Simple3[A, B]: Simple2[A]
 //│ ╙──       	              ^
 //│ Defined class Simple3[+A, +B]
-//│ Declared Simple3.Get: Simple3[anything, 'B] -> 'B
+//│ Declared Simple3.Get: Simple3[?, 'B] -> 'B
 
 
 
@@ -210,8 +210,8 @@ class BadPair[A, B]: AbstractPair[A, B]
 //│ ║  l.168: 	    method Map[C, D]: (A -> C) -> (B -> D) -> AbstractPair[C, D]
 //│ ╙──       	               ^
 //│ Defined class BadPair[+A, +B]
-//│ Defined BadPair.Test: BadPair['A, anything] -> ('A -> 'A -> 'a) -> 'a
-//│ Defined BadPair.Map: BadPair['A, anything] -> ('A -> 'y) -> anything -> BadPair['y, 'y]
+//│ Defined BadPair.Test: BadPair['A, ?] -> ('A -> 'A -> 'a) -> 'a
+//│ Defined BadPair.Map: BadPair['A, ?] -> ('A -> 'y) -> anything -> BadPair['y, 'y]
 
 bp = BadPair { x = 42; y = true }
 bp.(BadPair.Test) (fun x -> fun y -> if (y) then x else y)
@@ -234,7 +234,7 @@ BadPair = BadPair { x = 42; y = 0 }
 BadPair.Map
 BadPair.(BadPair.Map)
 //│ BadPair: BadPair[42, 0]
-//│ res: BadPair['A, anything] -> ('A -> 'y) -> anything -> BadPair['y, 'y]
+//│ res: BadPair['A, ?] -> ('A -> 'y) -> anything -> BadPair['y, 'y]
 //│ ╔══[ERROR] Class BadPair has no method BadPair.Map
 //│ ║  l.235: 	BadPair.(BadPair.Map)
 //│ ╙──       	^^^^^^^^^^^^^^^^^^^^^
@@ -575,7 +575,7 @@ class Dup[A, A]: { x: A }
 //│ ╙──       	          ^
 
 t = Dup { x = 42 }
-//│ t: Dup[?, anything] & {x: 42}
+//│ t: Dup[?, ?] & {x: 42}
 
 :stats
 t : Dup[bool, int]
@@ -817,7 +817,7 @@ class Test8C[A]
     method F = error
 //│ Defined class Test8C[+A]
 //│ Declared Test8C.F: Test8C['A] -> 'A
-//│ Defined Test8C.F: Test8C[anything] -> nothing
+//│ Defined Test8C.F: Test8C[?] -> nothing
 
 // We used to allow syntactically identitcal declarations for documentation,
 //  but that's actually a bad idea (and the implementation was broken)

--- a/shared/src/test/diff/mlscript/Dmitry.mls
+++ b/shared/src/test/diff/mlscript/Dmitry.mls
@@ -17,14 +17,14 @@ class Hidden[A]
 //│ ║  l.7: 	  method Foo s = case s of { Class1 -> s.payload | _ -> 123 }
 //│ ╙──     	                      ^
 //│ Defined class Hidden[-A]
-//│ Defined Hidden.Foo: Hidden['A] -> ((Class1 with {payload: 'payload}) | ~Class1) -> (123 | 'payload)
+//│ Defined Hidden.Foo: Hidden[nothing] -> ((Class1 with {payload: 'payload}) | ~Class1) -> (123 | 'payload)
 //│ Defined Hidden.Main: Hidden['A] -> 'A -> (123 | error)
 
 class Hidden2[A]
   method Foo s = case s of { Class1 -> s.payload | _ -> 123 }
   method Main (a: A) = this.Foo (a with { payload = 1 })
 //│ Defined class Hidden2[-A]
-//│ Defined Hidden2.Foo: Hidden2['A] -> ((Class1 with {payload: 'payload}) | ~Class1) -> (123 | 'payload)
+//│ Defined Hidden2.Foo: Hidden2[nothing] -> ((Class1 with {payload: 'payload}) | ~Class1) -> (123 | 'payload)
 //│ Defined Hidden2.Main: Hidden2['A] -> 'A -> (123 | 1)
 
 

--- a/shared/src/test/diff/mlscript/Dmitry.mls
+++ b/shared/src/test/diff/mlscript/Dmitry.mls
@@ -17,14 +17,14 @@ class Hidden[A]
 //│ ║  l.7: 	  method Foo s = case s of { Class1 -> s.payload | _ -> 123 }
 //│ ╙──     	                      ^
 //│ Defined class Hidden[-A]
-//│ Defined Hidden.Foo: Hidden[nothing] -> ((Class1 with {payload: 'payload}) | ~Class1) -> (123 | 'payload)
+//│ Defined Hidden.Foo: Hidden[?] -> ((Class1 with {payload: 'payload}) | ~Class1) -> (123 | 'payload)
 //│ Defined Hidden.Main: Hidden['A] -> 'A -> (123 | error)
 
 class Hidden2[A]
   method Foo s = case s of { Class1 -> s.payload | _ -> 123 }
   method Main (a: A) = this.Foo (a with { payload = 1 })
 //│ Defined class Hidden2[-A]
-//│ Defined Hidden2.Foo: Hidden2[nothing] -> ((Class1 with {payload: 'payload}) | ~Class1) -> (123 | 'payload)
+//│ Defined Hidden2.Foo: Hidden2[?] -> ((Class1 with {payload: 'payload}) | ~Class1) -> (123 | 'payload)
 //│ Defined Hidden2.Main: Hidden2['A] -> 'A -> (123 | 1)
 
 

--- a/shared/src/test/diff/mlscript/EitherClasses.mls
+++ b/shared/src/test/diff/mlscript/EitherClasses.mls
@@ -1,20 +1,22 @@
 class Left[A]: { value: A }
-def Left value = Left{ value }
 //│ Defined class Left[+A]
-//│ Left: ('value & 'A) -> (Left['A] with {value: 'value})
+
+Left{value=1}
+//│ res: Left[1]
+//│    = Left { value: 1 }
+
+def Left value = Left{ value }
+//│ Left: 'value -> Left['value]
 //│     = [Function: Left1]
 
 class Right[A]: { value: A }
 def Right value = Right{ value }
 //│ Defined class Right[+A]
-//│ Right: ('value & 'A) -> (Right['A] with {value: 'value})
+//│ Right: 'value -> Right['value]
 //│      = [Function: Right1]
 
 def testVal = if true then Left 1 else Right 2
-//│ testVal: Left['A] & {value: 1} | Right['A0] & {value: 2}
-//│   where
-//│     'A0 :> 2
-//│     'A :> 1
+//│ testVal: Left[1] | Right[2]
 //│        = Left { value: 1 }
 
 testVal.value
@@ -40,8 +42,6 @@ def res = case testVal of
   { Left -> testVal
   | Right -> 1
   }
-//│ res: 1 | Left['A] & {value: 1}
-//│   where
-//│     'A :> 1
+//│ res: 1 | Left[1]
 //│    = Left { value: 1 }
 

--- a/shared/src/test/diff/mlscript/ExplicitVariance.mls
+++ b/shared/src/test/diff/mlscript/ExplicitVariance.mls
@@ -21,7 +21,7 @@ class Covar[A]
 //│ ║  l.12: 	    let tmp = (error : Covar[{ x: int }]) : Covar[{}]
 //│ ╙──      	                             ^^^^^^^^^^
 //│ Defined class Covar[±A]
-//│ Defined Covar.CovarMtd: Covar['A] -> ()
+//│ Defined Covar.CovarMtd: Covar[anything] -> ()
 //│ ╔══[WARNING] Type definition Covar has bivariant type parameters:
 //│ ║  l.10: 	class Covar[A]
 //│ ║        	      ^^^^^

--- a/shared/src/test/diff/mlscript/ExplicitVariance.mls
+++ b/shared/src/test/diff/mlscript/ExplicitVariance.mls
@@ -29,18 +29,8 @@ class Covar[A]
 //│ ║  l.10: 	class Covar[A]
 //│ ╙──      	            ^
 
-// TODO this should work when variance analysis is implemented and taken into account 
-:e
+:re
 (error : Covar[{ x: int }]) : Covar[{}]
-//│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.34: 	(error : Covar[{ x: int }]) : Covar[{}]
-//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── type `anything` does not have field 'x'
-//│ ║  l.34: 	(error : Covar[{ x: int }]) : Covar[{}]
-//│ ║        	                                    ^^
-//│ ╟── Note: constraint arises from record type:
-//│ ║  l.34: 	(error : Covar[{ x: int }]) : Covar[{}]
-//│ ╙──      	               ^^^^^^^^^^
 //│ res: Covar[anything]
 //│ Runtime error:
 //│   Error: unexpected runtime error

--- a/shared/src/test/diff/mlscript/ExplicitVariance.mls
+++ b/shared/src/test/diff/mlscript/ExplicitVariance.mls
@@ -21,7 +21,7 @@ class Covar[A]
 //│ ║  l.12: 	    let tmp = (error : Covar[{ x: int }]) : Covar[{}]
 //│ ╙──      	                             ^^^^^^^^^^
 //│ Defined class Covar[±A]
-//│ Defined Covar.CovarMtd: Covar[anything] -> ()
+//│ Defined Covar.CovarMtd: Covar[?] -> ()
 //│ ╔══[WARNING] Type definition Covar has bivariant type parameters:
 //│ ║  l.10: 	class Covar[A]
 //│ ║        	      ^^^^^
@@ -31,7 +31,7 @@ class Covar[A]
 
 :re
 (error : Covar[{ x: int }]) : Covar[{}]
-//│ res: Covar[anything]
+//│ res: Covar[?]
 //│ Runtime error:
 //│   Error: unexpected runtime error
 

--- a/shared/src/test/diff/mlscript/ExprProb.mls
+++ b/shared/src/test/diff/mlscript/ExprProb.mls
@@ -32,7 +32,7 @@ rec def eval1_stub k e = case e of {
   }
 //│ eval1_stub: ('a -> 'b) -> 'c -> 'b
 //│   where
-//│     'c <: (Add[?]\rhs with {lhs: 'c}) | 'a & ~add
+//│     'c <: (Add[nothing]\rhs with {lhs: 'c}) | 'a & ~add
 //│           = [Function: eval1_stub]
 
 rec def eval1_stub k e = case e of {
@@ -41,7 +41,7 @@ rec def eval1_stub k e = case e of {
   }
 //│ eval1_stub: ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | 'a & ~add
+//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | 'a & ~add
 //│           = [Function: eval1_stub1]
 
 :ns
@@ -63,7 +63,7 @@ rec def eval1_stub e = case e of {
 eval1_stub
 //│ res: 'a -> (0 | 1)
 //│   where
-//│     'a <: (Add[?]\rhs with {lhs: 'a}) | Lit | ~Add[?] & ~Lit
+//│     'a <: (Add[nothing]\rhs with {lhs: 'a}) | Lit | ~Add[anything] & ~Lit
 //│    = [Function: eval1_stub2]
 
 // def eval1: ('b -> int) -> Expr['b] -> int
@@ -75,11 +75,11 @@ rec def eval1 k e = case e of {
   }
 //│ eval1: ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
+//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
 //│      = [Function: eval1]
 //│ constrain calls  : 83
 //│ annoying  calls  : 0
-//│ subtyping calls  : 82
+//│ subtyping calls  : 80
 
 :ns
 eval1
@@ -108,7 +108,7 @@ eval1
 
 :re
 error: ~Add[?]
-//│ res: ~Add[?]
+//│ res: ~Add[nothing]
 //│ Runtime error:
 //│   Error: unexpected runtime error
 
@@ -122,13 +122,13 @@ error: ('a & ~Lit) -> 'a
 error: ('a) -> ('a & Add[?])
 error: ('a) -> ('a & ~Add[?])
 error: ('a & ~Add[?]) -> 'a
-//│ res: 'a -> (Add[?] & 'a)
+//│ res: 'a -> (Add[anything] & 'a)
 //│ Runtime error:
 //│   Error: unexpected runtime error
-//│ res: 'a -> ('a & ~Add[?])
+//│ res: 'a -> ('a & ~Add[nothing])
 //│ Runtime error:
 //│   Error: unexpected runtime error
-//│ res: ('a & ~Add[?]) -> 'a
+//│ res: ('a & ~Add[anything]) -> 'a
 //│ Runtime error:
 //│   Error: unexpected runtime error
 
@@ -148,7 +148,7 @@ def eval1_ty_ugly: ('a -> int) -> (Lit | Add['b] | 'a & ~Lit & ~Add[?] as 'b) ->
 eval1_ty_ugly
 //│ res: ('a -> int) -> 'b -> int
 //│   where
-//│     'b := 'a & ~Add[?] & ~Lit | Add['b] | Lit
+//│     'b <: 'a & ~Add[anything] & ~Lit | Add['b] | Lit
 //│    = <no result>
 //│      eval1_ty_ugly is not implemented
 
@@ -156,15 +156,15 @@ eval1_ty_ugly
 def eval1_ty_ugly = eval1
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
+//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
 //│   <:  eval1_ty_ugly:
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b := 'a & ~Add[?] & ~Lit | Add['b] | Lit
+//│     'b <: 'a & ~Add[anything] & ~Lit | Add['b] | Lit
 //│              = [Function: eval1]
 //│ constrain calls  : 81
 //│ annoying  calls  : 36
-//│ subtyping calls  : 261
+//│ subtyping calls  : 207
 
 :ns
 def eval1_ty: ('a -> int) -> (Lit | Add['b] | 'a & ~lit & ~add as 'b) -> int
@@ -176,7 +176,7 @@ def eval1_ty: ('a -> int) -> (Lit | Add['b] | 'a & ~lit & ~add as 'b) -> int
 eval1_ty
 //│ res: ('a -> int) -> 'b -> int
 //│   where
-//│     'b := 'a & ~add & ~lit | Add['b] | Lit
+//│     'b <: 'a & ~add & ~lit | Add['b] | Lit
 //│    = <no result>
 //│      eval1_ty is not implemented
 
@@ -184,43 +184,43 @@ eval1_ty
 def eval1_ty = eval1
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
+//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
 //│   <:  eval1_ty:
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b := 'a & ~add & ~lit | Add['b] | Lit
+//│     'b <: 'a & ~add & ~lit | Add['b] | Lit
 //│         = [Function: eval1]
 //│ constrain calls  : 81
 //│ annoying  calls  : 36
-//│ subtyping calls  : 253
+//│ subtyping calls  : 209
 
 :stats
 eval1_ty_ugly = eval1_ty
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b := 'a & ~add & ~lit | Add['b] | Lit
+//│     'b <: 'a & ~add & ~lit | Add['b] | Lit
 //│   <:  eval1_ty_ugly:
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b := 'a & ~Add[?] & ~Lit | Add['b] | Lit
+//│     'b <: 'a & ~Add[anything] & ~Lit | Add['b] | Lit
 //│              = [Function: eval1]
 //│ constrain calls  : 15
 //│ annoying  calls  : 1
-//│ subtyping calls  : 213
+//│ subtyping calls  : 119
 
 :stats
 eval1_ty = eval1_ty_ugly
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b := 'a & ~Add[?] & ~Lit | Add['b] | Lit
+//│     'b <: 'a & ~Add[anything] & ~Lit | Add['b] | Lit
 //│   <:  eval1_ty:
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b := 'a & ~add & ~lit | Add['b] | Lit
+//│     'b <: 'a & ~add & ~lit | Add['b] | Lit
 //│         = [Function: eval1]
 //│ constrain calls  : 15
 //│ annoying  calls  : 1
-//│ subtyping calls  : 557
+//│ subtyping calls  : 463
 
 
 // Workaround:
@@ -240,13 +240,13 @@ eval1_ty
 def eval1_ty = eval1
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
+//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
 //│   <:  eval1_ty:
 //│ ('a -> int) -> E1['a] -> int
 //│         = [Function: eval1]
 //│ constrain calls  : 85
 //│ annoying  calls  : 38
-//│ subtyping calls  : 141
+//│ subtyping calls  : 139
 
 
 :stats
@@ -257,11 +257,11 @@ rec def pretty1 k e = case e of {
   }
 //│ pretty1: ('a -> string) -> 'b -> string
 //│   where
-//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
+//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
 //│        = [Function: pretty1]
 //│ constrain calls  : 94
 //│ annoying  calls  : 0
-//│ subtyping calls  : 86
+//│ subtyping calls  : 84
 
 
 :stats
@@ -275,11 +275,11 @@ rec def prettier1 k ev e = case e of {
   }
 //│ prettier1: ('a -> string) -> ('rhs -> int) -> 'b -> string
 //│   where
-//│     'b <: (Add[?] with {lhs: 'rhs & 'b, rhs: 'rhs & 'b}) | Lit | 'a & ~add & ~lit
+//│     'b <: (Add[nothing] with {lhs: 'rhs & 'b, rhs: 'rhs & 'b}) | Lit | 'a & ~add & ~lit
 //│          = [Function: prettier1]
 //│ constrain calls  : 305
 //│ annoying  calls  : 0
-//│ subtyping calls  : 108
+//│ subtyping calls  : 106
 
 :stats
 rec def prettier11 k ev e = case e of {
@@ -291,12 +291,12 @@ rec def prettier11 k ev e = case e of {
   }
 //│ prettier11: ('a -> string) -> ('rhs -> int) -> 'b -> string
 //│   where
-//│     'b <: (Add[?] with {lhs: 'c, rhs: 'rhs & 'b}) | Lit | 'a & ~add & ~lit
-//│     'c <: (Add[?] with {lhs: 'c, rhs: 'c}) | Lit | 'a & ~add & ~lit
+//│     'b <: (Add[nothing] with {lhs: 'c, rhs: 'rhs & 'b}) | Lit | 'a & ~add & ~lit
+//│     'c <: (Add[nothing] with {lhs: 'c, rhs: 'c}) | Lit | 'a & ~add & ~lit
 //│           = [Function: prettier11]
 //│ constrain calls  : 194
 //│ annoying  calls  : 0
-//│ subtyping calls  : 195
+//│ subtyping calls  : 191
 
 // Doesn't make much sense, but generates very ugly type unless aggressively simplified:
 :stats
@@ -307,13 +307,13 @@ rec def prettier12 k ev e = case e of {
       in if ev e == 0 then tmp else concat tmp (pretty1 k e.rhs)
   | _ -> k e
   }
-//│ prettier12: ('a -> string) -> ('b -> int) -> ((Add[?] with {lhs: 'c, rhs: 'c}) & 'b | Lit | 'a & ~add & ~lit) -> string
+//│ prettier12: ('a -> string) -> ('b -> int) -> ((Add[nothing] with {lhs: 'c, rhs: 'c}) & 'b | Lit | 'a & ~add & ~lit) -> string
 //│   where
-//│     'c <: (Add[?] with {lhs: 'c, rhs: 'c}) | Lit | 'a & ~add & ~lit
+//│     'c <: (Add[nothing] with {lhs: 'c, rhs: 'c}) | Lit | 'a & ~add & ~lit
 //│           = [Function: prettier12]
 //│ constrain calls  : 167
 //│ annoying  calls  : 0
-//│ subtyping calls  : 273
+//│ subtyping calls  : 267
 
 
 :stats
@@ -323,10 +323,7 @@ pretty1 done e1
 prettier1 done (eval1 done) e1
 prettier11 done (eval1 done) e1
 prettier12 done (eval1 done) e1
-//│ e1: Add['E] with {lhs: Lit & {val: 1}, rhs: Add['E0] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
-//│   where
-//│     'E :> (Add['E0] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}
-//│     'E0 :> Lit & {val: 2 | 3}
+//│ e1: Add[(Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
 //│   = Add {
 //│       lhs: Lit { val: 1 },
 //│       rhs: Add { lhs: Lit { val: 2 }, rhs: Lit { val: 3 } }
@@ -343,7 +340,7 @@ prettier12 done (eval1 done) e1
 //│    = '123'
 //│ constrain calls  : 1385
 //│ annoying  calls  : 490
-//│ subtyping calls  : 1206
+//│ subtyping calls  : 1323
 
 
 e1 = add (lit 1) (add (lit 2) (lit 3))
@@ -352,10 +349,7 @@ pretty1 done e1
 prettier1 done (eval1 done) e1
 prettier11 done (eval1 done) e1
 prettier12 done (eval1 done) e1
-//│ e1: Add['E] with {lhs: Lit & {val: 1}, rhs: Add['E0] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
-//│   where
-//│     'E :> (Add['E0] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}
-//│     'E0 :> Lit & {val: 2 | 3}
+//│ e1: Add[(Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
 //│   = Add {
 //│       lhs: Lit { val: 1 },
 //│       rhs: Add { lhs: Lit { val: 2 }, rhs: Lit { val: 3 } }
@@ -376,7 +370,7 @@ prettier12 done (eval1 done) e1
 class Nega[E]: { arg: E }
 def nega arg = Nega { arg }
 //│ Defined class Nega[+E]
-//│ nega: ('arg & 'E) -> (Nega['E] with {arg: 'arg})
+//│ nega: 'arg -> Nega['arg]
 //│     = [Function: nega]
 
 
@@ -387,7 +381,7 @@ rec def eval2 k = eval1 (fun x -> case x of {
   })
 //│ eval2: ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | (Nega[?] with {arg: 'b}) | 'a & ~add & ~lit & ~nega
+//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | (Nega[nothing] with {arg: 'b}) | 'a & ~add & ~lit & ~nega
 //│      = [Function: eval2]
 
 
@@ -398,11 +392,11 @@ rec def prettier2 k ev = prettier1 (fun x -> case x of {
   }) ev
 //│ prettier2: ('a -> string) -> ('rhs -> int) -> 'b -> string
 //│   where
-//│     'b <: (Add[?] with {lhs: 'rhs & 'b, rhs: 'rhs & 'b}) | Lit | (Nega[?] with {arg: 'b}) | 'a & ~add & ~lit & ~nega
+//│     'b <: (Add[nothing] with {lhs: 'rhs & 'b, rhs: 'rhs & 'b}) | Lit | (Nega[nothing] with {arg: 'b}) | 'a & ~add & ~lit & ~nega
 //│          = [Function: prettier2]
 //│ constrain calls  : 123
 //│ annoying  calls  : 0
-//│ subtyping calls  : 194
+//│ subtyping calls  : 190
 
 :stats
 rec def prettier22 k ev = prettier12 (fun x -> case x of {
@@ -412,13 +406,13 @@ rec def prettier22 k ev = prettier12 (fun x -> case x of {
 //│ prettier22: ('a -> string) -> ('b -> int) -> 'c -> string
 //│   where
 //│     'b <: {lhs: 'd, rhs: 'd}
-//│     'd <: (Add[?] with {lhs: 'd, rhs: 'd}) | Lit | 'e & ~add & ~lit
-//│     'e <: (Nega[?] with {arg: 'c}) | 'a & ~nega
-//│     'c <: Add[?] & 'b | Lit | 'e & ~add & ~lit
+//│     'd <: (Add[nothing] with {lhs: 'd, rhs: 'd}) | Lit | 'e & ~add & ~lit
+//│     'e <: (Nega[nothing] with {arg: 'c}) | 'a & ~nega
+//│     'c <: Add[nothing] & 'b | Lit | 'e & ~add & ~lit
 //│           = [Function: prettier22]
 //│ constrain calls  : 181
 //│ annoying  calls  : 0
-//│ subtyping calls  : 296
+//│ subtyping calls  : 288
 
 
 
@@ -431,12 +425,7 @@ eval2 done e1
 //│ subtyping calls  : 115
 
 e2 = add (lit 1) (nega e1)
-//│ e2: Add['E] with {lhs: Lit & {val: 1}, rhs: Nega['E0] & {arg: Add['E1] with {lhs: Lit & {val: 1}, rhs: Add['E2] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}}}
-//│   where
-//│     'E :> Lit & {val: 1} | Nega['E0] & {arg: Add['E1] with {lhs: Lit & {val: 1}, rhs: Add['E2] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}}
-//│     'E0 :> Add['E1] with {lhs: Lit & {val: 1}, rhs: Add['E2] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
-//│     'E1 :> (Add['E2] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}
-//│     'E2 :> Lit & {val: 2 | 3}
+//│ e2: Add[Lit & {val: 1} | Nega[Add[(Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]] with {lhs: Lit & {val: 1}, rhs: Nega[Add[(Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]}
 //│   = Add {
 //│       lhs: Lit { val: 1 },
 //│       rhs: Nega { arg: Add { lhs: [Lit], rhs: [Add] } }
@@ -451,11 +440,7 @@ eval2 done e2
 //│ subtyping calls  : 180
 
 d2 = nega (add (lit 1) (nega (lit 1)))
-//│ d2: Nega['E] & {arg: Add['E0] with {lhs: Lit & {val: 1}, rhs: Nega['E1] with {arg: Lit & {val: 1}}}}
-//│   where
-//│     'E :> Add['E0] with {lhs: Lit & {val: 1}, rhs: Nega['E1] with {arg: Lit & {val: 1}}}
-//│     'E0 :> Lit & {val: 1} | (Nega['E1] with {arg: Lit & {val: 1}})
-//│     'E1 :> Lit & {val: 1}
+//│ d2: Nega[Add[Lit & {val: 1} | Nega[Lit & {val: 1}]] with {lhs: Lit & {val: 1}, rhs: Nega[Lit & {val: 1}]}]
 //│   = Nega { arg: Add { lhs: Lit { val: 1 }, rhs: Nega { arg: [Lit] } } }
 
 :stats
@@ -470,37 +455,37 @@ eval2 done d2
 prettier2 done
 //│ res: ('rhs -> int) -> 'a -> string
 //│   where
-//│     'a <: (Add[?] with {lhs: 'rhs & 'a, rhs: 'rhs & 'a}) | Lit | (Nega[?] with {arg: 'a})
+//│     'a <: (Add[nothing] with {lhs: 'rhs & 'a, rhs: 'rhs & 'a}) | Lit | (Nega[nothing] with {arg: 'a})
 //│    = [Function (anonymous)]
 
 prettier22 done
 //│ res: ('a -> int) -> 'b -> string
 //│   where
 //│     'a <: {lhs: 'c, rhs: 'c}
-//│     'c <: (Add[?] with {lhs: 'c, rhs: 'c}) | Lit | 'd & ~add & ~lit
-//│     'd <: Nega[?] with {arg: 'b}
-//│     'b <: Add[?] & 'a | Lit | 'd & ~add & ~lit
+//│     'c <: (Add[nothing] with {lhs: 'c, rhs: 'c}) | Lit | 'd & ~add & ~lit
+//│     'd <: Nega[nothing] with {arg: 'b}
+//│     'b <: Add[nothing] & 'a | Lit | 'd & ~add & ~lit
 //│    = [Function (anonymous)]
 
 :stats
 prettier2 done (eval1 done)
 //│ res: 'a -> string
 //│   where
-//│     'a <: (Add[?] with {lhs: 'a & 'b, rhs: 'a & 'b}) | Lit | (Nega[?] with {arg: 'a})
-//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit
+//│     'a <: (Add[nothing] with {lhs: 'a & 'b, rhs: 'a & 'b}) | Lit | (Nega[nothing] with {arg: 'a})
+//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit
 //│    = [Function (anonymous)]
 //│ constrain calls  : 92
 //│ annoying  calls  : 0
-//│ subtyping calls  : 257
+//│ subtyping calls  : 251
 
 
 prettier22 done (eval1 done)
 //│ res: 'a -> string
 //│   where
-//│     'a <: (Add[?] with {lhs: 'b, rhs: 'b}) & 'c | Lit | 'd & ~add & ~lit
-//│     'c <: (Add[?] with {lhs: 'c, rhs: 'c}) | Lit
-//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'd & ~add & ~lit
-//│     'd <: Nega[?] with {arg: 'a}
+//│     'a <: (Add[nothing] with {lhs: 'b, rhs: 'b}) & 'c | Lit | 'd & ~add & ~lit
+//│     'c <: (Add[nothing] with {lhs: 'c, rhs: 'c}) | Lit
+//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | 'd & ~add & ~lit
+//│     'd <: Nega[nothing] with {arg: 'a}
 //│    = [Function (anonymous)]
 
 // TODO could probably merge `a` and `b` here!
@@ -508,12 +493,12 @@ prettier22 done (eval1 done)
 prettier2 done (eval2 done)
 //│ res: 'a -> string
 //│   where
-//│     'a <: (Add[?] with {lhs: 'a & 'b, rhs: 'a & 'b}) | Lit | (Nega[?] with {arg: 'a})
-//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | (Nega[?] with {arg: 'b})
+//│     'a <: (Add[nothing] with {lhs: 'a & 'b, rhs: 'a & 'b}) | Lit | (Nega[nothing] with {arg: 'a})
+//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | (Nega[nothing] with {arg: 'b})
 //│    = [Function (anonymous)]
 //│ constrain calls  : 103
 //│ annoying  calls  : 0
-//│ subtyping calls  : 330
+//│ subtyping calls  : 322
 
 prettier2 done (eval2 done) e2
 prettier2 done (eval2 done) d2
@@ -528,10 +513,10 @@ prettier22 done (eval2 done) e2
 prettier22 done (eval2 done) d2
 //│ res: 'a -> string
 //│   where
-//│     'a <: (Add[?] with {lhs: 'b, rhs: 'b}) & 'c | Lit | 'd & ~add & ~lit
-//│     'c <: (Add[?] with {lhs: 'c, rhs: 'c}) | Lit | (Nega[?] with {arg: 'c})
-//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'd & ~add & ~lit
-//│     'd <: Nega[?] with {arg: 'a}
+//│     'a <: (Add[nothing] with {lhs: 'b, rhs: 'b}) & 'c | Lit | 'd & ~add & ~lit
+//│     'c <: (Add[nothing] with {lhs: 'c, rhs: 'c}) | Lit | (Nega[nothing] with {arg: 'c})
+//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | 'd & ~add & ~lit
+//│     'd <: Nega[nothing] with {arg: 'a}
 //│    = [Function (anonymous)]
 //│ res: string
 //│    = '1-123'
@@ -539,7 +524,7 @@ prettier22 done (eval2 done) d2
 //│    = '-1'
 //│ constrain calls  : 1039
 //│ annoying  calls  : 335
-//│ subtyping calls  : 1124
+//│ subtyping calls  : 1112
 
 
 
@@ -556,7 +541,7 @@ eval1 done e2
 //│ ║  l.+1: 	eval1 done e2
 //│ ║        	^^^^^^^^^^^^^
 //│ ╟── application of type `Nega[?E] & {arg: ?arg}` does not match type `nothing`
-//│ ║  l.377: 	def nega arg = Nega { arg }
+//│ ║  l.371: 	def nega arg = Nega { arg }
 //│ ║         	               ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from reference:
 //│ ║  l.4: 	def done x = case x of {}
@@ -611,7 +596,7 @@ prettier2 done (eval1 done) e2
 //│ ║  l.+1: 	prettier2 done (eval1 done) e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Nega[?E] & {arg: ?arg}` does not match type `nothing`
-//│ ║  l.377: 	def nega arg = Nega { arg }
+//│ ║  l.371: 	def nega arg = Nega { arg }
 //│ ║         	               ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from reference:
 //│ ║  l.4: 	def done x = case x of {}
@@ -648,11 +633,11 @@ prettier2 done eval2
 //│ ╙──       	              ^^^^^^^^
 //│ res: 'a -> string | error
 //│   where
-//│     'a <: (Add[?] with {lhs: nothing -> int & 'a, rhs: nothing -> int & 'a}) | Lit | (Nega[?] with {arg: 'a})
+//│     'a <: (Add[nothing] with {lhs: nothing -> int & 'a, rhs: nothing -> int & 'a}) | Lit | (Nega[nothing] with {arg: 'a})
 //│    = [Function (anonymous)]
 //│ constrain calls  : 70
 //│ annoying  calls  : 0
-//│ subtyping calls  : 279
+//│ subtyping calls  : 275
 
 :e
 :stats
@@ -681,7 +666,7 @@ prettier2 done eval2 e1
 //│ ║  l.18: 	def lit val = Lit { val }
 //│ ║        	              ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.386: 	  | _ -> k x
+//│ ║  l.380: 	  | _ -> k x
 //│ ║         	         ^^^
 //│ ╟── from field selection:
 //│ ║  l.272: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
@@ -719,7 +704,7 @@ prettier2 done eval2 e2
 //│ ║  l.18: 	def lit val = Lit { val }
 //│ ║        	              ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.386: 	  | _ -> k x
+//│ ║  l.380: 	  | _ -> k x
 //│ ║         	         ^^^
 //│ ╟── from field selection:
 //│ ║  l.272: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
@@ -754,10 +739,10 @@ prettier2 done eval2 d2
 //│ ║  l.+1: 	prettier2 done eval2 d2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Nega[?E] & {arg: ?arg}` is not a function
-//│ ║  l.377: 	def nega arg = Nega { arg }
+//│ ║  l.371: 	def nega arg = Nega { arg }
 //│ ║         	               ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.386: 	  | _ -> k x
+//│ ║  l.380: 	  | _ -> k x
 //│ ║         	         ^^^
 //│ ╟── from field selection:
 //│ ║  l.272: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs

--- a/shared/src/test/diff/mlscript/ExprProb.mls
+++ b/shared/src/test/diff/mlscript/ExprProb.mls
@@ -32,7 +32,7 @@ rec def eval1_stub k e = case e of {
   }
 //│ eval1_stub: ('a -> 'b) -> 'c -> 'b
 //│   where
-//│     'c <: (Add[nothing]\rhs with {lhs: 'c}) | 'a & ~add
+//│     'c <: Add[anything] & {lhs: 'c} | 'a & ~add
 //│           = [Function: eval1_stub]
 
 rec def eval1_stub k e = case e of {
@@ -41,7 +41,7 @@ rec def eval1_stub k e = case e of {
   }
 //│ eval1_stub: ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | 'a & ~add
+//│     'b <: Add[anything] & {lhs: 'b, rhs: 'b} | 'a & ~add
 //│           = [Function: eval1_stub1]
 
 :ns
@@ -63,7 +63,7 @@ rec def eval1_stub e = case e of {
 eval1_stub
 //│ res: 'a -> (0 | 1)
 //│   where
-//│     'a <: (Add[nothing]\rhs with {lhs: 'a}) | Lit | ~Add[anything] & ~Lit
+//│     'a <: Add[anything] & {lhs: 'a} | Lit | ~Add[anything] & ~Lit
 //│    = [Function: eval1_stub2]
 
 // def eval1: ('b -> int) -> Expr['b] -> int
@@ -75,11 +75,11 @@ rec def eval1 k e = case e of {
   }
 //│ eval1: ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
+//│     'b <: Add[anything] & {lhs: 'b, rhs: 'b} | Lit | 'a & ~add & ~lit
 //│      = [Function: eval1]
 //│ constrain calls  : 83
 //│ annoying  calls  : 0
-//│ subtyping calls  : 80
+//│ subtyping calls  : 87
 
 :ns
 eval1
@@ -156,7 +156,7 @@ eval1_ty_ugly
 def eval1_ty_ugly = eval1
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
+//│     'b <: Add[anything] & {lhs: 'b, rhs: 'b} | Lit | 'a & ~add & ~lit
 //│   <:  eval1_ty_ugly:
 //│ ('a -> int) -> 'b -> int
 //│   where
@@ -164,7 +164,7 @@ def eval1_ty_ugly = eval1
 //│              = [Function: eval1]
 //│ constrain calls  : 81
 //│ annoying  calls  : 36
-//│ subtyping calls  : 207
+//│ subtyping calls  : 214
 
 :ns
 def eval1_ty: ('a -> int) -> (Lit | Add['b] | 'a & ~lit & ~add as 'b) -> int
@@ -184,7 +184,7 @@ eval1_ty
 def eval1_ty = eval1
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
+//│     'b <: Add[anything] & {lhs: 'b, rhs: 'b} | Lit | 'a & ~add & ~lit
 //│   <:  eval1_ty:
 //│ ('a -> int) -> 'b -> int
 //│   where
@@ -192,7 +192,7 @@ def eval1_ty = eval1
 //│         = [Function: eval1]
 //│ constrain calls  : 81
 //│ annoying  calls  : 36
-//│ subtyping calls  : 209
+//│ subtyping calls  : 216
 
 :stats
 eval1_ty_ugly = eval1_ty
@@ -240,13 +240,13 @@ eval1_ty
 def eval1_ty = eval1
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
+//│     'b <: Add[anything] & {lhs: 'b, rhs: 'b} | Lit | 'a & ~add & ~lit
 //│   <:  eval1_ty:
 //│ ('a -> int) -> E1['a] -> int
 //│         = [Function: eval1]
 //│ constrain calls  : 85
 //│ annoying  calls  : 38
-//│ subtyping calls  : 139
+//│ subtyping calls  : 146
 
 
 :stats
@@ -257,11 +257,11 @@ rec def pretty1 k e = case e of {
   }
 //│ pretty1: ('a -> string) -> 'b -> string
 //│   where
-//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
+//│     'b <: Add[anything] & {lhs: 'b, rhs: 'b} | Lit | 'a & ~add & ~lit
 //│        = [Function: pretty1]
 //│ constrain calls  : 94
 //│ annoying  calls  : 0
-//│ subtyping calls  : 84
+//│ subtyping calls  : 91
 
 
 :stats
@@ -275,11 +275,11 @@ rec def prettier1 k ev e = case e of {
   }
 //│ prettier1: ('a -> string) -> ('rhs -> int) -> 'b -> string
 //│   where
-//│     'b <: (Add[nothing] with {lhs: 'rhs & 'b, rhs: 'rhs & 'b}) | Lit | 'a & ~add & ~lit
+//│     'b <: Add[anything] & {lhs: 'rhs & 'b, rhs: 'rhs & 'b} | Lit | 'a & ~add & ~lit
 //│          = [Function: prettier1]
 //│ constrain calls  : 305
 //│ annoying  calls  : 0
-//│ subtyping calls  : 106
+//│ subtyping calls  : 113
 
 :stats
 rec def prettier11 k ev e = case e of {
@@ -291,12 +291,12 @@ rec def prettier11 k ev e = case e of {
   }
 //│ prettier11: ('a -> string) -> ('rhs -> int) -> 'b -> string
 //│   where
-//│     'b <: (Add[nothing] with {lhs: 'c, rhs: 'rhs & 'b}) | Lit | 'a & ~add & ~lit
-//│     'c <: (Add[nothing] with {lhs: 'c, rhs: 'c}) | Lit | 'a & ~add & ~lit
+//│     'b <: Add[anything] & {lhs: 'c, rhs: 'rhs & 'b} | Lit | 'a & ~add & ~lit
+//│     'c <: Add[anything] & {lhs: 'c, rhs: 'c} | Lit | 'a & ~add & ~lit
 //│           = [Function: prettier11]
 //│ constrain calls  : 194
 //│ annoying  calls  : 0
-//│ subtyping calls  : 191
+//│ subtyping calls  : 202
 
 // Doesn't make much sense, but generates very ugly type unless aggressively simplified:
 :stats
@@ -307,13 +307,13 @@ rec def prettier12 k ev e = case e of {
       in if ev e == 0 then tmp else concat tmp (pretty1 k e.rhs)
   | _ -> k e
   }
-//│ prettier12: ('a -> string) -> ('b -> int) -> ((Add[nothing] with {lhs: 'c, rhs: 'c}) & 'b | Lit | 'a & ~add & ~lit) -> string
+//│ prettier12: ('a -> string) -> ('b -> int) -> (Add[anything] & {lhs: 'c, rhs: 'c} & 'b | Lit | 'a & ~add & ~lit) -> string
 //│   where
-//│     'c <: (Add[nothing] with {lhs: 'c, rhs: 'c}) | Lit | 'a & ~add & ~lit
+//│     'c <: Add[anything] & {lhs: 'c, rhs: 'c} | Lit | 'a & ~add & ~lit
 //│           = [Function: prettier12]
 //│ constrain calls  : 167
 //│ annoying  calls  : 0
-//│ subtyping calls  : 267
+//│ subtyping calls  : 283
 
 
 :stats
@@ -323,7 +323,7 @@ pretty1 done e1
 prettier1 done (eval1 done) e1
 prettier11 done (eval1 done) e1
 prettier12 done (eval1 done) e1
-//│ e1: Add[(Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
+//│ e1: Add[Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}} | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
 //│   = Add {
 //│       lhs: Lit { val: 1 },
 //│       rhs: Add { lhs: Lit { val: 2 }, rhs: Lit { val: 3 } }
@@ -340,7 +340,7 @@ prettier12 done (eval1 done) e1
 //│    = '123'
 //│ constrain calls  : 1385
 //│ annoying  calls  : 490
-//│ subtyping calls  : 1323
+//│ subtyping calls  : 1352
 
 
 e1 = add (lit 1) (add (lit 2) (lit 3))
@@ -349,7 +349,7 @@ pretty1 done e1
 prettier1 done (eval1 done) e1
 prettier11 done (eval1 done) e1
 prettier12 done (eval1 done) e1
-//│ e1: Add[(Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
+//│ e1: Add[Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}} | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
 //│   = Add {
 //│       lhs: Lit { val: 1 },
 //│       rhs: Add { lhs: Lit { val: 2 }, rhs: Lit { val: 3 } }
@@ -381,7 +381,7 @@ rec def eval2 k = eval1 (fun x -> case x of {
   })
 //│ eval2: ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | (Nega[nothing] with {arg: 'b}) | 'a & ~add & ~lit & ~nega
+//│     'b <: Add[anything] & {lhs: 'b, rhs: 'b} | Lit | Nega[anything] & {arg: 'b} | 'a & ~add & ~lit & ~nega
 //│      = [Function: eval2]
 
 
@@ -392,11 +392,11 @@ rec def prettier2 k ev = prettier1 (fun x -> case x of {
   }) ev
 //│ prettier2: ('a -> string) -> ('rhs -> int) -> 'b -> string
 //│   where
-//│     'b <: (Add[nothing] with {lhs: 'rhs & 'b, rhs: 'rhs & 'b}) | Lit | (Nega[nothing] with {arg: 'b}) | 'a & ~add & ~lit & ~nega
+//│     'b <: Add[anything] & {lhs: 'rhs & 'b, rhs: 'rhs & 'b} | Lit | Nega[anything] & {arg: 'b} | 'a & ~add & ~lit & ~nega
 //│          = [Function: prettier2]
 //│ constrain calls  : 123
 //│ annoying  calls  : 0
-//│ subtyping calls  : 190
+//│ subtyping calls  : 201
 
 :stats
 rec def prettier22 k ev = prettier12 (fun x -> case x of {
@@ -406,13 +406,13 @@ rec def prettier22 k ev = prettier12 (fun x -> case x of {
 //│ prettier22: ('a -> string) -> ('b -> int) -> 'c -> string
 //│   where
 //│     'b <: {lhs: 'd, rhs: 'd}
-//│     'd <: (Add[nothing] with {lhs: 'd, rhs: 'd}) | Lit | 'e & ~add & ~lit
-//│     'e <: (Nega[nothing] with {arg: 'c}) | 'a & ~nega
-//│     'c <: Add[nothing] & 'b | Lit | 'e & ~add & ~lit
+//│     'd <: Add[anything] & {lhs: 'd, rhs: 'd} | Lit | 'e & ~add & ~lit
+//│     'e <: Nega[anything] & {arg: 'c} | 'a & ~nega
+//│     'c <: Add[anything] & 'b | Lit | 'e & ~add & ~lit
 //│           = [Function: prettier22]
 //│ constrain calls  : 181
 //│ annoying  calls  : 0
-//│ subtyping calls  : 288
+//│ subtyping calls  : 316
 
 
 
@@ -425,7 +425,7 @@ eval2 done e1
 //│ subtyping calls  : 115
 
 e2 = add (lit 1) (nega e1)
-//│ e2: Add[Lit & {val: 1} | Nega[Add[(Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]] with {lhs: Lit & {val: 1}, rhs: Nega[Add[(Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]}
+//│ e2: Add[Lit & {val: 1} | Nega[Add[Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}} | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]] with {lhs: Lit & {val: 1}, rhs: Nega[Add[Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}} | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]}
 //│   = Add {
 //│       lhs: Lit { val: 1 },
 //│       rhs: Nega { arg: Add { lhs: [Lit], rhs: [Add] } }
@@ -455,37 +455,37 @@ eval2 done d2
 prettier2 done
 //│ res: ('rhs -> int) -> 'a -> string
 //│   where
-//│     'a <: (Add[nothing] with {lhs: 'rhs & 'a, rhs: 'rhs & 'a}) | Lit | (Nega[nothing] with {arg: 'a})
+//│     'a <: Add[anything] & {lhs: 'rhs & 'a, rhs: 'rhs & 'a} | Lit | Nega[anything] & {arg: 'a}
 //│    = [Function (anonymous)]
 
 prettier22 done
 //│ res: ('a -> int) -> 'b -> string
 //│   where
 //│     'a <: {lhs: 'c, rhs: 'c}
-//│     'c <: (Add[nothing] with {lhs: 'c, rhs: 'c}) | Lit | 'd & ~add & ~lit
-//│     'd <: Nega[nothing] with {arg: 'b}
-//│     'b <: Add[nothing] & 'a | Lit | 'd & ~add & ~lit
+//│     'c <: Add[anything] & {lhs: 'c, rhs: 'c} | Lit | 'd & ~add & ~lit
+//│     'd <: Nega[anything] & {arg: 'b}
+//│     'b <: Add[anything] & 'a | Lit | 'd & ~add & ~lit
 //│    = [Function (anonymous)]
 
 :stats
 prettier2 done (eval1 done)
 //│ res: 'a -> string
 //│   where
-//│     'a <: (Add[nothing] with {lhs: 'a & 'b, rhs: 'a & 'b}) | Lit | (Nega[nothing] with {arg: 'a})
-//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit
+//│     'a <: Add[anything] & {lhs: 'a & 'b, rhs: 'a & 'b} | Lit | Nega[anything] & {arg: 'a}
+//│     'b <: Add[anything] & {lhs: 'b, rhs: 'b} | Lit
 //│    = [Function (anonymous)]
 //│ constrain calls  : 92
 //│ annoying  calls  : 0
-//│ subtyping calls  : 251
+//│ subtyping calls  : 226
 
 
 prettier22 done (eval1 done)
 //│ res: 'a -> string
 //│   where
-//│     'a <: (Add[nothing] with {lhs: 'b, rhs: 'b}) & 'c | Lit | 'd & ~add & ~lit
-//│     'c <: (Add[nothing] with {lhs: 'c, rhs: 'c}) | Lit
-//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | 'd & ~add & ~lit
-//│     'd <: Nega[nothing] with {arg: 'a}
+//│     'a <: Add[anything] & {lhs: 'b, rhs: 'b} & 'c | Lit | 'd & ~add & ~lit
+//│     'c <: Add[anything] & {lhs: 'c, rhs: 'c} | Lit
+//│     'b <: Add[anything] & {lhs: 'b, rhs: 'b} | Lit | 'd & ~add & ~lit
+//│     'd <: Nega[anything] & {arg: 'a}
 //│    = [Function (anonymous)]
 
 // TODO could probably merge `a` and `b` here!
@@ -493,12 +493,12 @@ prettier22 done (eval1 done)
 prettier2 done (eval2 done)
 //│ res: 'a -> string
 //│   where
-//│     'a <: (Add[nothing] with {lhs: 'a & 'b, rhs: 'a & 'b}) | Lit | (Nega[nothing] with {arg: 'a})
-//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | (Nega[nothing] with {arg: 'b})
+//│     'a <: Add[anything] & {lhs: 'a & 'b, rhs: 'a & 'b} | Lit | Nega[anything] & {arg: 'a}
+//│     'b <: Add[anything] & {lhs: 'b, rhs: 'b} | Lit | Nega[anything] & {arg: 'b}
 //│    = [Function (anonymous)]
 //│ constrain calls  : 103
 //│ annoying  calls  : 0
-//│ subtyping calls  : 322
+//│ subtyping calls  : 292
 
 prettier2 done (eval2 done) e2
 prettier2 done (eval2 done) d2
@@ -513,10 +513,10 @@ prettier22 done (eval2 done) e2
 prettier22 done (eval2 done) d2
 //│ res: 'a -> string
 //│   where
-//│     'a <: (Add[nothing] with {lhs: 'b, rhs: 'b}) & 'c | Lit | 'd & ~add & ~lit
-//│     'c <: (Add[nothing] with {lhs: 'c, rhs: 'c}) | Lit | (Nega[nothing] with {arg: 'c})
-//│     'b <: (Add[nothing] with {lhs: 'b, rhs: 'b}) | Lit | 'd & ~add & ~lit
-//│     'd <: Nega[nothing] with {arg: 'a}
+//│     'a <: Add[anything] & {lhs: 'b, rhs: 'b} & 'c | Lit | 'd & ~add & ~lit
+//│     'c <: Add[anything] & {lhs: 'c, rhs: 'c} | Lit | Nega[anything] & {arg: 'c}
+//│     'b <: Add[anything] & {lhs: 'b, rhs: 'b} | Lit | 'd & ~add & ~lit
+//│     'd <: Nega[anything] & {arg: 'a}
 //│    = [Function (anonymous)]
 //│ res: string
 //│    = '1-123'
@@ -524,7 +524,7 @@ prettier22 done (eval2 done) d2
 //│    = '-1'
 //│ constrain calls  : 1039
 //│ annoying  calls  : 335
-//│ subtyping calls  : 1112
+//│ subtyping calls  : 1115
 
 
 
@@ -540,7 +540,7 @@ eval1 done e2
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	eval1 done e2
 //│ ║        	^^^^^^^^^^^^^
-//│ ╟── application of type `Nega[?E] & {arg: ?arg}` does not match type `nothing`
+//│ ╟── application of type `Nega[?E] & {Nega#E = ?E, arg: ?arg}` does not match type `nothing`
 //│ ║  l.371: 	def nega arg = Nega { arg }
 //│ ║         	               ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from reference:
@@ -595,7 +595,7 @@ prettier2 done (eval1 done) e2
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done (eval1 done) e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── application of type `Nega[?E] & {arg: ?arg}` does not match type `nothing`
+//│ ╟── application of type `Nega[?E] & {Nega#E = ?E, arg: ?arg}` does not match type `nothing`
 //│ ║  l.371: 	def nega arg = Nega { arg }
 //│ ║         	               ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from reference:
@@ -609,7 +609,7 @@ prettier2 done (eval1 done) e2
 //│   Error: non-exhaustive case expression
 //│ constrain calls  : 676
 //│ annoying  calls  : 228
-//│ subtyping calls  : 4986
+//│ subtyping calls  : 5168
 
 :e
 :stats
@@ -633,11 +633,11 @@ prettier2 done eval2
 //│ ╙──       	              ^^^^^^^^
 //│ res: 'a -> string | error
 //│   where
-//│     'a <: (Add[nothing] with {lhs: nothing -> int & 'a, rhs: nothing -> int & 'a}) | Lit | (Nega[nothing] with {arg: 'a})
+//│     'a <: Add[anything] & {lhs: nothing -> int & 'a, rhs: nothing -> int & 'a} | Lit | Nega[anything] & {arg: 'a}
 //│    = [Function (anonymous)]
 //│ constrain calls  : 70
 //│ annoying  calls  : 0
-//│ subtyping calls  : 275
+//│ subtyping calls  : 259
 
 :e
 :stats
@@ -675,7 +675,7 @@ prettier2 done eval2 e1
 //│    = '123'
 //│ constrain calls  : 376
 //│ annoying  calls  : 108
-//│ subtyping calls  : 1852
+//│ subtyping calls  : 1870
 
 :e
 :stats
@@ -713,7 +713,7 @@ prettier2 done eval2 e2
 //│    = '1-123'
 //│ constrain calls  : 427
 //│ annoying  calls  : 131
-//│ subtyping calls  : 2498
+//│ subtyping calls  : 2552
 
 :e
 :stats
@@ -738,7 +738,7 @@ prettier2 done eval2 d2
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval2 d2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── application of type `Nega[?E] & {arg: ?arg}` is not a function
+//│ ╟── application of type `Nega[?E] & {Nega#E = ?E, arg: ?arg}` is not a function
 //│ ║  l.371: 	def nega arg = Nega { arg }
 //│ ║         	               ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
@@ -751,7 +751,7 @@ prettier2 done eval2 d2
 //│    = '-1-1'
 //│ constrain calls  : 301
 //│ annoying  calls  : 95
-//│ subtyping calls  : 1378
+//│ subtyping calls  : 1423
 
 :e
 :stats
@@ -789,5 +789,5 @@ prettier2 done eval1 e2
 //│    = '1-123'
 //│ constrain calls  : 421
 //│ annoying  calls  : 131
-//│ subtyping calls  : 2464
+//│ subtyping calls  : 2522
 

--- a/shared/src/test/diff/mlscript/ExprProb2.mls
+++ b/shared/src/test/diff/mlscript/ExprProb2.mls
@@ -19,29 +19,26 @@ def eval1 eval1 e = case e of {
   | Lit -> e.val
   | Add -> eval1 eval1 e.lhs + eval1 eval1 e.rhs
   }
-//│ eval1: ('a -> 'rhs -> int & 'a) -> ((Add[?] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val})) -> (int | 'val)
+//│ eval1: ('a -> 'rhs -> int & 'a) -> ((Add[nothing] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val})) -> (int | 'val)
 //│      = [Function: eval1]
 //│ constrain calls  : 36
 //│ annoying  calls  : 0
-//│ subtyping calls  : 64
+//│ subtyping calls  : 62
 
 :stats
 def eval1f eval1 e = case e of {
   | Lit -> e.val
   | Add -> eval1 e.lhs + eval1 e.rhs
   }
-//│ eval1f: ('rhs -> int) -> ((Add[?] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val})) -> (int | 'val)
+//│ eval1f: ('rhs -> int) -> ((Add[nothing] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val})) -> (int | 'val)
 //│       = [Function: eval1f]
 //│ constrain calls  : 32
 //│ annoying  calls  : 0
-//│ subtyping calls  : 60
+//│ subtyping calls  : 58
 
 
 e1 = add (lit 1) (add (lit 2) (lit 3))
-//│ e1: Add['E] with {lhs: Lit & {val: 1}, rhs: Add['E0] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
-//│   where
-//│     'E :> (Add['E0] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}
-//│     'E0 :> Lit & {val: 2 | 3}
+//│ e1: Add[(Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
 //│   = Add {
 //│       lhs: Lit { val: 1 },
 //│       rhs: Add { lhs: Lit { val: 2 }, rhs: Lit { val: 3 } }
@@ -53,9 +50,9 @@ eval1 eval1 e1
 //│    = 6
 
 def eval1_fixed_1 = eval1 eval1
-//│ eval1_fixed_1: ((Add[?] with {lhs: 'a, rhs: 'a}) | (Lit with {val: 'val})) -> (int | 'val)
+//│ eval1_fixed_1: ((Add[nothing] with {lhs: 'a, rhs: 'a}) | (Lit with {val: 'val})) -> (int | 'val)
 //│   where
-//│     'a <: (Add[?] with {lhs: 'a, rhs: 'a}) | Lit
+//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit
 //│              = [Function (anonymous)]
 
 eval1_fixed_1 e1
@@ -66,7 +63,7 @@ eval1_fixed_1 e1
 rec def eval1_fixed_2 = eval1f (fun x -> eval1f eval1_fixed_2 x)
 //│ eval1_fixed_2: 'a -> int
 //│   where
-//│     'a <: (Add[?] with {lhs: 'a, rhs: 'a}) | Lit
+//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit
 //│              = [Function (anonymous)]
 
 eval1_fixed_2 e1
@@ -78,9 +75,9 @@ eval1_fixed_2 e1
 def eval1_fixed_3 =
   let fixed fixed = eval1f (fun x -> eval1f (fixed fixed) x)
   in fixed fixed
-//│ eval1_fixed_3: ((Add[?] with {lhs: 'a, rhs: 'a}) | (Lit with {val: 'val})) -> (int | 'val)
+//│ eval1_fixed_3: ((Add[nothing] with {lhs: 'a, rhs: 'a}) | (Lit with {val: 'val})) -> (int | 'val)
 //│   where
-//│     'a <: (Add[?] with {lhs: 'a, rhs: 'a}) | Lit
+//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit
 //│              = [Function (anonymous)]
 
 eval1_fixed_3 e1
@@ -95,7 +92,7 @@ eval1_fixed_3 e1
 class Nega[E]: { arg: E }
 def nega arg = Nega { arg }
 //│ Defined class Nega[+E]
-//│ nega: ('arg & 'E) -> (Nega['E] with {arg: 'arg})
+//│ nega: 'arg -> Nega['arg]
 //│     = [Function: nega]
 
 
@@ -103,24 +100,19 @@ def eval2 eval2 e = case e of {
   | Nega -> 0 - (eval2 eval2 e.arg)
   | _ -> eval1 eval2 e
   }
-//│ eval2: ('a -> 'rhs -> int & 'a) -> ((Add[?] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val}) | (Nega[?] with {arg: 'rhs})) -> (int | 'val)
+//│ eval2: ('a -> 'rhs -> int & 'a) -> ((Add[nothing] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val}) | (Nega[nothing] with {arg: 'rhs})) -> (int | 'val)
 //│      = [Function: eval2]
 
 def eval2f eval2 e = case e of {
   | Nega -> 0 - (eval2 e.arg)
   | _ -> eval1f eval2 e
   }
-//│ eval2f: ('rhs -> int) -> ((Add[?] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val}) | (Nega[?] with {arg: 'rhs})) -> (int | 'val)
+//│ eval2f: ('rhs -> int) -> ((Add[nothing] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val}) | (Nega[nothing] with {arg: 'rhs})) -> (int | 'val)
 //│       = [Function: eval2f]
 
 
 e2 = add (lit 1) (nega e1)
-//│ e2: Add['E] with {lhs: Lit & {val: 1}, rhs: Nega['E0] & {arg: Add['E1] with {lhs: Lit & {val: 1}, rhs: Add['E2] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}}}
-//│   where
-//│     'E :> Lit & {val: 1} | Nega['E0] & {arg: Add['E1] with {lhs: Lit & {val: 1}, rhs: Add['E2] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}}
-//│     'E0 :> Add['E1] with {lhs: Lit & {val: 1}, rhs: Add['E2] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
-//│     'E1 :> (Add['E2] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}
-//│     'E2 :> Lit & {val: 2 | 3}
+//│ e2: Add[Lit & {val: 1} | Nega[Add[(Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]] with {lhs: Lit & {val: 1}, rhs: Nega[Add[(Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]}
 //│   = Add {
 //│       lhs: Lit { val: 1 },
 //│       rhs: Nega { arg: Add { lhs: [Lit], rhs: [Add] } }
@@ -128,9 +120,9 @@ e2 = add (lit 1) (nega e1)
 
 
 def eval2_fixed_1 = eval2 eval2
-//│ eval2_fixed_1: ((Add[?] with {lhs: 'a, rhs: 'a}) | (Lit with {val: 'val}) | (Nega[?] with {arg: 'a})) -> (int | 'val)
+//│ eval2_fixed_1: ((Add[nothing] with {lhs: 'a, rhs: 'a}) | (Lit with {val: 'val}) | (Nega[nothing] with {arg: 'a})) -> (int | 'val)
 //│   where
-//│     'a <: (Add[?] with {lhs: 'a, rhs: 'a}) | Lit | (Nega[?] with {arg: 'a})
+//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit | (Nega[nothing] with {arg: 'a})
 //│              = [Function (anonymous)]
 
 eval2_fixed_1 e1
@@ -147,7 +139,7 @@ def fix f = let fixed = fun x -> f (fun v -> (x x) v) in fixed fixed
 def eval2_fixed_2 = fix eval2f
 //│ eval2_fixed_2: 'a -> int
 //│   where
-//│     'a <: (Add[?] with {lhs: 'a, rhs: 'a}) | Lit | (Nega[?] with {arg: 'a})
+//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit | (Nega[nothing] with {arg: 'a})
 //│              = [Function (anonymous)]
 
 eval2_fixed_2 e1
@@ -169,14 +161,14 @@ eval2_fixed_2 e2
 rec def eval1_fixed = eval1f (eval1f eval1_fixed)
 //│ eval1_fixed: 'a -> int
 //│   where
-//│     'a <: (Add[?] with {lhs: 'a, rhs: 'a}) | Lit
+//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit
 //│ Runtime error:
 //│   ReferenceError: eval1_fixed is not defined
 
 rec def eval1_fixed() = eval1f (eval1f (eval1_fixed()))
 //│ eval1_fixed: () -> 'a -> int
 //│   where
-//│     'a <: (Add[?] with {lhs: 'a, rhs: 'a}) | Lit
+//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit
 //│            = [Function: eval1_fixed1]
 
 :re
@@ -208,7 +200,7 @@ def eval1_fixed = eval1f (fun x -> eval1f eval1f x)
 //│ ╟── Note: constraint arises from application:
 //│ ║  l.31: 	  | Add -> eval1 e.lhs + eval1 e.rhs
 //│ ╙──      	                         ^^^^^^^^^^^
-//│ eval1_fixed: ((Add[?] with {lhs: (Add[?] with {lhs: nothing -> int, rhs: nothing -> int}) | Lit, rhs: (Add[?] with {lhs: nothing -> int, rhs: nothing -> int}) | Lit}) | (Lit with {val: 'val})) -> (int | 'val)
+//│ eval1_fixed: ((Add[nothing] with {lhs: (Add[nothing] with {lhs: nothing -> int, rhs: nothing -> int}) | Lit, rhs: (Add[nothing] with {lhs: nothing -> int, rhs: nothing -> int}) | Lit}) | (Lit with {val: 'val})) -> (int | 'val)
 
 rec def eval1_fixed = eval1f (fun x -> eval1_fixed eval1_fixed x)
 //│ ╔══[ERROR] Type mismatch in binding of application:
@@ -241,7 +233,7 @@ rec def eval1_fixed = eval1f (fun x -> eval1_fixed eval1_fixed x)
 //│ ╟── from application:
 //│ ║  l.+1: 	rec def eval1_fixed = eval1f (fun x -> eval1_fixed eval1_fixed x)
 //│ ╙──      	                                       ^^^^^^^^^^^^^^^^^^^^^^^
-//│ eval1_fixed: ((Add[?] with {lhs: 'a, rhs: 'a}) | (Lit with {val: 'a -> int & 'val})) -> (int | 'val)
+//│ eval1_fixed: ((Add[nothing] with {lhs: 'a, rhs: 'a}) | (Lit with {val: 'a -> int & 'val})) -> (int | 'val)
 
 :e
 rec def eval1_fixed = eval1f eval1_fixed e1
@@ -282,7 +274,7 @@ def eval2_broken eval2 e = case e of {
   | Nega -> e.arg
   | _ -> eval1 eval2 e
   }
-//│ eval2_broken: ('a -> 'rhs -> int & 'a) -> ((Add[?] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'arg}) | (Nega[?] with {arg: 'arg})) -> ('arg | int)
+//│ eval2_broken: ('a -> 'rhs -> int & 'a) -> ((Add[nothing] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'arg}) | (Nega[nothing] with {arg: 'arg})) -> ('arg | int)
 
 :e
 eval2_broken eval2_broken e2
@@ -296,7 +288,7 @@ eval2_broken eval2_broken e2
 //│ ║  l.20: 	  | Add -> eval1 eval1 e.lhs + eval1 eval1 e.rhs
 //│ ║        	                               ^^^^^^^^^^^^^^^^^
 //│ ╟── from field selection:
-//│ ║  l.282: 	  | Nega -> e.arg
+//│ ║  l.274: 	  | Nega -> e.arg
 //│ ╙──       	            ^^^^^
 //│ res: error | int
 
@@ -305,7 +297,7 @@ def eval2f_oops eval2 e = case e of {
   | Nega -> 0 - (eval2 e.arg)
   | _ -> eval1 eval2 e // should be: eval1f eval2 e
   }
-//│ eval2f_oops: ('arg -> nothing & 'arg) -> ((Add[?] with {lhs: anything, rhs: anything}) | (Lit with {val: 'val}) | (Nega[?] with {arg: 'arg})) -> (int | 'val)
+//│ eval2f_oops: ('arg -> nothing & 'arg) -> ((Add[nothing] with {lhs: anything, rhs: anything}) | (Lit with {val: 'val}) | (Nega[nothing] with {arg: 'arg})) -> (int | 'val)
 
 :e
 fix eval2f_oops e2
@@ -313,13 +305,13 @@ fix eval2f_oops e2
 //│ ║  l.+1: 	fix eval2f_oops e2
 //│ ║        	^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not match type `Add[?] & ?c | Lit & ?d`
-//│ ║  l.143: 	def fix f = let fixed = fun x -> f (fun v -> (x x) v) in fixed fixed
+//│ ║  l.135: 	def fix f = let fixed = fun x -> f (fun v -> (x x) v) in fixed fixed
 //│ ║         	                                    ^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from reference:
 //│ ║  l.18: 	def eval1 eval1 e = case e of {
 //│ ║        	                         ^
 //│ ╟── from reference:
-//│ ║  l.304: 	def eval2f_oops eval2 e = case e of {
+//│ ║  l.296: 	def eval2f_oops eval2 e = case e of {
 //│ ╙──       	                               ^
 //│ res: error
 

--- a/shared/src/test/diff/mlscript/ExprProb2.mls
+++ b/shared/src/test/diff/mlscript/ExprProb2.mls
@@ -19,7 +19,7 @@ def eval1 eval1 e = case e of {
   | Lit -> e.val
   | Add -> eval1 eval1 e.lhs + eval1 eval1 e.rhs
   }
-//│ eval1: ('a -> 'rhs -> int & 'a) -> ((Add[anything] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val})) -> (int | 'val)
+//│ eval1: ('a -> 'rhs -> int & 'a) -> ((Add[?] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val})) -> (int | 'val)
 //│      = [Function: eval1]
 //│ constrain calls  : 36
 //│ annoying  calls  : 0
@@ -30,7 +30,7 @@ def eval1f eval1 e = case e of {
   | Lit -> e.val
   | Add -> eval1 e.lhs + eval1 e.rhs
   }
-//│ eval1f: ('rhs -> int) -> ((Add[anything] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val})) -> (int | 'val)
+//│ eval1f: ('rhs -> int) -> ((Add[?] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val})) -> (int | 'val)
 //│       = [Function: eval1f]
 //│ constrain calls  : 32
 //│ annoying  calls  : 0
@@ -50,9 +50,9 @@ eval1 eval1 e1
 //│    = 6
 
 def eval1_fixed_1 = eval1 eval1
-//│ eval1_fixed_1: (Add[anything] & {lhs: 'a, rhs: 'a} | (Lit with {val: 'val})) -> (int | 'val)
+//│ eval1_fixed_1: (Add[?] & {lhs: 'a, rhs: 'a} | (Lit with {val: 'val})) -> (int | 'val)
 //│   where
-//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit
+//│     'a <: Add[?] & {lhs: 'a, rhs: 'a} | Lit
 //│              = [Function (anonymous)]
 
 eval1_fixed_1 e1
@@ -63,7 +63,7 @@ eval1_fixed_1 e1
 rec def eval1_fixed_2 = eval1f (fun x -> eval1f eval1_fixed_2 x)
 //│ eval1_fixed_2: 'a -> int
 //│   where
-//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit
+//│     'a <: Add[?] & {lhs: 'a, rhs: 'a} | Lit
 //│              = [Function (anonymous)]
 
 eval1_fixed_2 e1
@@ -75,9 +75,9 @@ eval1_fixed_2 e1
 def eval1_fixed_3 =
   let fixed fixed = eval1f (fun x -> eval1f (fixed fixed) x)
   in fixed fixed
-//│ eval1_fixed_3: (Add[anything] & {lhs: 'a, rhs: 'a} | (Lit with {val: 'val})) -> (int | 'val)
+//│ eval1_fixed_3: (Add[?] & {lhs: 'a, rhs: 'a} | (Lit with {val: 'val})) -> (int | 'val)
 //│   where
-//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit
+//│     'a <: Add[?] & {lhs: 'a, rhs: 'a} | Lit
 //│              = [Function (anonymous)]
 
 eval1_fixed_3 e1
@@ -100,14 +100,14 @@ def eval2 eval2 e = case e of {
   | Nega -> 0 - (eval2 eval2 e.arg)
   | _ -> eval1 eval2 e
   }
-//│ eval2: ('a -> 'rhs -> int & 'a) -> ((Add[anything] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val}) | (Nega[anything] with {arg: 'rhs})) -> (int | 'val)
+//│ eval2: ('a -> 'rhs -> int & 'a) -> ((Add[?] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val}) | (Nega[?] with {arg: 'rhs})) -> (int | 'val)
 //│      = [Function: eval2]
 
 def eval2f eval2 e = case e of {
   | Nega -> 0 - (eval2 e.arg)
   | _ -> eval1f eval2 e
   }
-//│ eval2f: ('rhs -> int) -> ((Add[anything] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val}) | (Nega[anything] with {arg: 'rhs})) -> (int | 'val)
+//│ eval2f: ('rhs -> int) -> ((Add[?] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val}) | (Nega[?] with {arg: 'rhs})) -> (int | 'val)
 //│       = [Function: eval2f]
 
 
@@ -120,9 +120,9 @@ e2 = add (lit 1) (nega e1)
 
 
 def eval2_fixed_1 = eval2 eval2
-//│ eval2_fixed_1: (Add[anything] & {lhs: 'a, rhs: 'a} | (Lit with {val: 'val}) | Nega[anything] & {arg: 'a}) -> (int | 'val)
+//│ eval2_fixed_1: (Add[?] & {lhs: 'a, rhs: 'a} | (Lit with {val: 'val}) | Nega[?] & {arg: 'a}) -> (int | 'val)
 //│   where
-//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit | Nega[anything] & {arg: 'a}
+//│     'a <: Add[?] & {lhs: 'a, rhs: 'a} | Lit | Nega[?] & {arg: 'a}
 //│              = [Function (anonymous)]
 
 eval2_fixed_1 e1
@@ -139,7 +139,7 @@ def fix f = let fixed = fun x -> f (fun v -> (x x) v) in fixed fixed
 def eval2_fixed_2 = fix eval2f
 //│ eval2_fixed_2: 'a -> int
 //│   where
-//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit | Nega[anything] & {arg: 'a}
+//│     'a <: Add[?] & {lhs: 'a, rhs: 'a} | Lit | Nega[?] & {arg: 'a}
 //│              = [Function (anonymous)]
 
 eval2_fixed_2 e1
@@ -161,14 +161,14 @@ eval2_fixed_2 e2
 rec def eval1_fixed = eval1f (eval1f eval1_fixed)
 //│ eval1_fixed: 'a -> int
 //│   where
-//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit
+//│     'a <: Add[?] & {lhs: 'a, rhs: 'a} | Lit
 //│ Runtime error:
 //│   ReferenceError: eval1_fixed is not defined
 
 rec def eval1_fixed() = eval1f (eval1f (eval1_fixed()))
 //│ eval1_fixed: () -> 'a -> int
 //│   where
-//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit
+//│     'a <: Add[?] & {lhs: 'a, rhs: 'a} | Lit
 //│            = [Function: eval1_fixed1]
 
 :re
@@ -200,13 +200,13 @@ def eval1_fixed = eval1f (fun x -> eval1f eval1f x)
 //│ ╟── Note: constraint arises from application:
 //│ ║  l.31: 	  | Add -> eval1 e.lhs + eval1 e.rhs
 //│ ╙──      	                         ^^^^^^^^^^^
-//│ eval1_fixed: (Add[anything] & {lhs: (Add[anything] with {lhs: nothing -> int, rhs: nothing -> int}) | Lit, rhs: (Add[anything] with {lhs: nothing -> int, rhs: nothing -> int}) | Lit} | (Lit with {val: 'val})) -> (int | 'val)
+//│ eval1_fixed: (Add[?] & {lhs: (Add[?] with {lhs: nothing -> int, rhs: nothing -> int}) | Lit, rhs: (Add[?] with {lhs: nothing -> int, rhs: nothing -> int}) | Lit} | (Lit with {val: 'val})) -> (int | 'val)
 
 rec def eval1_fixed = eval1f (fun x -> eval1_fixed eval1_fixed x)
 //│ ╔══[ERROR] Type mismatch in binding of application:
 //│ ║  l.+1: 	rec def eval1_fixed = eval1f (fun x -> eval1_fixed eval1_fixed x)
 //│ ║        	                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── function of type `?a -> (?val | ?b)` does not match type `Add[anything] & ?c | Lit & ?d`
+//│ ╟── function of type `?a -> (?val | ?b)` does not match type `Add[?] & ?c | Lit & ?d`
 //│ ║  l.29: 	def eval1f eval1 e = case e of {
 //│ ║        	                 ^^^^^^^^^^^^^^^
 //│ ║  l.30: 	  | Lit -> e.val
@@ -215,7 +215,7 @@ rec def eval1_fixed = eval1f (fun x -> eval1_fixed eval1_fixed x)
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ║  l.32: 	  }
 //│ ║        	^^^
-//│ ╟── but it flows into application with expected type `Add[anything] & ?e | Lit & ?f`
+//│ ╟── but it flows into application with expected type `Add[?] & ?e | Lit & ?f`
 //│ ║  l.+1: 	rec def eval1_fixed = eval1f (fun x -> eval1_fixed eval1_fixed x)
 //│ ║        	                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from reference:
@@ -233,7 +233,7 @@ rec def eval1_fixed = eval1f (fun x -> eval1_fixed eval1_fixed x)
 //│ ╟── from application:
 //│ ║  l.+1: 	rec def eval1_fixed = eval1f (fun x -> eval1_fixed eval1_fixed x)
 //│ ╙──      	                                       ^^^^^^^^^^^^^^^^^^^^^^^
-//│ eval1_fixed: ((Add[anything] with {lhs: 'a, rhs: 'a}) | (Lit with {val: 'a -> int & 'val})) -> (int | 'val)
+//│ eval1_fixed: ((Add[?] with {lhs: 'a, rhs: 'a}) | (Lit with {val: 'a -> int & 'val})) -> (int | 'val)
 
 :e
 rec def eval1_fixed = eval1f eval1_fixed e1
@@ -274,7 +274,7 @@ def eval2_broken eval2 e = case e of {
   | Nega -> e.arg
   | _ -> eval1 eval2 e
   }
-//│ eval2_broken: ('a -> 'rhs -> int & 'a) -> ((Add[anything] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'arg}) | (Nega[anything] with {arg: 'arg})) -> ('arg | int)
+//│ eval2_broken: ('a -> 'rhs -> int & 'a) -> ((Add[?] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'arg}) | (Nega[?] with {arg: 'arg})) -> ('arg | int)
 
 :e
 eval2_broken eval2_broken e2
@@ -297,14 +297,14 @@ def eval2f_oops eval2 e = case e of {
   | Nega -> 0 - (eval2 e.arg)
   | _ -> eval1 eval2 e // should be: eval1f eval2 e
   }
-//│ eval2f_oops: ('arg -> nothing & 'arg) -> ((Add[anything] with {lhs: anything, rhs: anything}) | (Lit with {val: 'val}) | (Nega[anything] with {arg: 'arg})) -> (int | 'val)
+//│ eval2f_oops: ('arg -> nothing & 'arg) -> ((Add[?] with {lhs: anything, rhs: anything}) | (Lit with {val: 'val}) | (Nega[?] with {arg: 'arg})) -> (int | 'val)
 
 :e
 fix eval2f_oops e2
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	fix eval2f_oops e2
 //│ ║        	^^^^^^^^^^^^^^^
-//│ ╟── function of type `?a -> ?b` does not match type `Add[anything] & ?c | Lit & ?d`
+//│ ╟── function of type `?a -> ?b` does not match type `Add[?] & ?c | Lit & ?d`
 //│ ║  l.135: 	def fix f = let fixed = fun x -> f (fun v -> (x x) v) in fixed fixed
 //│ ║         	                                    ^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from reference:

--- a/shared/src/test/diff/mlscript/ExprProb2.mls
+++ b/shared/src/test/diff/mlscript/ExprProb2.mls
@@ -19,26 +19,26 @@ def eval1 eval1 e = case e of {
   | Lit -> e.val
   | Add -> eval1 eval1 e.lhs + eval1 eval1 e.rhs
   }
-//│ eval1: ('a -> 'rhs -> int & 'a) -> ((Add[nothing] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val})) -> (int | 'val)
+//│ eval1: ('a -> 'rhs -> int & 'a) -> ((Add[anything] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val})) -> (int | 'val)
 //│      = [Function: eval1]
 //│ constrain calls  : 36
 //│ annoying  calls  : 0
-//│ subtyping calls  : 62
+//│ subtyping calls  : 54
 
 :stats
 def eval1f eval1 e = case e of {
   | Lit -> e.val
   | Add -> eval1 e.lhs + eval1 e.rhs
   }
-//│ eval1f: ('rhs -> int) -> ((Add[nothing] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val})) -> (int | 'val)
+//│ eval1f: ('rhs -> int) -> ((Add[anything] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val})) -> (int | 'val)
 //│       = [Function: eval1f]
 //│ constrain calls  : 32
 //│ annoying  calls  : 0
-//│ subtyping calls  : 58
+//│ subtyping calls  : 50
 
 
 e1 = add (lit 1) (add (lit 2) (lit 3))
-//│ e1: Add[(Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
+//│ e1: Add[Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}} | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
 //│   = Add {
 //│       lhs: Lit { val: 1 },
 //│       rhs: Add { lhs: Lit { val: 2 }, rhs: Lit { val: 3 } }
@@ -50,9 +50,9 @@ eval1 eval1 e1
 //│    = 6
 
 def eval1_fixed_1 = eval1 eval1
-//│ eval1_fixed_1: ((Add[nothing] with {lhs: 'a, rhs: 'a}) | (Lit with {val: 'val})) -> (int | 'val)
+//│ eval1_fixed_1: (Add[anything] & {lhs: 'a, rhs: 'a} | (Lit with {val: 'val})) -> (int | 'val)
 //│   where
-//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit
+//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit
 //│              = [Function (anonymous)]
 
 eval1_fixed_1 e1
@@ -63,7 +63,7 @@ eval1_fixed_1 e1
 rec def eval1_fixed_2 = eval1f (fun x -> eval1f eval1_fixed_2 x)
 //│ eval1_fixed_2: 'a -> int
 //│   where
-//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit
+//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit
 //│              = [Function (anonymous)]
 
 eval1_fixed_2 e1
@@ -75,9 +75,9 @@ eval1_fixed_2 e1
 def eval1_fixed_3 =
   let fixed fixed = eval1f (fun x -> eval1f (fixed fixed) x)
   in fixed fixed
-//│ eval1_fixed_3: ((Add[nothing] with {lhs: 'a, rhs: 'a}) | (Lit with {val: 'val})) -> (int | 'val)
+//│ eval1_fixed_3: (Add[anything] & {lhs: 'a, rhs: 'a} | (Lit with {val: 'val})) -> (int | 'val)
 //│   where
-//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit
+//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit
 //│              = [Function (anonymous)]
 
 eval1_fixed_3 e1
@@ -100,19 +100,19 @@ def eval2 eval2 e = case e of {
   | Nega -> 0 - (eval2 eval2 e.arg)
   | _ -> eval1 eval2 e
   }
-//│ eval2: ('a -> 'rhs -> int & 'a) -> ((Add[nothing] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val}) | (Nega[nothing] with {arg: 'rhs})) -> (int | 'val)
+//│ eval2: ('a -> 'rhs -> int & 'a) -> ((Add[anything] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val}) | (Nega[anything] with {arg: 'rhs})) -> (int | 'val)
 //│      = [Function: eval2]
 
 def eval2f eval2 e = case e of {
   | Nega -> 0 - (eval2 e.arg)
   | _ -> eval1f eval2 e
   }
-//│ eval2f: ('rhs -> int) -> ((Add[nothing] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val}) | (Nega[nothing] with {arg: 'rhs})) -> (int | 'val)
+//│ eval2f: ('rhs -> int) -> ((Add[anything] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'val}) | (Nega[anything] with {arg: 'rhs})) -> (int | 'val)
 //│       = [Function: eval2f]
 
 
 e2 = add (lit 1) (nega e1)
-//│ e2: Add[Lit & {val: 1} | Nega[Add[(Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]] with {lhs: Lit & {val: 1}, rhs: Nega[Add[(Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]}
+//│ e2: Add[Lit & {val: 1} | Nega[Add[Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}} | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]] with {lhs: Lit & {val: 1}, rhs: Nega[Add[Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}} | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]}
 //│   = Add {
 //│       lhs: Lit { val: 1 },
 //│       rhs: Nega { arg: Add { lhs: [Lit], rhs: [Add] } }
@@ -120,9 +120,9 @@ e2 = add (lit 1) (nega e1)
 
 
 def eval2_fixed_1 = eval2 eval2
-//│ eval2_fixed_1: ((Add[nothing] with {lhs: 'a, rhs: 'a}) | (Lit with {val: 'val}) | (Nega[nothing] with {arg: 'a})) -> (int | 'val)
+//│ eval2_fixed_1: (Add[anything] & {lhs: 'a, rhs: 'a} | (Lit with {val: 'val}) | Nega[anything] & {arg: 'a}) -> (int | 'val)
 //│   where
-//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit | (Nega[nothing] with {arg: 'a})
+//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit | Nega[anything] & {arg: 'a}
 //│              = [Function (anonymous)]
 
 eval2_fixed_1 e1
@@ -139,7 +139,7 @@ def fix f = let fixed = fun x -> f (fun v -> (x x) v) in fixed fixed
 def eval2_fixed_2 = fix eval2f
 //│ eval2_fixed_2: 'a -> int
 //│   where
-//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit | (Nega[nothing] with {arg: 'a})
+//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit | Nega[anything] & {arg: 'a}
 //│              = [Function (anonymous)]
 
 eval2_fixed_2 e1
@@ -161,14 +161,14 @@ eval2_fixed_2 e2
 rec def eval1_fixed = eval1f (eval1f eval1_fixed)
 //│ eval1_fixed: 'a -> int
 //│   where
-//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit
+//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit
 //│ Runtime error:
 //│   ReferenceError: eval1_fixed is not defined
 
 rec def eval1_fixed() = eval1f (eval1f (eval1_fixed()))
 //│ eval1_fixed: () -> 'a -> int
 //│   where
-//│     'a <: (Add[nothing] with {lhs: 'a, rhs: 'a}) | Lit
+//│     'a <: Add[anything] & {lhs: 'a, rhs: 'a} | Lit
 //│            = [Function: eval1_fixed1]
 
 :re
@@ -200,13 +200,13 @@ def eval1_fixed = eval1f (fun x -> eval1f eval1f x)
 //│ ╟── Note: constraint arises from application:
 //│ ║  l.31: 	  | Add -> eval1 e.lhs + eval1 e.rhs
 //│ ╙──      	                         ^^^^^^^^^^^
-//│ eval1_fixed: ((Add[nothing] with {lhs: (Add[nothing] with {lhs: nothing -> int, rhs: nothing -> int}) | Lit, rhs: (Add[nothing] with {lhs: nothing -> int, rhs: nothing -> int}) | Lit}) | (Lit with {val: 'val})) -> (int | 'val)
+//│ eval1_fixed: (Add[anything] & {lhs: (Add[anything] with {lhs: nothing -> int, rhs: nothing -> int}) | Lit, rhs: (Add[anything] with {lhs: nothing -> int, rhs: nothing -> int}) | Lit} | (Lit with {val: 'val})) -> (int | 'val)
 
 rec def eval1_fixed = eval1f (fun x -> eval1_fixed eval1_fixed x)
 //│ ╔══[ERROR] Type mismatch in binding of application:
 //│ ║  l.+1: 	rec def eval1_fixed = eval1f (fun x -> eval1_fixed eval1_fixed x)
 //│ ║        	                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── function of type `?a -> (?val | ?b)` does not match type `Add[?] & ?c | Lit & ?d`
+//│ ╟── function of type `?a -> (?val | ?b)` does not match type `Add[anything] & ?c | Lit & ?d`
 //│ ║  l.29: 	def eval1f eval1 e = case e of {
 //│ ║        	                 ^^^^^^^^^^^^^^^
 //│ ║  l.30: 	  | Lit -> e.val
@@ -215,7 +215,7 @@ rec def eval1_fixed = eval1f (fun x -> eval1_fixed eval1_fixed x)
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ║  l.32: 	  }
 //│ ║        	^^^
-//│ ╟── but it flows into application with expected type `Add[?] & ?e | Lit & ?f`
+//│ ╟── but it flows into application with expected type `Add[anything] & ?e | Lit & ?f`
 //│ ║  l.+1: 	rec def eval1_fixed = eval1f (fun x -> eval1_fixed eval1_fixed x)
 //│ ║        	                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from reference:
@@ -233,7 +233,7 @@ rec def eval1_fixed = eval1f (fun x -> eval1_fixed eval1_fixed x)
 //│ ╟── from application:
 //│ ║  l.+1: 	rec def eval1_fixed = eval1f (fun x -> eval1_fixed eval1_fixed x)
 //│ ╙──      	                                       ^^^^^^^^^^^^^^^^^^^^^^^
-//│ eval1_fixed: ((Add[nothing] with {lhs: 'a, rhs: 'a}) | (Lit with {val: 'a -> int & 'val})) -> (int | 'val)
+//│ eval1_fixed: ((Add[anything] with {lhs: 'a, rhs: 'a}) | (Lit with {val: 'a -> int & 'val})) -> (int | 'val)
 
 :e
 rec def eval1_fixed = eval1f eval1_fixed e1
@@ -274,14 +274,14 @@ def eval2_broken eval2 e = case e of {
   | Nega -> e.arg
   | _ -> eval1 eval2 e
   }
-//│ eval2_broken: ('a -> 'rhs -> int & 'a) -> ((Add[nothing] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'arg}) | (Nega[nothing] with {arg: 'arg})) -> ('arg | int)
+//│ eval2_broken: ('a -> 'rhs -> int & 'a) -> ((Add[anything] with {lhs: 'rhs, rhs: 'rhs}) | (Lit with {val: 'arg}) | (Nega[anything] with {arg: 'arg})) -> ('arg | int)
 
 :e
 eval2_broken eval2_broken e2
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	eval2_broken eval2_broken e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── application of type `Add[?E] & {lhs: ?lhs, rhs: ?rhs}` does not match type `int`
+//│ ╟── application of type `Add[?E] & {Add#E = ?E, lhs: ?lhs, rhs: ?rhs}` does not match type `int`
 //│ ║  l.8: 	def add lhs rhs = Add { lhs; rhs }
 //│ ║       	                  ^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
@@ -297,14 +297,14 @@ def eval2f_oops eval2 e = case e of {
   | Nega -> 0 - (eval2 e.arg)
   | _ -> eval1 eval2 e // should be: eval1f eval2 e
   }
-//│ eval2f_oops: ('arg -> nothing & 'arg) -> ((Add[nothing] with {lhs: anything, rhs: anything}) | (Lit with {val: 'val}) | (Nega[nothing] with {arg: 'arg})) -> (int | 'val)
+//│ eval2f_oops: ('arg -> nothing & 'arg) -> ((Add[anything] with {lhs: anything, rhs: anything}) | (Lit with {val: 'val}) | (Nega[anything] with {arg: 'arg})) -> (int | 'val)
 
 :e
 fix eval2f_oops e2
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	fix eval2f_oops e2
 //│ ║        	^^^^^^^^^^^^^^^
-//│ ╟── function of type `?a -> ?b` does not match type `Add[?] & ?c | Lit & ?d`
+//│ ╟── function of type `?a -> ?b` does not match type `Add[anything] & ?c | Lit & ?d`
 //│ ║  l.135: 	def fix f = let fixed = fun x -> f (fun v -> (x x) v) in fixed fixed
 //│ ║         	                                    ^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from reference:

--- a/shared/src/test/diff/mlscript/ExprProb_Inv.mls
+++ b/shared/src/test/diff/mlscript/ExprProb_Inv.mls
@@ -14,11 +14,29 @@ def done x = case x of {}
 
 
 class Lit: { val: int }
+//│ Defined class Lit
+
+:dv
 class Add[E]: { lhs: E; rhs: E }
+  method Inv (x: E) = x
+//│ VARIANCE ANALYSIS
+//│ ⬤ ITERATION 1
+//│ | class Add  ± E31'
+//│ | | upd[+] {lhs: E31', rhs: E31'}
+//│ | | | upd[+] E31'
+//│ | | | | UPDATE Add.E31' from ± to +
+//│ | | | upd[+] E31'
+//│ ⬤ ITERATION 2
+//│ | class Add  + E31'
+//│ | | upd[+] {lhs: E31', rhs: E31'}
+//│ | | | upd[+] E31'
+//│ | | | upd[+] E31'
+//│ DONE
+//│ Defined class Add[+E]
+//│ Defined Add.Inv: Add['E] -> 'E -> 'E
+
 def lit val = Lit { val }
 def add lhs rhs = Add { lhs; rhs }
-//│ Defined class Lit
-//│ Defined class Add[+E]
 //│ lit: (int & 'val) -> (Lit with {val: 'val})
 //│    = [Function: lit]
 //│ add: ('lhs & 'E) -> ('E & 'rhs) -> (Add['E] with {lhs: 'lhs, rhs: 'rhs})
@@ -541,13 +559,13 @@ eval1 done e2
 //│ ║  l.+1: 	eval1 done e2
 //│ ║        	^^^^^^^^^^^^^
 //│ ╟── application of type `Nega[?E] & {Nega#E = ?E, arg: ?arg}` does not match type `nothing`
-//│ ║  l.372: 	def nega arg = Nega { arg }
+//│ ║  l.389: 	def nega arg = Nega { arg }
 //│ ║         	               ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from reference:
 //│ ║  l.4: 	def done x = case x of {}
 //│ ║       	                  ^
 //│ ╟── from field selection:
-//│ ║  l.74: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.91: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ╙──      	                                   ^^^^^
 //│ res: error | int
 //│ Runtime error:
@@ -560,30 +578,30 @@ prettier2 done eval1 e1
 //│ ║  l.+1: 	prettier2 done eval1 e1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> (?b | ?c)` does not match type `int`
-//│ ║  l.72: 	rec def eval1 k e = case e of {
+//│ ║  l.89: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.73: 	  | Lit -> e.val
+//│ ║  l.90: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.74: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.91: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.75: 	  | _ -> k e
+//│ ║  l.92: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.76: 	  }
+//│ ║  l.93: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval1 e1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Lit & {val: ?val}` is not a function
-//│ ║  l.18: 	def lit val = Lit { val }
+//│ ║  l.38: 	def lit val = Lit { val }
 //│ ║        	              ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.75: 	  | _ -> k e
+//│ ║  l.92: 	  | _ -> k e
 //│ ║        	         ^^^
 //│ ╟── from field selection:
-//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error
 //│    = '123'
@@ -596,13 +614,13 @@ prettier2 done (eval1 done) e2
 //│ ║  l.+1: 	prettier2 done (eval1 done) e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Nega[?E] & {Nega#E = ?E, arg: ?arg}` does not match type `nothing`
-//│ ║  l.372: 	def nega arg = Nega { arg }
+//│ ║  l.389: 	def nega arg = Nega { arg }
 //│ ║         	               ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from reference:
 //│ ║  l.4: 	def done x = case x of {}
 //│ ║       	                  ^
 //│ ╟── from field selection:
-//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error | string
 //│ Runtime error:
@@ -618,18 +636,18 @@ prettier2 done eval2
 //│ ║  l.+1: 	prettier2 done eval2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not match type `int`
-//│ ║  l.72: 	rec def eval1 k e = case e of {
+//│ ║  l.89: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.73: 	  | Lit -> e.val
+//│ ║  l.90: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.74: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.91: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.75: 	  | _ -> k e
+//│ ║  l.92: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.76: 	  }
+//│ ║  l.93: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ res: 'a -> string | error
 //│   where
@@ -646,30 +664,30 @@ prettier2 done eval2 e1
 //│ ║  l.+1: 	prettier2 done eval2 e1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not match type `int`
-//│ ║  l.72: 	rec def eval1 k e = case e of {
+//│ ║  l.89: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.73: 	  | Lit -> e.val
+//│ ║  l.90: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.74: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.91: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.75: 	  | _ -> k e
+//│ ║  l.92: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.76: 	  }
+//│ ║  l.93: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval2 e1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Lit & {val: ?val}` is not a function
-//│ ║  l.18: 	def lit val = Lit { val }
+//│ ║  l.38: 	def lit val = Lit { val }
 //│ ║        	              ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.381: 	  | _ -> k x
+//│ ║  l.398: 	  | _ -> k x
 //│ ║         	         ^^^
 //│ ╟── from field selection:
-//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error
 //│    = '123'
@@ -684,30 +702,30 @@ prettier2 done eval2 e2
 //│ ║  l.+1: 	prettier2 done eval2 e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not match type `int`
-//│ ║  l.72: 	rec def eval1 k e = case e of {
+//│ ║  l.89: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.73: 	  | Lit -> e.val
+//│ ║  l.90: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.74: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.91: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.75: 	  | _ -> k e
+//│ ║  l.92: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.76: 	  }
+//│ ║  l.93: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval2 e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Lit & {val: ?val}` is not a function
-//│ ║  l.18: 	def lit val = Lit { val }
+//│ ║  l.38: 	def lit val = Lit { val }
 //│ ║        	              ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.381: 	  | _ -> k x
+//│ ║  l.398: 	  | _ -> k x
 //│ ║         	         ^^^
 //│ ╟── from field selection:
-//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error
 //│    = '1-123'
@@ -722,30 +740,30 @@ prettier2 done eval2 d2
 //│ ║  l.+1: 	prettier2 done eval2 d2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not match type `int`
-//│ ║  l.72: 	rec def eval1 k e = case e of {
+//│ ║  l.89: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.73: 	  | Lit -> e.val
+//│ ║  l.90: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.74: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.91: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.75: 	  | _ -> k e
+//│ ║  l.92: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.76: 	  }
+//│ ║  l.93: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval2 d2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Nega[?E] & {Nega#E = ?E, arg: ?arg}` is not a function
-//│ ║  l.372: 	def nega arg = Nega { arg }
+//│ ║  l.389: 	def nega arg = Nega { arg }
 //│ ║         	               ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.381: 	  | _ -> k x
+//│ ║  l.398: 	  | _ -> k x
 //│ ║         	         ^^^
 //│ ╟── from field selection:
-//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error | string
 //│    = '-1-1'
@@ -760,30 +778,30 @@ prettier2 done eval1 e2
 //│ ║  l.+1: 	prettier2 done eval1 e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> (?b | ?c)` does not match type `int`
-//│ ║  l.72: 	rec def eval1 k e = case e of {
+//│ ║  l.89: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.73: 	  | Lit -> e.val
+//│ ║  l.90: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.74: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.91: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.75: 	  | _ -> k e
+//│ ║  l.92: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.76: 	  }
+//│ ║  l.93: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval1 e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Lit & {val: ?val}` is not a function
-//│ ║  l.18: 	def lit val = Lit { val }
+//│ ║  l.38: 	def lit val = Lit { val }
 //│ ║        	              ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.75: 	  | _ -> k e
+//│ ║  l.92: 	  | _ -> k e
 //│ ║        	         ^^^
 //│ ╟── from field selection:
-//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error
 //│    = '1-123'

--- a/shared/src/test/diff/mlscript/ExprProb_Inv.mls
+++ b/shared/src/test/diff/mlscript/ExprProb_Inv.mls
@@ -14,29 +14,13 @@ def done x = case x of {}
 
 
 class Lit: { val: int }
-//│ Defined class Lit
-
-:dv
 class Add[E]: { lhs: E; rhs: E }
   method Inv (x: E) = x
-//│ VARIANCE ANALYSIS
-//│ ⬤ ITERATION 1
-//│ | class Add  ± E31'
-//│ | | upd[+] {lhs: E31', rhs: E31'}
-//│ | | | upd[+] E31'
-//│ | | | | UPDATE Add.E31' from ± to +
-//│ | | | upd[+] E31'
-//│ ⬤ ITERATION 2
-//│ | class Add  + E31'
-//│ | | upd[+] {lhs: E31', rhs: E31'}
-//│ | | | upd[+] E31'
-//│ | | | upd[+] E31'
-//│ DONE
-//│ Defined class Add[+E]
-//│ Defined Add.Inv: Add['E] -> 'E -> 'E
-
 def lit val = Lit { val }
 def add lhs rhs = Add { lhs; rhs }
+//│ Defined class Lit
+//│ Defined class Add[=E]
+//│ Defined Add.Inv: Add['E] -> 'E -> 'E
 //│ lit: (int & 'val) -> (Lit with {val: 'val})
 //│    = [Function: lit]
 //│ add: ('lhs & 'E) -> ('E & 'rhs) -> (Add['E] with {lhs: 'lhs, rhs: 'rhs})
@@ -50,7 +34,7 @@ rec def eval1_stub k e = case e of {
   }
 //│ eval1_stub: ('a -> 'b) -> 'c -> 'b
 //│   where
-//│     'c <: Add[?] & {lhs: 'c} | 'a & ~add
+//│     'c <: (Add[?]\rhs with {lhs: 'c}) | 'a & ~add
 //│           = [Function: eval1_stub]
 
 rec def eval1_stub k e = case e of {
@@ -59,7 +43,7 @@ rec def eval1_stub k e = case e of {
   }
 //│ eval1_stub: ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: Add[?] & {lhs: 'b, rhs: 'b} | 'a & ~add
+//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | 'a & ~add
 //│           = [Function: eval1_stub1]
 
 :ns
@@ -81,7 +65,7 @@ rec def eval1_stub e = case e of {
 eval1_stub
 //│ res: 'a -> (0 | 1)
 //│   where
-//│     'a <: Add[?] & {lhs: 'a} | Lit | ~Add[?] & ~Lit
+//│     'a <: (Add[?]\rhs with {lhs: 'a}) | Lit | ~Add[?] & ~Lit
 //│    = [Function: eval1_stub2]
 
 // def eval1: ('b -> int) -> Expr['b] -> int
@@ -93,11 +77,11 @@ rec def eval1 k e = case e of {
   }
 //│ eval1: ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: Add[?] & {lhs: 'b, rhs: 'b} | Lit | 'a & ~add & ~lit
+//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
 //│      = [Function: eval1]
 //│ constrain calls  : 83
 //│ annoying  calls  : 0
-//│ subtyping calls  : 87
+//│ subtyping calls  : 82
 
 :ns
 eval1
@@ -126,7 +110,7 @@ eval1
 
 :re
 error: ~Add[?]
-//│ res: ~Add[nothing]
+//│ res: ~Add[?]
 //│ Runtime error:
 //│   Error: unexpected runtime error
 
@@ -143,7 +127,7 @@ error: ('a & ~Add[?]) -> 'a
 //│ res: 'a -> (Add[?] & 'a)
 //│ Runtime error:
 //│   Error: unexpected runtime error
-//│ res: 'a -> ('a & ~Add[nothing])
+//│ res: 'a -> ('a & ~Add[?])
 //│ Runtime error:
 //│   Error: unexpected runtime error
 //│ res: ('a & ~Add[?]) -> 'a
@@ -166,7 +150,7 @@ def eval1_ty_ugly: ('a -> int) -> (Lit | Add['b] | 'a & ~Lit & ~Add[?] as 'b) ->
 eval1_ty_ugly
 //│ res: ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: 'a & ~Add[?] & ~Lit | Add['b] | Lit
+//│     'b := 'a & ~Add[?] & ~Lit | Add['b] | Lit
 //│    = <no result>
 //│      eval1_ty_ugly is not implemented
 
@@ -174,15 +158,15 @@ eval1_ty_ugly
 def eval1_ty_ugly = eval1
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: Add[?] & {lhs: 'b, rhs: 'b} | Lit | 'a & ~add & ~lit
+//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
 //│   <:  eval1_ty_ugly:
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: 'a & ~Add[?] & ~Lit | Add['b] | Lit
+//│     'b := 'a & ~Add[?] & ~Lit | Add['b] | Lit
 //│              = [Function: eval1]
 //│ constrain calls  : 81
 //│ annoying  calls  : 36
-//│ subtyping calls  : 214
+//│ subtyping calls  : 261
 
 :ns
 def eval1_ty: ('a -> int) -> (Lit | Add['b] | 'a & ~lit & ~add as 'b) -> int
@@ -194,7 +178,7 @@ def eval1_ty: ('a -> int) -> (Lit | Add['b] | 'a & ~lit & ~add as 'b) -> int
 eval1_ty
 //│ res: ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: 'a & ~add & ~lit | Add['b] | Lit
+//│     'b := 'a & ~add & ~lit | Add['b] | Lit
 //│    = <no result>
 //│      eval1_ty is not implemented
 
@@ -202,50 +186,50 @@ eval1_ty
 def eval1_ty = eval1
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: Add[?] & {lhs: 'b, rhs: 'b} | Lit | 'a & ~add & ~lit
+//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
 //│   <:  eval1_ty:
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: 'a & ~add & ~lit | Add['b] | Lit
+//│     'b := 'a & ~add & ~lit | Add['b] | Lit
 //│         = [Function: eval1]
 //│ constrain calls  : 81
 //│ annoying  calls  : 36
-//│ subtyping calls  : 216
+//│ subtyping calls  : 253
 
 :stats
 eval1_ty_ugly = eval1_ty
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: 'a & ~add & ~lit | Add['b] | Lit
+//│     'b := 'a & ~add & ~lit | Add['b] | Lit
 //│   <:  eval1_ty_ugly:
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: 'a & ~Add[?] & ~Lit | Add['b] | Lit
+//│     'b := 'a & ~Add[?] & ~Lit | Add['b] | Lit
 //│              = [Function: eval1]
 //│ constrain calls  : 15
 //│ annoying  calls  : 1
-//│ subtyping calls  : 119
+//│ subtyping calls  : 213
 
 :stats
 eval1_ty = eval1_ty_ugly
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: 'a & ~Add[?] & ~Lit | Add['b] | Lit
+//│     'b := 'a & ~Add[?] & ~Lit | Add['b] | Lit
 //│   <:  eval1_ty:
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: 'a & ~add & ~lit | Add['b] | Lit
+//│     'b := 'a & ~add & ~lit | Add['b] | Lit
 //│         = [Function: eval1]
 //│ constrain calls  : 15
 //│ annoying  calls  : 1
-//│ subtyping calls  : 463
+//│ subtyping calls  : 557
 
 
 // Workaround:
 :ns
 type E1[A] = Lit | Add[E1[A]] | A & ~lit & ~add
 def eval1_ty: ('a -> int) -> E1['a] -> int
-//│ Defined type alias E1[+A]
+//│ Defined type alias E1[=A]
 //│ eval1_ty: ('a -> int) -> E1['a] -> int
 //│         = <missing implementation>
 
@@ -258,13 +242,13 @@ eval1_ty
 def eval1_ty = eval1
 //│ ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: Add[?] & {lhs: 'b, rhs: 'b} | Lit | 'a & ~add & ~lit
+//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
 //│   <:  eval1_ty:
 //│ ('a -> int) -> E1['a] -> int
 //│         = [Function: eval1]
 //│ constrain calls  : 85
 //│ annoying  calls  : 38
-//│ subtyping calls  : 146
+//│ subtyping calls  : 141
 
 
 :stats
@@ -275,11 +259,11 @@ rec def pretty1 k e = case e of {
   }
 //│ pretty1: ('a -> string) -> 'b -> string
 //│   where
-//│     'b <: Add[?] & {lhs: 'b, rhs: 'b} | Lit | 'a & ~add & ~lit
+//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'a & ~add & ~lit
 //│        = [Function: pretty1]
 //│ constrain calls  : 94
 //│ annoying  calls  : 0
-//│ subtyping calls  : 91
+//│ subtyping calls  : 86
 
 
 :stats
@@ -293,11 +277,11 @@ rec def prettier1 k ev e = case e of {
   }
 //│ prettier1: ('a -> string) -> ('rhs -> int) -> 'b -> string
 //│   where
-//│     'b <: Add[?] & {lhs: 'rhs & 'b, rhs: 'rhs & 'b} | Lit | 'a & ~add & ~lit
+//│     'b <: (Add[?] with {lhs: 'rhs & 'b, rhs: 'rhs & 'b}) | Lit | 'a & ~add & ~lit
 //│          = [Function: prettier1]
 //│ constrain calls  : 305
 //│ annoying  calls  : 0
-//│ subtyping calls  : 113
+//│ subtyping calls  : 108
 
 :stats
 rec def prettier11 k ev e = case e of {
@@ -309,12 +293,12 @@ rec def prettier11 k ev e = case e of {
   }
 //│ prettier11: ('a -> string) -> ('rhs -> int) -> 'b -> string
 //│   where
-//│     'b <: Add[?] & {lhs: 'c, rhs: 'rhs & 'b} | Lit | 'a & ~add & ~lit
-//│     'c <: Add[?] & {lhs: 'c, rhs: 'c} | Lit | 'a & ~add & ~lit
+//│     'b <: (Add[?] with {lhs: 'c, rhs: 'rhs & 'b}) | Lit | 'a & ~add & ~lit
+//│     'c <: (Add[?] with {lhs: 'c, rhs: 'c}) | Lit | 'a & ~add & ~lit
 //│           = [Function: prettier11]
 //│ constrain calls  : 194
 //│ annoying  calls  : 0
-//│ subtyping calls  : 202
+//│ subtyping calls  : 195
 
 // Doesn't make much sense, but generates very ugly type unless aggressively simplified:
 :stats
@@ -325,13 +309,13 @@ rec def prettier12 k ev e = case e of {
       in if ev e == 0 then tmp else concat tmp (pretty1 k e.rhs)
   | _ -> k e
   }
-//│ prettier12: ('a -> string) -> ('b -> int) -> (Add[?] & {lhs: 'c, rhs: 'c} & 'b | Lit | 'a & ~add & ~lit) -> string
+//│ prettier12: ('a -> string) -> ('b -> int) -> ((Add[?] with {lhs: 'c, rhs: 'c}) & 'b | Lit | 'a & ~add & ~lit) -> string
 //│   where
-//│     'c <: Add[?] & {lhs: 'c, rhs: 'c} | Lit | 'a & ~add & ~lit
+//│     'c <: (Add[?] with {lhs: 'c, rhs: 'c}) | Lit | 'a & ~add & ~lit
 //│           = [Function: prettier12]
 //│ constrain calls  : 167
 //│ annoying  calls  : 0
-//│ subtyping calls  : 283
+//│ subtyping calls  : 273
 
 
 :stats
@@ -341,7 +325,10 @@ pretty1 done e1
 prettier1 done (eval1 done) e1
 prettier11 done (eval1 done) e1
 prettier12 done (eval1 done) e1
-//│ e1: Add[Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}} | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
+//│ e1: Add['E] with {lhs: Lit & {val: 1}, rhs: Add['E0] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
+//│   where
+//│     'E :> (Add['E0] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}
+//│     'E0 :> Lit & {val: 2 | 3}
 //│   = Add {
 //│       lhs: Lit { val: 1 },
 //│       rhs: Add { lhs: Lit { val: 2 }, rhs: Lit { val: 3 } }
@@ -358,7 +345,7 @@ prettier12 done (eval1 done) e1
 //│    = '123'
 //│ constrain calls  : 1385
 //│ annoying  calls  : 490
-//│ subtyping calls  : 1352
+//│ subtyping calls  : 1206
 
 
 e1 = add (lit 1) (add (lit 2) (lit 3))
@@ -367,7 +354,10 @@ pretty1 done e1
 prettier1 done (eval1 done) e1
 prettier11 done (eval1 done) e1
 prettier12 done (eval1 done) e1
-//│ e1: Add[Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}} | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
+//│ e1: Add['E] with {lhs: Lit & {val: 1}, rhs: Add['E0] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}
+//│   where
+//│     'E :> (Add['E0] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}
+//│     'E0 :> Lit & {val: 2 | 3}
 //│   = Add {
 //│       lhs: Lit { val: 1 },
 //│       rhs: Add { lhs: Lit { val: 2 }, rhs: Lit { val: 3 } }
@@ -399,7 +389,7 @@ rec def eval2 k = eval1 (fun x -> case x of {
   })
 //│ eval2: ('a -> int) -> 'b -> int
 //│   where
-//│     'b <: Add[?] & {lhs: 'b, rhs: 'b} | Lit | Nega[?] & {arg: 'b} | 'a & ~add & ~lit & ~nega
+//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | Nega[?] & {arg: 'b} | 'a & ~add & ~lit & ~nega
 //│      = [Function: eval2]
 
 
@@ -410,11 +400,11 @@ rec def prettier2 k ev = prettier1 (fun x -> case x of {
   }) ev
 //│ prettier2: ('a -> string) -> ('rhs -> int) -> 'b -> string
 //│   where
-//│     'b <: Add[?] & {lhs: 'rhs & 'b, rhs: 'rhs & 'b} | Lit | Nega[?] & {arg: 'b} | 'a & ~add & ~lit & ~nega
+//│     'b <: (Add[?] with {lhs: 'rhs & 'b, rhs: 'rhs & 'b}) | Lit | Nega[?] & {arg: 'b} | 'a & ~add & ~lit & ~nega
 //│          = [Function: prettier2]
 //│ constrain calls  : 123
 //│ annoying  calls  : 0
-//│ subtyping calls  : 201
+//│ subtyping calls  : 188
 
 :stats
 rec def prettier22 k ev = prettier12 (fun x -> case x of {
@@ -424,13 +414,13 @@ rec def prettier22 k ev = prettier12 (fun x -> case x of {
 //│ prettier22: ('a -> string) -> ('b -> int) -> 'c -> string
 //│   where
 //│     'b <: {lhs: 'd, rhs: 'd}
-//│     'd <: Add[?] & {lhs: 'd, rhs: 'd} | Lit | 'e & ~add & ~lit
+//│     'd <: (Add[?] with {lhs: 'd, rhs: 'd}) | Lit | 'e & ~add & ~lit
 //│     'e <: Nega[?] & {arg: 'c} | 'a & ~nega
 //│     'c <: Add[?] & 'b | Lit | 'e & ~add & ~lit
 //│           = [Function: prettier22]
 //│ constrain calls  : 181
 //│ annoying  calls  : 0
-//│ subtyping calls  : 316
+//│ subtyping calls  : 290
 
 
 
@@ -443,7 +433,11 @@ eval2 done e1
 //│ subtyping calls  : 115
 
 e2 = add (lit 1) (nega e1)
-//│ e2: Add[Lit & {val: 1} | Nega[Add[Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}} | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]] with {lhs: Lit & {val: 1}, rhs: Nega[Add[Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}} | Lit & {val: 1}] with {lhs: Lit & {val: 1}, rhs: Add[Lit & {val: 2 | 3}] & {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]}
+//│ e2: Add['E] with {lhs: Lit & {val: 1}, rhs: Nega[Add['E0] with {lhs: Lit & {val: 1}, rhs: Add['E1] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]}
+//│   where
+//│     'E :> Lit & {val: 1} | Nega[Add['E0] with {lhs: Lit & {val: 1}, rhs: Add['E1] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}}]
+//│     'E0 :> (Add['E1] with {lhs: Lit & {val: 2}, rhs: Lit & {val: 3}}) | Lit & {val: 1}
+//│     'E1 :> Lit & {val: 2 | 3}
 //│   = Add {
 //│       lhs: Lit { val: 1 },
 //│       rhs: Nega { arg: Add { lhs: [Lit], rhs: [Add] } }
@@ -458,7 +452,9 @@ eval2 done e2
 //│ subtyping calls  : 180
 
 d2 = nega (add (lit 1) (nega (lit 1)))
-//│ d2: Nega[Add[Lit & {val: 1} | Nega[Lit & {val: 1}]] with {lhs: Lit & {val: 1}, rhs: Nega[Lit & {val: 1}]}]
+//│ d2: Nega[Add['E] with {lhs: Lit & {val: 1}, rhs: Nega[Lit & {val: 1}]}]
+//│   where
+//│     'E :> Lit & {val: 1} | Nega[Lit & {val: 1}]
 //│   = Nega { arg: Add { lhs: Lit { val: 1 }, rhs: Nega { arg: [Lit] } } }
 
 :stats
@@ -473,14 +469,14 @@ eval2 done d2
 prettier2 done
 //│ res: ('rhs -> int) -> 'a -> string
 //│   where
-//│     'a <: Add[?] & {lhs: 'rhs & 'a, rhs: 'rhs & 'a} | Lit | Nega[?] & {arg: 'a}
+//│     'a <: (Add[?] with {lhs: 'rhs & 'a, rhs: 'rhs & 'a}) | Lit | Nega[?] & {arg: 'a}
 //│    = [Function (anonymous)]
 
 prettier22 done
 //│ res: ('a -> int) -> 'b -> string
 //│   where
 //│     'a <: {lhs: 'c, rhs: 'c}
-//│     'c <: Add[?] & {lhs: 'c, rhs: 'c} | Lit | 'd & ~add & ~lit
+//│     'c <: (Add[?] with {lhs: 'c, rhs: 'c}) | Lit | 'd & ~add & ~lit
 //│     'd <: Nega[?] & {arg: 'b}
 //│     'b <: Add[?] & 'a | Lit | 'd & ~add & ~lit
 //│    = [Function (anonymous)]
@@ -489,20 +485,20 @@ prettier22 done
 prettier2 done (eval1 done)
 //│ res: 'a -> string
 //│   where
-//│     'a <: Add[?] & {lhs: 'a & 'b, rhs: 'a & 'b} | Lit | Nega[?] & {arg: 'a}
-//│     'b <: Add[?] & {lhs: 'b, rhs: 'b} | Lit
+//│     'a <: (Add[?] with {lhs: 'a & 'b, rhs: 'a & 'b}) | Lit | Nega[?] & {arg: 'a}
+//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit
 //│    = [Function (anonymous)]
 //│ constrain calls  : 92
 //│ annoying  calls  : 0
-//│ subtyping calls  : 226
+//│ subtyping calls  : 244
 
 
 prettier22 done (eval1 done)
 //│ res: 'a -> string
 //│   where
-//│     'a <: Add[?] & {lhs: 'b, rhs: 'b} & 'c | Lit | 'd & ~add & ~lit
-//│     'c <: Add[?] & {lhs: 'c, rhs: 'c} | Lit
-//│     'b <: Add[?] & {lhs: 'b, rhs: 'b} | Lit | 'd & ~add & ~lit
+//│     'a <: (Add[?] with {lhs: 'b, rhs: 'b}) & 'c | Lit | 'd & ~add & ~lit
+//│     'c <: (Add[?] with {lhs: 'c, rhs: 'c}) | Lit
+//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'd & ~add & ~lit
 //│     'd <: Nega[?] & {arg: 'a}
 //│    = [Function (anonymous)]
 
@@ -511,12 +507,12 @@ prettier22 done (eval1 done)
 prettier2 done (eval2 done)
 //│ res: 'a -> string
 //│   where
-//│     'a <: Add[?] & {lhs: 'a & 'b, rhs: 'a & 'b} | Lit | Nega[?] & {arg: 'a}
-//│     'b <: Add[?] & {lhs: 'b, rhs: 'b} | Lit | Nega[?] & {arg: 'b}
+//│     'a <: (Add[?] with {lhs: 'a & 'b, rhs: 'a & 'b}) | Lit | Nega[?] & {arg: 'a}
+//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | Nega[?] & {arg: 'b}
 //│    = [Function (anonymous)]
 //│ constrain calls  : 103
 //│ annoying  calls  : 0
-//│ subtyping calls  : 292
+//│ subtyping calls  : 304
 
 prettier2 done (eval2 done) e2
 prettier2 done (eval2 done) d2
@@ -531,9 +527,9 @@ prettier22 done (eval2 done) e2
 prettier22 done (eval2 done) d2
 //│ res: 'a -> string
 //│   where
-//│     'a <: Add[?] & {lhs: 'b, rhs: 'b} & 'c | Lit | 'd & ~add & ~lit
-//│     'c <: Add[?] & {lhs: 'c, rhs: 'c} | Lit | Nega[?] & {arg: 'c}
-//│     'b <: Add[?] & {lhs: 'b, rhs: 'b} | Lit | 'd & ~add & ~lit
+//│     'a <: (Add[?] with {lhs: 'b, rhs: 'b}) & 'c | Lit | 'd & ~add & ~lit
+//│     'c <: (Add[?] with {lhs: 'c, rhs: 'c}) | Lit | Nega[?] & {arg: 'c}
+//│     'b <: (Add[?] with {lhs: 'b, rhs: 'b}) | Lit | 'd & ~add & ~lit
 //│     'd <: Nega[?] & {arg: 'a}
 //│    = [Function (anonymous)]
 //│ res: string
@@ -542,7 +538,7 @@ prettier22 done (eval2 done) d2
 //│    = '-1'
 //│ constrain calls  : 1039
 //│ annoying  calls  : 335
-//│ subtyping calls  : 1115
+//│ subtyping calls  : 1103
 
 
 
@@ -559,13 +555,13 @@ eval1 done e2
 //│ ║  l.+1: 	eval1 done e2
 //│ ║        	^^^^^^^^^^^^^
 //│ ╟── application of type `Nega[?E] & {Nega#E = ?E, arg: ?arg}` does not match type `nothing`
-//│ ║  l.389: 	def nega arg = Nega { arg }
+//│ ║  l.379: 	def nega arg = Nega { arg }
 //│ ║         	               ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from reference:
 //│ ║  l.4: 	def done x = case x of {}
 //│ ║       	                  ^
 //│ ╟── from field selection:
-//│ ║  l.91: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.75: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ╙──      	                                   ^^^^^
 //│ res: error | int
 //│ Runtime error:
@@ -578,30 +574,30 @@ prettier2 done eval1 e1
 //│ ║  l.+1: 	prettier2 done eval1 e1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> (?b | ?c)` does not match type `int`
-//│ ║  l.89: 	rec def eval1 k e = case e of {
+//│ ║  l.73: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.90: 	  | Lit -> e.val
+//│ ║  l.74: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.91: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.75: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.92: 	  | _ -> k e
+//│ ║  l.76: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.93: 	  }
+//│ ║  l.77: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.274: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval1 e1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Lit & {val: ?val}` is not a function
-//│ ║  l.38: 	def lit val = Lit { val }
+//│ ║  l.19: 	def lit val = Lit { val }
 //│ ║        	              ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.92: 	  | _ -> k e
+//│ ║  l.76: 	  | _ -> k e
 //│ ║        	         ^^^
 //│ ╟── from field selection:
-//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.274: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error
 //│    = '123'
@@ -614,20 +610,20 @@ prettier2 done (eval1 done) e2
 //│ ║  l.+1: 	prettier2 done (eval1 done) e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Nega[?E] & {Nega#E = ?E, arg: ?arg}` does not match type `nothing`
-//│ ║  l.389: 	def nega arg = Nega { arg }
+//│ ║  l.379: 	def nega arg = Nega { arg }
 //│ ║         	               ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from reference:
 //│ ║  l.4: 	def done x = case x of {}
 //│ ║       	                  ^
 //│ ╟── from field selection:
-//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.274: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error | string
 //│ Runtime error:
 //│   Error: non-exhaustive case expression
 //│ constrain calls  : 676
 //│ annoying  calls  : 228
-//│ subtyping calls  : 5168
+//│ subtyping calls  : 5092
 
 :e
 :stats
@@ -636,26 +632,26 @@ prettier2 done eval2
 //│ ║  l.+1: 	prettier2 done eval2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not match type `int`
-//│ ║  l.89: 	rec def eval1 k e = case e of {
+//│ ║  l.73: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.90: 	  | Lit -> e.val
+//│ ║  l.74: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.91: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.75: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.92: 	  | _ -> k e
+//│ ║  l.76: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.93: 	  }
+//│ ║  l.77: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.274: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ res: 'a -> string | error
 //│   where
-//│     'a <: Add[?] & {lhs: nothing -> int & 'a, rhs: nothing -> int & 'a} | Lit | Nega[?] & {arg: 'a}
+//│     'a <: (Add[?] with {lhs: nothing -> int & 'a, rhs: nothing -> int & 'a}) | Lit | Nega[?] & {arg: 'a}
 //│    = [Function (anonymous)]
 //│ constrain calls  : 70
 //│ annoying  calls  : 0
-//│ subtyping calls  : 259
+//│ subtyping calls  : 262
 
 :e
 :stats
@@ -664,36 +660,36 @@ prettier2 done eval2 e1
 //│ ║  l.+1: 	prettier2 done eval2 e1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not match type `int`
-//│ ║  l.89: 	rec def eval1 k e = case e of {
+//│ ║  l.73: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.90: 	  | Lit -> e.val
+//│ ║  l.74: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.91: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.75: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.92: 	  | _ -> k e
+//│ ║  l.76: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.93: 	  }
+//│ ║  l.77: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.274: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval2 e1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Lit & {val: ?val}` is not a function
-//│ ║  l.38: 	def lit val = Lit { val }
+//│ ║  l.19: 	def lit val = Lit { val }
 //│ ║        	              ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.398: 	  | _ -> k x
+//│ ║  l.388: 	  | _ -> k x
 //│ ║         	         ^^^
 //│ ╟── from field selection:
-//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.274: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error
 //│    = '123'
 //│ constrain calls  : 376
 //│ annoying  calls  : 108
-//│ subtyping calls  : 1870
+//│ subtyping calls  : 1846
 
 :e
 :stats
@@ -702,36 +698,36 @@ prettier2 done eval2 e2
 //│ ║  l.+1: 	prettier2 done eval2 e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not match type `int`
-//│ ║  l.89: 	rec def eval1 k e = case e of {
+//│ ║  l.73: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.90: 	  | Lit -> e.val
+//│ ║  l.74: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.91: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.75: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.92: 	  | _ -> k e
+//│ ║  l.76: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.93: 	  }
+//│ ║  l.77: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.274: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval2 e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Lit & {val: ?val}` is not a function
-//│ ║  l.38: 	def lit val = Lit { val }
+//│ ║  l.19: 	def lit val = Lit { val }
 //│ ║        	              ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.398: 	  | _ -> k x
+//│ ║  l.388: 	  | _ -> k x
 //│ ║         	         ^^^
 //│ ╟── from field selection:
-//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.274: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error
 //│    = '1-123'
 //│ constrain calls  : 427
 //│ annoying  calls  : 131
-//│ subtyping calls  : 2552
+//│ subtyping calls  : 2513
 
 :e
 :stats
@@ -740,36 +736,36 @@ prettier2 done eval2 d2
 //│ ║  l.+1: 	prettier2 done eval2 d2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not match type `int`
-//│ ║  l.89: 	rec def eval1 k e = case e of {
+//│ ║  l.73: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.90: 	  | Lit -> e.val
+//│ ║  l.74: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.91: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.75: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.92: 	  | _ -> k e
+//│ ║  l.76: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.93: 	  }
+//│ ║  l.77: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.274: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval2 d2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Nega[?E] & {Nega#E = ?E, arg: ?arg}` is not a function
-//│ ║  l.389: 	def nega arg = Nega { arg }
+//│ ║  l.379: 	def nega arg = Nega { arg }
 //│ ║         	               ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.398: 	  | _ -> k x
+//│ ║  l.388: 	  | _ -> k x
 //│ ║         	         ^^^
 //│ ╟── from field selection:
-//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.274: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error | string
 //│    = '-1-1'
 //│ constrain calls  : 301
 //│ annoying  calls  : 95
-//│ subtyping calls  : 1423
+//│ subtyping calls  : 1414
 
 :e
 :stats
@@ -778,34 +774,34 @@ prettier2 done eval1 e2
 //│ ║  l.+1: 	prettier2 done eval1 e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> (?b | ?c)` does not match type `int`
-//│ ║  l.89: 	rec def eval1 k e = case e of {
+//│ ║  l.73: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.90: 	  | Lit -> e.val
+//│ ║  l.74: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.91: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.75: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.92: 	  | _ -> k e
+//│ ║  l.76: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.93: 	  }
+//│ ║  l.77: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.274: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval1 e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Lit & {val: ?val}` is not a function
-//│ ║  l.38: 	def lit val = Lit { val }
+//│ ║  l.19: 	def lit val = Lit { val }
 //│ ║        	              ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.92: 	  | _ -> k e
+//│ ║  l.76: 	  | _ -> k e
 //│ ║        	         ^^^
 //│ ╟── from field selection:
-//│ ║  l.290: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.274: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error
 //│    = '1-123'
 //│ constrain calls  : 421
 //│ annoying  calls  : 131
-//│ subtyping calls  : 2522
+//│ subtyping calls  : 2483
 

--- a/shared/src/test/diff/mlscript/ExprProb_Inv.mls
+++ b/shared/src/test/diff/mlscript/ExprProb_Inv.mls
@@ -541,13 +541,13 @@ eval1 done e2
 //│ ║  l.+1: 	eval1 done e2
 //│ ║        	^^^^^^^^^^^^^
 //│ ╟── application of type `Nega[?E] & {Nega#E = ?E, arg: ?arg}` does not match type `nothing`
-//│ ║  l.371: 	def nega arg = Nega { arg }
+//│ ║  l.372: 	def nega arg = Nega { arg }
 //│ ║         	               ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from reference:
 //│ ║  l.4: 	def done x = case x of {}
 //│ ║       	                  ^
 //│ ╟── from field selection:
-//│ ║  l.73: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.74: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ╙──      	                                   ^^^^^
 //│ res: error | int
 //│ Runtime error:
@@ -560,18 +560,18 @@ prettier2 done eval1 e1
 //│ ║  l.+1: 	prettier2 done eval1 e1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> (?b | ?c)` does not match type `int`
-//│ ║  l.71: 	rec def eval1 k e = case e of {
+//│ ║  l.72: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.72: 	  | Lit -> e.val
+//│ ║  l.73: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.73: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.74: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.74: 	  | _ -> k e
+//│ ║  l.75: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.75: 	  }
+//│ ║  l.76: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.272: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval1 e1
@@ -580,10 +580,10 @@ prettier2 done eval1 e1
 //│ ║  l.18: 	def lit val = Lit { val }
 //│ ║        	              ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.74: 	  | _ -> k e
+//│ ║  l.75: 	  | _ -> k e
 //│ ║        	         ^^^
 //│ ╟── from field selection:
-//│ ║  l.272: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error
 //│    = '123'
@@ -596,13 +596,13 @@ prettier2 done (eval1 done) e2
 //│ ║  l.+1: 	prettier2 done (eval1 done) e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Nega[?E] & {Nega#E = ?E, arg: ?arg}` does not match type `nothing`
-//│ ║  l.371: 	def nega arg = Nega { arg }
+//│ ║  l.372: 	def nega arg = Nega { arg }
 //│ ║         	               ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from reference:
 //│ ║  l.4: 	def done x = case x of {}
 //│ ║       	                  ^
 //│ ╟── from field selection:
-//│ ║  l.272: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error | string
 //│ Runtime error:
@@ -618,18 +618,18 @@ prettier2 done eval2
 //│ ║  l.+1: 	prettier2 done eval2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not match type `int`
-//│ ║  l.71: 	rec def eval1 k e = case e of {
+//│ ║  l.72: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.72: 	  | Lit -> e.val
+//│ ║  l.73: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.73: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.74: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.74: 	  | _ -> k e
+//│ ║  l.75: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.75: 	  }
+//│ ║  l.76: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.272: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ res: 'a -> string | error
 //│   where
@@ -646,18 +646,18 @@ prettier2 done eval2 e1
 //│ ║  l.+1: 	prettier2 done eval2 e1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not match type `int`
-//│ ║  l.71: 	rec def eval1 k e = case e of {
+//│ ║  l.72: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.72: 	  | Lit -> e.val
+//│ ║  l.73: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.73: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.74: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.74: 	  | _ -> k e
+//│ ║  l.75: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.75: 	  }
+//│ ║  l.76: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.272: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval2 e1
@@ -666,10 +666,10 @@ prettier2 done eval2 e1
 //│ ║  l.18: 	def lit val = Lit { val }
 //│ ║        	              ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.380: 	  | _ -> k x
+//│ ║  l.381: 	  | _ -> k x
 //│ ║         	         ^^^
 //│ ╟── from field selection:
-//│ ║  l.272: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error
 //│    = '123'
@@ -684,18 +684,18 @@ prettier2 done eval2 e2
 //│ ║  l.+1: 	prettier2 done eval2 e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not match type `int`
-//│ ║  l.71: 	rec def eval1 k e = case e of {
+//│ ║  l.72: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.72: 	  | Lit -> e.val
+//│ ║  l.73: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.73: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.74: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.74: 	  | _ -> k e
+//│ ║  l.75: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.75: 	  }
+//│ ║  l.76: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.272: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval2 e2
@@ -704,10 +704,10 @@ prettier2 done eval2 e2
 //│ ║  l.18: 	def lit val = Lit { val }
 //│ ║        	              ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.380: 	  | _ -> k x
+//│ ║  l.381: 	  | _ -> k x
 //│ ║         	         ^^^
 //│ ╟── from field selection:
-//│ ║  l.272: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error
 //│    = '1-123'
@@ -722,30 +722,30 @@ prettier2 done eval2 d2
 //│ ║  l.+1: 	prettier2 done eval2 d2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not match type `int`
-//│ ║  l.71: 	rec def eval1 k e = case e of {
+//│ ║  l.72: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.72: 	  | Lit -> e.val
+//│ ║  l.73: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.73: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.74: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.74: 	  | _ -> k e
+//│ ║  l.75: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.75: 	  }
+//│ ║  l.76: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.272: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval2 d2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── application of type `Nega[?E] & {Nega#E = ?E, arg: ?arg}` is not a function
-//│ ║  l.371: 	def nega arg = Nega { arg }
+//│ ║  l.372: 	def nega arg = Nega { arg }
 //│ ║         	               ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.380: 	  | _ -> k x
+//│ ║  l.381: 	  | _ -> k x
 //│ ║         	         ^^^
 //│ ╟── from field selection:
-//│ ║  l.272: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error | string
 //│    = '-1-1'
@@ -760,18 +760,18 @@ prettier2 done eval1 e2
 //│ ║  l.+1: 	prettier2 done eval1 e2
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> (?b | ?c)` does not match type `int`
-//│ ║  l.71: 	rec def eval1 k e = case e of {
+//│ ║  l.72: 	rec def eval1 k e = case e of {
 //│ ║        	                ^^^^^^^^^^^^^^^
-//│ ║  l.72: 	  | Lit -> e.val
+//│ ║  l.73: 	  | Lit -> e.val
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ║  l.73: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
+//│ ║  l.74: 	  | Add -> eval1 k e.lhs + eval1 k e.rhs
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.74: 	  | _ -> k e
+//│ ║  l.75: 	  | _ -> k e
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.75: 	  }
+//│ ║  l.76: 	  }
 //│ ║        	^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.272: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.+1: 	prettier2 done eval1 e2
@@ -780,10 +780,10 @@ prettier2 done eval1 e2
 //│ ║  l.18: 	def lit val = Lit { val }
 //│ ║        	              ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.74: 	  | _ -> k e
+//│ ║  l.75: 	  | _ -> k e
 //│ ║        	         ^^^
 //│ ╟── from field selection:
-//│ ║  l.272: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
+//│ ║  l.273: 	      else if ev e.rhs == 0 then prettier1 k ev e.lhs
 //│ ╙──       	                 ^^^^^
 //│ res: error
 //│    = '1-123'

--- a/shared/src/test/diff/mlscript/GenericClasses.mls
+++ b/shared/src/test/diff/mlscript/GenericClasses.mls
@@ -8,14 +8,12 @@ def None = None{}
 class Some[A]: { value: A }
 def Some v = Some { value = v }
 //│ Defined class Some[+A]
-//│ Some: ('value & 'A) -> (Some['A] with {value: 'value})
+//│ Some: 'value -> Some['value]
 //│     = [Function: Some1]
 
 Some 42
 (Some 42).value
-//│ res: Some['A] & {value: 42}
-//│   where
-//│     'A :> 42
+//│ res: Some[42]
 //│    = Some { value: 42 }
 //│ res: 42
 //│    = 42
@@ -33,13 +31,13 @@ Some 42 : Option[int]
 :e
 res.value
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.34: 	res.value
+//│ ║  l.32: 	res.value
 //│ ║        	^^^^^^^^^
 //│ ╟── type `None` does not have field 'value'
-//│ ║  l.23: 	type Option[A] = Some[A] | None
+//│ ║  l.21: 	type Option[A] = Some[A] | None
 //│ ║        	                           ^^^^
 //│ ╟── but it flows into reference with expected type `{value: ?value}`
-//│ ║  l.34: 	res.value
+//│ ║  l.32: 	res.value
 //│ ╙──      	^^^
 //│ res: error | int
 //│    = 42
@@ -47,17 +45,17 @@ res.value
 :e
 42: Option[int, int]
 //│ ╔══[ERROR] Wrong number of type arguments – expected 1, found 2
-//│ ║  l.48: 	42: Option[int, int]
+//│ ║  l.46: 	42: Option[int, int]
 //│ ╙──      	    ^^^^^^^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.48: 	42: Option[int, int]
+//│ ║  l.46: 	42: Option[int, int]
 //│ ║        	^^
 //│ ╟── integer literal of type `42` does not match type `None | Some[int]`
 //│ ╟── Note: constraint arises from union type:
-//│ ║  l.23: 	type Option[A] = Some[A] | None
+//│ ║  l.21: 	type Option[A] = Some[A] | None
 //│ ║        	                 ^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.48: 	42: Option[int, int]
+//│ ║  l.46: 	42: Option[int, int]
 //│ ╙──      	    ^^^^^^^^^^^^^^^^
 //│ res: Option[int]
 //│    = 42
@@ -73,7 +71,7 @@ Bar1
 //│    = [Function: res]
 
 g = Bar1 { x = 42 }
-//│ g: Bar1 & {x: 42}
+//│ g: Bar1 with {x: 42}
 //│  = Bar1 { x: 42 }
 
 g: Foo1['a]
@@ -95,13 +93,13 @@ res.x
 :e
 g: Foo1['a]: Foo1[string]
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.96: 	g: Foo1['a]: Foo1[string]
+//│ ║  l.94: 	g: Foo1['a]: Foo1[string]
 //│ ║        	^
 //│ ╟── type `int` is not an instance of `string`
-//│ ║  l.67: 	class Bar1: Foo1[int]
+//│ ║  l.65: 	class Bar1: Foo1[int]
 //│ ║        	                 ^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.96: 	g: Foo1['a]: Foo1[string]
+//│ ║  l.94: 	g: Foo1['a]: Foo1[string]
 //│ ╙──      	                  ^^^^^^
 //│ res: Foo1[string]
 //│    = Bar1 { x: 42 }
@@ -111,38 +109,38 @@ g: Foo1['a]: Foo1[string]
 class Foo2[A]
 //│ Defined class Foo2[±A]
 //│ ╔══[WARNING] Type definition Foo2 has bivariant type parameters:
-//│ ║  l.111: 	class Foo2[A]
+//│ ║  l.109: 	class Foo2[A]
 //│ ║         	      ^^^^
 //│ ╟── A is irrelevant and may be removed
-//│ ║  l.111: 	class Foo2[A]
+//│ ║  l.109: 	class Foo2[A]
 //│ ╙──       	           ^
 
 Foo2
-//│ res: anything -> Foo2['A]
+//│ res: anything -> Foo2[anything]
 //│    = [Function: res]
 
 :re
 error: Foo2[int]
-//│ res: Foo2[int]
+//│ res: Foo2[anything]
 //│ Runtime error:
 //│   Error: unexpected runtime error
 
 f = fun x -> case x of { Foo2 -> x }
-//│ f: (Foo2[?] & 'a) -> 'a
+//│ f: (Foo2[anything] & 'a) -> 'a
 //│  = [Function: f]
 
 f (Foo2 {})
-//│ res: Foo2['A]
+//│ res: Foo2[anything]
 //│    = Foo2 {}
 
 :re
 error: (Foo2[?] & 'a) -> 'a
-//│ res: (Foo2[?] & 'a) -> 'a
+//│ res: (Foo2[anything] & 'a) -> 'a
 //│ Runtime error:
 //│   Error: unexpected runtime error
 
 f: (Foo2[?] & 'a) -> 'a
-//│ res: (Foo2[?] & 'a) -> 'a
+//│ res: (Foo2[anything] & 'a) -> 'a
 //│    = [Function: f]
 
 :ns
@@ -154,48 +152,48 @@ f: (Foo2[?] & 'a) -> 'a
 //│    = [Function: f]
 
 f
-//│ res: (Foo2[?] & 'a) -> 'a
+//│ res: (Foo2[anything] & 'a) -> 'a
 //│    = [Function: f]
 
 
 def mrg: Foo2[int] & Foo2[string]
-//│ mrg: Foo2[in int | string out nothing]
+//│ mrg: Foo2[anything]
 //│    = <missing implementation>
 
 mrg: Foo2[int]
-//│ res: Foo2[int]
+//│ res: Foo2[anything]
 //│    = <no result>
 //│      mrg is not implemented
 
 :e
 mrg = Foo2{}
-//│ Foo2['A]
+//│ Foo2[anything]
 //│   <:  mrg:
-//│ Foo2[in int | string out nothing]
+//│ Foo2[anything]
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.171: 	mrg = Foo2{}
+//│ ║  l.169: 	mrg = Foo2{}
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── type `string` is not an instance of `int`
-//│ ║  l.161: 	def mrg: Foo2[int] & Foo2[string]
+//│ ║  l.159: 	def mrg: Foo2[int] & Foo2[string]
 //│ ║         	                          ^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.161: 	def mrg: Foo2[int] & Foo2[string]
+//│ ║  l.159: 	def mrg: Foo2[int] & Foo2[string]
 //│ ║         	              ^^^
 //│ ╟── Note: class type parameter A is defined at:
-//│ ║  l.111: 	class Foo2[A]
+//│ ║  l.109: 	class Foo2[A]
 //│ ╙──       	           ^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.171: 	mrg = Foo2{}
+//│ ║  l.169: 	mrg = Foo2{}
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── type `int` is not an instance of `string`
-//│ ║  l.161: 	def mrg: Foo2[int] & Foo2[string]
+//│ ║  l.159: 	def mrg: Foo2[int] & Foo2[string]
 //│ ║         	              ^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.161: 	def mrg: Foo2[int] & Foo2[string]
+//│ ║  l.159: 	def mrg: Foo2[int] & Foo2[string]
 //│ ╙──       	                          ^^^^^^
 //│    = Foo2 {}
 
 def mrg: Foo2[int] | Foo2[string]
-//│ mrg: Foo2[in int | string out nothing]
+//│ mrg: Foo2[anything]
 //│    = <missing implementation>
 

--- a/shared/src/test/diff/mlscript/GenericClasses.mls
+++ b/shared/src/test/diff/mlscript/GenericClasses.mls
@@ -61,6 +61,7 @@ res.value
 //│    = 42
 
 
+
 class Foo1[A]: { x: A }
 class Bar1: Foo1[int]
 //│ Defined class Foo1[+A]
@@ -71,7 +72,7 @@ Bar1
 //│    = [Function: res]
 
 g = Bar1 { x = 42 }
-//│ g: Bar1 with {x: 42}
+//│ g: Bar1 & {x: 42}
 //│  = Bar1 { x: 42 }
 
 g: Foo1['a]
@@ -93,54 +94,52 @@ res.x
 :e
 g: Foo1['a]: Foo1[string]
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.94: 	g: Foo1['a]: Foo1[string]
+//│ ║  l.95: 	g: Foo1['a]: Foo1[string]
 //│ ║        	^
 //│ ╟── type `int` is not an instance of `string`
-//│ ║  l.65: 	class Bar1: Foo1[int]
+//│ ║  l.66: 	class Bar1: Foo1[int]
 //│ ║        	                 ^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.94: 	g: Foo1['a]: Foo1[string]
+//│ ║  l.95: 	g: Foo1['a]: Foo1[string]
 //│ ╙──      	                  ^^^^^^
 //│ res: Foo1[string]
 //│    = Bar1 { x: 42 }
 
 
-:w
+
 class Foo2[A]
-//│ Defined class Foo2[±A]
-//│ ╔══[WARNING] Type definition Foo2 has bivariant type parameters:
-//│ ║  l.109: 	class Foo2[A]
-//│ ║         	      ^^^^
-//│ ╟── A is irrelevant and may be removed
-//│ ║  l.109: 	class Foo2[A]
-//│ ╙──       	           ^
+  method Foo2: A -> A
+  method Foo2 = id
+//│ Defined class Foo2[=A]
+//│ Declared Foo2.Foo2: Foo2['A] -> 'A -> 'A
+//│ Defined Foo2.Foo2: Foo2['A] -> 'a -> 'a
 
 Foo2
-//│ res: anything -> Foo2[anything]
+//│ res: anything -> Foo2['A]
 //│    = [Function: res]
 
 :re
 error: Foo2[int]
-//│ res: Foo2[anything]
+//│ res: Foo2[int]
 //│ Runtime error:
 //│   Error: unexpected runtime error
 
 f = fun x -> case x of { Foo2 -> x }
-//│ f: (Foo2[anything] & 'a) -> 'a
+//│ f: (Foo2[?] & 'a) -> 'a
 //│  = [Function: f]
 
 f (Foo2 {})
-//│ res: Foo2[anything]
+//│ res: Foo2['A]
 //│    = Foo2 {}
 
 :re
 error: (Foo2[?] & 'a) -> 'a
-//│ res: (Foo2[anything] & 'a) -> 'a
+//│ res: (Foo2[?] & 'a) -> 'a
 //│ Runtime error:
 //│   Error: unexpected runtime error
 
 f: (Foo2[?] & 'a) -> 'a
-//│ res: (Foo2[anything] & 'a) -> 'a
+//│ res: (Foo2[?] & 'a) -> 'a
 //│    = [Function: f]
 
 :ns
@@ -152,48 +151,189 @@ f: (Foo2[?] & 'a) -> 'a
 //│    = [Function: f]
 
 f
-//│ res: (Foo2[anything] & 'a) -> 'a
+//│ res: (Foo2[?] & 'a) -> 'a
 //│    = [Function: f]
 
 
 def mrg: Foo2[int] & Foo2[string]
-//│ mrg: Foo2[anything]
+//│ mrg: Foo2[in int | string out nothing]
 //│    = <missing implementation>
 
 mrg: Foo2[int]
-//│ res: Foo2[anything]
+//│ res: Foo2[int]
 //│    = <no result>
 //│      mrg is not implemented
 
 :e
 mrg = Foo2{}
-//│ Foo2[anything]
+//│ Foo2['A]
 //│   <:  mrg:
-//│ Foo2[anything]
+//│ Foo2[in int | string out nothing]
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.169: 	mrg = Foo2{}
+//│ ║  l.168: 	mrg = Foo2{}
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── type `string` is not an instance of `int`
-//│ ║  l.159: 	def mrg: Foo2[int] & Foo2[string]
+//│ ║  l.158: 	def mrg: Foo2[int] & Foo2[string]
 //│ ║         	                          ^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.159: 	def mrg: Foo2[int] & Foo2[string]
+//│ ║  l.158: 	def mrg: Foo2[int] & Foo2[string]
 //│ ║         	              ^^^
 //│ ╟── Note: class type parameter A is defined at:
-//│ ║  l.109: 	class Foo2[A]
+//│ ║  l.110: 	class Foo2[A]
 //│ ╙──       	           ^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.169: 	mrg = Foo2{}
+//│ ║  l.168: 	mrg = Foo2{}
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── type `int` is not an instance of `string`
-//│ ║  l.159: 	def mrg: Foo2[int] & Foo2[string]
+//│ ║  l.158: 	def mrg: Foo2[int] & Foo2[string]
 //│ ║         	              ^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.159: 	def mrg: Foo2[int] & Foo2[string]
+//│ ║  l.158: 	def mrg: Foo2[int] & Foo2[string]
 //│ ╙──       	                          ^^^^^^
 //│    = Foo2 {}
 
 def mrg: Foo2[int] | Foo2[string]
-//│ mrg: Foo2[anything]
+//│ mrg: Foo2[in int | string out nothing]
+//│    = <missing implementation>
+
+
+
+class Foo2_Co[A]
+  method Foo2_Co: A
+  method Foo2_Co = error
+//│ Defined class Foo2_Co[+A]
+//│ Declared Foo2_Co.Foo2_Co: Foo2_Co['A] -> 'A
+//│ Defined Foo2_Co.Foo2_Co: Foo2_Co[anything] -> nothing
+
+Foo2_Co
+//│ res: anything -> Foo2_Co[nothing]
+//│    = [Function: res]
+
+:re
+error: Foo2_Co[int]
+//│ res: Foo2_Co[int]
+//│ Runtime error:
+//│   Error: unexpected runtime error
+
+f = fun x -> case x of { Foo2_Co -> x }
+//│ f: (Foo2_Co[anything] & 'a) -> 'a
+//│  = [Function: f1]
+
+f (Foo2_Co {})
+//│ res: Foo2_Co[nothing]
+//│    = Foo2_Co {}
+
+:re
+error: (Foo2_Co[?] & 'a) -> 'a
+//│ res: (Foo2_Co[nothing] & 'a) -> 'a
+//│ Runtime error:
+//│   Error: unexpected runtime error
+
+f: (Foo2_Co[?] & 'a) -> 'a
+//│ res: (Foo2_Co[nothing] & 'a) -> 'a
+//│    = [Function: f1]
+
+:ns
+f: (Foo2_Co[?] & 'a) -> 'a
+//│ res: (Foo2_Co[?] & 'a) -> 'a
+//│   where
+//│     'a :> Foo2_Co[?] & 'a
+//│        <: (foo2_Co | ~{Foo2_Co#A <: ?} | ~foo2_Co | ~(foo2_Co & {Foo2_Co#A <: ?})) & (foo2_Co | ~(foo2_Co & {Foo2_Co#A <: ?}))
+//│    = [Function: f1]
+
+f
+//│ res: (Foo2_Co[anything] & 'a) -> 'a
+//│    = [Function: f1]
+
+
+def mrg: Foo2_Co[int] & Foo2_Co[string]
+//│ mrg: Foo2_Co[nothing]
+//│    = <missing implementation>
+
+mrg: Foo2_Co[int]
+//│ res: Foo2_Co[int]
+//│    = <no result>
+//│      mrg is not implemented
+
+mrg = Foo2_Co{}
+//│ Foo2_Co[nothing]
+//│   <:  mrg:
+//│ Foo2_Co[nothing]
+//│    = Foo2_Co {}
+
+def mrg: Foo2_Co[int] | Foo2_Co[string]
+//│ mrg: Foo2_Co[nothing]
+//│    = <missing implementation>
+
+
+
+:w
+class Foo2_Bi[A]
+//│ Defined class Foo2_Bi[±A]
+//│ ╔══[WARNING] Type definition Foo2_Bi has bivariant type parameters:
+//│ ║  l.271: 	class Foo2_Bi[A]
+//│ ║         	      ^^^^^^^
+//│ ╟── A is irrelevant and may be removed
+//│ ║  l.271: 	class Foo2_Bi[A]
+//│ ╙──       	              ^
+
+Foo2_Bi
+//│ res: anything -> Foo2_Bi[anything]
+//│    = [Function: res]
+
+:re
+error: Foo2_Bi[int]
+//│ res: Foo2_Bi[anything]
+//│ Runtime error:
+//│   Error: unexpected runtime error
+
+f = fun x -> case x of { Foo2_Bi -> x }
+//│ f: (Foo2_Bi[anything] & 'a) -> 'a
+//│  = [Function: f2]
+
+f (Foo2_Bi {})
+//│ res: Foo2_Bi[anything]
+//│    = Foo2_Bi {}
+
+:re
+error: (Foo2_Bi[?] & 'a) -> 'a
+//│ res: (Foo2_Bi[anything] & 'a) -> 'a
+//│ Runtime error:
+//│   Error: unexpected runtime error
+
+f: (Foo2_Bi[?] & 'a) -> 'a
+//│ res: (Foo2_Bi[anything] & 'a) -> 'a
+//│    = [Function: f2]
+
+:ns
+f: (Foo2_Bi[?] & 'a) -> 'a
+//│ res: (Foo2_Bi[?] & 'a) -> 'a
+//│   where
+//│     'a :> Foo2_Bi[?] & 'a
+//│        <: (foo2_Bi | ~{Foo2_Bi#A} | ~foo2_Bi | ~(foo2_Bi & {Foo2_Bi#A})) & (foo2_Bi | ~(foo2_Bi & {Foo2_Bi#A}))
+//│    = [Function: f2]
+
+f
+//│ res: (Foo2_Bi[anything] & 'a) -> 'a
+//│    = [Function: f2]
+
+
+def mrg: Foo2_Bi[int] & Foo2_Bi[string]
+//│ mrg: Foo2_Bi[anything]
+//│    = <missing implementation>
+
+mrg: Foo2_Bi[int]
+//│ res: Foo2_Bi[anything]
+//│    = <no result>
+//│      mrg is not implemented
+
+mrg = Foo2_Bi{}
+//│ Foo2_Bi[anything]
+//│   <:  mrg:
+//│ Foo2_Bi[anything]
+//│    = Foo2_Bi {}
+
+def mrg: Foo2_Bi[int] | Foo2_Bi[string]
+//│ mrg: Foo2_Bi[anything]
 //│    = <missing implementation>
 

--- a/shared/src/test/diff/mlscript/GenericClasses.mls
+++ b/shared/src/test/diff/mlscript/GenericClasses.mls
@@ -203,7 +203,7 @@ class Foo2_Co[A]
   method Foo2_Co = error
 //│ Defined class Foo2_Co[+A]
 //│ Declared Foo2_Co.Foo2_Co: Foo2_Co['A] -> 'A
-//│ Defined Foo2_Co.Foo2_Co: Foo2_Co[anything] -> nothing
+//│ Defined Foo2_Co.Foo2_Co: Foo2_Co[?] -> nothing
 
 Foo2_Co
 //│ res: anything -> Foo2_Co[nothing]
@@ -216,7 +216,7 @@ error: Foo2_Co[int]
 //│   Error: unexpected runtime error
 
 f = fun x -> case x of { Foo2_Co -> x }
-//│ f: (Foo2_Co[anything] & 'a) -> 'a
+//│ f: (Foo2_Co[?] & 'a) -> 'a
 //│  = [Function: f1]
 
 f (Foo2_Co {})
@@ -242,7 +242,7 @@ f: (Foo2_Co[?] & 'a) -> 'a
 //│    = [Function: f1]
 
 f
-//│ res: (Foo2_Co[anything] & 'a) -> 'a
+//│ res: (Foo2_Co[?] & 'a) -> 'a
 //│    = [Function: f1]
 
 

--- a/shared/src/test/diff/mlscript/GenericClasses.mls
+++ b/shared/src/test/diff/mlscript/GenericClasses.mls
@@ -278,31 +278,31 @@ class Foo2_Bi[A]
 //│ ╙──       	              ^
 
 Foo2_Bi
-//│ res: anything -> Foo2_Bi[anything]
+//│ res: anything -> Foo2_Bi[?]
 //│    = [Function: res]
 
 :re
 error: Foo2_Bi[int]
-//│ res: Foo2_Bi[anything]
+//│ res: Foo2_Bi[?]
 //│ Runtime error:
 //│   Error: unexpected runtime error
 
 f = fun x -> case x of { Foo2_Bi -> x }
-//│ f: (Foo2_Bi[anything] & 'a) -> 'a
+//│ f: (Foo2_Bi[?] & 'a) -> 'a
 //│  = [Function: f2]
 
 f (Foo2_Bi {})
-//│ res: Foo2_Bi[anything]
+//│ res: Foo2_Bi[?]
 //│    = Foo2_Bi {}
 
 :re
 error: (Foo2_Bi[?] & 'a) -> 'a
-//│ res: (Foo2_Bi[anything] & 'a) -> 'a
+//│ res: (Foo2_Bi[?] & 'a) -> 'a
 //│ Runtime error:
 //│   Error: unexpected runtime error
 
 f: (Foo2_Bi[?] & 'a) -> 'a
-//│ res: (Foo2_Bi[anything] & 'a) -> 'a
+//│ res: (Foo2_Bi[?] & 'a) -> 'a
 //│    = [Function: f2]
 
 :ns
@@ -314,26 +314,26 @@ f: (Foo2_Bi[?] & 'a) -> 'a
 //│    = [Function: f2]
 
 f
-//│ res: (Foo2_Bi[anything] & 'a) -> 'a
+//│ res: (Foo2_Bi[?] & 'a) -> 'a
 //│    = [Function: f2]
 
 
 def mrg: Foo2_Bi[int] & Foo2_Bi[string]
-//│ mrg: Foo2_Bi[anything]
+//│ mrg: Foo2_Bi[?]
 //│    = <missing implementation>
 
 mrg: Foo2_Bi[int]
-//│ res: Foo2_Bi[anything]
+//│ res: Foo2_Bi[?]
 //│    = <no result>
 //│      mrg is not implemented
 
 mrg = Foo2_Bi{}
-//│ Foo2_Bi[anything]
+//│ Foo2_Bi[?]
 //│   <:  mrg:
-//│ Foo2_Bi[anything]
+//│ Foo2_Bi[?]
 //│    = Foo2_Bi {}
 
 def mrg: Foo2_Bi[int] | Foo2_Bi[string]
-//│ mrg: Foo2_Bi[anything]
+//│ mrg: Foo2_Bi[?]
 //│    = <missing implementation>
 

--- a/shared/src/test/diff/mlscript/GenericClasses2.mls
+++ b/shared/src/test/diff/mlscript/GenericClasses2.mls
@@ -13,7 +13,7 @@ Bar1
 //│    = [Function: res]
 
 b = Bar1{x = 1}
-//│ b: Bar1 with {x: 1}
+//│ b: Bar1 & {x: 1}
 //│  = Bar1 { x: 1 }
 
 :e
@@ -98,7 +98,7 @@ error: {A: 1}
 //│   Error: unexpected runtime error
 
 b = Bar2{x = 1}
-//│ b: Bar2 with {x: 1}
+//│ b: Bar2 & {x: 1}
 //│  = Bar2 { x: 1 }
 
 :e
@@ -106,12 +106,12 @@ c = b: Foo2[string]
 //│ ╔══[ERROR] Type mismatch in type ascription:
 //│ ║  l.105: 	c = b: Foo2[string]
 //│ ║         	    ^
-//│ ╟── type `string` is not an instance of `int`
-//│ ║  l.105: 	c = b: Foo2[string]
-//│ ║         	            ^^^^^^
-//│ ╟── Note: constraint arises from type reference:
+//│ ╟── type `int` is not an instance of `string`
 //│ ║  l.36: 	class Bar2: Foo2[int] & { x: int }
-//│ ╙──      	                 ^^^
+//│ ║        	                 ^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.105: 	c = b: Foo2[string]
+//│ ╙──       	            ^^^^^^
 //│ c: Foo2[string]
 //│  = Bar2 { x: 1 }
 
@@ -136,12 +136,12 @@ d: Foo2[string]
 //│ ╔══[ERROR] Type mismatch in type ascription:
 //│ ║  l.135: 	d: Foo2[string]
 //│ ║         	^
-//│ ╟── type `string` is not an instance of `int`
-//│ ║  l.135: 	d: Foo2[string]
-//│ ║         	        ^^^^^^
-//│ ╟── Note: constraint arises from type reference:
+//│ ╟── type `int` is not an instance of `string`
 //│ ║  l.36: 	class Bar2: Foo2[int] & { x: int }
-//│ ╙──      	                 ^^^
+//│ ║        	                 ^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.135: 	d: Foo2[string]
+//│ ╙──       	        ^^^^^^
 //│ res: Foo2[string]
 //│    = Bar2 { x: 1 }
 

--- a/shared/src/test/diff/mlscript/GenericClasses2.mls
+++ b/shared/src/test/diff/mlscript/GenericClasses2.mls
@@ -5,7 +5,7 @@ class Bar1: Foo1[int]
 //│ Defined class Bar1
 
 Foo1
-//│ res: {x: 'x & 'A} -> (Foo1['A] with {x: 'x})
+//│ res: {x: 'x} -> Foo1['x]
 //│    = [Function: res]
 
 Bar1
@@ -13,7 +13,7 @@ Bar1
 //│    = [Function: res]
 
 b = Bar1{x = 1}
-//│ b: Bar1 & {x: 1}
+//│ b: Bar1 with {x: 1}
 //│  = Bar1 { x: 1 }
 
 :e
@@ -98,7 +98,7 @@ error: {A: 1}
 //│   Error: unexpected runtime error
 
 b = Bar2{x = 1}
-//│ b: Bar2 & {x: 1}
+//│ b: Bar2 with {x: 1}
 //│  = Bar2 { x: 1 }
 
 :e

--- a/shared/src/test/diff/mlscript/Group_2021_12_02.mls
+++ b/shared/src/test/diff/mlscript/Group_2021_12_02.mls
@@ -54,12 +54,12 @@ rec def evalPeel f e = case e of {
   | Add -> eval f e.lhs + eval f e.rhs
   | _ -> f e
   }
-//│ evalPeel: (('b | 'b0 | 'a) -> (int & 'val)) -> (Add & {lhs: Expr['b0], rhs: Expr['b]} | Lit & {val: 'val} | 'a & ~add & ~lit) -> (int | 'val)
+//│ evalPeel: ('b -> (int & 'val)) -> ('b & ~add & ~lit | Add & {lhs: Expr['b], rhs: Expr['b]} | Lit & {val: 'val}) -> (int | 'val)
 //│         = <no result>
 //│           eval is not implemented
 
 eval = evalPeel
-//│ (('b | 'b0 | 'a) -> (int & 'val)) -> (Add & {lhs: Expr['b0], rhs: Expr['b]} | Lit & {val: 'val} | 'a & ~add & ~lit) -> (int | 'val)
+//│ ('b -> (int & 'val)) -> ('b & ~add & ~lit | Add & {lhs: Expr['b], rhs: Expr['b]} | Lit & {val: 'val}) -> (int | 'val)
 //│   <:  eval:
 //│ ('b -> int) -> Expr['b] -> int
 //│     = <no result>

--- a/shared/src/test/diff/mlscript/HeadOption.mls
+++ b/shared/src/test/diff/mlscript/HeadOption.mls
@@ -58,58 +58,58 @@ class Cons[A]: List[A] & { head: A; tail: List[A] }
 :stats
 l0 = Cons { head = 1; tail = Nil {} }
 //│ l0: Cons[1] with {tail: Nil[anything]}
-//│ constrain calls  : 32
-//│ annoying  calls  : 6
-//│ subtyping calls  : 52
+//│ constrain calls  : 21
+//│ annoying  calls  : 2
+//│ subtyping calls  : 36
 
 :stats
 Cons.HeadOption l0
 //│ res: Some[1]
-//│ constrain calls  : 75
-//│ annoying  calls  : 27
-//│ subtyping calls  : 97
+//│ constrain calls  : 37
+//│ annoying  calls  : 23
+//│ subtyping calls  : 47
 
 :stats
 l1 = Cons { head = 1; tail = Cons { head = 2; tail = Cons { head = 3; tail = Nil {} } } }
-//│ l1: Cons[1 | 2 | 3] with {head: 1, tail: Cons[1 | 2 | 3] with {head: 2, tail: Cons[1 | 2 | 3] with {head: 3, tail: Nil[anything]}}}
-//│ constrain calls  : 164
-//│ annoying  calls  : 18
-//│ subtyping calls  : 315
+//│ l1: Cons[1] with {tail: Cons[2] with {tail: Cons[3] with {tail: Nil[anything]}}}
+//│ constrain calls  : 53
+//│ annoying  calls  : 6
+//│ subtyping calls  : 116
 
 :stats
 Cons.HeadOption l1
-//│ res: Some[1 | 2 | 3]
-//│ constrain calls  : 234
-//│ annoying  calls  : 27
-//│ subtyping calls  : 299
+//│ res: Some[1]
+//│ constrain calls  : 37
+//│ annoying  calls  : 23
+//│ subtyping calls  : 47
 
 :stats
 l2 = Cons { head = 0; tail = l1 }
-//│ l2: Cons[0 | 1 | 2 | 3] with {head: 0, tail: Cons[0 | 1 | 2 | 3] with {head: 1, tail: Cons[0 | 1 | 2 | 3] with {head: 2, tail: Cons[0 | 1 | 2 | 3] with {head: 3, tail: Nil[anything]}}}}
-//│ constrain calls  : 136
-//│ annoying  calls  : 6
-//│ subtyping calls  : 548
+//│ l2: Cons[0] with {tail: Cons[1] with {tail: Cons[2] with {tail: Cons[3] with {tail: Nil[anything]}}}}
+//│ constrain calls  : 17
+//│ annoying  calls  : 2
+//│ subtyping calls  : 132
 
 :stats
 Cons.HeadOption l2
-//│ res: Some[0 | 1 | 2 | 3]
-//│ constrain calls  : 355
-//│ annoying  calls  : 27
-//│ subtyping calls  : 451
+//│ res: Some[0]
+//│ constrain calls  : 38
+//│ annoying  calls  : 23
+//│ subtyping calls  : 47
 
 :stats
 l3 = Cons { head = 0-1; tail = l2 }
-//│ l3: Cons[int] with {head: int, tail: Cons[int] with {head: 0, tail: Cons[int] with {head: 1, tail: Cons[int] with {head: 2, tail: Cons[int] with {head: 3, tail: Nil[anything]}}}}}
-//│ constrain calls  : 226
-//│ annoying  calls  : 6
-//│ subtyping calls  : 781
+//│ l3: Cons[int] with {tail: Cons[0] with {tail: Cons[1] with {tail: Cons[2] with {tail: Cons[3] with {tail: Nil[anything]}}}}}
+//│ constrain calls  : 35
+//│ annoying  calls  : 2
+//│ subtyping calls  : 164
 
 :stats
 Cons.HeadOption l3
 //│ res: Some[int]
-//│ constrain calls  : 517
-//│ annoying  calls  : 27
-//│ subtyping calls  : 553
+//│ constrain calls  : 44
+//│ annoying  calls  : 23
+//│ subtyping calls  : 50
 
 
 :stats
@@ -119,30 +119,30 @@ rec def lr1 = Cons { head = 0; tail = lr1 }
 //│     'tail :> Cons[0] with {tail: 'tail}
 //│ constrain calls  : 20
 //│ annoying  calls  : 2
-//│ subtyping calls  : 44
+//│ subtyping calls  : 43
 
 :stats
 Cons.HeadOption lr1
 //│ res: Some[0]
-//│ constrain calls  : 42
+//│ constrain calls  : 36
 //│ annoying  calls  : 21
-//│ subtyping calls  : 46
+//│ subtyping calls  : 39
 
 :stats
 rec def lr2 = Cons { head = 0; tail = Cons { head = 1; tail = Cons { head = 3; tail = lr2 } } }
 //│ lr2: 'tail
 //│   where
-//│     'tail :> Cons[0 | 1 | 3] with {head: 0, tail: Cons[0 | 1 | 3] with {head: 1, tail: Cons[0 | 1 | 3] with {head: 3, tail: 'tail}}}
-//│ constrain calls  : 286
-//│ annoying  calls  : 18
-//│ subtyping calls  : 336
+//│     'tail :> Cons[0] with {tail: Cons[1] with {tail: Cons[3] with {tail: 'tail}}}
+//│ constrain calls  : 52
+//│ annoying  calls  : 6
+//│ subtyping calls  : 123
 
 :stats
 Cons.HeadOption lr2
-//│ res: Some[0 | 1 | 3]
-//│ constrain calls  : 397
-//│ annoying  calls  : 27
-//│ subtyping calls  : 317
+//│ res: Some[0]
+//│ constrain calls  : 38
+//│ annoying  calls  : 23
+//│ subtyping calls  : 47
 
 
 // FIXME

--- a/shared/src/test/diff/mlscript/HeadOption.mls
+++ b/shared/src/test/diff/mlscript/HeadOption.mls
@@ -25,7 +25,7 @@ class None[A]: Option[A]
 class List[A]
     method HeadOption: Option[A]
 //│ Defined class List[±A]
-//│ Declared List.HeadOption: List[anything] -> Option[anything]
+//│ Declared List.HeadOption: List[?] -> Option[?]
 //│ ╔══[WARNING] Type definition List has bivariant type parameters:
 //│ ║  l.25: 	class List[A]
 //│ ║        	      ^^^^
@@ -37,7 +37,7 @@ class List[A]
 class Nil[A]: List[A]
     method HeadOption = None {}
 //│ Defined class Nil[±A]
-//│ Defined Nil.HeadOption: Nil[anything] -> None[anything]
+//│ Defined Nil.HeadOption: Nil[?] -> None[?]
 //│ ╔══[WARNING] Type definition Nil has bivariant type parameters:
 //│ ║  l.37: 	class Nil[A]: List[A]
 //│ ║        	      ^^^
@@ -57,10 +57,10 @@ class Cons[A]: List[A] & { head: A; tail: List[A] }
 
 :stats
 l0 = Cons { head = 1; tail = Nil {} }
-//│ l0: Cons[1] with {tail: Nil[anything]}
+//│ l0: Cons[1] with {tail: Nil[?]}
 //│ constrain calls  : 21
 //│ annoying  calls  : 2
-//│ subtyping calls  : 36
+//│ subtyping calls  : 38
 
 :stats
 Cons.HeadOption l0
@@ -71,10 +71,10 @@ Cons.HeadOption l0
 
 :stats
 l1 = Cons { head = 1; tail = Cons { head = 2; tail = Cons { head = 3; tail = Nil {} } } }
-//│ l1: Cons[1] with {tail: Cons[2] with {tail: Cons[3] with {tail: Nil[anything]}}}
+//│ l1: Cons[1] with {tail: Cons[2] with {tail: Cons[3] with {tail: Nil[?]}}}
 //│ constrain calls  : 53
 //│ annoying  calls  : 6
-//│ subtyping calls  : 116
+//│ subtyping calls  : 118
 
 :stats
 Cons.HeadOption l1
@@ -85,10 +85,10 @@ Cons.HeadOption l1
 
 :stats
 l2 = Cons { head = 0; tail = l1 }
-//│ l2: Cons[0] with {tail: Cons[1] with {tail: Cons[2] with {tail: Cons[3] with {tail: Nil[anything]}}}}
+//│ l2: Cons[0] with {tail: Cons[1] with {tail: Cons[2] with {tail: Cons[3] with {tail: Nil[?]}}}}
 //│ constrain calls  : 17
 //│ annoying  calls  : 2
-//│ subtyping calls  : 132
+//│ subtyping calls  : 134
 
 :stats
 Cons.HeadOption l2
@@ -99,10 +99,10 @@ Cons.HeadOption l2
 
 :stats
 l3 = Cons { head = 0-1; tail = l2 }
-//│ l3: Cons[int] with {tail: Cons[0] with {tail: Cons[1] with {tail: Cons[2] with {tail: Cons[3] with {tail: Nil[anything]}}}}}
+//│ l3: Cons[int] with {tail: Cons[0] with {tail: Cons[1] with {tail: Cons[2] with {tail: Cons[3] with {tail: Nil[?]}}}}}
 //│ constrain calls  : 35
 //│ annoying  calls  : 2
-//│ subtyping calls  : 164
+//│ subtyping calls  : 166
 
 :stats
 Cons.HeadOption l3

--- a/shared/src/test/diff/mlscript/HeadOption.mls
+++ b/shared/src/test/diff/mlscript/HeadOption.mls
@@ -145,8 +145,26 @@ Cons.HeadOption lr2
 //│ subtyping calls  : 47
 
 
-// FIXME
-// :e
-// l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
+:e
+l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
+//│ ╔══[ERROR] Type mismatch in application:
+//│ ║  l.149: 	l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
+//│ ║         	                                 ^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── record literal of type `{tail: ?a}` does not have field 'head'
+//│ ║  l.149: 	l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
+//│ ╙──       	                                      ^^^^^^^^^^^^^^^^^
+//│ ╔══[ERROR] Type mismatch in application:
+//│ ║  l.149: 	l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
+//│ ║         	                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── record literal of type `{tail: ?a}` does not have field 'head'
+//│ ║  l.149: 	l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
+//│ ╙──       	                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╔══[ERROR] Type mismatch in application:
+//│ ║  l.149: 	l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
+//│ ║         	     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── record literal of type `{tail: ?a}` does not have field 'head'
+//│ ║  l.149: 	l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
+//│ ╙──       	          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ l1: (Cons[nothing] with {tail: (Cons[nothing] with {tail: (Cons[nothing] with {tail: Nil[?]}) | error}) | error}) | error
 
 

--- a/shared/src/test/diff/mlscript/HeadOption.mls
+++ b/shared/src/test/diff/mlscript/HeadOption.mls
@@ -25,7 +25,7 @@ class None[A]: Option[A]
 class List[A]
     method HeadOption: Option[A]
 //│ Defined class List[±A]
-//│ Declared List.HeadOption: List['A] -> Option['A]
+//│ Declared List.HeadOption: List[anything] -> Option[anything]
 //│ ╔══[WARNING] Type definition List has bivariant type parameters:
 //│ ║  l.25: 	class List[A]
 //│ ║        	      ^^^^
@@ -37,7 +37,7 @@ class List[A]
 class Nil[A]: List[A]
     method HeadOption = None {}
 //│ Defined class Nil[±A]
-//│ Defined Nil.HeadOption: Nil['A] -> None['A0]
+//│ Defined Nil.HeadOption: Nil[anything] -> None[anything]
 //│ ╔══[WARNING] Type definition Nil has bivariant type parameters:
 //│ ║  l.37: 	class Nil[A]: List[A]
 //│ ║        	      ^^^
@@ -48,9 +48,7 @@ class Nil[A]: List[A]
 class Cons[A]: List[A] & { head: A; tail: List[A] }
     method HeadOption = Some { payload = error: A }
 //│ Defined class Cons[+A]
-//│ Defined Cons.HeadOption: Cons['A] -> (Some['A0] with {payload: 'A})
-//│   where
-//│     'A0 :> 'A
+//│ Defined Cons.HeadOption: Cons['A] -> Some['A]
 
 // * Incur much fewer constraining/subtyping checks:
 // class Cons[A]: List[A] & { head: A; tail: list }
@@ -59,138 +57,96 @@ class Cons[A]: List[A] & { head: A; tail: List[A] }
 
 :stats
 l0 = Cons { head = 1; tail = Nil {} }
-//│ l0: Cons['A] with {head: 1, tail: Nil['A]}
-//│   where
-//│     'A :> 1
+//│ l0: Cons[1] with {tail: Nil[anything]}
 //│ constrain calls  : 32
 //│ annoying  calls  : 6
-//│ subtyping calls  : 65
+//│ subtyping calls  : 52
 
 :stats
 Cons.HeadOption l0
-//│ res: Some['A] & {payload: 1}
-//│   where
-//│     'A :> 1
+//│ res: Some[1]
 //│ constrain calls  : 75
 //│ annoying  calls  : 27
-//│ subtyping calls  : 100
+//│ subtyping calls  : 97
 
 :stats
 l1 = Cons { head = 1; tail = Cons { head = 2; tail = Cons { head = 3; tail = Nil {} } } }
-//│ l1: Cons['A] with {head: 1, tail: Cons['A] with {head: 2, tail: Cons['A] with {head: 3, tail: Nil['A]}}}
-//│   where
-//│     'A :> 1 | 2 | 3
+//│ l1: Cons[1 | 2 | 3] with {head: 1, tail: Cons[1 | 2 | 3] with {head: 2, tail: Cons[1 | 2 | 3] with {head: 3, tail: Nil[anything]}}}
 //│ constrain calls  : 164
 //│ annoying  calls  : 18
-//│ subtyping calls  : 344
+//│ subtyping calls  : 315
 
 :stats
 Cons.HeadOption l1
-//│ res: Some['A] & {payload: 1 | 2 | 3}
-//│   where
-//│     'A :> 1 | 2 | 3
+//│ res: Some[1 | 2 | 3]
 //│ constrain calls  : 234
 //│ annoying  calls  : 27
-//│ subtyping calls  : 319
+//│ subtyping calls  : 299
 
 :stats
 l2 = Cons { head = 0; tail = l1 }
-//│ l2: Cons['A] with {head: 0, tail: Cons['A] with {head: 1, tail: Cons['A] with {head: 2, tail: Cons['A] with {head: 3, tail: Nil['A]}}}}
-//│   where
-//│     'A :> 0 | 1 | 2 | 3
+//│ l2: Cons[0 | 1 | 2 | 3] with {head: 0, tail: Cons[0 | 1 | 2 | 3] with {head: 1, tail: Cons[0 | 1 | 2 | 3] with {head: 2, tail: Cons[0 | 1 | 2 | 3] with {head: 3, tail: Nil[anything]}}}}
 //│ constrain calls  : 136
 //│ annoying  calls  : 6
-//│ subtyping calls  : 649
+//│ subtyping calls  : 548
 
 :stats
 Cons.HeadOption l2
-//│ res: Some['A] & {payload: 0 | 1 | 2 | 3}
-//│   where
-//│     'A :> 0 | 1 | 2 | 3
+//│ res: Some[0 | 1 | 2 | 3]
 //│ constrain calls  : 355
 //│ annoying  calls  : 27
-//│ subtyping calls  : 484
+//│ subtyping calls  : 451
 
 :stats
 l3 = Cons { head = 0-1; tail = l2 }
-//│ l3: Cons['A] with {head: int, tail: Cons['A] with {head: 0, tail: Cons['A] with {head: 1, tail: Cons['A] with {head: 2, tail: Cons['A] with {head: 3, tail: Nil['A]}}}}}
-//│   where
-//│     'A :> int
+//│ l3: Cons[int] with {head: int, tail: Cons[int] with {head: 0, tail: Cons[int] with {head: 1, tail: Cons[int] with {head: 2, tail: Cons[int] with {head: 3, tail: Nil[anything]}}}}}
 //│ constrain calls  : 226
 //│ annoying  calls  : 6
-//│ subtyping calls  : 809
+//│ subtyping calls  : 781
 
 :stats
 Cons.HeadOption l3
-//│ res: Some['A] & {payload: int}
-//│   where
-//│     'A :> int
+//│ res: Some[int]
 //│ constrain calls  : 517
 //│ annoying  calls  : 27
-//│ subtyping calls  : 564
+//│ subtyping calls  : 553
 
 
 :stats
 rec def lr1 = Cons { head = 0; tail = lr1 }
 //│ lr1: 'tail
 //│   where
-//│     'tail :> Cons['A] with {head: 0, tail: 'tail}
-//│     'A :> 0
+//│     'tail :> Cons[0] with {tail: 'tail}
 //│ constrain calls  : 20
 //│ annoying  calls  : 2
-//│ subtyping calls  : 51
+//│ subtyping calls  : 44
 
 :stats
 Cons.HeadOption lr1
-//│ res: Some['A] & {payload: 0}
-//│   where
-//│     'A :> 0
+//│ res: Some[0]
 //│ constrain calls  : 42
 //│ annoying  calls  : 21
-//│ subtyping calls  : 49
+//│ subtyping calls  : 46
 
 :stats
 rec def lr2 = Cons { head = 0; tail = Cons { head = 1; tail = Cons { head = 3; tail = lr2 } } }
 //│ lr2: 'tail
 //│   where
-//│     'tail :> Cons['A] with {head: 0, tail: Cons['A] with {head: 1, tail: Cons['A] with {head: 3, tail: 'tail}}}
-//│     'A :> 0 | 1 | 3
+//│     'tail :> Cons[0 | 1 | 3] with {head: 0, tail: Cons[0 | 1 | 3] with {head: 1, tail: Cons[0 | 1 | 3] with {head: 3, tail: 'tail}}}
 //│ constrain calls  : 286
 //│ annoying  calls  : 18
-//│ subtyping calls  : 434
+//│ subtyping calls  : 336
 
 :stats
 Cons.HeadOption lr2
-//│ res: Some['A] & {payload: 0 | 1 | 3}
-//│   where
-//│     'A :> 0 | 1 | 3
+//│ res: Some[0 | 1 | 3]
 //│ constrain calls  : 397
 //│ annoying  calls  : 27
-//│ subtyping calls  : 337
+//│ subtyping calls  : 317
 
 
-:e
-l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
-//│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.173: 	l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
-//│ ║         	                                 ^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── record literal of type `{tail: ?a}` does not have field 'head'
-//│ ║  l.173: 	l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
-//│ ╙──       	                                      ^^^^^^^^^^^^^^^^^
-//│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.173: 	l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
-//│ ║         	                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── record literal of type `{tail: ?a}` does not have field 'head'
-//│ ║  l.173: 	l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
-//│ ╙──       	                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.173: 	l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
-//│ ║         	     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── record literal of type `{tail: ?a}` does not have field 'head'
-//│ ║  l.173: 	l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
-//│ ╙──       	          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ l1: (Cons['A] with {head: nothing, tail: (Cons['A] with {head: nothing, tail: (Cons['A] with {head: nothing, tail: Nil['A]}) | error}) | error}) | error
-//│   where
-//│     'A :> error
+// FIXME
+// :e
+// l1 = Cons { tail = Cons { tail = Cons { tail = Nil {} } } }
 
 

--- a/shared/src/test/diff/mlscript/Lists.mls
+++ b/shared/src/test/diff/mlscript/Lists.mls
@@ -20,21 +20,15 @@ def Cons head tail = Cons { head; tail }
 
 
 Cons 2
-//│ res: (List['A] & 'tail) -> (Cons['A] with {head: 2, tail: 'tail})
-//│   where
-//│     'A :> 2
+//│ res: (List['A] & 'tail) -> (Cons[2 | 'A] with {head: 2, tail: 'tail})
 //│    = [Function (anonymous)]
 
 def c = Cons 2 Nil
-//│ c: Cons['A] with {head: 2, tail: Nil}
-//│   where
-//│     'A :> 2
+//│ c: Cons[2] with {tail: Nil}
 //│  = Cons { head: 2, tail: Nil {} }
 
 def d = Cons 1 c
-//│ d: Cons['A] with {head: 1, tail: Cons['A] with {head: 2, tail: Nil}}
-//│   where
-//│     'A :> 1 | 2
+//│ d: Cons[1 | 2] with {head: 1, tail: Cons[1 | 2] with {head: 2, tail: Nil}}
 //│  = Cons { head: 1, tail: Cons { head: 2, tail: Nil {} } }
 
 d.head
@@ -46,33 +40,23 @@ res: 1
 //│    = 1
 
 d.tail
-//│ res: Cons['A] with {head: 2, tail: Nil}
-//│   where
-//│     'A :> 1 | 2
+//│ res: Cons[1 | 2] with {head: 2, tail: Nil}
 //│    = Cons { head: 2, tail: Nil {} }
 
 Cons 1 res
-//│ res: Cons['A] with {head: 1, tail: Cons['A] with {head: 2, tail: Nil}}
-//│   where
-//│     'A :> 1 | 2
+//│ res: Cons[1 | 2] with {head: 1, tail: Cons[1 | 2] with {head: 2, tail: Nil}}
 //│    = Cons { head: 1, tail: Cons { head: 2, tail: Nil {} } }
 
 res.tail
-//│ res: Cons['A] with {head: 2, tail: Nil}
-//│   where
-//│     'A :> 1 | 2
+//│ res: Cons[1 | 2] with {head: 2, tail: Nil}
 //│    = Cons { head: 2, tail: Nil {} }
 
 Cons 1 (Cons 2 Nil)
-//│ res: Cons['A] with {head: 1, tail: Cons['A] with {head: 2, tail: Nil}}
-//│   where
-//│     'A :> 1 | 2
+//│ res: Cons[1 | 2] with {head: 1, tail: Cons[1 | 2] with {head: 2, tail: Nil}}
 //│    = Cons { head: 1, tail: Cons { head: 2, tail: Nil {} } }
 
 res.tail
-//│ res: Cons['A] with {head: 2, tail: Nil}
-//│   where
-//│     'A :> 1 | 2
+//│ res: Cons[1 | 2] with {head: 2, tail: Nil}
 //│    = Cons { head: 2, tail: Nil {} }
 
 // We can now access the tail's tail, thanks to the refined type
@@ -83,13 +67,13 @@ res.tail
 :e
 res.tail.head
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.84: 	res.tail.head
+//│ ║  l.68: 	res.tail.head
 //│ ║        	^^^^^^^^
 //│ ╟── application of type `Nil` does not have field 'tail'
 //│ ║  l.13: 	def Nil = Nil {}
 //│ ║        	          ^^^^^^
 //│ ╟── but it flows into reference with expected type `{tail: ?tail}`
-//│ ║  l.84: 	res.tail.head
+//│ ║  l.68: 	res.tail.head
 //│ ║        	^^^
 //│ ╟── Note: class Nil is defined at:
 //│ ║  l.2: 	class Nil: {}
@@ -102,20 +86,16 @@ res.tail.head
 
 // This used to yield a more precise Cons constructor, but it's no longer necessary in the new class semantics
 def Cons head tail = originalCons { head; tail } with { head; tail }
-//│ Cons: ('A & 'head) -> (List['A] & 'tail) -> (Cons['A] & {head: 'head, tail: 'tail})
+//│ Cons: ('A & 'head) -> (List['A] & 'tail) -> (Cons['A] with {head: 'head, tail: 'tail})
 //│     = [Function: Cons2]
 
 
 Cons 2
-//│ res: (List['A] & 'tail) -> (Cons['A] & {head: 2, tail: 'tail})
-//│   where
-//│     'A :> 2
+//│ res: (List['A] & 'tail) -> (Cons[2 | 'A] with {head: 2, tail: 'tail})
 //│    = [Function (anonymous)]
 
 Cons 2 Nil
-//│ res: Cons['A] with {head: 2, tail: Nil}
-//│   where
-//│     'A :> 2
+//│ res: Cons[2] with {tail: Nil}
 //│    = Cons { head: 2, tail: Nil {} }
 
 res.head
@@ -125,23 +105,21 @@ res.head
 :e
 Cons 1 res
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.126: 	Cons 1 res
+//│ ║  l.106: 	Cons 1 res
 //│ ║         	^^^^^^^^^^
 //│ ╟── integer literal of type `2` does not match type `Cons[?A] | Nil`
-//│ ║  l.115: 	Cons 2 Nil
-//│ ║         	     ^
+//│ ║  l.97: 	Cons 2 Nil
+//│ ║        	     ^
 //│ ╟── but it flows into reference with expected type `Cons[?A0] | Nil`
-//│ ║  l.126: 	Cons 1 res
+//│ ║  l.106: 	Cons 1 res
 //│ ║         	       ^^^
 //│ ╟── Note: constraint arises from union type:
 //│ ║  l.4: 	type List[A] = Nil | Cons[A]
 //│ ║       	               ^^^^^^^^^^^^^
 //│ ╟── from reference:
-//│ ║  l.104: 	def Cons head tail = originalCons { head; tail } with { head; tail }
-//│ ╙──       	                                          ^^^^
-//│ res: (Cons['A] with {head: 1, tail: 2}) | error
-//│   where
-//│     'A :> 1
+//│ ║  l.88: 	def Cons head tail = originalCons { head; tail } with { head; tail }
+//│ ╙──      	                                          ^^^^
+//│ res: (Cons[1] with {tail: 2}) | error
 //│    = Cons { head: 1, tail: 2 }
 
 // Here there used to be a loss of precision in the older with-field approach.
@@ -154,9 +132,7 @@ Cons 1 res
 // But then I reverted to the use of simple field-hiding types, as they are simpler!
 // 
 Cons 1 (Cons 2 Nil)
-//│ res: Cons['A] with {head: 1, tail: Cons['A] with {head: 2, tail: Nil}}
-//│   where
-//│     'A :> 1 | 2
+//│ res: Cons[1 | 2] with {head: 1, tail: Cons[1 | 2] with {head: 2, tail: Nil}}
 //│    = Cons { head: 1, tail: Cons { head: 2, tail: Nil {} } }
 
 { a = res.head; b = res.tail.head; c = res.tail.tail }
@@ -164,15 +140,11 @@ Cons 1 (Cons 2 Nil)
 //│    = { a: 1, b: 2, c: Nil {} }
 
 Cons 2 Nil
-//│ res: Cons['A] with {head: 2, tail: Nil}
-//│   where
-//│     'A :> 2
+//│ res: Cons[2] with {tail: Nil}
 //│    = Cons { head: 2, tail: Nil {} }
 
 Cons 1 (id res)
-//│ res: Cons['A] with {head: 1, tail: Cons['A] with {head: 2, tail: Nil}}
-//│   where
-//│     'A :> 1 | 2
+//│ res: Cons[1 | 2] with {head: 1, tail: Cons[1 | 2] with {head: 2, tail: Nil}}
 //│    = Cons { head: 1, tail: Cons { head: 2, tail: Nil {} } }
 
 { a = res.head; b = res.tail.head; c = res.tail.tail }
@@ -181,15 +153,11 @@ Cons 1 (id res)
 
 
 def Cons head = originalCons { head=0; tail=Nil } with { head }
-//│ Cons: 'a -> (Cons['A] with {head: 'a, tail: Nil})
-//│   where
-//│     'A :> 0
+//│ Cons: 'a -> (Cons[0] with {head: 'a, tail: Nil})
 //│     = [Function: Cons3]
 
 Cons 1
-//│ res: Cons['A] with {head: 1, tail: Nil}
-//│   where
-//│     'A :> 0
+//│ res: Cons[0] with {head: 1, tail: Nil}
 //│    = Cons { head: 1, tail: Nil {} }
 
 res.head
@@ -197,9 +165,7 @@ res.head
 //│    = 1
 
 def c = Cons 1
-//│ c: Cons['A] with {head: 1, tail: Nil}
-//│   where
-//│     'A :> 0
+//│ c: Cons[0] with {head: 1, tail: Nil}
 //│  = Cons { head: 1, tail: Nil {} }
 
 c.head
@@ -208,17 +174,15 @@ c.head
 
 def c: 'a -> List['b] -> List['a | 'b]
 c 1 (c 2 Nil)
-//│ c: 'a -> List['b] -> List['a | 'b]
+//│ c: 'a -> List['a] -> List['a]
 //│  = <missing implementation>
-//│ res: List['a]
-//│   where
-//│     'a :> 2 | 1
+//│ res: List[1 | 2]
 //│    = <no result>
 //│      c is not implemented
 
 def c: 'a -> ('l & List['b]) -> (Cons[anything] & { head: 'a; tail: 'l })
 c 1 (c 2 Nil)
-//│ c: 'a -> (List['b] & 'l) -> (Cons[anything] with {head: 'a, tail: 'l})
+//│ c: 'a -> (List[anything] & 'l) -> (Cons[anything] with {head: 'a, tail: 'l})
 //│  = <missing implementation>
 //│ res: Cons[anything] with {head: 1, tail: Cons[anything] with {head: 2, tail: Nil}}
 //│    = <no result>

--- a/shared/src/test/diff/mlscript/Lists.mls
+++ b/shared/src/test/diff/mlscript/Lists.mls
@@ -28,7 +28,7 @@ def c = Cons 2 Nil
 //│  = Cons { head: 2, tail: Nil {} }
 
 def d = Cons 1 c
-//│ d: Cons[1 | 2] with {head: 1, tail: Cons[1 | 2] with {head: 2, tail: Nil}}
+//│ d: Cons[1 | 2] with {head: 1, tail: Cons[2] with {tail: Nil}}
 //│  = Cons { head: 1, tail: Cons { head: 2, tail: Nil {} } }
 
 d.head
@@ -40,23 +40,23 @@ res: 1
 //│    = 1
 
 d.tail
-//│ res: Cons[1 | 2] with {head: 2, tail: Nil}
+//│ res: Cons[2] with {tail: Nil}
 //│    = Cons { head: 2, tail: Nil {} }
 
 Cons 1 res
-//│ res: Cons[1 | 2] with {head: 1, tail: Cons[1 | 2] with {head: 2, tail: Nil}}
+//│ res: Cons[1 | 2] with {head: 1, tail: Cons[2] with {tail: Nil}}
 //│    = Cons { head: 1, tail: Cons { head: 2, tail: Nil {} } }
 
 res.tail
-//│ res: Cons[1 | 2] with {head: 2, tail: Nil}
+//│ res: Cons[2] with {tail: Nil}
 //│    = Cons { head: 2, tail: Nil {} }
 
 Cons 1 (Cons 2 Nil)
-//│ res: Cons[1 | 2] with {head: 1, tail: Cons[1 | 2] with {head: 2, tail: Nil}}
+//│ res: Cons[1 | 2] with {head: 1, tail: Cons[2] with {tail: Nil}}
 //│    = Cons { head: 1, tail: Cons { head: 2, tail: Nil {} } }
 
 res.tail
-//│ res: Cons[1 | 2] with {head: 2, tail: Nil}
+//│ res: Cons[2] with {tail: Nil}
 //│    = Cons { head: 2, tail: Nil {} }
 
 // We can now access the tail's tail, thanks to the refined type
@@ -86,7 +86,7 @@ res.tail.head
 
 // This used to yield a more precise Cons constructor, but it's no longer necessary in the new class semantics
 def Cons head tail = originalCons { head; tail } with { head; tail }
-//│ Cons: ('A & 'head) -> (List['A] & 'tail) -> (Cons['A] with {head: 'head, tail: 'tail})
+//│ Cons: ('A & 'head) -> (List['A] & 'tail) -> (Cons['A] & {head: 'head, tail: 'tail})
 //│     = [Function: Cons2]
 
 
@@ -132,7 +132,7 @@ Cons 1 res
 // But then I reverted to the use of simple field-hiding types, as they are simpler!
 // 
 Cons 1 (Cons 2 Nil)
-//│ res: Cons[1 | 2] with {head: 1, tail: Cons[1 | 2] with {head: 2, tail: Nil}}
+//│ res: Cons[1 | 2] with {head: 1, tail: Cons[2] with {tail: Nil}}
 //│    = Cons { head: 1, tail: Cons { head: 2, tail: Nil {} } }
 
 { a = res.head; b = res.tail.head; c = res.tail.tail }
@@ -144,7 +144,7 @@ Cons 2 Nil
 //│    = Cons { head: 2, tail: Nil {} }
 
 Cons 1 (id res)
-//│ res: Cons[1 | 2] with {head: 1, tail: Cons[1 | 2] with {head: 2, tail: Nil}}
+//│ res: Cons[1 | 2] with {head: 1, tail: Cons[2] with {tail: Nil}}
 //│    = Cons { head: 1, tail: Cons { head: 2, tail: Nil {} } }
 
 { a = res.head; b = res.tail.head; c = res.tail.tail }

--- a/shared/src/test/diff/mlscript/Lists.mls
+++ b/shared/src/test/diff/mlscript/Lists.mls
@@ -182,8 +182,8 @@ c 1 (c 2 Nil)
 
 def c: 'a -> ('l & List['b]) -> (Cons[anything] & { head: 'a; tail: 'l })
 c 1 (c 2 Nil)
-//│ c: 'a -> (List[anything] & 'l) -> (Cons[anything] with {head: 'a, tail: 'l})
+//│ c: 'a -> (List[?] & 'l) -> (Cons[?] with {head: 'a, tail: 'l})
 //│  = <missing implementation>
-//│ res: Cons[anything] with {head: 1, tail: Cons[anything] with {head: 2, tail: Nil}}
+//│ res: Cons[?] with {head: 1, tail: Cons[?] with {head: 2, tail: Nil}}
 //│    = <no result>
 //│      c is not implemented

--- a/shared/src/test/diff/mlscript/MethodAndMatches.mls
+++ b/shared/src/test/diff/mlscript/MethodAndMatches.mls
@@ -79,12 +79,12 @@ def bar0 = foo
 def bar1: Type1[int] -> int -> Type1[int]
 bar1 d1
 bar1 d1 0
-//│ bar1: Type1[anything] -> int -> Type1[anything]
+//│ bar1: Type1[?] -> int -> Type1[?]
 //│     = <missing implementation>
-//│ res: int -> Type1[anything]
+//│ res: int -> Type1[?]
 //│    = <no result>
 //│      bar1 is not implemented
-//│ res: Type1[anything]
+//│ res: Type1[?]
 //│    = <no result>
 //│      bar1 is not implemented
 
@@ -92,7 +92,7 @@ bar1 d1 0
 def bar1 = foo
 //│ (Base1['A] & ~derived1 | Derived1) -> 'A -> (Base1['A] | Derived1)
 //│   <:  bar1:
-//│ Type1[anything] -> int -> Type1[anything]
+//│ Type1[?] -> int -> Type1[?]
 //│ ╔══[ERROR] Type mismatch in def definition:
 //│ ║  l.92: 	def bar1 = foo
 //│ ║        	^^^^^^^^^^^^^^

--- a/shared/src/test/diff/mlscript/MethodAndMatches.mls
+++ b/shared/src/test/diff/mlscript/MethodAndMatches.mls
@@ -16,7 +16,7 @@ type Type1[A] = Derived1 | Derived3['a, 'b]
 //│ Defined Derived1.M1: Derived1 -> int -> Derived1
 //│ Defined Derived1.M2: Derived1 -> Derived1
 //│ Defined class Derived2[-C, -D]
-//│ Defined Derived2.M1: Derived2['C, 'D] -> {c: anything, d: anything} -> Derived2['C0, 'D0]
+//│ Defined Derived2.M1: Derived2[nothing, nothing] -> {c: anything, d: anything} -> Derived2[anything, anything]
 //│ Defined class Derived3[=C, =D]
 //│ Defined Derived3.M1: Derived3['C, 'D] -> {c: 'c & 'C0, d: 'd & 'D0} -> (Derived3['C0, 'D0] with {c: 'c, d: 'd})
 //│ Defined type alias Type1[±A]
@@ -36,16 +36,14 @@ def foo b x = case b of {
 //│    = [Function: foo]
 
 d1 = Derived1 { x = 1 }
-//│ d1: Derived1 & {x: 1}
+//│ d1: Derived1 with {x: 1}
 //│   = Derived1 { x: 1 }
 
 foo d1
 foo d1 0
-//│ res: 'A -> (Base1['A] | Derived1)
+//│ res: anything -> (Base1[anything] | Derived1)
 //│    = [Function (anonymous)]
-//│ res: Base1['A] | Derived1
-//│   where
-//│     'A :> 0
+//│ res: Base1[anything] | Derived1
 //│    = Derived1 { x: 2 }
 
 def bar0: Base1[int] -> int -> Base1[int]
@@ -67,7 +65,7 @@ def bar0 = foo
 //│   <:  bar0:
 //│ Base1[int] -> int -> Base1[int]
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.65: 	def bar0 = foo
+//│ ║  l.63: 	def bar0 = foo
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── expression of type `Base1[int] & ~?a | Derived1` does not have field 'x'
 //│ ╟── Note: constraint arises from record type:
@@ -81,12 +79,12 @@ def bar0 = foo
 def bar1: Type1[int] -> int -> Type1[int]
 bar1 d1
 bar1 d1 0
-//│ bar1: Type1[int] -> int -> Type1[int]
+//│ bar1: Type1[anything] -> int -> Type1[anything]
 //│     = <missing implementation>
-//│ res: int -> Type1[int]
+//│ res: int -> Type1[anything]
 //│    = <no result>
 //│      bar1 is not implemented
-//│ res: Type1[int]
+//│ res: Type1[anything]
 //│    = <no result>
 //│      bar1 is not implemented
 
@@ -94,12 +92,12 @@ bar1 d1 0
 def bar1 = foo
 //│ (Base1['A] & ~derived1 | Derived1) -> 'A -> (Base1['A] | Derived1)
 //│   <:  bar1:
-//│ Type1[int] -> int -> Type1[int]
+//│ Type1[anything] -> int -> Type1[anything]
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.94: 	def bar1 = foo
+//│ ║  l.92: 	def bar1 = foo
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── type `int` is not a record (expected a record with fields: c, d)
-//│ ║  l.81: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.79: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ║        	                        ^^^
 //│ ╟── Note: constraint arises from record type:
 //│ ║  l.10: 	class Derived3[C, D]: Base1[{ c: C; d: D }] & { c: C; d: D }
@@ -108,7 +106,7 @@ def bar1 = foo
 //│ ║  l.33: 	  | Base1 -> b.M1 x
 //│ ╙──      	                  ^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.94: 	def bar1 = foo
+//│ ║  l.92: 	def bar1 = foo
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── type `Base1[?A]` does not match type `Derived1 | Derived3[?a, ?b]`
 //│ ║  l.3: 	  method M1: A -> Base1[A]
@@ -117,10 +115,10 @@ def bar1 = foo
 //│ ║  l.12: 	type Type1[A] = Derived1 | Derived3['a, 'b]
 //│ ║        	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.81: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.79: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.94: 	def bar1 = foo
+//│ ║  l.92: 	def bar1 = foo
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── type `Base1[?A]` does not match type `Derived1 | Derived3[?a, ?b]`
 //│ ║  l.3: 	  method M1: A -> Base1[A]
@@ -129,10 +127,10 @@ def bar1 = foo
 //│ ║  l.12: 	type Type1[A] = Derived1 | Derived3['a, 'b]
 //│ ║        	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.81: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.79: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.94: 	def bar1 = foo
+//│ ║  l.92: 	def bar1 = foo
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── type `Base1[?A]` does not match type `Derived1 | Derived3[?a, ?b]`
 //│ ║  l.3: 	  method M1: A -> Base1[A]
@@ -141,10 +139,10 @@ def bar1 = foo
 //│ ║  l.12: 	type Type1[A] = Derived1 | Derived3['a, 'b]
 //│ ║        	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.81: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.79: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.94: 	def bar1 = foo
+//│ ║  l.92: 	def bar1 = foo
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── type `Base1[?A]` does not match type `Derived1 | Derived3[?a, ?b]`
 //│ ║  l.3: 	  method M1: A -> Base1[A]
@@ -153,10 +151,10 @@ def bar1 = foo
 //│ ║  l.12: 	type Type1[A] = Derived1 | Derived3['a, 'b]
 //│ ║        	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.81: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.79: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.94: 	def bar1 = foo
+//│ ║  l.92: 	def bar1 = foo
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── type `Base1[?A]` does not match type `Derived1 | Derived3[?a, ?b]`
 //│ ║  l.3: 	  method M1: A -> Base1[A]
@@ -165,10 +163,10 @@ def bar1 = foo
 //│ ║  l.12: 	type Type1[A] = Derived1 | Derived3['a, 'b]
 //│ ║        	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.81: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.79: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.94: 	def bar1 = foo
+//│ ║  l.92: 	def bar1 = foo
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── type `{c: ?a, d: ?b}` does not match type `int`
 //│ ║  l.10: 	class Derived3[C, D]: Base1[{ c: C; d: D }] & { c: C; d: D }
@@ -177,7 +175,7 @@ def bar1 = foo
 //│ ║  l.4: 	class Derived1: Base1[int] & { x: int }
 //│ ╙──     	                      ^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.94: 	def bar1 = foo
+//│ ║  l.92: 	def bar1 = foo
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── type `Base1[?A]` does not match type `Derived1 | Derived3[?a, ?b]`
 //│ ║  l.3: 	  method M1: A -> Base1[A]
@@ -186,7 +184,7 @@ def bar1 = foo
 //│ ║  l.12: 	type Type1[A] = Derived1 | Derived3['a, 'b]
 //│ ║        	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.81: 	def bar1: Type1[int] -> int -> Type1[int]
+//│ ║  l.79: 	def bar1: Type1[int] -> int -> Type1[int]
 //│ ╙──      	                               ^^^^^^^^^^
 //│     = [Function: foo]
 
@@ -209,25 +207,25 @@ def bar2 = foo
 //│   <:  bar2:
 //│ Base1['a] -> 'a -> Base1['a]
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.207: 	def bar2 = foo
+//│ ║  l.205: 	def bar2 = foo
 //│ ║         	^^^^^^^^^^^^^^
 //│ ╟── type `int` is not an instance of type 'a
 //│ ║  l.4: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                      ^^^
 //│ ╟── Note: constraint arises from type variable:
-//│ ║  l.193: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║  l.191: 	def bar2: Base1['a] -> 'a -> Base1['a]
 //│ ╙──       	                ^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.207: 	def bar2 = foo
+//│ ║  l.205: 	def bar2 = foo
 //│ ║         	^^^^^^^^^^^^^^
 //│ ╟── type `'a` does not match type `int`
-//│ ║  l.193: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║  l.191: 	def bar2: Base1['a] -> 'a -> Base1['a]
 //│ ║         	                ^^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.4: 	class Derived1: Base1[int] & { x: int }
 //│ ╙──     	                      ^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.207: 	def bar2 = foo
+//│ ║  l.205: 	def bar2 = foo
 //│ ║         	^^^^^^^^^^^^^^
 //│ ╟── expression of type `Base1['a] & ~?a | (Derived1\x with {Base1#A = 'a})` does not have field 'x'
 //│ ╟── Note: constraint arises from record type:

--- a/shared/src/test/diff/mlscript/MethodAndMatches.mls
+++ b/shared/src/test/diff/mlscript/MethodAndMatches.mls
@@ -16,7 +16,7 @@ type Type1[A] = Derived1 | Derived3['a, 'b]
 //│ Defined Derived1.M1: Derived1 -> int -> Derived1
 //│ Defined Derived1.M2: Derived1 -> Derived1
 //│ Defined class Derived2[-C, -D]
-//│ Defined Derived2.M1: Derived2[nothing, nothing] -> {c: anything, d: anything} -> Derived2[anything, anything]
+//│ Defined Derived2.M1: Derived2[?, ?] -> {c: anything, d: anything} -> Derived2[anything, anything]
 //│ Defined class Derived3[=C, =D]
 //│ Defined Derived3.M1: Derived3['C, 'D] -> {c: 'c & 'C0, d: 'd & 'D0} -> (Derived3['C0, 'D0] with {c: 'c, d: 'd})
 //│ Defined type alias Type1[±A]

--- a/shared/src/test/diff/mlscript/MethodAndMatches.mls
+++ b/shared/src/test/diff/mlscript/MethodAndMatches.mls
@@ -36,7 +36,7 @@ def foo b x = case b of {
 //│    = [Function: foo]
 
 d1 = Derived1 { x = 1 }
-//│ d1: Derived1 with {x: 1}
+//│ d1: Derived1 & {x: 1}
 //│   = Derived1 { x: 1 }
 
 foo d1
@@ -168,15 +168,6 @@ def bar1 = foo
 //│ ╔══[ERROR] Type mismatch in def definition:
 //│ ║  l.92: 	def bar1 = foo
 //│ ║        	^^^^^^^^^^^^^^
-//│ ╟── type `{c: ?a, d: ?b}` does not match type `int`
-//│ ║  l.10: 	class Derived3[C, D]: Base1[{ c: C; d: D }] & { c: C; d: D }
-//│ ║        	                            ^^^^^^^^^^^^^^
-//│ ╟── Note: constraint arises from type reference:
-//│ ║  l.4: 	class Derived1: Base1[int] & { x: int }
-//│ ╙──     	                      ^^^
-//│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.92: 	def bar1 = foo
-//│ ║        	^^^^^^^^^^^^^^
 //│ ╟── type `Base1[?A]` does not match type `Derived1 | Derived3[?a, ?b]`
 //│ ║  l.3: 	  method M1: A -> Base1[A]
 //│ ║       	                  ^^^^^^^^
@@ -207,32 +198,32 @@ def bar2 = foo
 //│   <:  bar2:
 //│ Base1['a] -> 'a -> Base1['a]
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.205: 	def bar2 = foo
+//│ ║  l.196: 	def bar2 = foo
 //│ ║         	^^^^^^^^^^^^^^
 //│ ╟── type `int` is not an instance of type 'a
 //│ ║  l.4: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                      ^^^
 //│ ╟── Note: constraint arises from type variable:
-//│ ║  l.191: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║  l.182: 	def bar2: Base1['a] -> 'a -> Base1['a]
 //│ ╙──       	                ^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.205: 	def bar2 = foo
+//│ ║  l.196: 	def bar2 = foo
 //│ ║         	^^^^^^^^^^^^^^
-//│ ╟── type `'a` does not match type `int`
-//│ ║  l.191: 	def bar2: Base1['a] -> 'a -> Base1['a]
-//│ ║         	                ^^
-//│ ╟── Note: constraint arises from type reference:
-//│ ║  l.4: 	class Derived1: Base1[int] & { x: int }
-//│ ╙──     	                      ^^^
-//│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.205: 	def bar2 = foo
-//│ ║         	^^^^^^^^^^^^^^
-//│ ╟── expression of type `Base1['a] & ~?a | (Derived1\x with {Base1#A = 'a})` does not have field 'x'
+//│ ╟── expression of type `Base1['a] & ~?a | (Derived1\x with {Base1#A :> 'a})` does not have field 'x'
 //│ ╟── Note: constraint arises from record type:
 //│ ║  l.4: 	class Derived1: Base1[int] & { x: int }
 //│ ║       	                             ^^^^^^^^^^
 //│ ╟── from refined scrutinee:
 //│ ║  l.31: 	def foo b x = case b of {
 //│ ╙──      	                   ^
+//│ ╔══[ERROR] Type mismatch in def definition:
+//│ ║  l.196: 	def bar2 = foo
+//│ ║         	^^^^^^^^^^^^^^
+//│ ╟── type `'a` does not match type `int`
+//│ ║  l.182: 	def bar2: Base1['a] -> 'a -> Base1['a]
+//│ ║         	                                   ^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.4: 	class Derived1: Base1[int] & { x: int }
+//│ ╙──     	                      ^^^
 //│     = [Function: foo]
 

--- a/shared/src/test/diff/mlscript/Methods.mls
+++ b/shared/src/test/diff/mlscript/Methods.mls
@@ -103,10 +103,10 @@ class WrapperWrapper[A]: Wrapper[Wrapper[A]]
     method Apply2 f = WrapperWrapper { x = this.x.Apply f }
 //│ Defined class WrapperWrapper[+A]
 //│ Declared WrapperWrapper.Apply2: WrapperWrapper['A] -> ('A -> 'B) -> WrapperWrapper['B]
-//│ Defined WrapperWrapper.Apply2: WrapperWrapper['A] -> ('A -> 'B) -> (WrapperWrapper['B] with {Wrapper#A <: Wrapper['B], x: Wrapper['B]})
+//│ Defined WrapperWrapper.Apply2: WrapperWrapper['A] -> ('A -> 'B) -> WrapperWrapper['B]
 
 WrapperWrapper { x = Psyduck { x = 0 } }
-//│ res: WrapperWrapper[0] with {Wrapper#A <: Wrapper[0], x: Psyduck[0] with {x: 0}}
+//│ res: WrapperWrapper[0] with {x: Psyduck[0]}
 //│    = WrapperWrapper { x: Psyduck { x: 0 } }
 
 res.Apply2 (fun x -> mul x 2)

--- a/shared/src/test/diff/mlscript/Methods.mls
+++ b/shared/src/test/diff/mlscript/Methods.mls
@@ -124,8 +124,8 @@ class Asc[A, B]: { x: A; y: B }
     method Left = { x = this.x; y = this.y } : { x: A }
     method Right2 = this : { y: B }
 //│ Defined class Asc[+A, +B]
-//│ Defined Asc.Left: Asc['A, anything] -> {x: 'A}
-//│ Defined Asc.Right2: Asc[anything, 'B] -> {y: 'B}
+//│ Defined Asc.Left: Asc['A, ?] -> {x: 'A}
+//│ Defined Asc.Right2: Asc[?, 'B] -> {y: 'B}
 
 
 
@@ -161,17 +161,17 @@ class Tru[A, B]: Pair[A, B]
     method Test f = true
     method True = this.Test (fun x -> error)
 //│ Defined class Tru[+A, +B]
-//│ Defined Tru.Test: Tru[anything, anything] -> anything -> true
-//│ Defined Tru.True: Tru[anything, anything] -> true
+//│ Defined Tru.Test: Tru[?, ?] -> anything -> true
+//│ Defined Tru.True: Tru[?, ?] -> true
 
 class True2[A, B]: Pair[A, B]
     method Test: anything -> bool
     method True = this.Test (fun x -> error)
     method Test f = true
 //│ Defined class True2[+A, +B]
-//│ Declared True2.Test: True2[anything, anything] -> anything -> bool
-//│ Defined True2.True: True2[anything, anything] -> bool
-//│ Defined True2.Test: True2[anything, anything] -> anything -> true
+//│ Declared True2.Test: True2[?, ?] -> anything -> bool
+//│ Defined True2.True: True2[?, ?] -> bool
+//│ Defined True2.Test: True2[?, ?] -> anything -> true
 
 p = Pair { x = 42; y = true }
 fx = fun x -> mul x 2
@@ -236,8 +236,8 @@ class Class2C: Class2B[int, bool]
 //│ Defined trait Trait2A[+A]
 //│ Declared Trait2A.MtdB: Trait2A['A] -> 'A
 //│ Defined class Class2B[+A, +B]
-//│ Declared Class2B.MtdA: Class2B['A, anything] -> 'A
-//│ Declared Class2B.MtdB: Class2B[anything, 'B] -> 'B
+//│ Declared Class2B.MtdA: Class2B['A, ?] -> 'A
+//│ Declared Class2B.MtdB: Class2B[?, 'B] -> 'B
 //│ Defined class Class2C
 //│ Defined Class2C.MtdA: Class2C -> 42
 //│ Defined Class2C.MtdB: Class2C -> true
@@ -302,7 +302,7 @@ class Test4A[A]: { x: A }
 //│ ║  l.297: 	    method Mth4A[A]: A
 //│ ╙──       	                 ^
 //│ Defined class Test4A[+A]
-//│ Declared Test4A.Mth4A: Test4A[anything] -> nothing
+//│ Declared Test4A.Mth4A: Test4A[?] -> nothing
 
 
 class Test[A]: { x: A }

--- a/shared/src/test/diff/mlscript/Methods.mls
+++ b/shared/src/test/diff/mlscript/Methods.mls
@@ -84,41 +84,37 @@ class Wrapper[A]: { x: A }
     // method Apply f = Wrapper { x = f this.x }
 //│ Defined class Wrapper[+A]
 //│ Declared Wrapper.Apply: Wrapper['A] -> ('A -> 'B) -> Wrapper['B]
-//│ Defined Wrapper.Apply: Wrapper['A] -> ('A -> ('x & 'A0)) -> (Wrapper['A0] with {x: 'x})
+//│ Defined Wrapper.Apply: Wrapper['A] -> ('A -> 'x) -> Wrapper['x]
 
 class IntWrapper: Wrapper[int]
     method Apply f = Wrapper { x = f this.x }
 //│ Defined class IntWrapper
-//│ Defined IntWrapper.Apply: IntWrapper -> (int -> ('x & 'A)) -> (Wrapper['A] with {x: 'x})
+//│ Defined IntWrapper.Apply: IntWrapper -> (int -> 'x) -> Wrapper['x]
 
 class Psyduck[B]: Wrapper[B]
     method Apply[A]: (B -> A) -> Psyduck[A]
     method Apply f = Psyduck { x = f this.x }
 //│ Defined class Psyduck[+B]
 //│ Declared Psyduck.Apply: Psyduck['B] -> ('B -> 'A) -> Psyduck['A]
-//│ Defined Psyduck.Apply: Psyduck['B] -> ('B -> ('x & 'B0)) -> (Psyduck['B0] with {x: 'x})
+//│ Defined Psyduck.Apply: Psyduck['B] -> ('B -> 'x) -> Psyduck['x]
 
 class WrapperWrapper[A]: Wrapper[Wrapper[A]]
     method Apply2[B]: (A -> B) -> WrapperWrapper[B]
     method Apply2 f = WrapperWrapper { x = this.x.Apply f }
 //│ Defined class WrapperWrapper[+A]
 //│ Declared WrapperWrapper.Apply2: WrapperWrapper['A] -> ('A -> 'B) -> WrapperWrapper['B]
-//│ Defined WrapperWrapper.Apply2: WrapperWrapper['A] -> ('A -> 'B) -> WrapperWrapper['B]
+//│ Defined WrapperWrapper.Apply2: WrapperWrapper['A] -> ('A -> 'B) -> (WrapperWrapper['B] with {Wrapper#A <: Wrapper['B], x: Wrapper['B]})
 
 WrapperWrapper { x = Psyduck { x = 0 } }
-//│ res: WrapperWrapper['A] with {x: Psyduck['A] & {x: 0}}
-//│   where
-//│     'A :> 0
+//│ res: WrapperWrapper[0] with {Wrapper#A <: Wrapper[0], x: Psyduck[0] with {x: 0}}
 //│    = WrapperWrapper { x: Psyduck { x: 0 } }
 
 res.Apply2 (fun x -> mul x 2)
-//│ res: WrapperWrapper['B]
-//│   where
-//│     'B :> int
+//│ res: WrapperWrapper[int]
 //│    = WrapperWrapper { x: Psyduck { x: 0 } }
 
 Wrapper
-//│ res: {x: 'x & 'A} -> (Wrapper['A] with {x: 'x})
+//│ res: {x: 'x} -> Wrapper['x]
 //│    = [Function: res]
 
 
@@ -128,8 +124,8 @@ class Asc[A, B]: { x: A; y: B }
     method Left = { x = this.x; y = this.y } : { x: A }
     method Right2 = this : { y: B }
 //│ Defined class Asc[+A, +B]
-//│ Defined Asc.Left: Asc['A, 'B] -> {x: 'A}
-//│ Defined Asc.Right2: Asc['A, 'B] -> {y: 'B}
+//│ Defined Asc.Left: Asc['A, anything] -> {x: 'A}
+//│ Defined Asc.Right2: Asc[anything, 'B] -> {y: 'B}
 
 
 
@@ -159,32 +155,29 @@ class Pair[A, B]: AbstractPair[A, B]
     method Map fx fy = Pair { x = fx this.x; y = fy this.y }
 //│ Defined class Pair[+A, +B]
 //│ Defined Pair.Test: Pair['A, 'B] -> ('A -> 'B -> bool) -> bool
-//│ Defined Pair.Map: Pair['A, 'B] -> ('A -> ('x & 'A0)) -> ('B -> ('y & 'B0)) -> (Pair['A0, 'B0] with {x: 'x, y: 'y})
+//│ Defined Pair.Map: Pair['A, 'B] -> ('A -> 'x) -> ('B -> 'y) -> Pair['x, 'y]
 
 class Tru[A, B]: Pair[A, B]
     method Test f = true
     method True = this.Test (fun x -> error)
 //│ Defined class Tru[+A, +B]
-//│ Defined Tru.Test: Tru['A, 'B] -> anything -> true
-//│ Defined Tru.True: Tru['A, 'B] -> true
+//│ Defined Tru.Test: Tru[anything, anything] -> anything -> true
+//│ Defined Tru.True: Tru[anything, anything] -> true
 
 class True2[A, B]: Pair[A, B]
     method Test: anything -> bool
     method True = this.Test (fun x -> error)
     method Test f = true
 //│ Defined class True2[+A, +B]
-//│ Declared True2.Test: True2['A, 'B] -> anything -> bool
-//│ Defined True2.True: True2['A, 'B] -> bool
-//│ Defined True2.Test: True2['A, 'B] -> anything -> true
+//│ Declared True2.Test: True2[anything, anything] -> anything -> bool
+//│ Defined True2.True: True2[anything, anything] -> bool
+//│ Defined True2.Test: True2[anything, anything] -> anything -> true
 
 p = Pair { x = 42; y = true }
 fx = fun x -> mul x 2
 fy = fun x -> not x
 ft = fun x -> fun y -> if (y) then gt x 0 else y
-//│ p: Pair['A, 'B] & {x: 42, y: true}
-//│   where
-//│     'B :> true
-//│     'A :> 42
+//│ p: Pair[42, true]
 //│  = Pair { x: 42, y: true }
 //│ fx: int -> int
 //│   = [Function: fx]
@@ -196,10 +189,7 @@ ft = fun x -> fun y -> if (y) then gt x 0 else y
 p.Map fx fy
 p.Test ft
 (p.Map fx fy).Test ft
-//│ res: AbstractPair['C, 'D]
-//│   where
-//│     'D :> bool
-//│     'C :> int
+//│ res: AbstractPair[int, bool]
 //│    = Pair { x: 84, y: false }
 //│ res: bool
 //│    = true
@@ -208,20 +198,14 @@ p.Test ft
 
 t = Tru { x = "foo"; y = false }
 t.(Tru.True)
-//│ t: Tru['A, 'B] & {x: "foo", y: false}
-//│   where
-//│     'B :> false
-//│     'A :> "foo"
+//│ t: Tru["foo", false]
 //│  = Tru { x: 'foo', y: false }
 //│ res: true
 //│    = undefined
 
 t = True2 { x = "bar"; y = false }
 t.(True2.True)
-//│ t: True2['A, 'B] & {x: "bar", y: false}
-//│   where
-//│     'B :> false
-//│     'A :> "bar"
+//│ t: True2["bar", false]
 //│  = True2 { x: 'bar', y: false }
 //│ res: bool
 //│    = undefined
@@ -252,8 +236,8 @@ class Class2C: Class2B[int, bool]
 //│ Defined trait Trait2A[+A]
 //│ Declared Trait2A.MtdB: Trait2A['A] -> 'A
 //│ Defined class Class2B[+A, +B]
-//│ Declared Class2B.MtdA: Class2B['A, 'B] -> 'A
-//│ Declared Class2B.MtdB: Class2B['A, 'B] -> 'B
+//│ Declared Class2B.MtdA: Class2B['A, anything] -> 'A
+//│ Declared Class2B.MtdB: Class2B[anything, 'B] -> 'B
 //│ Defined class Class2C
 //│ Defined Class2C.MtdA: Class2C -> 42
 //│ Defined Class2C.MtdB: Class2C -> true
@@ -264,19 +248,19 @@ class Class3C: Class2C
     method MtdA = 42
     method MtdB = 42
 //│ ╔══[ERROR] Type mismatch in method definition:
-//│ ║  l.265: 	    method MtdB = 42
+//│ ║  l.249: 	    method MtdB = 42
 //│ ║         	           ^^^^^^^^^
 //│ ╟── integer literal of type `42` does not match type `bool`
-//│ ║  l.265: 	    method MtdB = 42
+//│ ║  l.249: 	    method MtdB = 42
 //│ ║         	                  ^^
 //│ ╟── but it flows into method definition with expected type `bool`
-//│ ║  l.265: 	    method MtdB = 42
+//│ ║  l.249: 	    method MtdB = 42
 //│ ║         	           ^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.249: 	class Class2C: Class2B[int, bool]
+//│ ║  l.233: 	class Class2C: Class2B[int, bool]
 //│ ║         	                            ^^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.248: 	    method MtdB: B
+//│ ║  l.232: 	    method MtdB: B
 //│ ╙──       	           ^^^^^^^
 //│ Defined class Class3C
 //│ Defined Class3C.MtdA: Class3C -> 42
@@ -312,13 +296,13 @@ Test3B.F
 class Test4A[A]: { x: A }
     method Mth4A[A]: A
 //│ ╔══[WARNING] Method type parameter A
-//│ ║  l.312: 	class Test4A[A]: { x: A }
+//│ ║  l.296: 	class Test4A[A]: { x: A }
 //│ ║         	             ^
 //│ ╟── shadows class type parameter A
-//│ ║  l.313: 	    method Mth4A[A]: A
+//│ ║  l.297: 	    method Mth4A[A]: A
 //│ ╙──       	                 ^
 //│ Defined class Test4A[+A]
-//│ Declared Test4A.Mth4A: Test4A['A] -> nothing
+//│ Declared Test4A.Mth4A: Test4A[anything] -> nothing
 
 
 class Test[A]: { x: A }
@@ -367,13 +351,13 @@ Ber.F
 :e
 Ber
 //│ ╔══[ERROR] Instantiation of an abstract type is forbidden
-//│ ║  l.368: 	Ber
+//│ ║  l.352: 	Ber
 //│ ║         	^^^
 //│ ╟── Note that class Ber is abstract:
-//│ ║  l.360: 	class Ber: Fee & Fee2
+//│ ║  l.344: 	class Ber: Fee & Fee2
 //│ ║         	      ^^^^^^^^^^^^^^^
 //│ ╟── Hint: method F is abstract
-//│ ║  l.360: 	class Ber: Fee & Fee2
+//│ ║  l.344: 	class Ber: Fee & Fee2
 //│ ╙──       	      ^^^^^^^^^^^^^^^
 //│ res: error
 //│    = [Function: res]

--- a/shared/src/test/diff/mlscript/Methods2.mls
+++ b/shared/src/test/diff/mlscript/Methods2.mls
@@ -15,7 +15,7 @@ class None[A]: Option[A]
 //│ Defined Some.Get: Some['A] -> 'A
 //│ Defined Some.Destruct: (Some['A] & 'this) -> (Some['A] & 'this)
 //│ Defined class None[+A]
-//│ Defined None.Get: None['A] -> nothing
+//│ Defined None.Get: None[anything] -> nothing
 //│ Defined None.Destruct: (None['A] & 'this) -> (None['A] & 'this)
 
 
@@ -24,7 +24,7 @@ class List[A]
     method HeadOption: Option[A]
     method Map[B]: (A -> B) -> List[B]
 //│ Defined class List[+A]
-//│ Declared List.Size: List['A] -> int
+//│ Declared List.Size: List[anything] -> int
 //│ Declared List.HeadOption: List['A] -> Option['A]
 //│ Declared List.Map: List['A] -> ('A -> 'B) -> List['B]
 
@@ -33,26 +33,24 @@ class Nil[A]: List[A]
     method HeadOption = None {}
     method Map[B] f = Nil {}
 //│ Defined class Nil[+A]
-//│ Defined Nil.Size: Nil['A] -> 0
-//│ Defined Nil.HeadOption: Nil['A] -> None['A0]
-//│ Defined Nil.Map: Nil['A] -> anything -> Nil['A0]
+//│ Defined Nil.Size: Nil[anything] -> 0
+//│ Defined Nil.HeadOption: Nil[anything] -> None[nothing]
+//│ Defined Nil.Map: Nil[anything] -> anything -> Nil[nothing]
 
 class Cons[A]: List[A] & { head: A; tail: List[A] }
     method Size = succ this.tail.Size
     method HeadOption = Some { payload = this.head }
     method Map[B] f = Cons { head = f this.head; tail = this.tail.Map f }
 //│ Defined class Cons[+A]
-//│ Defined Cons.Size: Cons['A] -> int
-//│ Defined Cons.HeadOption: Cons['A] -> (Some['A0] with {payload: 'A})
-//│   where
-//│     'A0 :> 'A
-//│ Defined Cons.Map: Cons['A] -> ('A -> ('B & 'head)) -> (Cons['B] with {head: 'head})
+//│ Defined Cons.Size: Cons[anything] -> int
+//│ Defined Cons.HeadOption: Cons['A] -> Some['A]
+//│ Defined Cons.Map: Cons['A] -> ('A -> 'B) -> (Cons['B] with {tail: List['B]})
 
 // Note that the useless `with {tail: List['A]}` refinement is kept
 //  because the approximate subtyping check `list & {List#A = 'A} <: List['A]` currently returns false
 //  as we do not try to expand type aliases right now.
 Cons.Size
-//│ res: Cons['A] -> int
+//│ res: Cons[anything] -> int
 //│    = undefined
 
 List.HeadOption
@@ -60,15 +58,11 @@ List.HeadOption
 //│    = undefined
 
 Cons.HeadOption
-//│ res: Cons['A] -> (Some['A0] with {payload: 'A})
-//│   where
-//│     'A0 :> 'A
+//│ res: Cons['A] -> Some['A]
 //│    = undefined
 
 l = Cons { head = 0; tail = Cons { head = 1; tail = Nil {} } }
-//│ l: Cons['A] with {head: 0, tail: Cons['A] with {head: 1, tail: Nil['A]}}
-//│   where
-//│     'A :> 0 | 1
+//│ l: Cons[0 | 1] with {head: 0, tail: Cons[0 | 1] with {head: 1, tail: Nil[0 | 1]}}
 //│  = Cons { head: 0, tail: Cons { head: 1, tail: Nil {} } }
 
 l.Size
@@ -77,104 +71,84 @@ l.Size
 
 :stats
 l.Map (fun x -> mul x 2)
-//│ res: List['B]
-//│   where
-//│     'B :> int
+//│ res: List[int]
 //│    = Cons { head: 0, tail: Cons { head: 2, tail: Nil {} } }
 //│ constrain calls  : 112
 //│ annoying  calls  : 6
-//│ subtyping calls  : 10
+//│ subtyping calls  : 9
 
 l0 = Cons { head = 0; tail = Nil {} }
-//│ l0: Cons['A] with {head: 0, tail: Nil['A]}
-//│   where
-//│     'A :> 0
+//│ l0: Cons[0] with {head: 0, tail: Nil[0]}
 //│   = Cons { head: 0, tail: Nil {} }
 
 :re
 :stats
 Cons.HeadOption l0
-//│ res: Some['A] & {payload: 0}
-//│   where
-//│     'A :> 0
+//│ res: Some[0]
 //│ Runtime error:
 //│   TypeError: (intermediate value).HeadOption is not a function
 //│ constrain calls  : 75
 //│ annoying  calls  : 27
-//│ subtyping calls  : 100
+//│ subtyping calls  : 101
 
 
 l1 = Cons { head = 0; tail = Nil {} }
-//│ l1: Cons['A] with {head: 0, tail: Nil['A]}
-//│   where
-//│     'A :> 0
+//│ l1: Cons[0] with {head: 0, tail: Nil[0]}
 //│   = Cons { head: 0, tail: Nil {} }
 
 :re
 :stats
 Cons.HeadOption l1
-//│ res: Some['A] & {payload: 0}
-//│   where
-//│     'A :> 0
+//│ res: Some[0]
 //│ Runtime error:
 //│   TypeError: (intermediate value).HeadOption is not a function
 //│ constrain calls  : 75
 //│ annoying  calls  : 27
-//│ subtyping calls  : 100
+//│ subtyping calls  : 101
 
 :re
 :stats
 Cons.HeadOption l
-//│ res: Some['A] & {payload: 0 | 1}
-//│   where
-//│     'A :> 0 | 1
+//│ res: Some[0 | 1]
 //│ Runtime error:
 //│   TypeError: (intermediate value).HeadOption is not a function
 //│ constrain calls  : 141
 //│ annoying  calls  : 27
-//│ subtyping calls  : 191
+//│ subtyping calls  : 190
 
 :stats
 o = l.(Cons.HeadOption)
-//│ o: Some['A] & {payload: 0 | 1}
-//│   where
-//│     'A :> 0 | 1
+//│ o: Some[0 | 1]
 //│  = undefined
 //│ constrain calls  : 139
 //│ annoying  calls  : 27
-//│ subtyping calls  : 191
+//│ subtyping calls  : 190
 
 o = l.(Cons.HeadOption)
-//│ o: Some['A] & {payload: 0 | 1}
-//│   where
-//│     'A :> 0 | 1
+//│ o: Some[0 | 1]
 //│  = undefined
 
 o = l.HeadOption
-//│ o: Option['A]
-//│   where
-//│     'A :> 0 | 1
+//│ o: Option[0 | 1]
 //│  = Some { payload: 0 }
 
 :e
 case o of {None -> 0 | Some -> o.payload}
 //│ ╔══[ERROR] Type mismatch in `case` expression:
-//│ ║  l.160: 	case o of {None -> 0 | Some -> o.payload}
+//│ ║  l.136: 	case o of {None -> 0 | Some -> o.payload}
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── type `Option[?A]` does not match type `None[?] & ?a | Some[?] & ?b`
 //│ ║  l.24: 	    method HeadOption: Option[A]
 //│ ║        	                       ^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `None[?] & ?a | Some[?] & ?c`
-//│ ║  l.160: 	case o of {None -> 0 | Some -> o.payload}
+//│ ║  l.136: 	case o of {None -> 0 | Some -> o.payload}
 //│ ╙──       	     ^
 //│ res: 0
 //│    = 0
 
 v = o.Destruct
 case v of {None -> 0 | Some -> v.payload}
-//│ v: None['A] | Some['A]
-//│   where
-//│     'A :> 0 | 1
+//│ v: None[0 | 1] | Some[0 | 1]
 //│  = Some { payload: 0 }
 //│ res: 0 | 1
 //│    = 0
@@ -184,18 +158,16 @@ def newHeadOption x = case x of {
     | Cons -> Some {payload = x.head}
     | _ -> None{}
     }
-//│ newHeadOption: ((Cons[?]\tail with {head: 'payload & 'A}) | ~Cons[?]) -> (None['A0] | (Some['A] with {payload: 'payload}))
+//│ newHeadOption: ((Cons[nothing]\tail with {head: 'payload}) | ~Cons[anything]) -> (None[nothing] | Some['payload])
 //│              = [Function: newHeadOption]
 
 // Note that `o` is not a list, so this takes the default case:
 newHeadOption o
-//│ res: None['A] | (Some['A0] with {payload: nothing})
+//│ res: None[nothing] | Some[nothing]
 //│    = None {}
 
 newHeadOption l
-//│ res: None['A] | Some['A0] & {payload: 0}
-//│   where
-//│     'A0 :> 0
+//│ res: None[nothing] | Some[0]
 //│    = Some { payload: 0 }
 
 case res of {None -> 0 | Some -> res.payload}
@@ -208,15 +180,15 @@ case res of {None -> 0 | Some -> res.payload}
 case o of {
     Some -> o.Get | None -> 0 }
 //│ ╔══[ERROR] Type mismatch in `case` expression:
-//│ ║  l.208: 	case o of {
+//│ ║  l.180: 	case o of {
 //│ ║         	^^^^^^^^^^^
-//│ ║  l.209: 	    Some -> o.Get | None -> 0 }
+//│ ║  l.181: 	    Some -> o.Get | None -> 0 }
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── type `Option[?A]` does not match type `None[?] & ?a | Some[?] & ?b`
 //│ ║  l.24: 	    method HeadOption: Option[A]
 //│ ║        	                       ^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `None[?] & ?a | Some[?] & ?c`
-//│ ║  l.208: 	case o of {
+//│ ║  l.180: 	case o of {
 //│ ╙──       	     ^
 //│ res: 0 | 1
 //│    = 0

--- a/shared/src/test/diff/mlscript/Methods2.mls
+++ b/shared/src/test/diff/mlscript/Methods2.mls
@@ -15,7 +15,7 @@ class None[A]: Option[A]
 //│ Defined Some.Get: Some['A] -> 'A
 //│ Defined Some.Destruct: (Some['A] & 'this) -> (Some['A] & 'this)
 //│ Defined class None[+A]
-//│ Defined None.Get: None[anything] -> nothing
+//│ Defined None.Get: None[?] -> nothing
 //│ Defined None.Destruct: (None['A] & 'this) -> (None['A] & 'this)
 
 
@@ -24,7 +24,7 @@ class List[A]
     method HeadOption: Option[A]
     method Map[B]: (A -> B) -> List[B]
 //│ Defined class List[+A]
-//│ Declared List.Size: List[anything] -> int
+//│ Declared List.Size: List[?] -> int
 //│ Declared List.HeadOption: List['A] -> Option['A]
 //│ Declared List.Map: List['A] -> ('A -> 'B) -> List['B]
 
@@ -33,16 +33,16 @@ class Nil[A]: List[A]
     method HeadOption = None {}
     method Map[B] f = Nil {}
 //│ Defined class Nil[+A]
-//│ Defined Nil.Size: Nil[anything] -> 0
-//│ Defined Nil.HeadOption: Nil[anything] -> None[nothing]
-//│ Defined Nil.Map: Nil[anything] -> anything -> Nil[nothing]
+//│ Defined Nil.Size: Nil[?] -> 0
+//│ Defined Nil.HeadOption: Nil[?] -> None[nothing]
+//│ Defined Nil.Map: Nil[?] -> anything -> Nil[nothing]
 
 class Cons[A]: List[A] & { head: A; tail: List[A] }
     method Size = succ this.tail.Size
     method HeadOption = Some { payload = this.head }
     method Map[B] f = Cons { head = f this.head; tail = this.tail.Map f }
 //│ Defined class Cons[+A]
-//│ Defined Cons.Size: Cons[anything] -> int
+//│ Defined Cons.Size: Cons[?] -> int
 //│ Defined Cons.HeadOption: Cons['A] -> Some['A]
 //│ Defined Cons.Map: Cons['A] -> ('A -> 'B) -> Cons['B]
 
@@ -50,7 +50,7 @@ class Cons[A]: List[A] & { head: A; tail: List[A] }
 //  because the approximate subtyping check `list & {List#A = 'A} <: List['A]` currently returns false
 //  as we do not try to expand type aliases right now.
 Cons.Size
-//│ res: Cons[anything] -> int
+//│ res: Cons[?] -> int
 //│    = undefined
 
 List.HeadOption
@@ -137,10 +137,10 @@ case o of {None -> 0 | Some -> o.payload}
 //│ ╔══[ERROR] Type mismatch in `case` expression:
 //│ ║  l.136: 	case o of {None -> 0 | Some -> o.payload}
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── type `Option[?A]` does not match type `None[anything] & ?a | Some[anything] & ?b`
+//│ ╟── type `Option[?A]` does not match type `None[?] & ?a | Some[?] & ?b`
 //│ ║  l.24: 	    method HeadOption: Option[A]
 //│ ║        	                       ^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `None[anything] & ?a | Some[anything] & ?c`
+//│ ╟── but it flows into reference with expected type `None[?] & ?a | Some[?] & ?c`
 //│ ║  l.136: 	case o of {None -> 0 | Some -> o.payload}
 //│ ╙──       	     ^
 //│ res: 0
@@ -158,7 +158,7 @@ def newHeadOption x = case x of {
     | Cons -> Some {payload = x.head}
     | _ -> None{}
     }
-//│ newHeadOption: ((Cons[anything]\tail with {head: 'payload}) | ~Cons[anything]) -> (None[nothing] | Some['payload])
+//│ newHeadOption: ((Cons[?]\tail with {head: 'payload}) | ~Cons[?]) -> (None[nothing] | Some['payload])
 //│              = [Function: newHeadOption]
 
 // Note that `o` is not a list, so this takes the default case:
@@ -184,10 +184,10 @@ case o of {
 //│ ║         	^^^^^^^^^^^
 //│ ║  l.181: 	    Some -> o.Get | None -> 0 }
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── type `Option[?A]` does not match type `None[anything] & ?a | Some[anything] & ?b`
+//│ ╟── type `Option[?A]` does not match type `None[?] & ?a | Some[?] & ?b`
 //│ ║  l.24: 	    method HeadOption: Option[A]
 //│ ║        	                       ^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `None[anything] & ?a | Some[anything] & ?c`
+//│ ╟── but it flows into reference with expected type `None[?] & ?a | Some[?] & ?c`
 //│ ║  l.180: 	case o of {
 //│ ╙──       	     ^
 //│ res: 0 | 1

--- a/shared/src/test/diff/mlscript/Methods2.mls
+++ b/shared/src/test/diff/mlscript/Methods2.mls
@@ -44,7 +44,7 @@ class Cons[A]: List[A] & { head: A; tail: List[A] }
 //│ Defined class Cons[+A]
 //│ Defined Cons.Size: Cons[anything] -> int
 //│ Defined Cons.HeadOption: Cons['A] -> Some['A]
-//│ Defined Cons.Map: Cons['A] -> ('A -> 'B) -> (Cons['B] with {tail: List['B]})
+//│ Defined Cons.Map: Cons['A] -> ('A -> 'B) -> Cons['B]
 
 // Note that the useless `with {tail: List['A]}` refinement is kept
 //  because the approximate subtyping check `list & {List#A = 'A} <: List['A]` currently returns false
@@ -62,7 +62,7 @@ Cons.HeadOption
 //│    = undefined
 
 l = Cons { head = 0; tail = Cons { head = 1; tail = Nil {} } }
-//│ l: Cons[0 | 1] with {head: 0, tail: Cons[0 | 1] with {head: 1, tail: Nil[0 | 1]}}
+//│ l: Cons[0 | 1] with {head: 0, tail: Cons[1] with {tail: Nil[nothing]}}
 //│  = Cons { head: 0, tail: Cons { head: 1, tail: Nil {} } }
 
 l.Size
@@ -73,12 +73,12 @@ l.Size
 l.Map (fun x -> mul x 2)
 //│ res: List[int]
 //│    = Cons { head: 0, tail: Cons { head: 2, tail: Nil {} } }
-//│ constrain calls  : 112
+//│ constrain calls  : 76
 //│ annoying  calls  : 6
-//│ subtyping calls  : 9
+//│ subtyping calls  : 10
 
 l0 = Cons { head = 0; tail = Nil {} }
-//│ l0: Cons[0] with {head: 0, tail: Nil[0]}
+//│ l0: Cons[0] with {tail: Nil[nothing]}
 //│   = Cons { head: 0, tail: Nil {} }
 
 :re
@@ -87,13 +87,13 @@ Cons.HeadOption l0
 //│ res: Some[0]
 //│ Runtime error:
 //│   TypeError: (intermediate value).HeadOption is not a function
-//│ constrain calls  : 75
+//│ constrain calls  : 39
 //│ annoying  calls  : 27
-//│ subtyping calls  : 101
+//│ subtyping calls  : 63
 
 
 l1 = Cons { head = 0; tail = Nil {} }
-//│ l1: Cons[0] with {head: 0, tail: Nil[0]}
+//│ l1: Cons[0] with {tail: Nil[nothing]}
 //│   = Cons { head: 0, tail: Nil {} }
 
 :re
@@ -102,9 +102,9 @@ Cons.HeadOption l1
 //│ res: Some[0]
 //│ Runtime error:
 //│   TypeError: (intermediate value).HeadOption is not a function
-//│ constrain calls  : 75
+//│ constrain calls  : 39
 //│ annoying  calls  : 27
-//│ subtyping calls  : 101
+//│ subtyping calls  : 63
 
 :re
 :stats
@@ -112,17 +112,17 @@ Cons.HeadOption l
 //│ res: Some[0 | 1]
 //│ Runtime error:
 //│   TypeError: (intermediate value).HeadOption is not a function
-//│ constrain calls  : 141
+//│ constrain calls  : 48
 //│ annoying  calls  : 27
-//│ subtyping calls  : 190
+//│ subtyping calls  : 88
 
 :stats
 o = l.(Cons.HeadOption)
 //│ o: Some[0 | 1]
 //│  = undefined
-//│ constrain calls  : 139
+//│ constrain calls  : 46
 //│ annoying  calls  : 27
-//│ subtyping calls  : 190
+//│ subtyping calls  : 88
 
 o = l.(Cons.HeadOption)
 //│ o: Some[0 | 1]
@@ -137,10 +137,10 @@ case o of {None -> 0 | Some -> o.payload}
 //│ ╔══[ERROR] Type mismatch in `case` expression:
 //│ ║  l.136: 	case o of {None -> 0 | Some -> o.payload}
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── type `Option[?A]` does not match type `None[?] & ?a | Some[?] & ?b`
+//│ ╟── type `Option[?A]` does not match type `None[anything] & ?a | Some[anything] & ?b`
 //│ ║  l.24: 	    method HeadOption: Option[A]
 //│ ║        	                       ^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `None[?] & ?a | Some[?] & ?c`
+//│ ╟── but it flows into reference with expected type `None[anything] & ?a | Some[anything] & ?c`
 //│ ║  l.136: 	case o of {None -> 0 | Some -> o.payload}
 //│ ╙──       	     ^
 //│ res: 0
@@ -158,7 +158,7 @@ def newHeadOption x = case x of {
     | Cons -> Some {payload = x.head}
     | _ -> None{}
     }
-//│ newHeadOption: ((Cons[nothing]\tail with {head: 'payload}) | ~Cons[anything]) -> (None[nothing] | Some['payload])
+//│ newHeadOption: ((Cons[anything]\tail with {head: 'payload}) | ~Cons[anything]) -> (None[nothing] | Some['payload])
 //│              = [Function: newHeadOption]
 
 // Note that `o` is not a list, so this takes the default case:
@@ -184,10 +184,10 @@ case o of {
 //│ ║         	^^^^^^^^^^^
 //│ ║  l.181: 	    Some -> o.Get | None -> 0 }
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── type `Option[?A]` does not match type `None[?] & ?a | Some[?] & ?b`
+//│ ╟── type `Option[?A]` does not match type `None[anything] & ?a | Some[anything] & ?b`
 //│ ║  l.24: 	    method HeadOption: Option[A]
 //│ ║        	                       ^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `None[?] & ?a | Some[?] & ?c`
+//│ ╟── but it flows into reference with expected type `None[anything] & ?a | Some[anything] & ?c`
 //│ ║  l.180: 	case o of {
 //│ ╙──       	     ^
 //│ res: 0 | 1

--- a/shared/src/test/diff/mlscript/Neg.mls
+++ b/shared/src/test/diff/mlscript/Neg.mls
@@ -121,11 +121,11 @@ class Foo[A]
 //│ ╙──       	          ^
 
 def f: ~Foo[1 | 2] | ~Foo[2 | 3]
-//│ f: ~Foo[in 1 | 2 | 3 out 2]
+//│ f: ~Foo[anything]
 //│  = <missing implementation>
 
 def f: (~Foo[1 | 2] & 'a | ~Foo[2 | 3] & 'a) -> 'a
-//│ f: ('a & ~Foo[in 1 | 2 | 3 out 2]) -> 'a
+//│ f: ('a & ~Foo[anything]) -> 'a
 //│  = <missing implementation>
 
 def f: (~{x: 1 | 2} & 'a | ~{x: 2 | 3} & 'a) -> 'a

--- a/shared/src/test/diff/mlscript/Neg.mls
+++ b/shared/src/test/diff/mlscript/Neg.mls
@@ -121,11 +121,11 @@ class Foo[A]
 //│ ╙──       	          ^
 
 def f: ~Foo[1 | 2] | ~Foo[2 | 3]
-//│ f: ~Foo[anything]
+//│ f: ~Foo[?]
 //│  = <missing implementation>
 
 def f: (~Foo[1 | 2] & 'a | ~Foo[2 | 3] & 'a) -> 'a
-//│ f: ('a & ~Foo[anything]) -> 'a
+//│ f: ('a & ~Foo[?]) -> 'a
 //│  = <missing implementation>
 
 def f: (~{x: 1 | 2} & 'a | ~{x: 2 | 3} & 'a) -> 'a

--- a/shared/src/test/diff/mlscript/NestedClassArgs.mls
+++ b/shared/src/test/diff/mlscript/NestedClassArgs.mls
@@ -13,41 +13,31 @@ class C[A]
 //│ ╙──     	        ^
 
 def c: C[C[int]]
-//│ c: C[C[int]]
+//│ c: C[anything]
 
 def c: 'a -> C[C['a]]
-//│ c: 'a -> C[C['a]]
+//│ c: anything -> C[anything]
 
 def c: C[C['a]] -> 'a
-//│ c: C[C['a]] -> 'a
+//│ c: C[anything] -> nothing
 
 def c: C['a] as 'a
-//│ c: 'a
-//│   where
-//│     'a := C['a]
+//│ c: C[anything]
 
 def c: C['a] | 'a as 'a
-//│ c: 'a
-//│   where
-//│     'a :> C['a]
+//│ c: C[anything]
 
 def c: C[C['a]] as 'a
-//│ c: 'a
-//│   where
-//│     'a := C[C['a]]
+//│ c: C[anything]
 
 def c: C[C['a] & 'a] as 'a
-//│ c: 'a
-//│   where
-//│     'a := C[C['a] & 'a]
+//│ c: C[anything]
 
 def c: C[C['a] & 'a | 'a] as 'a
-//│ c: 'a
-//│   where
-//│     'a := C['a]
+//│ c: C[anything]
 
 def c: C['a]
-//│ c: C['a]
+//│ c: C[anything]
 
 
 class C2[A]: { a: A }
@@ -58,24 +48,22 @@ def mkC: 'a -> C2['a]
 //│ mkC: 'a -> C2['a]
 
 mkC' a = C2 { a }
-//│ mkC': ('a & 'A) -> (C2['A] with {a: 'a})
+//│ mkC': 'a -> C2['a]
 
 mkC = mkC'
-//│ ('a & 'A) -> (C2['A] with {a: 'a})
+//│ 'a -> C2['a]
 //│   <:  mkC:
 //│ 'a -> C2['a]
 
 rec def rc = mkC(rc)
-//│ rc: 'rc
-//│   where
-//│     'rc :> C2['a]
-//│     'a :> 'rc
-
-rec def rc = mkC'(rc)
 //│ rc: 'a
 //│   where
-//│     'a :> C2['A] with {a: 'a}
-//│     'A :> 'a
+//│     'a :> C2['a]
+
+rec def rc = mkC'(rc)
+//│ rc: 'A
+//│   where
+//│     'A :> C2['A]
 
 
 
@@ -83,115 +71,107 @@ rec def rc = mkC'(rc)
 class C3[A]: { a: C3[A] }
 //│ Defined class C3[±A]
 //│ ╔══[WARNING] Type definition C3 has bivariant type parameters:
-//│ ║  l.83: 	class C3[A]: { a: C3[A] }
+//│ ║  l.71: 	class C3[A]: { a: C3[A] }
 //│ ║        	      ^^
 //│ ╟── A is irrelevant and may be removed
-//│ ║  l.83: 	class C3[A]: { a: C3[A] }
+//│ ║  l.71: 	class C3[A]: { a: C3[A] }
 //│ ╙──      	         ^
 
 def c: 'a -> C3['a]
-//│ c: 'a -> C3['a]
+//│ c: anything -> C3[anything]
 
 rec def c a = C3 { a = c a }
 //│ anything -> 'a
 //│   where
-//│     'a :> C3['A] with {a: 'a}
+//│     'a :> C3[anything] with {a: 'a}
 //│   <:  c:
-//│ 'a -> C3['a]
+//│ anything -> C3[anything]
 
 rec def c (a: 'X) = C3 { a = c a: 'X }: C3['X]
-//│ anything -> C3['X]
+//│ anything -> C3[anything]
 //│   <:  c:
-//│ 'a -> C3['a]
+//│ anything -> C3[anything]
 
 
 :w
 class C4[A]: { a: C[C4[A]] }
 //│ Defined class C4[±A]
 //│ ╔══[WARNING] Type definition C4 has bivariant type parameters:
-//│ ║  l.109: 	class C4[A]: { a: C[C4[A]] }
-//│ ║         	      ^^
+//│ ║  l.97: 	class C4[A]: { a: C[C4[A]] }
+//│ ║        	      ^^
 //│ ╟── A is irrelevant and may be removed
-//│ ║  l.109: 	class C4[A]: { a: C[C4[A]] }
-//│ ╙──       	         ^
+//│ ║  l.97: 	class C4[A]: { a: C[C4[A]] }
+//│ ╙──      	         ^
 
 def c: 'a -> C4['a]
-//│ c: 'a -> C4['a]
+//│ c: anything -> C4[anything]
 
 C{}
-//│ res: C['A]
+//│ res: C[anything]
 
 def c4 a = C4{ a = C{} }
-//│ c4: anything -> C4['A]
+//│ c4: anything -> C4[anything]
 
 def c = c4
-//│ anything -> C4['A]
+//│ anything -> C4[anything]
 //│   <:  c:
-//│ 'a -> C4['a]
+//│ anything -> C4[anything]
 
 
 :w
 class C5[A]: { a: C2[C5[A]] }
 //│ Defined class C5[±A]
 //│ ╔══[WARNING] Type definition C5 has bivariant type parameters:
-//│ ║  l.134: 	class C5[A]: { a: C2[C5[A]] }
+//│ ║  l.122: 	class C5[A]: { a: C2[C5[A]] }
 //│ ║         	      ^^
 //│ ╟── A is irrelevant and may be removed
-//│ ║  l.134: 	class C5[A]: { a: C2[C5[A]] }
+//│ ║  l.122: 	class C5[A]: { a: C2[C5[A]] }
 //│ ╙──       	         ^
 
 def c: 'a -> C5['a]
-//│ c: 'a -> C5['a]
+//│ c: anything -> C5[anything]
 
 rec def c5 a = C5{ a = C2 { a = c5 a } }
 //│ c5: anything -> 'a
 //│   where
-//│     'a :> C5['A] with {a: C2['A0] with {a: 'a}}
-//│     'A0 :> 'a | C5['A]
-//│         <: C5['A]
+//│     'a :> C5[anything] with {a: C2['a | C5[anything]] with {a: 'a}}
 
 c = c5
 //│ anything -> 'a
 //│   where
-//│     'a :> C5['A] with {a: C2['A0] with {a: 'a}}
-//│     'A0 :> 'a | C5['A]
-//│         <: C5['A]
+//│     'a :> C5[anything] with {a: C2['a | C5[anything]] with {a: 'a}}
 //│   <:  c:
-//│ 'a -> C5['a]
+//│ anything -> C5[anything]
 
 
 :w
 class C6[A]: { a: C5[C6[A]] }
 //│ Defined class C6[±A]
 //│ ╔══[WARNING] Type definition C6 has bivariant type parameters:
-//│ ║  l.164: 	class C6[A]: { a: C5[C6[A]] }
+//│ ║  l.148: 	class C6[A]: { a: C5[C6[A]] }
 //│ ║         	      ^^
 //│ ╟── A is irrelevant and may be removed
-//│ ║  l.164: 	class C6[A]: { a: C5[C6[A]] }
+//│ ║  l.148: 	class C6[A]: { a: C5[C6[A]] }
 //│ ╙──       	         ^
 
 def c: 'a -> C6['a]
-//│ c: 'a -> C6['a]
+//│ c: anything -> C6[anything]
 
 // :s
 // :d
 // rec def c a = C6{ a = c5 (c a) }
 
 rec def c6 a = C6{ a = c5 (c6 a) }
-//│ c6: anything -> (C6['A] with {a: 'a})
+//│ c6: anything -> (C6[anything] with {a: 'a})
 //│   where
-//│     'a :> C5[C6['A]] with {a: C2['A0] with {a: 'a}}
-//│     'A0 :> 'a | C5[C6['A]]
-//│         <: C5[C6['A]]
+//│     'a :> C5[anything] with {a: C2['a | C5[anything]] with {a: 'a}}
 
 c = c6
-//│ anything -> (C6['A] with {a: 'a})
+//│ anything -> (C6[anything] with {a: 'a})
 //│   where
-//│     'a :> C5[C6['A]] with {a: C2['A0] with {a: 'a}}
-//│     'A0 :> 'a | C5[C6['A]]
-//│         <: C5[C6['A]]
+//│     'a :> C5[anything] with {a: C2['a | C5[anything]] with {a: 'a}}
 //│   <:  c:
-//│ 'a -> C6['a]
+//│ anything -> C6[anything]
 
 
 
@@ -207,7 +187,7 @@ class L[T]: { h: T; t: O[L[T]] }
 //│ Defined type alias O[+T]
 //│ Defined class L[=T]
 //│ Declared L.Append: L['T] -> 'T -> L['T]
-//│ Defined L.Append: (L['T] & 'this) -> ('T & 'h) -> (L['T] with {h: 'h, t: S[L['T]] & {v: L['T] & 'this}})
+//│ Defined L.Append: (L['T] & 'this) -> ('T & 'h) -> (L['T] with {h: 'h, t: S[L['T]] with {v: L['T] & 'this}})
 
 // :ds
 // L.Append
@@ -232,7 +212,5 @@ def appendNil elem = L { h = elem; t = N{} }
 
 
 S{v=1}
-//│ res: S['T] & {v: 1}
-//│   where
-//│     'T :> 1
+//│ res: S[1]
 

--- a/shared/src/test/diff/mlscript/NestedClassArgs_Co.mls
+++ b/shared/src/test/diff/mlscript/NestedClassArgs_Co.mls
@@ -7,7 +7,7 @@ class C[A]
   method Co = error
 //│ Defined class C[+A]
 //│ Declared C.Co: C['A] -> 'A
-//│ Defined C.Co: C[anything] -> nothing
+//│ Defined C.Co: C[?] -> nothing
 
 def c: C[C[int]]
 //│ c: C[C[int]]
@@ -79,7 +79,7 @@ class C3[A]: { a: C3[A] }
   method Co = error
 //│ Defined class C3[+A]
 //│ Declared C3.Co: C3['A] -> 'A
-//│ Defined C3.Co: C3[anything] -> nothing
+//│ Defined C3.Co: C3[?] -> nothing
 
 def c: 'a -> C3['a]
 //│ c: 'a -> C3['a]
@@ -102,7 +102,7 @@ class C4[A]: { a: C[C4[A]] }
   method Co = error
 //│ Defined class C4[+A]
 //│ Declared C4.Co: C4['A] -> 'A
-//│ Defined C4.Co: C4[anything] -> nothing
+//│ Defined C4.Co: C4[?] -> nothing
 
 def c: 'a -> C4['a]
 //│ c: 'a -> C4['a]
@@ -124,7 +124,7 @@ class C5[A]: { a: C2[C5[A]] }
   method Co = error
 //│ Defined class C5[+A]
 //│ Declared C5.Co: C5['A] -> 'A
-//│ Defined C5.Co: C5[anything] -> nothing
+//│ Defined C5.Co: C5[?] -> nothing
 
 def c: 'a -> C5['a]
 //│ c: 'a -> C5['a]
@@ -147,7 +147,7 @@ class C6[A]: { a: C5[C6[A]] }
   method Co = error
 //│ Defined class C6[+A]
 //│ Declared C6.Co: C6['A] -> 'A
-//│ Defined C6.Co: C6[anything] -> nothing
+//│ Defined C6.Co: C6[?] -> nothing
 
 def c: 'a -> C6['a]
 //│ c: 'a -> C6['a]

--- a/shared/src/test/diff/mlscript/NestedClassArgs_Co.mls
+++ b/shared/src/test/diff/mlscript/NestedClassArgs_Co.mls
@@ -3,11 +3,11 @@
 
 
 class C[A]
-  method In: A -> A
-  method In = id
-//│ Defined class C[=A]
-//│ Declared C.In: C['A] -> 'A -> 'A
-//│ Defined C.In: C['A] -> 'a -> 'a
+  method Co: A
+  method Co = error
+//│ Defined class C[+A]
+//│ Declared C.Co: C['A] -> 'A
+//│ Defined C.Co: C[anything] -> nothing
 
 def c: C[C[int]]
 //│ c: C[C[int]]
@@ -21,7 +21,7 @@ def c: C[C['a]] -> 'a
 def c: C['a] as 'a
 //│ c: 'a
 //│   where
-//│     'a := C['a]
+//│     'a :> C['a]
 
 def c: C['a] | 'a as 'a
 //│ c: 'a
@@ -31,61 +31,55 @@ def c: C['a] | 'a as 'a
 def c: C[C['a]] as 'a
 //│ c: 'a
 //│   where
-//│     'a := C[C['a]]
+//│     'a :> C[C['a]]
 
 def c: C[C['a] & 'a] as 'a
 //│ c: 'a
 //│   where
-//│     'a := C[C['a] & 'a]
+//│     'a :> C[C['a] & 'a]
 
 def c: C[C['a] & 'a | 'a] as 'a
 //│ c: 'a
 //│   where
-//│     'a := C['a]
+//│     'a :> C['a]
 
 def c: C['a]
-//│ c: C['a]
+//│ c: C[nothing]
 
 
 class C2[A]: { a: A }
-  method In: A -> A
-  method In = id
-//│ Defined class C2[=A]
-//│ Declared C2.In: C2['A] -> 'A -> 'A
-//│ Defined C2.In: C2['A] -> 'a -> 'a
+//│ Defined class C2[+A]
 
 
 def mkC: 'a -> C2['a]
 //│ mkC: 'a -> C2['a]
 
 mkC' a = C2 { a }
-//│ mkC': ('a & 'A) -> (C2['A] with {a: 'a})
+//│ mkC': 'a -> C2['a]
 
 mkC = mkC'
-//│ ('a & 'A) -> (C2['A] with {a: 'a})
+//│ 'a -> C2['a]
 //│   <:  mkC:
 //│ 'a -> C2['a]
 
 rec def rc = mkC(rc)
-//│ rc: 'rc
-//│   where
-//│     'rc :> C2['a]
-//│     'a :> 'rc
-
-rec def rc = mkC'(rc)
 //│ rc: 'a
 //│   where
-//│     'a :> C2['A] with {a: 'a}
-//│     'A :> 'a
+//│     'a :> C2['a]
+
+rec def rc = mkC'(rc)
+//│ rc: 'A
+//│   where
+//│     'A :> C2['A]
 
 
 
 class C3[A]: { a: C3[A] }
-  method In: A -> A
-  method In = id
-//│ Defined class C3[=A]
-//│ Declared C3.In: C3['A] -> 'A -> 'A
-//│ Defined C3.In: C3['A] -> 'a -> 'a
+  method Co: A
+  method Co = error
+//│ Defined class C3[+A]
+//│ Declared C3.Co: C3['A] -> 'A
+//│ Defined C3.Co: C3[anything] -> nothing
 
 def c: 'a -> C3['a]
 //│ c: 'a -> C3['a]
@@ -93,71 +87,67 @@ def c: 'a -> C3['a]
 rec def c a = C3 { a = c a }
 //│ anything -> 'a
 //│   where
-//│     'a :> C3['A] with {a: 'a}
+//│     'a :> C3[nothing] with {a: 'a}
 //│   <:  c:
 //│ 'a -> C3['a]
 
 rec def c (a: 'X) = C3 { a = c a: 'X }: C3['X]
-//│ anything -> C3['X]
+//│ anything -> C3[nothing]
 //│   <:  c:
 //│ 'a -> C3['a]
 
 
 class C4[A]: { a: C[C4[A]] }
-  method In: A -> A
-  method In = id
-//│ Defined class C4[=A]
-//│ Declared C4.In: C4['A] -> 'A -> 'A
-//│ Defined C4.In: C4['A] -> 'a -> 'a
+  method Co: A
+  method Co = error
+//│ Defined class C4[+A]
+//│ Declared C4.Co: C4['A] -> 'A
+//│ Defined C4.Co: C4[anything] -> nothing
 
 def c: 'a -> C4['a]
 //│ c: 'a -> C4['a]
 
 C{}
-//│ res: C['A]
+//│ res: C[nothing]
 
 def c4 a = C4{ a = C{} }
-//│ c4: anything -> C4['A]
+//│ c4: anything -> (C4[nothing] with {a: C[nothing]})
 
 def c = c4
-//│ anything -> C4['A]
+//│ anything -> (C4[nothing] with {a: C[nothing]})
 //│   <:  c:
 //│ 'a -> C4['a]
 
 
 class C5[A]: { a: C2[C5[A]] }
-  method In: A -> A
-  method In = id
-//│ Defined class C5[=A]
-//│ Declared C5.In: C5['A] -> 'A -> 'A
-//│ Defined C5.In: C5['A] -> 'a -> 'a
+  method Co: A
+  method Co = error
+//│ Defined class C5[+A]
+//│ Declared C5.Co: C5['A] -> 'A
+//│ Defined C5.Co: C5[anything] -> nothing
 
 def c: 'a -> C5['a]
 //│ c: 'a -> C5['a]
 
 rec def c5 a = C5{ a = C2 { a = c5 a } }
-//│ c5: anything -> 'a
+//│ c5: anything -> 'A
 //│   where
-//│     'a :> C5['A] with {a: C2['A0] with {a: 'a}}
-//│     'A0 :> 'a | C5['A]
-//│         <: C5['A]
+//│     'A :> C5[nothing] with {a: C2['A]}
 
 c = c5
-//│ anything -> 'a
+//│ anything -> 'A
 //│   where
-//│     'a :> C5['A] with {a: C2['A0] with {a: 'a}}
-//│     'A0 :> 'a | C5['A]
-//│         <: C5['A]
+//│     'A :> C5[nothing] with {a: C2['A]}
 //│   <:  c:
 //│ 'a -> C5['a]
 
 
 class C6[A]: { a: C5[C6[A]] }
-  method In: A -> A
-  method In = id
-//│ Defined class C6[=A]
-//│ Declared C6.In: C6['A] -> 'A -> 'A
-//│ Defined C6.In: C6['A] -> 'a -> 'a
+  method Co: A
+  method Co = error
+//│ Defined class C6[+A]
+//│ Declared C6.Co: C6['A] -> 'A
+//│ Defined C6.Co: C6[anything] -> nothing
 
 def c: 'a -> C6['a]
 //│ c: 'a -> C6['a]
@@ -167,18 +157,14 @@ def c: 'a -> C6['a]
 // rec def c a = C6{ a = c5 (c a) }
 
 rec def c6 a = C6{ a = c5 (c6 a) }
-//│ c6: anything -> (C6['A] with {a: 'a})
+//│ c6: anything -> (C6[nothing] with {a: 'A})
 //│   where
-//│     'a :> C5[C6['A]] with {a: C2['A0] with {a: 'a}}
-//│     'A0 :> 'a | C5[C6['A]]
-//│         <: C5[C6['A]]
+//│     'A :> C5[nothing] with {a: C2['A]}
 
 c = c6
-//│ anything -> (C6['A] with {a: 'a})
+//│ anything -> (C6[nothing] with {a: 'A})
 //│   where
-//│     'a :> C5[C6['A]] with {a: C2['A0] with {a: 'a}}
-//│     'A0 :> 'a | C5[C6['A]]
-//│         <: C5[C6['A]]
+//│     'A :> C5[nothing] with {a: C2['A]}
 //│   <:  c:
 //│ 'a -> C6['a]
 
@@ -187,17 +173,13 @@ c = c6
 
 class N: {}
 class S[T]: { v: T }
-  method In: T -> ()
-  method In _ = ()
 type O[T] = S[T] | N
 class L[T]: { h: T; t: O[L[T]] }
   method Append: T -> L[T]
   method Append elem = L { h = elem; t = S { v = this } }
 //│ Defined class N
-//│ Defined class S[=T]
-//│ Declared S.In: S['T] -> 'T -> ()
-//│ Defined S.In: S['T] -> anything -> ()
-//│ Defined type alias O[=T]
+//│ Defined class S[+T]
+//│ Defined type alias O[+T]
 //│ Defined class L[=T]
 //│ Declared L.Append: L['T] -> 'T -> L['T]
 //│ Defined L.Append: (L['T] & 'this) -> ('T & 'h) -> (L['T] with {h: 'h, t: S[L['T]] & {v: L['T] & 'this}})
@@ -213,10 +195,10 @@ L.Append
 
 
 def append ls elem = L { h = elem; t = S { v = ls } }
-//│ append: (L['T] & 'v) -> ('T & 'h) -> (L['T] with {h: 'h, t: S[L['T]] with {v: 'v}})
+//│ append: (L['T] & 'v) -> ('T & 'h) -> (L['T] with {h: 'h, t: S['v]})
 
 def append0 ls = L { h = 0; t = S { v = ls } }
-//│ append0: (L['T] & 'v) -> (L['T] with {h: 0, t: S[L['T]] with {v: 'v}})
+//│ append0: (L['T] & 'v) -> (L['T] with {h: 0, t: S['v]})
 //│   where
 //│     'T :> 0
 
@@ -225,7 +207,5 @@ def appendNil elem = L { h = elem; t = N{} }
 
 
 S{v=1}
-//│ res: S['T] & {v: 1}
-//│   where
-//│     'T :> 1
+//│ res: S[1]
 

--- a/shared/src/test/diff/mlscript/Paper.mls
+++ b/shared/src/test/diff/mlscript/Paper.mls
@@ -11,15 +11,15 @@ def flatMap f opt = case opt of {
   | Some -> f opt.value
   | None -> None{}
   }
-//│ flatMap: ('value -> 'a) -> (None | (Some[anything] with {value: 'value})) -> (None | 'a)
+//│ flatMap: ('value -> 'a) -> (None | (Some[?] with {value: 'value})) -> (None | 'a)
 //│        = [Function: flatMap]
 
 def flatMap2 f opt = case opt of { Some -> f opt.value | _ -> opt }
-//│ flatMap2: ('value -> 'a) -> ((Some[anything] with {value: 'value}) | 'a & ~some) -> 'a
+//│ flatMap2: ('value -> 'a) -> ((Some[?] with {value: 'value}) | 'a & ~some) -> 'a
 //│         = [Function: flatMap2]
 
 def flatMap3 f opt = case opt of { Some -> f opt | _ -> opt }
-//│ flatMap3: ('a -> 'b) -> (Some[anything] & 'a | 'b & ~some) -> 'b
+//│ flatMap3: ('a -> 'b) -> (Some[?] & 'a | 'b & ~some) -> 'b
 //│         = [Function: flatMap3]
 
 
@@ -39,7 +39,7 @@ rec def map2 f ls = case ls of {
 //│ map2: ('value -> 'value0) -> 'a -> 'tail
 //│   where
 //│     'tail :> (Cons['value0] with {tail: 'tail}) | None
-//│     'a <: (Cons[anything] with {tail: 'a, value: 'value}) | None
+//│     'a <: (Cons[?] with {tail: 'a, value: 'value}) | None
 //│     = [Function: map2]
 
 

--- a/shared/src/test/diff/mlscript/Paper.mls
+++ b/shared/src/test/diff/mlscript/Paper.mls
@@ -11,15 +11,15 @@ def flatMap f opt = case opt of {
   | Some -> f opt.value
   | None -> None{}
   }
-//│ flatMap: ('value -> 'a) -> (None | (Some[?] with {value: 'value})) -> (None | 'a)
+//│ flatMap: ('value -> 'a) -> (None | (Some[nothing] with {value: 'value})) -> (None | 'a)
 //│        = [Function: flatMap]
 
 def flatMap2 f opt = case opt of { Some -> f opt.value | _ -> opt }
-//│ flatMap2: ('value -> 'a) -> ((Some[?] with {value: 'value}) | 'a & ~some) -> 'a
+//│ flatMap2: ('value -> 'a) -> ((Some[nothing] with {value: 'value}) | 'a & ~some) -> 'a
 //│         = [Function: flatMap2]
 
 def flatMap3 f opt = case opt of { Some -> f opt | _ -> opt }
-//│ flatMap3: ('a -> 'b) -> (Some[?] & 'a | 'b & ~some) -> 'b
+//│ flatMap3: ('a -> 'b) -> (Some[nothing] & 'a | 'b & ~some) -> 'b
 //│         = [Function: flatMap3]
 
 
@@ -36,10 +36,10 @@ rec def map2 f ls = case ls of {
   | Cons -> Cons{value = f ls.value; tail = map2 f ls.tail}
   | None -> None{}
   }
-//│ map2: ('value -> ('value0 & 'A)) -> 'a -> 'tail
+//│ map2: ('value -> 'value0) -> 'a -> 'tail
 //│   where
-//│     'tail :> (Cons['A] with {tail: 'tail, value: 'value0}) | None
-//│     'a <: (Cons[?] with {tail: 'a, value: 'value}) | None
+//│     'tail :> (Cons['value0] with {tail: 'tail}) | None
+//│     'a <: (Cons[nothing] with {tail: 'a, value: 'value}) | None
 //│     = [Function: map2]
 
 
@@ -117,9 +117,7 @@ def tryDiv: int -> int -> Option[int]
 //│       = <missing implementation>
 
 def tryDiv x y = case y of { 0 -> None{} | _ -> Some { value = safeDiv x y } }
-//│ int -> (0 | int & ~0) -> (None | Some['A] & {value: int})
-//│   where
-//│     'A :> int
+//│ int -> (0 | int & ~0) -> (None | Some[int])
 //│   <:  tryDiv:
 //│ int -> int -> Option[int]
 //│       = [Function: tryDiv]

--- a/shared/src/test/diff/mlscript/Paper.mls
+++ b/shared/src/test/diff/mlscript/Paper.mls
@@ -11,15 +11,15 @@ def flatMap f opt = case opt of {
   | Some -> f opt.value
   | None -> None{}
   }
-//│ flatMap: ('value -> 'a) -> (None | (Some[nothing] with {value: 'value})) -> (None | 'a)
+//│ flatMap: ('value -> 'a) -> (None | (Some[anything] with {value: 'value})) -> (None | 'a)
 //│        = [Function: flatMap]
 
 def flatMap2 f opt = case opt of { Some -> f opt.value | _ -> opt }
-//│ flatMap2: ('value -> 'a) -> ((Some[nothing] with {value: 'value}) | 'a & ~some) -> 'a
+//│ flatMap2: ('value -> 'a) -> ((Some[anything] with {value: 'value}) | 'a & ~some) -> 'a
 //│         = [Function: flatMap2]
 
 def flatMap3 f opt = case opt of { Some -> f opt | _ -> opt }
-//│ flatMap3: ('a -> 'b) -> (Some[nothing] & 'a | 'b & ~some) -> 'b
+//│ flatMap3: ('a -> 'b) -> (Some[anything] & 'a | 'b & ~some) -> 'b
 //│         = [Function: flatMap3]
 
 
@@ -39,7 +39,7 @@ rec def map2 f ls = case ls of {
 //│ map2: ('value -> 'value0) -> 'a -> 'tail
 //│   where
 //│     'tail :> (Cons['value0] with {tail: 'tail}) | None
-//│     'a <: (Cons[nothing] with {tail: 'a, value: 'value}) | None
+//│     'a <: (Cons[anything] with {tail: 'a, value: 'value}) | None
 //│     = [Function: map2]
 
 

--- a/shared/src/test/diff/mlscript/Random1.mls
+++ b/shared/src/test/diff/mlscript/Random1.mls
@@ -13,21 +13,21 @@ class G[A]: { a: G[A] }
 def g: G['a] & {a: 'a} as 'a
 //│ g: 'a
 //│   where
-//│     'a :> G[anything] with {a: 'a}
+//│     'a :> G[?] with {a: 'a}
 //│  = <missing implementation>
 
 :NoJS
 
 rec def g2 a = G { a }
-//│ g2: (G[anything] & 'a) -> (G[anything] with {a: 'a})
+//│ g2: (G[?] & 'a) -> (G[?] with {a: 'a})
 
 :e
 g = g2
-//│ (G[anything] & 'a) -> (G[anything] with {a: 'a})
+//│ (G[?] & 'a) -> (G[?] with {a: 'a})
 //│   <:  g:
 //│ 'a
 //│   where
-//│     'a :> G[anything] with {a: 'a}
+//│     'a :> G[?] with {a: 'a}
 //│ ╔══[ERROR] Type mismatch in def definition:
 //│ ║  l.25: 	g = g2
 //│ ║        	^^^^^^
@@ -44,25 +44,25 @@ g = g2
 rec def g2 = G { a = g2 }
 //│ g2: 'a
 //│   where
-//│     'a :> G[anything] with {a: 'a}
+//│     'a :> G[?] with {a: 'a}
 
 g = g2
 //│ 'a
 //│   where
-//│     'a :> G[anything] with {a: 'a}
+//│     'a :> G[?] with {a: 'a}
 //│   <:  g:
 //│ 'a
 //│   where
-//│     'a :> G[anything] with {a: 'a}
+//│     'a :> G[?] with {a: 'a}
 
 g = g
 //│ 'a
 //│   where
-//│     'a :> G[anything] with {a: 'a}
+//│     'a :> G[?] with {a: 'a}
 //│   <:  g:
 //│ 'a
 //│   where
-//│     'a :> G[anything] with {a: 'a}
+//│     'a :> G[?] with {a: 'a}
 
 
 def manual: 'a -> nothing as 'a

--- a/shared/src/test/diff/mlscript/Random1.mls
+++ b/shared/src/test/diff/mlscript/Random1.mls
@@ -31,10 +31,10 @@ g = g2
 //│ ╔══[ERROR] Type mismatch in def definition:
 //│ ║  l.25: 	g = g2
 //│ ║        	^^^^^^
-//│ ╟── function of type `?b -> ?c` does not match type `(G[anything] with {a: ?a}) | 'a`
+//│ ╟── function of type `?b -> ?c` does not match type `(G[?] with {a: ?a}) | 'a`
 //│ ║  l.21: 	rec def g2 a = G { a }
 //│ ║        	           ^^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `(G[anything] with {a: ?a0}) | 'a`
+//│ ╟── but it flows into reference with expected type `(G[?] with {a: ?a0}) | 'a`
 //│ ║  l.25: 	g = g2
 //│ ║        	    ^^
 //│ ╟── Note: constraint arises from local type binding:

--- a/shared/src/test/diff/mlscript/Random1.mls
+++ b/shared/src/test/diff/mlscript/Random1.mls
@@ -13,28 +13,28 @@ class G[A]: { a: G[A] }
 def g: G['a] & {a: 'a} as 'a
 //│ g: 'a
 //│   where
-//│     'a := G['a] & {a: 'a}
+//│     'a :> G[anything] with {a: 'a}
 //│  = <missing implementation>
 
 :NoJS
 
 rec def g2 a = G { a }
-//│ g2: (G['A] & 'a) -> (G['A] with {a: 'a})
+//│ g2: (G[anything] & 'a) -> (G[anything] with {a: 'a})
 
 :e
 g = g2
-//│ (G['A] & 'a) -> (G['A] with {a: 'a})
+//│ (G[anything] & 'a) -> (G[anything] with {a: 'a})
 //│   <:  g:
 //│ 'a
 //│   where
-//│     'a := G['a] & {a: 'a}
+//│     'a :> G[anything] with {a: 'a}
 //│ ╔══[ERROR] Type mismatch in def definition:
 //│ ║  l.25: 	g = g2
 //│ ║        	^^^^^^
-//│ ╟── function of type `?b -> ?c` does not match type `(G[?a] with {a: ?a}) | 'a`
+//│ ╟── function of type `?b -> ?c` does not match type `(G[anything] with {a: ?a}) | 'a`
 //│ ║  l.21: 	rec def g2 a = G { a }
 //│ ║        	           ^^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `(G[?a0] with {a: ?a0}) | 'a`
+//│ ╟── but it flows into reference with expected type `(G[anything] with {a: ?a0}) | 'a`
 //│ ║  l.25: 	g = g2
 //│ ║        	    ^^
 //│ ╟── Note: constraint arises from local type binding:
@@ -44,25 +44,25 @@ g = g2
 rec def g2 = G { a = g2 }
 //│ g2: 'a
 //│   where
-//│     'a :> G['A] with {a: 'a}
+//│     'a :> G[anything] with {a: 'a}
 
 g = g2
 //│ 'a
 //│   where
-//│     'a :> G['A] with {a: 'a}
+//│     'a :> G[anything] with {a: 'a}
 //│   <:  g:
 //│ 'a
 //│   where
-//│     'a := G['a] & {a: 'a}
+//│     'a :> G[anything] with {a: 'a}
 
 g = g
 //│ 'a
 //│   where
-//│     'a := G['a] & {a: 'a}
+//│     'a :> G[anything] with {a: 'a}
 //│   <:  g:
 //│ 'a
 //│   where
-//│     'a := G['a] & {a: 'a}
+//│     'a :> G[anything] with {a: 'a}
 
 
 def manual: 'a -> nothing as 'a

--- a/shared/src/test/diff/mlscript/Random2.mls
+++ b/shared/src/test/diff/mlscript/Random2.mls
@@ -90,7 +90,7 @@ def Some v = Some{v}
 def foo(x: Some['a]) =
   let _ = x.v : Some[?]
   in x: Some['a & some]
-//│ foo: Some['a & (Some[nothing] | Some[nothing] & ~some)] -> Some[Some[anything] & 'a]
+//│ foo: Some[Some[nothing] & 'a] -> Some[Some[anything] & 'a]
 
 def f: Some['a]
 //│ f: Some[nothing]

--- a/shared/src/test/diff/mlscript/Random2.mls
+++ b/shared/src/test/diff/mlscript/Random2.mls
@@ -84,19 +84,16 @@ class Some[A]: { v: A }
 //│ Defined class Some[+A]
 
 def Some v = Some{v}
-//│ Some: ('v & 'A) -> (Some['A] with {v: 'v})
+//│ Some: 'v -> Some['v]
 
 
 def foo(x: Some['a]) =
   let _ = x.v : Some[?]
   in x: Some['a & some]
-//│ foo: Some['a] -> Some[Some[?] & 'a0]
-//│   where
-//│     'a := Some[?] & 'a0
-//│     'a0 <: {Some#A :> anything <: nothing, v: nothing} | ~Some[?]
+//│ foo: Some['a & (Some[nothing] | Some[nothing] & ~some)] -> Some[Some[anything] & 'a]
 
 def f: Some['a]
-//│ f: Some['a]
+//│ f: Some[nothing]
 
 
 
@@ -110,6 +107,6 @@ def foo(x: 'a, y: 'a) = (x + 1, y)
 def foo(f: 'a -> 'a, x: 'a) =
   let _ = x + 1
   in error: Some['a & some]
-//│ foo: ('a -> 'a, int,) -> Some[Some[?] & 'a0]
+//│ foo: ('a -> 'a, int,) -> Some[nothing]
 
 

--- a/shared/src/test/diff/mlscript/Random2.mls
+++ b/shared/src/test/diff/mlscript/Random2.mls
@@ -90,7 +90,7 @@ def Some v = Some{v}
 def foo(x: Some['a]) =
   let _ = x.v : Some[?]
   in x: Some['a & some]
-//│ foo: Some[Some[nothing] & 'a] -> Some[Some[anything] & 'a]
+//│ foo: Some[Some[nothing] & 'a] -> Some[Some[?] & 'a]
 
 def f: Some['a]
 //│ f: Some[nothing]

--- a/shared/src/test/diff/mlscript/RecursiveTypes.mls
+++ b/shared/src/test/diff/mlscript/RecursiveTypes.mls
@@ -216,8 +216,7 @@ rec def foo (c: C['a]) = foo (c.a)
 foo
 //│ res: 'a -> nothing
 //│   where
-//│     'a <: C['a0]
-//│     'a0 <: 'a
+//│     'a <: C['a]
 //│    = [Function: foo]
 
 type Rec = C[Rec]
@@ -229,8 +228,7 @@ def foo_ty: Rec -> nothing
 foo_ty = foo
 //│ 'a -> nothing
 //│   where
-//│     'a <: C['a0]
-//│     'a0 <: 'a
+//│     'a <: C['a]
 //│   <:  foo_ty:
 //│ Rec -> nothing
 //│       = [Function: foo]
@@ -238,7 +236,7 @@ foo_ty = foo
 def foo_ty2: (C['r] as 'r) -> nothing
 //│ foo_ty2: 'r -> nothing
 //│   where
-//│     'r := C['r]
+//│     'r <: C['r]
 //│        = <missing implementation>
 
 :ns
@@ -252,7 +250,7 @@ foo_ty2
 foo_ty = foo_ty2
 //│ 'r -> nothing
 //│   where
-//│     'r := C['r]
+//│     'r <: C['r]
 //│   <:  foo_ty:
 //│ Rec -> nothing
 //│       = <no result>
@@ -263,28 +261,26 @@ foo_ty2 = foo_ty
 //│   <:  foo_ty2:
 //│ 'r -> nothing
 //│   where
-//│     'r := C['r]
+//│     'r <: C['r]
 //│        = <no result>
 //│          foo_ty and foo_ty2 are not implemented
 
 foo_ty2 = foo
 //│ 'a -> nothing
 //│   where
-//│     'a <: C['a0]
-//│     'a0 <: 'a
+//│     'a <: C['a]
 //│   <:  foo_ty2:
 //│ 'r -> nothing
 //│   where
-//│     'r := C['r]
+//│     'r <: C['r]
 //│        = [Function: foo]
 
 
 
 rec def bar = C { a = bar }
-//│ bar: 'a
+//│ bar: 'A
 //│   where
-//│     'a :> C['A] with {a: 'a}
-//│     'A :> 'a
+//│     'A :> C['A]
 //│ Runtime error:
 //│   ReferenceError: bar is not defined
 
@@ -295,10 +291,9 @@ def bar_ty: Rec2
 //│       = <missing implementation>
 
 bar_ty = bar
-//│ 'a
+//│ 'A
 //│   where
-//│     'a :> C['A] with {a: 'a}
-//│     'A :> 'a
+//│     'A :> C['A]
 //│   <:  bar_ty:
 //│ Rec2
 //│ Runtime error:
@@ -307,7 +302,7 @@ bar_ty = bar
 def bar_ty2: C['r] as 'r
 //│ bar_ty2: 'r
 //│   where
-//│     'r := C['r]
+//│     'r :> C['r]
 //│        = <missing implementation>
 
 :ns
@@ -321,14 +316,14 @@ bar_ty2
 bar_ty2
 //│ res: 'r
 //│   where
-//│     'r := C['r]
+//│     'r :> C['r]
 //│    = <no result>
 //│      bar_ty2 is not implemented
 
 bar_ty = bar_ty2
 //│ 'r
 //│   where
-//│     'r := C['r]
+//│     'r :> C['r]
 //│   <:  bar_ty:
 //│ Rec2
 //│       = <no result>
@@ -339,19 +334,18 @@ bar_ty2 = bar_ty
 //│   <:  bar_ty2:
 //│ 'r
 //│   where
-//│     'r := C['r]
+//│     'r :> C['r]
 //│        = <no result>
 //│          bar_ty and bar_ty2 are not implemented
 
 bar_ty2 = bar
-//│ 'a
+//│ 'A
 //│   where
-//│     'a :> C['A] with {a: 'a}
-//│     'A :> 'a
+//│     'A :> C['A]
 //│   <:  bar_ty2:
 //│ 'r
 //│   where
-//│     'r := C['r]
+//│     'r :> C['r]
 //│ Runtime error:
 //│   ReferenceError: bar is not defined
 
@@ -392,22 +386,22 @@ bar2_ty2 = bar2_ty
 bar2_ty2 = bar_ty2
 //│ 'r
 //│   where
-//│     'r := C['r]
+//│     'r :> C['r]
 //│   <:  bar2_ty2:
 //│ 'r
 //│   where
 //│     'r :> {x: 'r}
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.392: 	bar2_ty2 = bar_ty2
+//│ ║  l.386: 	bar2_ty2 = bar_ty2
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── type `C[?r]` does not match type `{x: ?r0} | 'r`
-//│ ║  l.307: 	def bar_ty2: C['r] as 'r
+//│ ║  l.302: 	def bar_ty2: C['r] as 'r
 //│ ║         	             ^^^^^
 //│ ╟── but it flows into reference with expected type `{x: ?r1} | 'r`
-//│ ║  l.392: 	bar2_ty2 = bar_ty2
+//│ ║  l.386: 	bar2_ty2 = bar_ty2
 //│ ║         	           ^^^^^^^
 //│ ╟── Note: constraint arises from local type binding:
-//│ ║  l.367: 	def bar2_ty2: { x: 'r } as 'r
+//│ ║  l.361: 	def bar2_ty2: { x: 'r } as 'r
 //│ ╙──       	              ^^^^^^^^^
 //│ Runtime error:
 //│   ReferenceError: bar_ty21 is not defined
@@ -420,42 +414,42 @@ bar_ty2 = bar2_ty2
 //│   <:  bar_ty2:
 //│ 'r
 //│   where
-//│     'r := C['r]
+//│     'r :> C['r]
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.416: 	bar_ty2 = bar2_ty2
+//│ ║  l.410: 	bar_ty2 = bar2_ty2
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── type `{x: ?r}` does not match type `C[?r0] | 'r`
-//│ ║  l.367: 	def bar2_ty2: { x: 'r } as 'r
+//│ ║  l.361: 	def bar2_ty2: { x: 'r } as 'r
 //│ ║         	              ^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `C[?r1] | 'r`
-//│ ║  l.416: 	bar_ty2 = bar2_ty2
+//│ ║  l.410: 	bar_ty2 = bar2_ty2
 //│ ║         	          ^^^^^^^^
 //│ ╟── Note: constraint arises from local type binding:
-//│ ║  l.307: 	def bar_ty2: C['r] as 'r
+//│ ║  l.302: 	def bar_ty2: C['r] as 'r
 //│ ╙──       	             ^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.416: 	bar_ty2 = bar2_ty2
+//│ ║  l.410: 	bar_ty2 = bar2_ty2
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── type `{x: ?r}` does not match type `C[?r0] | 'r`
-//│ ║  l.367: 	def bar2_ty2: { x: 'r } as 'r
+//│ ║  l.361: 	def bar2_ty2: { x: 'r } as 'r
 //│ ║         	              ^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `C[?r1] | 'r`
-//│ ║  l.416: 	bar_ty2 = bar2_ty2
+//│ ║  l.410: 	bar_ty2 = bar2_ty2
 //│ ║         	          ^^^^^^^^
 //│ ╟── Note: constraint arises from local type binding:
-//│ ║  l.307: 	def bar_ty2: C['r] as 'r
+//│ ║  l.302: 	def bar_ty2: C['r] as 'r
 //│ ╙──       	             ^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.416: 	bar_ty2 = bar2_ty2
+//│ ║  l.410: 	bar_ty2 = bar2_ty2
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── type `{x: ?r}` does not match type `C[?r0] | 'r`
-//│ ║  l.367: 	def bar2_ty2: { x: 'r } as 'r
+//│ ║  l.361: 	def bar2_ty2: { x: 'r } as 'r
 //│ ║         	              ^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `C[?r1] | 'r`
-//│ ║  l.416: 	bar_ty2 = bar2_ty2
+//│ ║  l.410: 	bar_ty2 = bar2_ty2
 //│ ║         	          ^^^^^^^^
 //│ ╟── Note: constraint arises from local type binding:
-//│ ║  l.307: 	def bar_ty2: C['r] as 'r
+//│ ║  l.302: 	def bar_ty2: C['r] as 'r
 //│ ╙──       	             ^^^^^
 //│ Runtime error:
 //│   ReferenceError: bar2_ty21 is not defined
@@ -517,13 +511,13 @@ f
 :e
 f 1
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.518: 	f 1
+//│ ║  l.512: 	f 1
 //│ ║         	^^^
 //│ ╟── operator application of type `int` does not have field 'a'
-//│ ║  l.484: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.478: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ║         	                                             ^^^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.484: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.478: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ╙──       	                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error | int | 'a\a & {a: int}
 //│   where
@@ -534,13 +528,13 @@ f 1
 :e
 f { a = 1 }
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.535: 	f { a = 1 }
+//│ ║  l.529: 	f { a = 1 }
 //│ ║         	^^^^^^^^^^^
 //│ ╟── operator application of type `int` does not have field 'a'
-//│ ║  l.484: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.478: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ║         	                                             ^^^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.484: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.478: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ╙──       	                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error
 //│    = { a: 1 }
@@ -562,13 +556,13 @@ f ainf
 //│ Runtime error:
 //│   ReferenceError: ainf is not defined
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.558: 	f ainf
+//│ ║  l.552: 	f ainf
 //│ ║         	^^^^^^
 //│ ╟── operator application of type `int` does not have field 'a'
-//│ ║  l.484: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.478: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ║         	                                             ^^^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.484: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.478: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ╙──       	                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error
 //│ Runtime error:
@@ -583,13 +577,13 @@ f infina
 //│ Runtime error:
 //│   ReferenceError: infina is not defined
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.579: 	f infina
+//│ ║  l.573: 	f infina
 //│ ║         	^^^^^^^^
 //│ ╟── operator application of type `int` does not have field 'a'
-//│ ║  l.484: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.478: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ║         	                                             ^^^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.484: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.478: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ╙──       	                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error | 'infina | int | 'a\a & {a: int}
 //│   where
@@ -609,16 +603,16 @@ def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as
 :e
 f_manual 1
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.610: 	f_manual 1
+//│ ║  l.604: 	f_manual 1
 //│ ║         	^^^^^^^^^^
 //│ ╟── integer literal of type `1` does not have field 'a'
-//│ ║  l.610: 	f_manual 1
+//│ ║  l.604: 	f_manual 1
 //│ ║         	         ^
 //│ ╟── Note: constraint arises from record type:
-//│ ║  l.602: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
+//│ ║  l.596: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
 //│ ║         	                ^^^^^^^^^^^^^^^^^
 //│ ╟── from intersection type:
-//│ ║  l.602: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
+//│ ║  l.596: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
 //│ ╙──       	              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: 'e | error
 //│   where
@@ -629,16 +623,16 @@ f_manual 1
 :e
 f_manual { a = 1 }
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.630: 	f_manual { a = 1 }
+//│ ║  l.624: 	f_manual { a = 1 }
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── integer literal of type `1` does not have field 'a'
-//│ ║  l.630: 	f_manual { a = 1 }
+//│ ║  l.624: 	f_manual { a = 1 }
 //│ ║         	               ^
 //│ ╟── Note: constraint arises from record type:
-//│ ║  l.602: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
+//│ ║  l.596: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
 //│ ║         	                ^^^^^^^^^^^^^^^^^
 //│ ╟── from intersection type:
-//│ ║  l.602: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
+//│ ║  l.596: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
 //│ ╙──       	                    ^^^^^^^^^^^^
 //│ res: 'e | 1 | error
 //│   where
@@ -677,16 +671,16 @@ def f_manual_ns: 'a | ('b & (({a: 'd & 'c} as 'c) | ~{a: 'e | int} | ~{})\a & ((
 :e
 f_manual_ns ainf
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.678: 	f_manual_ns ainf
+//│ ║  l.672: 	f_manual_ns ainf
 //│ ║         	^^^^^^^^^^^^^^^^
 //│ ╟── type `int` does not have field 'a'
-//│ ║  l.668: 	def f_manual_ns: 'a | ('b & (({a: 'd & 'c} as 'c) | ~{a: 'e | int} | ~{})\a & (({a: 'd & 'c} as 'c) | ~{a: 'e | int})\a & (({a: 'f} as 'c) as 'f) & (int | ~{a: 'e | int} | ~{})\a & (int | ~{a: 'e | int})\a & int & int) -> ('g | 'd | ('b | 'h\a & {a: 'e | int} as 'h))
+//│ ║  l.662: 	def f_manual_ns: 'a | ('b & (({a: 'd & 'c} as 'c) | ~{a: 'e | int} | ~{})\a & (({a: 'd & 'c} as 'c) | ~{a: 'e | int})\a & (({a: 'f} as 'c) as 'f) & (int | ~{a: 'e | int} | ~{})\a & (int | ~{a: 'e | int})\a & int & int) -> ('g | 'd | ('b | 'h\a & {a: 'e | int} as 'h))
 //│ ║         	                                                              ^^^
 //│ ╟── Note: constraint arises from record type:
-//│ ║  l.668: 	def f_manual_ns: 'a | ('b & (({a: 'd & 'c} as 'c) | ~{a: 'e | int} | ~{})\a & (({a: 'd & 'c} as 'c) | ~{a: 'e | int})\a & (({a: 'f} as 'c) as 'f) & (int | ~{a: 'e | int} | ~{})\a & (int | ~{a: 'e | int})\a & int & int) -> ('g | 'd | ('b | 'h\a & {a: 'e | int} as 'h))
+//│ ║  l.662: 	def f_manual_ns: 'a | ('b & (({a: 'd & 'c} as 'c) | ~{a: 'e | int} | ~{})\a & (({a: 'd & 'c} as 'c) | ~{a: 'e | int})\a & (({a: 'f} as 'c) as 'f) & (int | ~{a: 'e | int} | ~{})\a & (int | ~{a: 'e | int})\a & int & int) -> ('g | 'd | ('b | 'h\a & {a: 'e | int} as 'h))
 //│ ║         	                              ^^^^^^^^^^^^
 //│ ╟── from intersection type:
-//│ ║  l.668: 	def f_manual_ns: 'a | ('b & (({a: 'd & 'c} as 'c) | ~{a: 'e | int} | ~{})\a & (({a: 'd & 'c} as 'c) | ~{a: 'e | int})\a & (({a: 'f} as 'c) as 'f) & (int | ~{a: 'e | int} | ~{})\a & (int | ~{a: 'e | int})\a & int & int) -> ('g | 'd | ('b | 'h\a & {a: 'e | int} as 'h))
+//│ ║  l.662: 	def f_manual_ns: 'a | ('b & (({a: 'd & 'c} as 'c) | ~{a: 'e | int} | ~{})\a & (({a: 'd & 'c} as 'c) | ~{a: 'e | int})\a & (({a: 'f} as 'c) as 'f) & (int | ~{a: 'e | int} | ~{})\a & (int | ~{a: 'e | int})\a & int & int) -> ('g | 'd | ('b | 'h\a & {a: 'e | int} as 'h))
 //│ ╙──       	                                  ^^^^^^^
 //│ res: error
 //│    = <no result>
@@ -739,13 +733,13 @@ r + 1
 :e
 r.a
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.740: 	r.a
+//│ ║  l.734: 	r.a
 //│ ║         	^^^
 //│ ╟── integer literal of type `1` does not have field 'a'
-//│ ║  l.727: 	r = f 1
+//│ ║  l.721: 	r = f 1
 //│ ║         	      ^
 //│ ╟── but it flows into reference with expected type `{a: ?a}`
-//│ ║  l.740: 	r.a
+//│ ║  l.734: 	r.a
 //│ ╙──       	^
 //│ res: error | int
 //│ Runtime error:

--- a/shared/src/test/diff/mlscript/Seqs.mls
+++ b/shared/src/test/diff/mlscript/Seqs.mls
@@ -76,7 +76,7 @@ def Cons head tail =
 
 // * Works thanks to variance analysis
 Nil: ListBase[anything]
-//│ res: ListBase[anything]
+//│ res: ListBase[?]
 //│    = Nil { size: 0 }
 
 def c = Cons 1 Nil
@@ -84,7 +84,7 @@ def c = Cons 1 Nil
 //│  = Cons { size: 1, head: 1, tail: Nil { size: 0 } }
 
 c: ListBase[int]
-//│ res: ListBase[anything]
+//│ res: ListBase[?]
 //│    = Cons { size: 1, head: 1, tail: Nil { size: 0 } }
 
 c.head

--- a/shared/src/test/diff/mlscript/Seqs.mls
+++ b/shared/src/test/diff/mlscript/Seqs.mls
@@ -90,13 +90,11 @@ Nil: ListBase[anything]
 //│    = Nil { size: 0 }
 
 def c = Cons 1 Nil
-//│ c: Cons['A] with {head: 1, tail: Nil & {size: 0}}
-//│   where
-//│     'A :> 1
+//│ c: Cons[1] with {tail: Nil & {size: 0}}
 //│  = Cons { size: 1, head: 1, tail: Nil { size: 0 } }
 
 c: ListBase[int]
-//│ res: ListBase[int]
+//│ res: ListBase[anything]
 //│    = Cons { size: 1, head: 1, tail: Nil { size: 0 } }
 
 c.head
@@ -112,9 +110,7 @@ c.size
 //│    = 1
 
 def d = Cons 2 c
-//│ d: Cons['A] with {head: 2, tail: Cons['A] with {head: 1, tail: Nil & {size: 0}}}
-//│   where
-//│     'A :> 1 | 2
+//│ d: Cons[1 | 2] with {head: 2, tail: Cons[1 | 2] with {head: 1, tail: Nil & {size: 0}}}
 //│  = Cons {
 //│      size: 2,
 //│      head: 2,
@@ -130,9 +126,7 @@ d.size
 //│    = 2
 
 d.tail
-//│ res: Cons['A] with {head: 1, tail: Nil & {size: 0}}
-//│   where
-//│     'A :> 1 | 2
+//│ res: Cons[1 | 2] with {head: 1, tail: Nil & {size: 0}}
 //│    = Cons { size: 1, head: 1, tail: Nil { size: 0 } }
 
 d.tail.size

--- a/shared/src/test/diff/mlscript/Seqs.mls
+++ b/shared/src/test/diff/mlscript/Seqs.mls
@@ -52,7 +52,7 @@ Cons 1 Nil
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.45: 	Cons 1 Nil
 //│ ║        	^^^^^^^^^^
-//│ ╟── application of type `Cons[?A] & {head: ?head, size: ?size, tail: ?tail}` is not a function
+//│ ╟── application of type `Cons[?A] with {Cons#A = ?A, head: ?head, size: ?size, tail: ?tail}` is not a function
 //│ ║  l.45: 	Cons 1 Nil
 //│ ╙──      	^^^^^^
 //│ res: error
@@ -74,18 +74,8 @@ def Cons head tail =
 //│ Cons: ('head & 'A) -> (List['A] & {size: int} & 'tail) -> (Cons['A] with {head: 'head, tail: 'tail})
 //│     = [Function: Cons1]
 
-// We do not yet perform variance analysis
-:e
+// * Works thanks to variance analysis
 Nil: ListBase[anything]
-//│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.79: 	Nil: ListBase[anything]
-//│ ║        	^^^
-//│ ╟── type `anything` does not match type `nothing`
-//│ ║  l.79: 	Nil: ListBase[anything]
-//│ ║        	              ^^^^^^^^
-//│ ╟── Note: constraint arises from type reference:
-//│ ║  l.21: 	class Nil: ListBase[nothing] & {}
-//│ ╙──      	                    ^^^^^^^
 //│ res: ListBase[anything]
 //│    = Nil { size: 0 }
 
@@ -110,7 +100,7 @@ c.size
 //│    = 1
 
 def d = Cons 2 c
-//│ d: Cons[1 | 2] with {head: 2, tail: Cons[1 | 2] with {head: 1, tail: Nil & {size: 0}}}
+//│ d: Cons[1 | 2] with {head: 2, tail: Cons[1] with {tail: Nil & {size: 0}}}
 //│  = Cons {
 //│      size: 2,
 //│      head: 2,
@@ -126,7 +116,7 @@ d.size
 //│    = 2
 
 d.tail
-//│ res: Cons[1 | 2] with {head: 1, tail: Nil & {size: 0}}
+//│ res: Cons[1] with {tail: Nil & {size: 0}}
 //│    = Cons { size: 1, head: 1, tail: Nil { size: 0 } }
 
 d.tail.size

--- a/shared/src/test/diff/mlscript/Simple.mls
+++ b/shared/src/test/diff/mlscript/Simple.mls
@@ -23,9 +23,7 @@ class Bar: {}
 //│ Defined class Bar
 
 def foo = Foo { field = id 1 }
-//│ foo: Foo['A] & {field: 1}
-//│   where
-//│     'A :> 1
+//│ foo: Foo[1]
 //│    = Foo { field: 1 }
 
 (if true then foo else { field = 2 }).field
@@ -33,13 +31,11 @@ def foo = Foo { field = id 1 }
 //│    = 1
 
 Foo { field = id 1 }
-//│ res: Foo['A] & {field: 1}
-//│   where
-//│     'A :> 1
+//│ res: Foo[1]
 //│    = Foo { field: 1 }
 
 def test x = case x of { Bar -> 1 | Foo -> 2 }
-//│ test: (Bar | Foo[?]) -> (1 | 2)
+//│ test: (Bar | Foo[nothing]) -> (1 | 2)
 //│     = [Function: test]
 
 test foo
@@ -47,7 +43,7 @@ test foo
 //│    = 2
 
 def test x = case x of { Bar -> 1 | Foo -> x.field }
-//│ test: (Bar | (Foo[?] with {field: 'field})) -> (1 | 'field)
+//│ test: (Bar | (Foo[nothing] with {field: 'field})) -> (1 | 'field)
 //│     = [Function: test1]
 
 test foo
@@ -59,7 +55,7 @@ test (Foo { field = 2 })
 //│    = 2
 
 def test x = case x of { Foo -> x.field | _ -> 1 }
-//│ test: ((Foo[?] with {field: 'field}) | ~Foo[?]) -> (1 | 'field)
+//│ test: ((Foo[nothing] with {field: 'field}) | ~Foo[anything]) -> (1 | 'field)
 //│     = [Function: test2]
 
 

--- a/shared/src/test/diff/mlscript/Simple.mls
+++ b/shared/src/test/diff/mlscript/Simple.mls
@@ -35,7 +35,7 @@ Foo { field = id 1 }
 //│    = Foo { field: 1 }
 
 def test x = case x of { Bar -> 1 | Foo -> 2 }
-//│ test: (Bar | Foo[anything]) -> (1 | 2)
+//│ test: (Bar | Foo[?]) -> (1 | 2)
 //│     = [Function: test]
 
 test foo
@@ -43,7 +43,7 @@ test foo
 //│    = 2
 
 def test x = case x of { Bar -> 1 | Foo -> x.field }
-//│ test: (Bar | (Foo[anything] with {field: 'field})) -> (1 | 'field)
+//│ test: (Bar | (Foo[?] with {field: 'field})) -> (1 | 'field)
 //│     = [Function: test1]
 
 test foo
@@ -55,7 +55,7 @@ test (Foo { field = 2 })
 //│    = 2
 
 def test x = case x of { Foo -> x.field | _ -> 1 }
-//│ test: ((Foo[anything] with {field: 'field}) | ~Foo[anything]) -> (1 | 'field)
+//│ test: ((Foo[?] with {field: 'field}) | ~Foo[?]) -> (1 | 'field)
 //│     = [Function: test2]
 
 

--- a/shared/src/test/diff/mlscript/Simple.mls
+++ b/shared/src/test/diff/mlscript/Simple.mls
@@ -35,7 +35,7 @@ Foo { field = id 1 }
 //│    = Foo { field: 1 }
 
 def test x = case x of { Bar -> 1 | Foo -> 2 }
-//│ test: (Bar | Foo[nothing]) -> (1 | 2)
+//│ test: (Bar | Foo[anything]) -> (1 | 2)
 //│     = [Function: test]
 
 test foo
@@ -43,7 +43,7 @@ test foo
 //│    = 2
 
 def test x = case x of { Bar -> 1 | Foo -> x.field }
-//│ test: (Bar | (Foo[nothing] with {field: 'field})) -> (1 | 'field)
+//│ test: (Bar | (Foo[anything] with {field: 'field})) -> (1 | 'field)
 //│     = [Function: test1]
 
 test foo
@@ -55,7 +55,7 @@ test (Foo { field = 2 })
 //│    = 2
 
 def test x = case x of { Foo -> x.field | _ -> 1 }
-//│ test: ((Foo[nothing] with {field: 'field}) | ~Foo[anything]) -> (1 | 'field)
+//│ test: ((Foo[anything] with {field: 'field}) | ~Foo[anything]) -> (1 | 'field)
 //│     = [Function: test2]
 
 

--- a/shared/src/test/diff/mlscript/SimpleMethods.mls
+++ b/shared/src/test/diff/mlscript/SimpleMethods.mls
@@ -76,8 +76,8 @@ class Tru[A]
     method Test f = true
     method Tru = this.Test (fun x -> error)
 //│ Defined class Tru[±A]
-//│ Defined Tru.Test: Tru[anything] -> anything -> true
-//│ Defined Tru.Tru: Tru[anything] -> true
+//│ Defined Tru.Test: Tru[?] -> anything -> true
+//│ Defined Tru.Tru: Tru[?] -> true
 //│ ╔══[WARNING] Type definition Tru has bivariant type parameters:
 //│ ║  l.75: 	class Tru[A]
 //│ ║        	      ^^^

--- a/shared/src/test/diff/mlscript/SimpleMethods.mls
+++ b/shared/src/test/diff/mlscript/SimpleMethods.mls
@@ -76,8 +76,8 @@ class Tru[A]
     method Test f = true
     method Tru = this.Test (fun x -> error)
 //│ Defined class Tru[±A]
-//│ Defined Tru.Test: Tru['A] -> anything -> true
-//│ Defined Tru.Tru: Tru['A] -> true
+//│ Defined Tru.Test: Tru[anything] -> anything -> true
+//│ Defined Tru.Tru: Tru[anything] -> true
 //│ ╔══[WARNING] Type definition Tru has bivariant type parameters:
 //│ ║  l.75: 	class Tru[A]
 //│ ║        	      ^^^

--- a/shared/src/test/diff/mlscript/Stress.mls
+++ b/shared/src/test/diff/mlscript/Stress.mls
@@ -28,7 +28,7 @@ def foo x = case x of {
   | G -> x.fG
   | H -> x.fH
   }
-//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA}) | (C[anything] with {fC: 'fA}) | (D[anything] with {fD: 'fA}) | (E[anything] with {fE: 'fA}) | (F[anything] with {fF: 'fA}) | (G[anything] with {fG: 'fA}) | (H[anything] with {fH: 'fA})) -> 'fA
+//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA}) | (C[?] with {fC: 'fA}) | (D[?] with {fD: 'fA}) | (E[?] with {fE: 'fA}) | (F[?] with {fF: 'fA}) | (G[?] with {fG: 'fA}) | (H[?] with {fH: 'fA})) -> 'fA
 //│ constrain calls  : 26
 //│ annoying  calls  : 0
 //│ subtyping calls  : 978
@@ -59,7 +59,7 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int]
 foo arg
-//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA})) -> 'fA
+//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA})) -> 'fA
 //│ arg: A[int] | B[int]
 //│ res: int
 //│ constrain calls  : 37
@@ -77,7 +77,7 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int]
 foo arg
-//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA}) | (C[anything] with {fC: 'fA})) -> 'fA
+//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA}) | (C[?] with {fC: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int]
 //│ res: int
 //│ constrain calls  : 50
@@ -96,7 +96,7 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int] | D[int]
 foo arg
-//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA}) | (C[anything] with {fC: 'fA}) | (D[anything] with {fD: 'fA})) -> 'fA
+//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA}) | (C[?] with {fC: 'fA}) | (D[?] with {fD: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int] | D[int]
 //│ res: int
 //│ constrain calls  : 63
@@ -130,7 +130,7 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int] | D[int] | E[int]
 foo arg
-//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA}) | (C[anything] with {fC: 'fA}) | (D[anything] with {fD: 'fA}) | (E[anything] with {fE: 'fA})) -> 'fA
+//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA}) | (C[?] with {fC: 'fA}) | (D[?] with {fD: 'fA}) | (E[?] with {fE: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int] | D[int] | E[int]
 //│ res: int
 //│ constrain calls  : 76
@@ -151,7 +151,7 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int]
 foo arg
-//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA}) | (C[anything] with {fC: 'fA}) | (D[anything] with {fD: 'fA}) | (E[anything] with {fE: 'fA}) | (F[anything] with {fF: 'fA})) -> 'fA
+//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA}) | (C[?] with {fC: 'fA}) | (D[?] with {fD: 'fA}) | (E[?] with {fE: 'fA}) | (F[?] with {fF: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int]
 //│ res: int
 //│ constrain calls  : 89
@@ -173,7 +173,7 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int] | G[int]
 foo arg
-//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA}) | (C[anything] with {fC: 'fA}) | (D[anything] with {fD: 'fA}) | (E[anything] with {fE: 'fA}) | (F[anything] with {fF: 'fA}) | (G[anything] with {fG: 'fA})) -> 'fA
+//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA}) | (C[?] with {fC: 'fA}) | (D[?] with {fD: 'fA}) | (E[?] with {fE: 'fA}) | (F[?] with {fF: 'fA}) | (G[?] with {fG: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int] | G[int]
 //│ res: int
 //│ constrain calls  : 102
@@ -196,7 +196,7 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int] | G[int] | H[int]
 foo arg
-//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA}) | (C[anything] with {fC: 'fA}) | (D[anything] with {fD: 'fA}) | (E[anything] with {fE: 'fA}) | (F[anything] with {fF: 'fA}) | (G[anything] with {fG: 'fA}) | (H[anything] with {fH: 'fA})) -> 'fA
+//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA}) | (C[?] with {fC: 'fA}) | (D[?] with {fD: 'fA}) | (E[?] with {fE: 'fA}) | (F[?] with {fF: 'fA}) | (G[?] with {fG: 'fA}) | (H[?] with {fH: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int] | G[int] | H[int]
 //│ res: int
 //│ constrain calls  : 115

--- a/shared/src/test/diff/mlscript/Stress.mls
+++ b/shared/src/test/diff/mlscript/Stress.mls
@@ -28,10 +28,10 @@ def foo x = case x of {
   | G -> x.fG
   | H -> x.fH
   }
-//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA}) | (C[nothing] with {fC: 'fA}) | (D[nothing] with {fD: 'fA}) | (E[nothing] with {fE: 'fA}) | (F[nothing] with {fF: 'fA}) | (G[nothing] with {fG: 'fA}) | (H[nothing] with {fH: 'fA})) -> 'fA
+//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA}) | (C[anything] with {fC: 'fA}) | (D[anything] with {fD: 'fA}) | (E[anything] with {fE: 'fA}) | (F[anything] with {fF: 'fA}) | (G[anything] with {fG: 'fA}) | (H[anything] with {fH: 'fA})) -> 'fA
 //│ constrain calls  : 26
 //│ annoying  calls  : 0
-//│ subtyping calls  : 1026
+//│ subtyping calls  : 978
 
 
 // ====== 1 & all ====== //
@@ -59,12 +59,12 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int]
 foo arg
-//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA})) -> 'fA
+//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA})) -> 'fA
 //│ arg: A[int] | B[int]
 //│ res: int
 //│ constrain calls  : 37
 //│ annoying  calls  : 20
-//│ subtyping calls  : 85
+//│ subtyping calls  : 73
 
 
 // ====== 3 ====== //
@@ -77,12 +77,12 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int]
 foo arg
-//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA}) | (C[nothing] with {fC: 'fA})) -> 'fA
+//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA}) | (C[anything] with {fC: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int]
 //│ res: int
 //│ constrain calls  : 50
 //│ annoying  calls  : 30
-//│ subtyping calls  : 176
+//│ subtyping calls  : 158
 
 
 // ====== 4 ====== //
@@ -96,12 +96,12 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int] | D[int]
 foo arg
-//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA}) | (C[nothing] with {fC: 'fA}) | (D[nothing] with {fD: 'fA})) -> 'fA
+//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA}) | (C[anything] with {fC: 'fA}) | (D[anything] with {fD: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int] | D[int]
 //│ res: int
 //│ constrain calls  : 63
 //│ annoying  calls  : 40
-//│ subtyping calls  : 314
+//│ subtyping calls  : 290
 
 :stats
 foo (arg with { x = 1} with { y = 2 })
@@ -130,12 +130,12 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int] | D[int] | E[int]
 foo arg
-//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA}) | (C[nothing] with {fC: 'fA}) | (D[nothing] with {fD: 'fA}) | (E[nothing] with {fE: 'fA})) -> 'fA
+//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA}) | (C[anything] with {fC: 'fA}) | (D[anything] with {fD: 'fA}) | (E[anything] with {fE: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int] | D[int] | E[int]
 //│ res: int
 //│ constrain calls  : 76
 //│ annoying  calls  : 50
-//│ subtyping calls  : 510
+//│ subtyping calls  : 480
 
 
 // ====== 6 ====== //
@@ -151,12 +151,12 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int]
 foo arg
-//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA}) | (C[nothing] with {fC: 'fA}) | (D[nothing] with {fD: 'fA}) | (E[nothing] with {fE: 'fA}) | (F[nothing] with {fF: 'fA})) -> 'fA
+//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA}) | (C[anything] with {fC: 'fA}) | (D[anything] with {fD: 'fA}) | (E[anything] with {fE: 'fA}) | (F[anything] with {fF: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int]
 //│ res: int
 //│ constrain calls  : 89
 //│ annoying  calls  : 60
-//│ subtyping calls  : 775
+//│ subtyping calls  : 739
 
 
 // ====== 7 ====== //
@@ -173,12 +173,12 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int] | G[int]
 foo arg
-//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA}) | (C[nothing] with {fC: 'fA}) | (D[nothing] with {fD: 'fA}) | (E[nothing] with {fE: 'fA}) | (F[nothing] with {fF: 'fA}) | (G[nothing] with {fG: 'fA})) -> 'fA
+//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA}) | (C[anything] with {fC: 'fA}) | (D[anything] with {fD: 'fA}) | (E[anything] with {fE: 'fA}) | (F[anything] with {fF: 'fA}) | (G[anything] with {fG: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int] | G[int]
 //│ res: int
 //│ constrain calls  : 102
 //│ annoying  calls  : 70
-//│ subtyping calls  : 1120
+//│ subtyping calls  : 1078
 
 
 // ====== 8 ====== //
@@ -196,11 +196,11 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int] | G[int] | H[int]
 foo arg
-//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA}) | (C[nothing] with {fC: 'fA}) | (D[nothing] with {fD: 'fA}) | (E[nothing] with {fE: 'fA}) | (F[nothing] with {fF: 'fA}) | (G[nothing] with {fG: 'fA}) | (H[nothing] with {fH: 'fA})) -> 'fA
+//│ foo: ((A[anything] with {fA: 'fA}) | (B[anything] with {fB: 'fA}) | (C[anything] with {fC: 'fA}) | (D[anything] with {fD: 'fA}) | (E[anything] with {fE: 'fA}) | (F[anything] with {fF: 'fA}) | (G[anything] with {fG: 'fA}) | (H[anything] with {fH: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int] | G[int] | H[int]
 //│ res: int
 //│ constrain calls  : 115
 //│ annoying  calls  : 80
-//│ subtyping calls  : 1556
+//│ subtyping calls  : 1508
 
 

--- a/shared/src/test/diff/mlscript/Stress.mls
+++ b/shared/src/test/diff/mlscript/Stress.mls
@@ -28,10 +28,10 @@ def foo x = case x of {
   | G -> x.fG
   | H -> x.fH
   }
-//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA}) | (C[?] with {fC: 'fA}) | (D[?] with {fD: 'fA}) | (E[?] with {fE: 'fA}) | (F[?] with {fF: 'fA}) | (G[?] with {fG: 'fA}) | (H[?] with {fH: 'fA})) -> 'fA
+//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA}) | (C[nothing] with {fC: 'fA}) | (D[nothing] with {fD: 'fA}) | (E[nothing] with {fE: 'fA}) | (F[nothing] with {fF: 'fA}) | (G[nothing] with {fG: 'fA}) | (H[nothing] with {fH: 'fA})) -> 'fA
 //│ constrain calls  : 26
 //│ annoying  calls  : 0
-//│ subtyping calls  : 1042
+//│ subtyping calls  : 1026
 
 
 // ====== 1 & all ====== //
@@ -59,12 +59,12 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int]
 foo arg
-//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA})) -> 'fA
+//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA})) -> 'fA
 //│ arg: A[int] | B[int]
 //│ res: int
 //│ constrain calls  : 37
 //│ annoying  calls  : 20
-//│ subtyping calls  : 89
+//│ subtyping calls  : 85
 
 
 // ====== 3 ====== //
@@ -77,12 +77,12 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int]
 foo arg
-//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA}) | (C[?] with {fC: 'fA})) -> 'fA
+//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA}) | (C[nothing] with {fC: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int]
 //│ res: int
 //│ constrain calls  : 50
 //│ annoying  calls  : 30
-//│ subtyping calls  : 182
+//│ subtyping calls  : 176
 
 
 // ====== 4 ====== //
@@ -96,12 +96,12 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int] | D[int]
 foo arg
-//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA}) | (C[?] with {fC: 'fA}) | (D[?] with {fD: 'fA})) -> 'fA
+//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA}) | (C[nothing] with {fC: 'fA}) | (D[nothing] with {fD: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int] | D[int]
 //│ res: int
 //│ constrain calls  : 63
 //│ annoying  calls  : 40
-//│ subtyping calls  : 322
+//│ subtyping calls  : 314
 
 :stats
 foo (arg with { x = 1} with { y = 2 })
@@ -130,12 +130,12 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int] | D[int] | E[int]
 foo arg
-//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA}) | (C[?] with {fC: 'fA}) | (D[?] with {fD: 'fA}) | (E[?] with {fE: 'fA})) -> 'fA
+//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA}) | (C[nothing] with {fC: 'fA}) | (D[nothing] with {fD: 'fA}) | (E[nothing] with {fE: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int] | D[int] | E[int]
 //│ res: int
 //│ constrain calls  : 76
 //│ annoying  calls  : 50
-//│ subtyping calls  : 520
+//│ subtyping calls  : 510
 
 
 // ====== 6 ====== //
@@ -151,12 +151,12 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int]
 foo arg
-//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA}) | (C[?] with {fC: 'fA}) | (D[?] with {fD: 'fA}) | (E[?] with {fE: 'fA}) | (F[?] with {fF: 'fA})) -> 'fA
+//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA}) | (C[nothing] with {fC: 'fA}) | (D[nothing] with {fD: 'fA}) | (E[nothing] with {fE: 'fA}) | (F[nothing] with {fF: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int]
 //│ res: int
 //│ constrain calls  : 89
 //│ annoying  calls  : 60
-//│ subtyping calls  : 787
+//│ subtyping calls  : 775
 
 
 // ====== 7 ====== //
@@ -173,12 +173,12 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int] | G[int]
 foo arg
-//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA}) | (C[?] with {fC: 'fA}) | (D[?] with {fD: 'fA}) | (E[?] with {fE: 'fA}) | (F[?] with {fF: 'fA}) | (G[?] with {fG: 'fA})) -> 'fA
+//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA}) | (C[nothing] with {fC: 'fA}) | (D[nothing] with {fD: 'fA}) | (E[nothing] with {fE: 'fA}) | (F[nothing] with {fF: 'fA}) | (G[nothing] with {fG: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int] | G[int]
 //│ res: int
 //│ constrain calls  : 102
 //│ annoying  calls  : 70
-//│ subtyping calls  : 1134
+//│ subtyping calls  : 1120
 
 
 // ====== 8 ====== //
@@ -196,11 +196,11 @@ def foo x = case x of {
   }
 def arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int] | G[int] | H[int]
 foo arg
-//│ foo: ((A[?] with {fA: 'fA}) | (B[?] with {fB: 'fA}) | (C[?] with {fC: 'fA}) | (D[?] with {fD: 'fA}) | (E[?] with {fE: 'fA}) | (F[?] with {fF: 'fA}) | (G[?] with {fG: 'fA}) | (H[?] with {fH: 'fA})) -> 'fA
+//│ foo: ((A[nothing] with {fA: 'fA}) | (B[nothing] with {fB: 'fA}) | (C[nothing] with {fC: 'fA}) | (D[nothing] with {fD: 'fA}) | (E[nothing] with {fE: 'fA}) | (F[nothing] with {fF: 'fA}) | (G[nothing] with {fG: 'fA}) | (H[nothing] with {fH: 'fA})) -> 'fA
 //│ arg: A[int] | B[int] | C[int] | D[int] | E[int] | F[int] | G[int] | H[int]
 //│ res: int
 //│ constrain calls  : 115
 //│ annoying  calls  : 80
-//│ subtyping calls  : 1572
+//│ subtyping calls  : 1556
 
 

--- a/shared/src/test/diff/mlscript/StressUgly.mls
+++ b/shared/src/test/diff/mlscript/StressUgly.mls
@@ -9,7 +9,7 @@ class Add[E]: { lhs: E; rhs: E }
 def eval1_ty_ugly: Add['b] | 'a & ~Lit as 'b
 //│ eval1_ty_ugly: 'b
 //│   where
-//│     'b := 'a & ~Lit | Add['b]
+//│     'b :> Add['b]
 //│              = <missing implementation>
 
 // def eval1_ty: Add['b]
@@ -26,7 +26,7 @@ def eval1_ty: Add[int] // ~500
 eval1_ty = eval1_ty_ugly
 //│ 'b
 //│   where
-//│     'b := 'a & ~Lit | Add['b]
+//│     'b :> Add['b]
 //│   <:  eval1_ty:
 //│ Add[int]
 //│ ╔══[ERROR] Type mismatch in def definition:
@@ -108,5 +108,5 @@ eval1_ty = eval1_ty_ugly
 //│           eval1_ty_ugly is not implemented
 //│ constrain calls  : 45
 //│ annoying  calls  : 32
-//│ subtyping calls  : 142
+//│ subtyping calls  : 116
 

--- a/shared/src/test/diff/mlscript/StressUgly.mls
+++ b/shared/src/test/diff/mlscript/StressUgly.mls
@@ -1,15 +1,19 @@
 
 class Lit: { val: int }
 class Add[E]: { lhs: E; rhs: E }
+  method In: E -> E
+  method In = id
 //│ Defined class Lit
-//│ Defined class Add[+E]
+//│ Defined class Add[=E]
+//│ Declared Add.In: Add['E] -> 'E -> 'E
+//│ Defined Add.In: Add['E] -> 'a -> 'a
 
 
 
 def eval1_ty_ugly: Add['b] | 'a & ~Lit as 'b
 //│ eval1_ty_ugly: 'b
 //│   where
-//│     'b :> Add['b]
+//│     'b := 'a & ~Lit | Add['b]
 //│              = <missing implementation>
 
 // def eval1_ty: Add['b]
@@ -26,87 +30,87 @@ def eval1_ty: Add[int] // ~500
 eval1_ty = eval1_ty_ugly
 //│ 'b
 //│   where
-//│     'b :> Add['b]
+//│     'b := 'a & ~Lit | Add['b]
 //│   <:  eval1_ty:
 //│ Add[int]
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.26: 	eval1_ty = eval1_ty_ugly
+//│ ║  l.30: 	eval1_ty = eval1_ty_ugly
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── type `Add[?b]` is not an instance of `int`
-//│ ║  l.9: 	def eval1_ty_ugly: Add['b] | 'a & ~Lit as 'b
-//│ ║       	                   ^^^^^^^
+//│ ║  l.13: 	def eval1_ty_ugly: Add['b] | 'a & ~Lit as 'b
+//│ ║        	                   ^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.16: 	def eval1_ty: Add[int] // ~500
+//│ ║  l.20: 	def eval1_ty: Add[int] // ~500
 //│ ╙──      	                  ^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.26: 	eval1_ty = eval1_ty_ugly
+//│ ║  l.30: 	eval1_ty = eval1_ty_ugly
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── type `int` is not an instance of `Add[int]`
-//│ ║  l.16: 	def eval1_ty: Add[int] // ~500
+//│ ║  l.20: 	def eval1_ty: Add[int] // ~500
 //│ ║        	                  ^^^
 //│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.16: 	def eval1_ty: Add[int] // ~500
+//│ ║  l.20: 	def eval1_ty: Add[int] // ~500
 //│ ║        	              ^^^^^^^^
 //│ ╟── from local type binding:
-//│ ║  l.9: 	def eval1_ty_ugly: Add['b] | 'a & ~Lit as 'b
-//│ ╙──     	                   ^^^^^^^^^^^^^^^^^^^
+//│ ║  l.13: 	def eval1_ty_ugly: Add['b] | 'a & ~Lit as 'b
+//│ ╙──      	                   ^^^^^^^^^^^^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.26: 	eval1_ty = eval1_ty_ugly
+//│ ║  l.30: 	eval1_ty = eval1_ty_ugly
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── type `int` does not match type `Add[?] | Lit`
-//│ ║  l.16: 	def eval1_ty: Add[int] // ~500
+//│ ║  l.20: 	def eval1_ty: Add[int] // ~500
 //│ ║        	                  ^^^
 //│ ╟── but it flows into reference with expected type `Add[?] | Lit`
-//│ ║  l.26: 	eval1_ty = eval1_ty_ugly
+//│ ║  l.30: 	eval1_ty = eval1_ty_ugly
 //│ ║        	           ^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.16: 	def eval1_ty: Add[int] // ~500
+//│ ║  l.20: 	def eval1_ty: Add[int] // ~500
 //│ ╙──      	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.26: 	eval1_ty = eval1_ty_ugly
+//│ ║  l.30: 	eval1_ty = eval1_ty_ugly
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── type `int` does not match type `Lit | {lhs: int, rhs: int}`
-//│ ║  l.16: 	def eval1_ty: Add[int] // ~500
+//│ ║  l.20: 	def eval1_ty: Add[int] // ~500
 //│ ║        	                  ^^^
 //│ ╟── but it flows into reference with expected type `Lit | {lhs: int, rhs: int}`
-//│ ║  l.26: 	eval1_ty = eval1_ty_ugly
+//│ ║  l.30: 	eval1_ty = eval1_ty_ugly
 //│ ║        	           ^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from record type:
 //│ ║  l.3: 	class Add[E]: { lhs: E; rhs: E }
 //│ ║       	              ^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.16: 	def eval1_ty: Add[int] // ~500
+//│ ║  l.20: 	def eval1_ty: Add[int] // ~500
 //│ ╙──      	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.26: 	eval1_ty = eval1_ty_ugly
+//│ ║  l.30: 	eval1_ty = eval1_ty_ugly
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── type `int` does not match type `Lit | {lhs: int, rhs: int}`
-//│ ║  l.16: 	def eval1_ty: Add[int] // ~500
+//│ ║  l.20: 	def eval1_ty: Add[int] // ~500
 //│ ║        	                  ^^^
 //│ ╟── but it flows into reference with expected type `Lit | {lhs: int, rhs: int}`
-//│ ║  l.26: 	eval1_ty = eval1_ty_ugly
+//│ ║  l.30: 	eval1_ty = eval1_ty_ugly
 //│ ║        	           ^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from record type:
 //│ ║  l.3: 	class Add[E]: { lhs: E; rhs: E }
 //│ ║       	              ^^^^^^^^^^^^^^^^^^
 //│ ╟── from applied type reference:
-//│ ║  l.16: 	def eval1_ty: Add[int] // ~500
+//│ ║  l.20: 	def eval1_ty: Add[int] // ~500
 //│ ╙──      	              ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.26: 	eval1_ty = eval1_ty_ugly
+//│ ║  l.30: 	eval1_ty = eval1_ty_ugly
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── type `int` does not match type `Lit | {Add#E = int}`
-//│ ║  l.16: 	def eval1_ty: Add[int] // ~500
+//│ ║  l.20: 	def eval1_ty: Add[int] // ~500
 //│ ║        	                  ^^^
 //│ ╟── but it flows into reference with expected type `Lit | {Add#E = int}`
-//│ ║  l.26: 	eval1_ty = eval1_ty_ugly
+//│ ║  l.30: 	eval1_ty = eval1_ty_ugly
 //│ ║        	           ^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.16: 	def eval1_ty: Add[int] // ~500
+//│ ║  l.20: 	def eval1_ty: Add[int] // ~500
 //│ ╙──      	              ^^^^^^^^
 //│         = <no result>
 //│           eval1_ty_ugly is not implemented
 //│ constrain calls  : 45
 //│ annoying  calls  : 32
-//│ subtyping calls  : 116
+//│ subtyping calls  : 142
 

--- a/shared/src/test/diff/mlscript/This.mls
+++ b/shared/src/test/diff/mlscript/This.mls
@@ -31,7 +31,7 @@ b.Boom 1 // : A
 class Myself[A]
   method Me = this
 //│ Defined class Myself[±A]
-//│ Defined Myself.Me: (Myself[anything] & 'this) -> (Myself[anything] & 'this)
+//│ Defined Myself.Me: (Myself[?] & 'this) -> (Myself[?] & 'this)
 //│ ╔══[WARNING] Type definition Myself has bivariant type parameters:
 //│ ║  l.31: 	class Myself[A]
 //│ ║        	      ^^^^^^
@@ -40,10 +40,10 @@ class Myself[A]
 //│ ╙──      	             ^
 
 m0 = Myself {}
-//│ m0: Myself[anything]
+//│ m0: Myself[?]
 
 m0.Me
-//│ res: Myself[anything]
+//│ res: Myself[?]
 
 
 

--- a/shared/src/test/diff/mlscript/This.mls
+++ b/shared/src/test/diff/mlscript/This.mls
@@ -31,7 +31,7 @@ b.Boom 1 // : A
 class Myself[A]
   method Me = this
 //│ Defined class Myself[±A]
-//│ Defined Myself.Me: (Myself['A] & 'this) -> (Myself['A] & 'this)
+//│ Defined Myself.Me: (Myself[anything] & 'this) -> (Myself[anything] & 'this)
 //│ ╔══[WARNING] Type definition Myself has bivariant type parameters:
 //│ ║  l.31: 	class Myself[A]
 //│ ║        	      ^^^^^^
@@ -40,10 +40,10 @@ class Myself[A]
 //│ ╙──      	             ^
 
 m0 = Myself {}
-//│ m0: Myself['A]
+//│ m0: Myself[anything]
 
 m0.Me
-//│ res: Myself['A]
+//│ res: Myself[anything]
 
 
 

--- a/shared/src/test/diff/mlscript/Tony.mls
+++ b/shared/src/test/diff/mlscript/Tony.mls
@@ -6,12 +6,12 @@ class None: {}
 
 
 def flatMap3 = fun f -> fun opt -> case opt of { Some -> f opt | _ -> opt }
-//│ flatMap3: ('a -> 'b) -> (Some[nothing] & 'a | 'b & ~some) -> 'b
+//│ flatMap3: ('a -> 'b) -> (Some[anything] & 'a | 'b & ~some) -> 'b
 //│         = [Function: flatMap3]
 
 
 def arg = if true then Some{value = 42} with {payload = 23} else None {}
-//│ arg: None | (Some[42] with {payload: 23})
+//│ arg: None | Some[42] & {payload: 23}
 //│    = Some { value: 42, payload: 23 }
 
 // > TODO don't distribute neg inters + handle better at constraint top level
@@ -34,7 +34,7 @@ flatMap3 (fun x -> x.value) arg
 
 
 def foo = flatMap3 (fun x -> x.value)
-//│ foo: ((Some[nothing] with {value: 'a}) | 'a & ~some) -> 'a
+//│ foo: ((Some[anything] with {value: 'a}) | 'a & ~some) -> 'a
 //│    = [Function (anonymous)]
 
 foo arg
@@ -68,7 +68,7 @@ fun f -> flatMap3 f arg
 
 
 def foo = flatMap3 (fun x -> x)
-//│ foo: ('a & (Some[nothing] | ~some)) -> 'a
+//│ foo: ('a & (Some[anything] | ~some)) -> 'a
 //│    = [Function (anonymous)]
 
 foo 1
@@ -83,11 +83,11 @@ def simpler = fun f -> case None{} of { Some -> f 1 | _ -> None{} }
 //│        = [Function: simpler]
 
 def simpler = fun f -> fun opt -> case opt of { Some -> f opt | None -> opt }
-//│ simpler: ('a -> 'b) -> (None & 'b | Some[nothing] & 'a) -> 'b
+//│ simpler: ('a -> 'b) -> (None & 'b | Some[anything] & 'a) -> 'b
 //│        = [Function: simpler1]
 
 simpler (fun x -> x.value)
-//│ res: (None & 'a | (Some[nothing] with {value: 'a})) -> 'a
+//│ res: (None & 'a | (Some[anything] with {value: 'a})) -> 'a
 //│    = [Function (anonymous)]
 
 :e
@@ -95,7 +95,7 @@ res 1
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.94: 	res 1
 //│ ║        	^^^^^
-//│ ╟── integer literal of type `1` does not match type `None & ?a | Some[?] & ?b`
+//│ ╟── integer literal of type `1` does not match type `None & ?a | Some[anything] & ?b`
 //│ ║  l.94: 	res 1
 //│ ║        	    ^
 //│ ╟── Note: constraint arises from reference:

--- a/shared/src/test/diff/mlscript/Tony.mls
+++ b/shared/src/test/diff/mlscript/Tony.mls
@@ -6,14 +6,12 @@ class None: {}
 
 
 def flatMap3 = fun f -> fun opt -> case opt of { Some -> f opt | _ -> opt }
-//│ flatMap3: ('a -> 'b) -> (Some[?] & 'a | 'b & ~some) -> 'b
+//│ flatMap3: ('a -> 'b) -> (Some[nothing] & 'a | 'b & ~some) -> 'b
 //│         = [Function: flatMap3]
 
 
 def arg = if true then Some{value = 42} with {payload = 23} else None {}
-//│ arg: None | Some['A] & {payload: 23, value: 42}
-//│   where
-//│     'A :> 42
+//│ arg: None | (Some[42] with {payload: 23})
 //│    = Some { value: 42, payload: 23 }
 
 // > TODO don't distribute neg inters + handle better at constraint top level
@@ -27,9 +25,7 @@ flatMap3 (fun x -> add x.value x.payload) arg
 
 
 def arg = if true then Some{value = 42} else None {}
-//│ arg: None | Some['A] & {value: 42}
-//│   where
-//│     'A :> 42
+//│ arg: None | Some[42]
 //│    = Some { value: 42 }
 
 flatMap3 (fun x -> x.value) arg
@@ -38,7 +34,7 @@ flatMap3 (fun x -> x.value) arg
 
 
 def foo = flatMap3 (fun x -> x.value)
-//│ foo: ((Some[?] with {value: 'a}) | 'a & ~some) -> 'a
+//│ foo: ((Some[nothing] with {value: 'a}) | 'a & ~some) -> 'a
 //│    = [Function (anonymous)]
 
 foo arg
@@ -65,16 +61,14 @@ foo (None{})
 
 
 fun f -> flatMap3 f arg
-//│ res: ((Some['A] & {value: 42}) -> 'a) -> (None | 'a)
-//│   where
-//│     'A :> 42
+//│ res: (Some[42] -> 'a) -> (None | 'a)
 //│    = [Function: res]
 
 
 
 
 def foo = flatMap3 (fun x -> x)
-//│ foo: ('a & (Some[?] | ~some)) -> 'a
+//│ foo: ('a & (Some[nothing] | ~some)) -> 'a
 //│    = [Function (anonymous)]
 
 foo 1
@@ -89,23 +83,23 @@ def simpler = fun f -> case None{} of { Some -> f 1 | _ -> None{} }
 //│        = [Function: simpler]
 
 def simpler = fun f -> fun opt -> case opt of { Some -> f opt | None -> opt }
-//│ simpler: ('a -> 'b) -> (None & 'b | Some[?] & 'a) -> 'b
+//│ simpler: ('a -> 'b) -> (None & 'b | Some[nothing] & 'a) -> 'b
 //│        = [Function: simpler1]
 
 simpler (fun x -> x.value)
-//│ res: (None & 'a | (Some[?] with {value: 'a})) -> 'a
+//│ res: (None & 'a | (Some[nothing] with {value: 'a})) -> 'a
 //│    = [Function (anonymous)]
 
 :e
 res 1
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.100: 	res 1
-//│ ║         	^^^^^
+//│ ║  l.94: 	res 1
+//│ ║        	^^^^^
 //│ ╟── integer literal of type `1` does not match type `None & ?a | Some[?] & ?b`
-//│ ║  l.100: 	res 1
-//│ ║         	    ^
+//│ ║  l.94: 	res 1
+//│ ║        	    ^
 //│ ╟── Note: constraint arises from reference:
-//│ ║  l.91: 	def simpler = fun f -> fun opt -> case opt of { Some -> f opt | None -> opt }
+//│ ║  l.85: 	def simpler = fun f -> fun opt -> case opt of { Some -> f opt | None -> opt }
 //│ ╙──      	                                       ^^^
 //│ res: error
 //│ Runtime error:

--- a/shared/src/test/diff/mlscript/Tony.mls
+++ b/shared/src/test/diff/mlscript/Tony.mls
@@ -6,7 +6,7 @@ class None: {}
 
 
 def flatMap3 = fun f -> fun opt -> case opt of { Some -> f opt | _ -> opt }
-//│ flatMap3: ('a -> 'b) -> (Some[anything] & 'a | 'b & ~some) -> 'b
+//│ flatMap3: ('a -> 'b) -> (Some[?] & 'a | 'b & ~some) -> 'b
 //│         = [Function: flatMap3]
 
 
@@ -34,7 +34,7 @@ flatMap3 (fun x -> x.value) arg
 
 
 def foo = flatMap3 (fun x -> x.value)
-//│ foo: ((Some[anything] with {value: 'a}) | 'a & ~some) -> 'a
+//│ foo: ((Some[?] with {value: 'a}) | 'a & ~some) -> 'a
 //│    = [Function (anonymous)]
 
 foo arg
@@ -68,7 +68,7 @@ fun f -> flatMap3 f arg
 
 
 def foo = flatMap3 (fun x -> x)
-//│ foo: ('a & (Some[anything] | ~some)) -> 'a
+//│ foo: ('a & (Some[?] | ~some)) -> 'a
 //│    = [Function (anonymous)]
 
 foo 1
@@ -83,11 +83,11 @@ def simpler = fun f -> case None{} of { Some -> f 1 | _ -> None{} }
 //│        = [Function: simpler]
 
 def simpler = fun f -> fun opt -> case opt of { Some -> f opt | None -> opt }
-//│ simpler: ('a -> 'b) -> (None & 'b | Some[anything] & 'a) -> 'b
+//│ simpler: ('a -> 'b) -> (None & 'b | Some[?] & 'a) -> 'b
 //│        = [Function: simpler1]
 
 simpler (fun x -> x.value)
-//│ res: (None & 'a | (Some[anything] with {value: 'a})) -> 'a
+//│ res: (None & 'a | (Some[?] with {value: 'a})) -> 'a
 //│    = [Function (anonymous)]
 
 :e
@@ -95,7 +95,7 @@ res 1
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.94: 	res 1
 //│ ║        	^^^^^
-//│ ╟── integer literal of type `1` does not match type `None & ?a | Some[anything] & ?b`
+//│ ╟── integer literal of type `1` does not match type `None & ?a | Some[?] & ?b`
 //│ ║  l.94: 	res 1
 //│ ║        	    ^
 //│ ╟── Note: constraint arises from reference:

--- a/shared/src/test/diff/mlscript/TraitMatching.mls
+++ b/shared/src/test/diff/mlscript/TraitMatching.mls
@@ -143,7 +143,7 @@ class C3: { default: string } & ~MyTrait[anything]
 //│ ╙──       	      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 def strawman: C2 & ~MyTrait[anything]
-//│ strawman: C2 & ~MyTrait[anything]
+//│ strawman: C2 & ~MyTrait[?]
 //│         = <missing implementation>
 
 test2 strawman
@@ -161,7 +161,7 @@ strawman: ~{ value: anything }
 //│ ╔══[ERROR] Type mismatch in type ascription:
 //│ ║  l.160: 	strawman: ~{ value: anything }
 //│ ║         	^^^^^^^^
-//│ ╟── type `C2 & ~MyTrait[anything]` does not match type `~{value: anything}`
+//│ ╟── type `C2 & ~MyTrait[?]` does not match type `~{value: anything}`
 //│ ║  l.145: 	def strawman: C2 & ~MyTrait[anything]
 //│ ║         	              ^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `~{value: anything}`

--- a/shared/src/test/diff/mlscript/TypeClasses.mls
+++ b/shared/src/test/diff/mlscript/TypeClasses.mls
@@ -66,7 +66,7 @@ cmi.Empty.real
 //│    = 0
 
 cmi.Add (Complex 1 2) (Complex 3 4)
-//│ res: (Complex[int] with {imaginary: 2 | 4, real: 1 | 3}) | Complex[int]
+//│ res: Complex[1 | 2 | 3 | 4] & {imaginary: 2 | 4, real: 1 | 3} | Complex[int]
 //│    = Complex { real: 4, imaginary: 6 }
 
 
@@ -105,7 +105,7 @@ class ComplexMonoid_bad_0[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ╟── function of type `?a -> ?b` is not an instance of type Complex
 //│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into application with expected type `Complex[?]`
+//│ ╟── but it flows into application with expected type `Complex[anything]`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from applied type reference:
@@ -135,7 +135,7 @@ class ComplexMonoid_bad_0[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ╟── function of type `?a -> ?b` does not have field 'Complex#A'
 //│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into application with expected type `{Complex#A = A}`
+//│ ╟── but it flows into application with expected type `{Complex#A <: A}`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from applied type reference:
@@ -145,7 +145,7 @@ class ComplexMonoid_bad_0[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.3: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ Defined class ComplexMonoid_bad_0[=A]
-//│ Defined ComplexMonoid_bad_0.Empty: ComplexMonoid_bad_0['A] -> 'imaginary -> (Complex['imaginary | {real: Monoid['A]}] with {real: {real: Monoid['A]}})
+//│ Defined ComplexMonoid_bad_0.Empty: ComplexMonoid_bad_0['A] -> 'imaginary -> (Complex['imaginary | {real: Monoid['A]}] & {real: {real: Monoid['A]}})
 //│ Defined ComplexMonoid_bad_0.Add: ComplexMonoid_bad_0['A] -> anything -> anything -> nothing
 
 
@@ -164,7 +164,7 @@ class ComplexMonoid_bad_1[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ╟── function of type `?a -> ?b` is not an instance of type Complex
 //│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into application with expected type `Complex[?]`
+//│ ╟── but it flows into application with expected type `Complex[anything]`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base.Empty; imaginary = this.imaginary.Empty }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from applied type reference:
@@ -194,7 +194,7 @@ class ComplexMonoid_bad_1[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ╟── function of type `?a -> ?b` does not have field 'Complex#A'
 //│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into application with expected type `{Complex#A = A}`
+//│ ╟── but it flows into application with expected type `{Complex#A <: A}`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base.Empty; imaginary = this.imaginary.Empty }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from applied type reference:
@@ -204,7 +204,7 @@ class ComplexMonoid_bad_1[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.3: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ Defined class ComplexMonoid_bad_1[=A]
-//│ Defined ComplexMonoid_bad_1.Empty: ComplexMonoid_bad_1['A] -> 'imaginary -> (Complex['imaginary | {imaginary: error, real: 'A}] with {real: {imaginary: error, real: 'A}})
+//│ Defined ComplexMonoid_bad_1.Empty: ComplexMonoid_bad_1['A] -> 'imaginary -> (Complex['imaginary | {imaginary: error, real: 'A}] & {real: {imaginary: error, real: 'A}})
 //│ Defined ComplexMonoid_bad_1.Add: ComplexMonoid_bad_1['A] -> anything -> anything -> nothing
 
 

--- a/shared/src/test/diff/mlscript/TypeClasses.mls
+++ b/shared/src/test/diff/mlscript/TypeClasses.mls
@@ -30,7 +30,7 @@ class Complex[A]: { real: A; imaginary: A }
   method Map f = Complex { real = f this.real; imaginary = f this.imaginary }
 def Complex real imaginary = Complex { real; imaginary }
 //│ Defined class Complex[+A]
-//│ Defined Complex.Map: Complex['A] -> ('A -> ('imaginary & 'A0)) -> (Complex['A0] with {imaginary: 'imaginary, real: 'imaginary})
+//│ Defined Complex.Map: Complex['A] -> ('A -> 'imaginary) -> Complex['imaginary]
 //│ Complex: ('real & 'A) -> ('A & 'imaginary) -> (Complex['A] with {imaginary: 'imaginary, real: 'real})
 //│        = [Function: Complex1]
 
@@ -41,14 +41,9 @@ class ComplexMonoid[A]: Monoid[Complex[A]] & { base: Monoid[A] }
   method Add2 (self: Complex['_]) (that: Complex['_]) =
     Complex (this.base.(Monoid.Add) self.real that.real) (this.base.(Monoid.Add) self.imaginary that.imaginary)
 //│ Defined class ComplexMonoid[=A]
-//│ Defined ComplexMonoid.Empty: ComplexMonoid['A] -> (Complex['A0] with {imaginary: 'A, real: 'A})
-//│   where
-//│     'A0 :> 'A
-//│ Defined ComplexMonoid.Add: ComplexMonoid['A] -> {imaginary: 'A & 'A0, real: 'A & 'A0} -> {imaginary: 'A & 'A0, real: 'A & 'A0} -> (Complex['A0] with {imaginary: 'A, real: 'A})
-//│ Defined ComplexMonoid.Add2: ComplexMonoid['A] -> Complex['_] -> Complex['_0] -> (Complex['A0] with {imaginary: 'A, real: 'A})
-//│   where
-//│     '_0 <: 'A & 'A0
-//│     '_ <: 'A & 'A0
+//│ Defined ComplexMonoid.Empty: ComplexMonoid['A] -> Complex['A]
+//│ Defined ComplexMonoid.Add: ComplexMonoid['A] -> {imaginary: 'A, real: 'A} -> {imaginary: 'A, real: 'A} -> Complex['A]
+//│ Defined ComplexMonoid.Add2: ComplexMonoid['A] -> Complex['A] -> Complex['A] -> Complex['A]
 
 cmi = ComplexMonoid { base = IntMonoid }
 //│ cmi: ComplexMonoid[int] with {base: IntMonoid}
@@ -71,7 +66,7 @@ cmi.Empty.real
 //│    = 0
 
 cmi.Add (Complex 1 2) (Complex 3 4)
-//│ res: Complex[int]
+//│ res: (Complex[int] with {imaginary: 2 | 4, real: 1 | 3}) | Complex[int]
 //│    = Complex { real: 4, imaginary: 6 }
 
 
@@ -95,7 +90,7 @@ cmi = ComplexMonoid { base = IntMonoid }
 //│ ║  l.37: 	class ComplexMonoid[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║        	                                                     ^^^^^^^^^
 //│ ╟── from reference:
-//│ ║  l.57: 	def ComplexMonoid base = ComplexMonoid { base }
+//│ ║  l.52: 	def ComplexMonoid base = ComplexMonoid { base }
 //│ ╙──      	                                         ^^^^
 //│ cmi: (ComplexMonoid['A] with {base: {base: IntMonoid}}) | error
 
@@ -150,7 +145,7 @@ class ComplexMonoid_bad_0[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.3: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ Defined class ComplexMonoid_bad_0[=A]
-//│ Defined ComplexMonoid_bad_0.Empty: ComplexMonoid_bad_0['A] -> ('imaginary & 'A0) -> (Complex['A0] with {imaginary: 'imaginary, real: {real: Monoid['A]}})
+//│ Defined ComplexMonoid_bad_0.Empty: ComplexMonoid_bad_0['A] -> 'imaginary -> (Complex['imaginary | {real: Monoid['A]}] with {real: {real: Monoid['A]}})
 //│ Defined ComplexMonoid_bad_0.Add: ComplexMonoid_bad_0['A] -> anything -> anything -> nothing
 
 
@@ -209,7 +204,7 @@ class ComplexMonoid_bad_1[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.3: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ Defined class ComplexMonoid_bad_1[=A]
-//│ Defined ComplexMonoid_bad_1.Empty: ComplexMonoid_bad_1['A] -> ('imaginary & 'A0) -> (Complex['A0] with {imaginary: 'imaginary, real: {imaginary: error, real: 'A}})
+//│ Defined ComplexMonoid_bad_1.Empty: ComplexMonoid_bad_1['A] -> 'imaginary -> (Complex['imaginary | {imaginary: error, real: 'A}] with {real: {imaginary: error, real: 'A}})
 //│ Defined ComplexMonoid_bad_1.Add: ComplexMonoid_bad_1['A] -> anything -> anything -> nothing
 
 
@@ -237,11 +232,7 @@ class ComplexMonoid_bad_2[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.+5: 	    Complex (this.base.Add self.real that.real) (this.base.Add self.imaginary that.imaginary)
 //│ ╙──      	                                                 ^^^^^^^^^
 //│ Defined class ComplexMonoid_bad_2[=A]
-//│ Defined ComplexMonoid_bad_2.Add: ComplexMonoid_bad_2['A] -> {imaginary: 'A & 'A0, real: 'A & 'A0} -> {imaginary: 'A & 'A0, real: 'A & 'A0} -> (Complex['A0] with {imaginary: 'A, real: 'A})
-//│ Defined ComplexMonoid_bad_2.Add2: ComplexMonoid_bad_2['A] -> Complex['_] -> Complex['_0] -> (Complex['A0] with {imaginary: (Complex['A1] with {imaginary: 'A2, real: 'A2}) | error, real: (Complex['A3] with {imaginary: 'A2, real: 'A2}) | error})
-//│   where
-//│     'A0 :> (Complex[in 'A1 & 'A3 out 'A1 | 'A3] with {imaginary: 'A2, real: 'A2}) | error
-//│     '_0 <: {imaginary: 'A1 & 'A2 & 'A3, real: 'A1 & 'A2 & 'A3}
-//│     '_ <: {imaginary: 'A1 & 'A2 & 'A3, real: 'A1 & 'A2 & 'A3}
+//│ Defined ComplexMonoid_bad_2.Add: ComplexMonoid_bad_2['A] -> {imaginary: 'A, real: 'A} -> {imaginary: 'A, real: 'A} -> Complex['A]
+//│ Defined ComplexMonoid_bad_2.Add2: ComplexMonoid_bad_2['A] -> Complex[{imaginary: 'A0, real: 'A0}] -> Complex[{imaginary: 'A0, real: 'A0}] -> (Complex[Complex['A0] | error] with {imaginary: Complex['A0] | error, real: Complex['A0] | error})
 
 

--- a/shared/src/test/diff/mlscript/TypeClasses.mls
+++ b/shared/src/test/diff/mlscript/TypeClasses.mls
@@ -105,7 +105,7 @@ class ComplexMonoid_bad_0[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ╟── function of type `?a -> ?b` is not an instance of type Complex
 //│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into application with expected type `Complex[anything]`
+//│ ╟── but it flows into application with expected type `Complex[?]`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from applied type reference:
@@ -164,7 +164,7 @@ class ComplexMonoid_bad_1[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ╟── function of type `?a -> ?b` is not an instance of type Complex
 //│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into application with expected type `Complex[anything]`
+//│ ╟── but it flows into application with expected type `Complex[?]`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base.Empty; imaginary = this.imaginary.Empty }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from applied type reference:

--- a/shared/src/test/diff/mlscript/Variant-sub.mls
+++ b/shared/src/test/diff/mlscript/Variant-sub.mls
@@ -12,7 +12,7 @@ def None = None{}
 
 def flatMap = fun f -> fun opt ->
   case opt of { Some -> f opt.v | None -> opt }
-//│ flatMap: ('v -> 'a) -> (None & 'a | (Some[nothing] with {v: 'v})) -> 'a
+//│ flatMap: ('v -> 'a) -> (None & 'a | (Some[anything] with {v: 'v})) -> 'a
 //│        = [Function: flatMap]
 
 f x = Some x
@@ -30,7 +30,7 @@ flatMap f "oops"
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.29: 	flatMap f "oops"
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ╟── string literal of type `"oops"` does not match type `None & ?a | Some[?] & ?b`
+//│ ╟── string literal of type `"oops"` does not match type `None & ?a | Some[anything] & ?b`
 //│ ║  l.29: 	flatMap f "oops"
 //│ ║        	          ^^^^^^
 //│ ╟── Note: constraint arises from reference:

--- a/shared/src/test/diff/mlscript/Variant-sub.mls
+++ b/shared/src/test/diff/mlscript/Variant-sub.mls
@@ -12,7 +12,7 @@ def None = None{}
 
 def flatMap = fun f -> fun opt ->
   case opt of { Some -> f opt.v | None -> opt }
-//│ flatMap: ('v -> 'a) -> (None & 'a | (Some[anything] with {v: 'v})) -> 'a
+//│ flatMap: ('v -> 'a) -> (None & 'a | (Some[?] with {v: 'v})) -> 'a
 //│        = [Function: flatMap]
 
 f x = Some x
@@ -30,7 +30,7 @@ flatMap f "oops"
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.29: 	flatMap f "oops"
 //│ ║        	^^^^^^^^^^^^^^^^
-//│ ╟── string literal of type `"oops"` does not match type `None & ?a | Some[anything] & ?b`
+//│ ╟── string literal of type `"oops"` does not match type `None & ?a | Some[?] & ?b`
 //│ ║  l.29: 	flatMap f "oops"
 //│ ║        	          ^^^^^^
 //│ ╟── Note: constraint arises from reference:

--- a/shared/src/test/diff/mlscript/Variant-sub.mls
+++ b/shared/src/test/diff/mlscript/Variant-sub.mls
@@ -5,47 +5,45 @@ class Some[A]: { v: A }
 
 def Some v = Some{v}
 def None = None{}
-//│ Some: ('v & 'A) -> (Some['A] with {v: 'v})
+//│ Some: 'v -> Some['v]
 //│     = [Function: Some1]
 //│ None: None
 //│     = None {}
 
 def flatMap = fun f -> fun opt ->
   case opt of { Some -> f opt.v | None -> opt }
-//│ flatMap: ('v -> 'a) -> (None & 'a | (Some[?] with {v: 'v})) -> 'a
+//│ flatMap: ('v -> 'a) -> (None & 'a | (Some[nothing] with {v: 'v})) -> 'a
 //│        = [Function: flatMap]
 
 f x = Some x
 flatMap f (Some 1)
 flatMap f None
-//│ f: ('v & 'A) -> (Some['A] with {v: 'v})
+//│ f: 'v -> Some['v]
 //│  = [Function: f]
-//│ res: Some['A] & {v: 1}
-//│   where
-//│     'A :> 1
+//│ res: Some[1]
 //│    = Some { v: 1 }
-//│ res: None | (Some['A] with {v: nothing})
+//│ res: None | Some[nothing]
 //│    = None {}
 
 :e
 flatMap f "oops"
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.31: 	flatMap f "oops"
+//│ ║  l.29: 	flatMap f "oops"
 //│ ║        	^^^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` does not match type `None & ?a | Some[?] & ?b`
-//│ ║  l.31: 	flatMap f "oops"
+//│ ║  l.29: 	flatMap f "oops"
 //│ ║        	          ^^^^^^
 //│ ╟── Note: constraint arises from reference:
 //│ ║  l.14: 	  case opt of { Some -> f opt.v | None -> opt }
 //│ ╙──      	       ^^^
-//│ res: error | (Some['A] with {v: nothing})
+//│ res: error | Some[nothing]
 //│ Runtime error:
 //│   Error: non-exhaustive case expression
 
 class NoneBecause: None & { reason: string }
 flatMap f (NoneBecause { reason = "uh uh" })
 //│ Defined class NoneBecause
-//│ res: NoneBecause & {reason: "uh uh"} | (Some['A] with {v: nothing})
+//│ res: NoneBecause & {reason: "uh uh"} | Some[nothing]
 //│    = NoneBecause { reason: 'uh uh' }
 
 type Expr = Lit | Neg | Var | Plus
@@ -75,11 +73,11 @@ rec def evalOpt x = case x of {
         Some (l + r)
       ) (evalOpt x.rhs)) (evalOpt x.lhs)
   }
-//│ evalOpt: 'a -> (NoneBecause | (Some[in 'A out 'A | int] with {v: int}))
+//│ evalOpt: 'a -> (NoneBecause | Some[int])
 //│   where
-//│     'a <: Lit & {v: int & 'A} | (Neg with {sub: 'a}) | (Plus with {lhs: 'a, rhs: 'a}) | Var
+//│     'a <: Lit & {v: int} | (Neg with {sub: 'a}) | (Plus with {lhs: 'a, rhs: 'a}) | Var
 //│        = [Function: evalOpt]
 
 evalOpt (Plus{lhs = Lit{v=2}; rhs = Lit{v=3}})
-//│ res: NoneBecause | (Some[in 'A out 2 | 3 | int | 'A] with {v: int})
+//│ res: NoneBecause | Some[int]
 //│    = Some { v: 5 }

--- a/shared/src/test/diff/mlscript/Wildcards.mls
+++ b/shared/src/test/diff/mlscript/Wildcards.mls
@@ -26,37 +26,34 @@ def f x = x : ?
 //│ f: nothing -> anything
 //│  = [Function: f]
 
-:w
 class E[A]
-//│ Defined class E[±A]
-//│ ╔══[WARNING] Type definition E has bivariant type parameters:
-//│ ║  l.30: 	class E[A]
-//│ ║        	      ^
-//│ ╟── A is irrelevant and may be removed
-//│ ║  l.30: 	class E[A]
-//│ ╙──      	        ^
+  method In: A -> A
+  method In = id
+//│ Defined class E[=A]
+//│ Declared E.In: E['A] -> 'A -> 'A
+//│ Defined E.In: E['A] -> 'a -> 'a
 
 :e
 E{} : E[?]
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.40: 	E{} : E[?]
+//│ ║  l.37: 	E{} : E[?]
 //│ ║        	^^^
 //│ ╟── type `anything` does not match type `nothing`
-//│ ║  l.40: 	E{} : E[?]
+//│ ║  l.37: 	E{} : E[?]
 //│ ║        	        ^
 //│ ╟── Note: constraint arises from type wildcard:
-//│ ║  l.40: 	E{} : E[?]
+//│ ║  l.37: 	E{} : E[?]
 //│ ╙──      	        ^
-//│ res: E[anything]
+//│ res: E[?]
 //│    = E {}
 
 def e: E[?]
 def e = E{}
-//│ e: E[anything]
+//│ e: E[?]
 //│  = <missing implementation>
-//│ E[anything]
+//│ E['A]
 //│   <:  e:
-//│ E[anything]
+//│ E[?]
 //│  = E {}
 
 
@@ -66,11 +63,11 @@ type Als1[A] = int -> A
 :e
 add 1 : Als1[?]
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.67: 	add 1 : Als1[?]
+//│ ║  l.64: 	add 1 : Als1[?]
 //│ ║        	^^^^^
 //│ ╟── type `int` does not match type `nothing`
 //│ ╟── Note: constraint arises from type wildcard:
-//│ ║  l.67: 	add 1 : Als1[?]
+//│ ║  l.64: 	add 1 : Als1[?]
 //│ ╙──      	             ^
 //│ res: Als1[anything]
 //│    = [Function (anonymous)]
@@ -91,10 +88,10 @@ type Als2[A] = A -> int
 :e
 add 1 : Als2[?]
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.92: 	add 1 : Als2[?]
+//│ ║  l.89: 	add 1 : Als2[?]
 //│ ║        	^^^^^
 //│ ╟── type `anything` does not match type `int`
-//│ ║  l.92: 	add 1 : Als2[?]
+//│ ║  l.89: 	add 1 : Als2[?]
 //│ ╙──      	             ^
 //│ res: Als2[nothing]
 //│    = [Function (anonymous)]
@@ -122,13 +119,13 @@ q = 1
 :e
 q + 1
 //│ ╔══[ERROR] Type mismatch in operator application:
-//│ ║  l.123: 	q + 1
+//│ ║  l.120: 	q + 1
 //│ ║         	^^^
 //│ ╟── type `anything` does not match type `int`
-//│ ║  l.112: 	def q: ?
+//│ ║  l.109: 	def q: ?
 //│ ║         	       ^
 //│ ╟── but it flows into reference with expected type `int`
-//│ ║  l.123: 	q + 1
+//│ ║  l.120: 	q + 1
 //│ ╙──       	^
 //│ res: error | int
 //│    = 2
@@ -136,13 +133,13 @@ q + 1
 :e
 q q
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.137: 	q q
+//│ ║  l.134: 	q q
 //│ ║         	^^^
 //│ ╟── type `anything` is not a function
-//│ ║  l.112: 	def q: ?
+//│ ║  l.109: 	def q: ?
 //│ ║         	       ^
 //│ ╟── but it flows into reference with expected type `anything -> ?a`
-//│ ║  l.137: 	q q
+//│ ║  l.134: 	q q
 //│ ╙──       	^
 //│ res: error
 //│ Runtime error:

--- a/shared/src/test/diff/mlscript/Wildcards.mls
+++ b/shared/src/test/diff/mlscript/Wildcards.mls
@@ -47,16 +47,16 @@ E{} : E[?]
 //│ ╟── Note: constraint arises from type wildcard:
 //│ ║  l.40: 	E{} : E[?]
 //│ ╙──      	        ^
-//│ res: E[?]
+//│ res: E[anything]
 //│    = E {}
 
 def e: E[?]
 def e = E{}
-//│ e: E[?]
+//│ e: E[anything]
 //│  = <missing implementation>
-//│ E['A]
+//│ E[anything]
 //│   <:  e:
-//│ E[?]
+//│ E[anything]
 //│  = E {}
 
 
@@ -72,16 +72,16 @@ add 1 : Als1[?]
 //│ ╟── Note: constraint arises from type wildcard:
 //│ ║  l.67: 	add 1 : Als1[?]
 //│ ╙──      	             ^
-//│ res: Als1[?]
+//│ res: Als1[anything]
 //│    = [Function (anonymous)]
 
 def a1: Als1[?]
 a1 = add 1
-//│ a1: Als1[?]
+//│ a1: Als1[anything]
 //│   = <missing implementation>
 //│ int -> int
 //│   <:  a1:
-//│ Als1[?]
+//│ Als1[anything]
 //│   = [Function (anonymous)]
 
 
@@ -96,16 +96,16 @@ add 1 : Als2[?]
 //│ ╟── type `anything` does not match type `int`
 //│ ║  l.92: 	add 1 : Als2[?]
 //│ ╙──      	             ^
-//│ res: Als2[?]
+//│ res: Als2[nothing]
 //│    = [Function (anonymous)]
 
 def a2: Als2[?]
 a2 = add 1
-//│ a2: Als2[?]
+//│ a2: Als2[nothing]
 //│   = <missing implementation>
 //│ int -> int
 //│   <:  a2:
-//│ Als2[?]
+//│ Als2[nothing]
 //│   = [Function (anonymous)]
 
 

--- a/shared/src/test/diff/mlscript/Wildcards.mls
+++ b/shared/src/test/diff/mlscript/Wildcards.mls
@@ -69,16 +69,16 @@ add 1 : Als1[?]
 //│ ╟── Note: constraint arises from type wildcard:
 //│ ║  l.64: 	add 1 : Als1[?]
 //│ ╙──      	             ^
-//│ res: Als1[anything]
+//│ res: Als1[?]
 //│    = [Function (anonymous)]
 
 def a1: Als1[?]
 a1 = add 1
-//│ a1: Als1[anything]
+//│ a1: Als1[?]
 //│   = <missing implementation>
 //│ int -> int
 //│   <:  a1:
-//│ Als1[anything]
+//│ Als1[?]
 //│   = [Function (anonymous)]
 
 
@@ -93,16 +93,16 @@ add 1 : Als2[?]
 //│ ╟── type `anything` does not match type `int`
 //│ ║  l.89: 	add 1 : Als2[?]
 //│ ╙──      	             ^
-//│ res: Als2[nothing]
+//│ res: Als2[?]
 //│    = [Function (anonymous)]
 
 def a2: Als2[?]
 a2 = add 1
-//│ a2: Als2[nothing]
+//│ a2: Als2[?]
 //│   = <missing implementation>
 //│ int -> int
 //│   <:  a2:
-//│ Als2[nothing]
+//│ Als2[?]
 //│   = [Function (anonymous)]
 
 

--- a/shared/src/test/diff/mlscript/With.mls
+++ b/shared/src/test/diff/mlscript/With.mls
@@ -175,9 +175,7 @@ class C[A]: { x: A }
 //│ Defined class C[+A]
 
 c = C{x = 1}
-//│ c: C['A] & {x: 1}
-//│   where
-//│     'A :> 1
+//│ c: C[1]
 //│  = C { x: 1 }
 
 c.x
@@ -185,9 +183,7 @@ c.x
 //│    = 1
 
 d = c with { x = "hi"; y = 2 }
-//│ d: C['A] with {x: "hi", y: 2}
-//│   where
-//│     'A :> 1
+//│ d: C[1] with {x: "hi", y: 2}
 //│  = C { x: 'hi', y: 2 }
 
 d.x
@@ -195,9 +191,7 @@ d.x
 //│    = 'hi'
 
 d: C['a]
-//│ res: C['a]
-//│   where
-//│     'a :> "hi" | 1
+//│ res: C["hi" | 1]
 //│    = C { x: 'hi', y: 2 }
 
 res.x

--- a/shared/src/test/diff/mlscript/Yicong.mls
+++ b/shared/src/test/diff/mlscript/Yicong.mls
@@ -56,10 +56,7 @@ class C2[A]: { a: A }
 //│ Defined class C2[+A]
 
 r = if true then C1 {a=x} else C2 {a=(3,4,5,4)}
-//│ r: C1['A] & {a: 1} | C2['A0] & {a: (3, 4, 5, 4,)}
-//│   where
-//│     'A0 :> (3, 4, 5, 4,)
-//│     'A :> 1
+//│ r: C1[1] | C2[(3, 4, 5, 4,)]
 //│  = C1 { a: 1 }
 
 case r of { C1 -> r.a | _ -> 0 }
@@ -97,10 +94,10 @@ def f: ((1,2)&t1 | (3,4)&t2) -> anything
 :e
 f ((true,false))
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.98: 	f ((true,false))
+//│ ║  l.95: 	f ((true,false))
 //│ ║        	^^^^^^^^^^^^^^^^
 //│ ╟── reference of type `true` does not match type `1 | 3`
-//│ ║  l.98: 	f ((true,false))
+//│ ║  l.95: 	f ((true,false))
 //│ ╙──      	    ^^^^
 //│ res: error
 //│    = <no result>
@@ -109,13 +106,13 @@ f ((true,false))
 :e
 fun (x, y) -> f ((x,y))
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.110: 	fun (x, y) -> f ((x,y))
+//│ ║  l.107: 	fun (x, y) -> f ((x,y))
 //│ ║         	              ^^^^^^^^^
 //│ ╟── tuple literal of type `(?a, ?b,)` does not match type `(1, 2,) & t1 | (3, 4,) & t2`
-//│ ║  l.110: 	fun (x, y) -> f ((x,y))
+//│ ║  l.107: 	fun (x, y) -> f ((x,y))
 //│ ║         	                 ^^^^^
 //│ ╟── Note: constraint arises from union type:
-//│ ║  l.93: 	def f: ((1,2)&t1 | (3,4)&t2) -> anything
+//│ ║  l.90: 	def f: ((1,2)&t1 | (3,4)&t2) -> anything
 //│ ╙──      	       ^^^^^^^^^^^^^^^^^^^^^
 //│ res: (nothing, nothing,) -> anything
 //│    = <no result>
@@ -186,10 +183,10 @@ def h f = (f (1,2,false), f (1,true))
 :e
 h (fun x -> x[0])
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.187: 	h (fun x -> x[0])
+//│ ║  l.184: 	h (fun x -> x[0])
 //│ ║         	^^^^^^^^^^^^^^^^^
 //│ ╟── tuple literal of type `(1, true,)` does not match type `(?a,)`
-//│ ║  l.182: 	def h f = (f (1,2,false), f (1,true))
+//│ ║  l.179: 	def h f = (f (1,2,false), f (1,true))
 //│ ╙──       	                            ^^^^^^^^
 //│ res: (undefined, undefined,) | error
 //│    = [ undefined, undefined ]
@@ -197,13 +194,13 @@ h (fun x -> x[0])
 :e
 h (fun (x, y) -> x)
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.198: 	h (fun (x, y) -> x)
+//│ ║  l.195: 	h (fun (x, y) -> x)
 //│ ║         	^^^^^^^^^^^^^^^^^^^
 //│ ╟── tuple literal of type `(1, 2, false,)` does not match type `(?a, ?b,)`
-//│ ║  l.182: 	def h f = (f (1,2,false), f (1,true))
+//│ ║  l.179: 	def h f = (f (1,2,false), f (1,true))
 //│ ║         	             ^^^^^^^^^^^
 //│ ╟── Note: constraint arises from tuple literal:
-//│ ║  l.198: 	h (fun (x, y) -> x)
+//│ ║  l.195: 	h (fun (x, y) -> x)
 //│ ╙──       	       ^^^^^^
 //│ res: (1, 1,) | error
 //│    = [ 1, 1 ]
@@ -234,30 +231,30 @@ fx ((a,b,c)) = a + b + c
 fx q1
 fx q2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.234: 	fx q1
+//│ ║  l.231: 	fx q1
 //│ ║         	^^^^^
 //│ ╟── tuple literal of type `(1, 1, 1, 1,)` does not match type `(?a, ?b, ?c,)`
-//│ ║  l.223: 	q1 = (1,1,1,1)
+//│ ║  l.220: 	q1 = (1,1,1,1)
 //│ ║         	     ^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `(?d, ?e, ?f,)`
-//│ ║  l.234: 	fx q1
+//│ ║  l.231: 	fx q1
 //│ ║         	   ^^
 //│ ╟── Note: constraint arises from tuple literal:
-//│ ║  l.225: 	fx ((a,b,c)) = a + b + c
+//│ ║  l.222: 	fx ((a,b,c)) = a + b + c
 //│ ╙──       	    ^^^^^^^
 //│ res: error | int
 //│    = 3
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.235: 	fx q2
+//│ ║  l.232: 	fx q2
 //│ ║         	^^^^^
 //│ ╟── tuple literal of type `(1, 1,)` does not match type `(?a, ?b, ?c,)`
-//│ ║  l.224: 	q2 = (1,1)
+//│ ║  l.221: 	q2 = (1,1)
 //│ ║         	     ^^^^^
 //│ ╟── but it flows into reference with expected type `(?d, ?e, ?f,)`
-//│ ║  l.235: 	fx q2
+//│ ║  l.232: 	fx q2
 //│ ║         	   ^^
 //│ ╟── Note: constraint arises from tuple literal:
-//│ ║  l.225: 	fx ((a,b,c)) = a + b + c
+//│ ║  l.222: 	fx ((a,b,c)) = a + b + c
 //│ ╙──       	    ^^^^^^^
 //│ res: error | int
 //│    = NaN
@@ -287,13 +284,13 @@ sum t2
 //│ t2: (1, 1, 2, true,)
 //│   = [ 1, 1, 2, true ]
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.286: 	sum t2
+//│ ║  l.283: 	sum t2
 //│ ║         	^^^^^^
 //│ ╟── reference of type `true` does not match type `int`
-//│ ║  l.285: 	t2 = (1,1,2,true)
+//│ ║  l.282: 	t2 = (1,1,2,true)
 //│ ║         	            ^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.273: 	def sum: Array[int] -> int
+//│ ║  l.270: 	def sum: Array[int] -> int
 //│ ╙──       	               ^^^
 //│ res: error | int
 //│    = <no result>
@@ -313,9 +310,7 @@ def tk: Array['a] -> Wrapped['a]
 tk ((1,2,3,true,false))
 //│ tk: Array['a] -> Wrapped['a]
 //│   = <missing implementation>
-//│ res: Wrapped['a]
-//│   where
-//│     'a :> 1 | 2 | 3 | false | true
+//│ res: Wrapped[1 | 2 | 3 | false | true]
 //│    = <no result>
 //│      tk is not implemented
 
@@ -324,16 +319,11 @@ two = Two {fst=(1,2,3); snd=(true,false)}
 two.fst
 tk (two.snd)
 //│ Defined class Two[+A, +B]
-//│ two: Two['A, 'B] with {fst: (1, 2, 3,), snd: (true, false,)}
-//│   where
-//│     'B :> bool
-//│     'A :> 1 | 2 | 3
+//│ two: Two[1 | 2 | 3, bool] with {fst: (1, 2, 3,), snd: (true, false,)}
 //│    = Two { fst: [ 1, 2, 3 ], snd: [ true, false ] }
 //│ res: (1, 2, 3,)
 //│    = [ 1, 2, 3 ]
-//│ res: Wrapped['a]
-//│   where
-//│     'a :> bool
+//│ res: Wrapped[bool]
 //│    = <no result>
 //│      tk is not implemented
 
@@ -347,32 +337,32 @@ a1._2
 //│   <:  a1:
 //│ Array[int]
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.342: 	a1 = (1,2,true,'hello')
+//│ ║  l.332: 	a1 = (1,2,true,'hello')
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── reference of type `true` does not match type `int`
-//│ ║  l.342: 	a1 = (1,2,true,'hello')
+//│ ║  l.332: 	a1 = (1,2,true,'hello')
 //│ ║         	          ^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.341: 	def a1: Array[int]
+//│ ║  l.331: 	def a1: Array[int]
 //│ ╙──       	              ^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.342: 	a1 = (1,2,true,'hello')
+//│ ║  l.332: 	a1 = (1,2,true,'hello')
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"hello"` does not match type `int`
-//│ ║  l.342: 	a1 = (1,2,true,'hello')
+//│ ║  l.332: 	a1 = (1,2,true,'hello')
 //│ ║         	               ^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.341: 	def a1: Array[int]
+//│ ║  l.331: 	def a1: Array[int]
 //│ ╙──       	              ^^^
 //│   = [ 1, 2, true, 'hello' ]
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.343: 	a1._2
+//│ ║  l.333: 	a1._2
 //│ ║         	^^^^^
 //│ ╟── type `Array[int]` does not have field '_2'
-//│ ║  l.341: 	def a1: Array[int]
+//│ ║  l.331: 	def a1: Array[int]
 //│ ║         	        ^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `{_2: ?a}`
-//│ ║  l.343: 	a1._2
+//│ ║  l.333: 	a1._2
 //│ ╙──       	^^
 //│ res: error
 //│    = undefined
@@ -413,13 +403,13 @@ append2 ((mut 1, mut 2, mut false)) ((mut (), mut 'hi'))
 :e
 append2 ((mut 1, mut 2, mut false)) ((mut (), 'hi'))
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.414: 	append2 ((mut 1, mut 2, mut false)) ((mut (), 'hi'))
+//│ ║  l.404: 	append2 ((mut 1, mut 2, mut false)) ((mut (), 'hi'))
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── tuple literal of type `(mut ?a, "hi",)` does not match type `MutArray[?bb]`
-//│ ║  l.414: 	append2 ((mut 1, mut 2, mut false)) ((mut (), 'hi'))
+//│ ║  l.404: 	append2 ((mut 1, mut 2, mut false)) ((mut (), 'hi'))
 //│ ║         	                                     ^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.403: 	def append2: MutArray['aa] -> MutArray['bb] -> MutArray['aa | 'bb]
+//│ ║  l.393: 	def append2: MutArray['aa] -> MutArray['bb] -> MutArray['aa | 'bb]
 //│ ╙──       	                              ^^^^^^^^^^^^^
 //│ res: MutArray['bb] | error
 //│   where
@@ -509,7 +499,7 @@ def intersect: Array['a] -> Array['b] -> Array['a & 'b]
 iarr = intersect ((1,2,3,false)) ((1,5,true,'hi',false))
 //│ intersect: Array['a] -> Array['b] -> Array['a & 'b]
 //│          = <missing implementation>
-//│ iarr: Array["hi" | 1 | 5 | false | true | 2 | 3]
+//│ iarr: Array[1 | false]
 //│     = <no result>
 //│       intersect is not implemented
 
@@ -517,31 +507,31 @@ iarr = intersect ((1,2,3,false)) ((1,5,true,'hi',false))
 fst iarr
 snd (T1 ((1,2,3)))
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.517: 	fst iarr
+//│ ║  l.507: 	fst iarr
 //│ ║         	^^^^^^^^
 //│ ╟── type `Array[?a & ?b]` is not a 2-element tuple
-//│ ║  l.508: 	def intersect: Array['a] -> Array['b] -> Array['a & 'b]
+//│ ║  l.498: 	def intersect: Array['a] -> Array['b] -> Array['a & 'b]
 //│ ║         	                                         ^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `(?c, ?d,)`
-//│ ║  l.517: 	fst iarr
+//│ ║  l.507: 	fst iarr
 //│ ║         	    ^^^^
 //│ ╟── Note: constraint arises from tuple literal:
-//│ ║  l.487: 	def fst ((a, b)) = a
+//│ ║  l.477: 	def fst ((a, b)) = a
 //│ ╙──       	         ^^^^^^
 //│ res: error
 //│    = <no result>
 //│      iarr and intersect are not implemented
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.518: 	snd (T1 ((1,2,3)))
+//│ ║  l.508: 	snd (T1 ((1,2,3)))
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── tuple literal of type `(1, 2, 3,)` does not match type `(?a, ?b,) | ~t1`
-//│ ║  l.518: 	snd (T1 ((1,2,3)))
+//│ ║  l.508: 	snd (T1 ((1,2,3)))
 //│ ║         	         ^^^^^^^
 //│ ╟── but it flows into application with expected type `(?a, ?b,) | ~t1`
-//│ ║  l.518: 	snd (T1 ((1,2,3)))
+//│ ║  l.508: 	snd (T1 ((1,2,3)))
 //│ ║         	     ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from tuple literal:
-//│ ║  l.488: 	def snd ((a, b)) = b
+//│ ║  l.478: 	def snd ((a, b)) = b
 //│ ╙──       	         ^^^^^^
 //│ res: error
 //│    = 2
@@ -583,7 +573,7 @@ inn2 (T2 r1)
 //│ res: Array[Array[Array[bool | int]]]
 //│    = <no result>
 //│      v3 is not implemented
-//│ res: Array[T1 & (int | true)]
+//│ res: Array[T1 & int | T1 & true]
 //│    = <no result>
 //│      inn2 is not implemented
 
@@ -591,31 +581,31 @@ inn2 (T2 r1)
 inn (T1 v3)
 inn2 v1
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.591: 	inn (T1 v3)
+//│ ║  l.581: 	inn (T1 v3)
 //│ ║         	^^^^^^^^^^^
 //│ ╟── type `Array[Array[(int, true,)]]` does not match type `t2 | ~t1`
-//│ ║  l.555: 	def v3: Array[Array[(int, true)]]
+//│ ║  l.545: 	def v3: Array[Array[(int, true)]]
 //│ ║         	        ^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `t2 | ~t1`
-//│ ║  l.591: 	inn (T1 v3)
+//│ ║  l.581: 	inn (T1 v3)
 //│ ║         	        ^^
 //│ ╟── Note: constraint arises from type reference:
-//│ ║  l.551: 	def inn: (T1 & T2 & Array['a]) -> 'a
+//│ ║  l.541: 	def inn: (T1 & T2 & Array['a]) -> 'a
 //│ ║         	               ^^
 //│ ╟── from intersection type:
-//│ ║  l.551: 	def inn: (T1 & T2 & Array['a]) -> 'a
+//│ ║  l.541: 	def inn: (T1 & T2 & Array['a]) -> 'a
 //│ ╙──       	         ^^^^^^^^^^^^^^^^^^^^^
 //│ res: Array[(int, true,)] | error
 //│    = <no result>
 //│      inn is not implemented
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.592: 	inn2 v1
+//│ ║  l.582: 	inn2 v1
 //│ ║         	^^^^^^^
 //│ ╟── integer literal of type `1` does not match type `Array[?a]`
-//│ ║  l.549: 	v1 = T1 (T2 ((1,2,true)))
+//│ ║  l.539: 	v1 = T1 (T2 ((1,2,true)))
 //│ ║         	              ^
 //│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.552: 	def inn2: (T2 & Array[Array['a]]) -> Array[T1 & 'a]
+//│ ║  l.542: 	def inn2: (T2 & Array[Array['a]]) -> Array[T1 & 'a]
 //│ ╙──       	                      ^^^^^^^^^
 //│ res: Array[nothing] | error
 //│    = <no result>
@@ -652,16 +642,16 @@ ra: (Array['a], Array['a]) as 'a
 ra: ('a, 'a, 'a) as 'a
 ra: (Array['a], Array['a], Array['a]) as 'a
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.652: 	ra: ('a, 'a, 'a) as 'a
+//│ ║  l.642: 	ra: ('a, 'a, 'a) as 'a
 //│ ║         	^^
 //│ ╟── type `(?a, ?a,)` does not match type `(?a0, ?a0, ?a0,)`
-//│ ║  l.624: 	def ra: ('a, 'a) as 'a
+//│ ║  l.614: 	def ra: ('a, 'a) as 'a
 //│ ║         	        ^^^^^^^^
 //│ ╟── but it flows into reference with expected type `(?a1, ?a1, ?a1,)`
-//│ ║  l.652: 	ra: ('a, 'a, 'a) as 'a
+//│ ║  l.642: 	ra: ('a, 'a, 'a) as 'a
 //│ ║         	^^
 //│ ╟── Note: constraint arises from tuple type:
-//│ ║  l.652: 	ra: ('a, 'a, 'a) as 'a
+//│ ║  l.642: 	ra: ('a, 'a, 'a) as 'a
 //│ ╙──       	    ^^^^^^^^^^^^
 //│ res: 'a
 //│   where
@@ -670,16 +660,16 @@ ra: (Array['a], Array['a], Array['a]) as 'a
 //│    = <no result>
 //│      ra is not implemented
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.653: 	ra: (Array['a], Array['a], Array['a]) as 'a
+//│ ║  l.643: 	ra: (Array['a], Array['a], Array['a]) as 'a
 //│ ║         	^^
 //│ ╟── type `(?a, ?a,)` does not match type `(Array[?a0], Array[?a0], Array[?a0],)`
-//│ ║  l.624: 	def ra: ('a, 'a) as 'a
+//│ ║  l.614: 	def ra: ('a, 'a) as 'a
 //│ ║         	        ^^^^^^^^
 //│ ╟── but it flows into reference with expected type `(Array[?a1], Array[?a1], Array[?a1],)`
-//│ ║  l.653: 	ra: (Array['a], Array['a], Array['a]) as 'a
+//│ ║  l.643: 	ra: (Array['a], Array['a], Array['a]) as 'a
 //│ ║         	^^
 //│ ╟── Note: constraint arises from tuple type:
-//│ ║  l.653: 	ra: (Array['a], Array['a], Array['a]) as 'a
+//│ ║  l.643: 	ra: (Array['a], Array['a], Array['a]) as 'a
 //│ ╙──       	    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: 'a
 //│   where
@@ -698,19 +688,19 @@ tktup ((1,2,3,true))
 :e
 tktup a123
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.699: 	tktup a123
+//│ ║  l.689: 	tktup a123
 //│ ║         	^^^^^^^^^^
 //│ ╟── type `Array[int]` does not have field '_3'
-//│ ║  l.381: 	def a123: Array[int]
+//│ ║  l.371: 	def a123: Array[int]
 //│ ║         	          ^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `{_3: ?a}`
-//│ ║  l.699: 	tktup a123
+//│ ║  l.689: 	tktup a123
 //│ ║         	      ^^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.691: 	def tktup t = (t._2, t._3)
+//│ ║  l.681: 	def tktup t = (t._2, t._3)
 //│ ║         	                     ^^^^
 //│ ╟── from reference:
-//│ ║  l.691: 	def tktup t = (t._2, t._3)
+//│ ║  l.681: 	def tktup t = (t._2, t._3)
 //│ ╙──       	                     ^
 //│ res: (nothing, nothing,) | error
 //│    = [ undefined, undefined ]
@@ -761,10 +751,10 @@ ta3[1-2]
 :e
 ((defined ta2[0])[1+4], ta[1])[0]
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.762: 	((defined ta2[0])[1+4], ta[1])[0]
+//│ ║  l.752: 	((defined ta2[0])[1+4], ta[1])[0]
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── possibly-undefined array access of type `undefined` does not match type `~undefined`
-//│ ║  l.762: 	((defined ta2[0])[1+4], ta[1])[0]
+//│ ║  l.752: 	((defined ta2[0])[1+4], ta[1])[0]
 //│ ╙──       	 ^^^^^^^^^^^^^^^^^^^^^
 //│ res: error | false | int | true | undefined
 //│    = undefined
@@ -778,53 +768,53 @@ ge[2]
 //│ ge: int -> int
 //│   = [Function: ge]
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.774: 	ta3[ge 3][ge (1+2)]
+//│ ║  l.764: 	ta3[ge 3][ge (1+2)]
 //│ ║         	^^^^^^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"hello"` does not match type `Array[?a]`
-//│ ║  l.743: 	ta3 = ((1,2,3), "hello", false)
+//│ ║  l.733: 	ta3 = ((1,2,3), "hello", false)
 //│ ║         	                ^^^^^^^
 //│ ╟── but it flows into array access with expected type `Array[?b]`
-//│ ║  l.774: 	ta3[ge 3][ge (1+2)]
+//│ ║  l.764: 	ta3[ge 3][ge (1+2)]
 //│ ╙──       	^^^^^^^^^
 //│ res: 1 | 2 | 3 | error | undefined
 //│ Runtime error:
 //│   TypeError: Cannot read properties of undefined (reading '4')
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.775: 	true[false]
+//│ ║  l.765: 	true[false]
 //│ ║         	^^^^^^^^^^^
 //│ ╟── reference of type `false` does not match type `int`
-//│ ║  l.775: 	true[false]
+//│ ║  l.765: 	true[false]
 //│ ╙──       	     ^^^^^
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.775: 	true[false]
+//│ ║  l.765: 	true[false]
 //│ ║         	^^^^^^^^^^^
 //│ ╟── reference of type `true` does not match type `Array[?a]`
-//│ ║  l.775: 	true[false]
+//│ ║  l.765: 	true[false]
 //│ ╙──       	^^^^
 //│ res: error | undefined
 //│    = undefined
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.776: 	4["hello"]
+//│ ║  l.766: 	4["hello"]
 //│ ║         	^^^^^^^^^^
 //│ ╟── string literal of type `"hello"` does not match type `int`
-//│ ║  l.776: 	4["hello"]
+//│ ║  l.766: 	4["hello"]
 //│ ╙──       	  ^^^^^^^
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.776: 	4["hello"]
+//│ ║  l.766: 	4["hello"]
 //│ ║         	^^^^^^^^^^
 //│ ╟── integer literal of type `4` does not match type `Array[?a]`
-//│ ║  l.776: 	4["hello"]
+//│ ║  l.766: 	4["hello"]
 //│ ╙──       	^
 //│ res: error | undefined
 //│    = undefined
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.777: 	ge[2]
+//│ ║  l.767: 	ge[2]
 //│ ║         	^^^^^
 //│ ╟── function of type `?a -> ?b` does not match type `Array[?c]`
-//│ ║  l.773: 	def ge x = x + 1
+//│ ║  l.763: 	def ge x = x + 1
 //│ ║         	       ^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `Array[?d]`
-//│ ║  l.777: 	ge[2]
+//│ ║  l.767: 	ge[2]
 //│ ╙──       	^^
 //│ res: error | undefined
 //│    = undefined
@@ -851,21 +841,21 @@ mkarr (1,true,"hi")[0]
 mkarr 3 [  1]
 mk1[2  ]
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.851: 	mkarr 3 [  1]
+//│ ║  l.841: 	mkarr 3 [  1]
 //│ ║         	      ^^^^^^^
 //│ ╟── integer literal of type `3` does not match type `Array[?a]`
-//│ ║  l.851: 	mkarr 3 [  1]
+//│ ║  l.841: 	mkarr 3 [  1]
 //│ ╙──       	      ^
 //│ res: Array[error | undefined]
 //│    = [ undefined, undefined, undefined, undefined, undefined ]
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.852: 	mk1[2  ]
+//│ ║  l.842: 	mk1[2  ]
 //│ ║         	^^^^^^^^
 //│ ╟── integer literal of type `6` does not match type `Array[?a]`
-//│ ║  l.834: 	mk1 = defined (mkarr 6)[ 0]
+//│ ║  l.824: 	mk1 = defined (mkarr 6)[ 0]
 //│ ║         	                     ^
 //│ ╟── but it flows into reference with expected type `Array[?b]`
-//│ ║  l.852: 	mk1[2  ]
+//│ ║  l.842: 	mk1[2  ]
 //│ ╙──       	^^^
 //│ res: error | undefined
 //│    = undefined
@@ -915,13 +905,13 @@ dup (defined ara[1])._1 (defined (defined arb[10])[8])._2 + 1
 :e
 (1,2,3)._1[1]
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.916: 	(1,2,3)._1[1]
+//│ ║  l.906: 	(1,2,3)._1[1]
 //│ ║         	^^^^^^^^^^^^^
 //│ ╟── integer literal of type `1` does not match type `Array[?a]`
-//│ ║  l.916: 	(1,2,3)._1[1]
+//│ ║  l.906: 	(1,2,3)._1[1]
 //│ ║         	 ^
 //│ ╟── but it flows into field selection with expected type `Array[?b]`
-//│ ║  l.916: 	(1,2,3)._1[1]
+//│ ║  l.906: 	(1,2,3)._1[1]
 //│ ╙──       	^^^^^^^^^^
 //│ res: error | undefined
 //│ Runtime error:

--- a/shared/src/test/diff/mlscript/Yuheng.mls
+++ b/shared/src/test/diff/mlscript/Yuheng.mls
@@ -109,7 +109,7 @@ rec def eval(e) = case e of
   }
 //│ eval: 'a -> 'value
 //│   where
-//│     'a <: (IntLit with {value: 'value}) | (Pair[?, ?] with {lhs: 'a, rhs: 'a})
+//│     'a <: (IntLit with {value: 'value}) | (Pair[anything, anything] with {lhs: 'a, rhs: 'a})
 //│     'value :> ('value, 'value,)
 //│     = [Function: eval]
 
@@ -120,7 +120,7 @@ rec def eval(e) = case e of
   }
 //│ eval: 'a -> 'value
 //│   where
-//│     'a <: (IntLit with {value: 'value}) | (Pair[?, ?] with {lhs: 'a, rhs: 'a}) | ~IntLit & ~Pair[?, ?]
+//│     'a <: (IntLit with {value: 'value}) | (Pair[anything, anything] with {lhs: 'a, rhs: 'a}) | ~IntLit & ~Pair[anything, anything]
 //│     'value :> ('value, 'value,)
 //│     = [Function: eval1]
 
@@ -143,7 +143,7 @@ p = Pair {
   rhs = Pair {
     lhs = IntLit { value = 2 };
     rhs = IntLit { value = 3 } } }
-//│ p: Pair[int, (int, int,)] with {lhs: IntLit & {value: 1}, rhs: Pair[int, int] with {lhs: IntLit & {value: 2}, rhs: IntLit & {value: 3}}}
+//│ p: Pair[anything, anything] with {lhs: IntLit & {value: 1}, rhs: Pair[anything, anything] with {lhs: IntLit & {value: 2}, rhs: IntLit & {value: 3}}}
 //│  = Pair {
 //│      lhs: IntLit { value: 1 },
 //│      rhs: Pair { lhs: IntLit { value: 2 }, rhs: IntLit { value: 3 } }
@@ -236,7 +236,7 @@ eval (Pair {
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ║  l.+5: 	    rhs = IntLit { value = 3 } } } })
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── application of type `Pair[?A, ?B] & {lhs: ?lhs, rhs: ?rhs}` does not match type `int`
+//│ ╟── application of type `Pair[?A, ?B] with {lhs: ?lhs, rhs: ?rhs}` does not match type `int`
 //│ ║  l.+3: 	  rhs = IntLit { value = Pair {
 //│ ║        	                         ^^^^^^
 //│ ║  l.+4: 	    lhs = IntLit { value = 2 };
@@ -248,7 +248,7 @@ eval (Pair {
 //│ ╙──      	                                   ^^^
 //│ res: 'a
 //│   where
-//│     'a :> ('a, 'a,) | 1 | (Pair[int, int] with {lhs: IntLit & {value: 2}, rhs: IntLit & {value: 3}})
+//│     'a :> ('a, 'a,) | 1 | (Pair[anything, anything] with {lhs: IntLit & {value: 2}, rhs: IntLit & {value: 3}})
 
 
 p = Pair2 {
@@ -273,12 +273,12 @@ p = Pair2 {
 //│ ╟── Note: constraint arises from tuple type:
 //│ ║  l.181: 	class Pair2[A, B]: Expr[(A, B)] & { lhs: Expr[A]; rhs: Expr[A] }
 //│ ╙──       	                        ^^^^^^
-//│ p: error | (Pair2[in (int, 'B,) | int out nothing, 'B0] with {Expr#A :> ((int, 'B,) | int, 'B0,) <: (nothing, 'B0,), lhs: IntLit & {value: 1}, rhs: Pair2[int, 'B] with {lhs: IntLit & {value: 2}, rhs: IntLit & {value: 3}}})
+//│ p: error | (Pair2[anything, anything] with {lhs: IntLit & {value: 1}, rhs: Pair2[anything, anything] with {lhs: IntLit & {value: 2}, rhs: IntLit & {value: 3}}})
 
 
 
 def eval: Expr['a] -> 'a
-//│ eval: Expr['a] -> 'a
+//│ eval: Expr[anything] -> nothing
 
 rec def eval(e) = case e of
   { IntLit -> e.value
@@ -286,10 +286,10 @@ rec def eval(e) = case e of
   }
 //│ 'a -> 'value
 //│   where
-//│     'a <: (IntLit with {value: 'value}) | (Pair[?, ?] with {lhs: 'a, rhs: 'a})
+//│     'a <: (IntLit with {value: 'value}) | (Pair[anything, anything] with {lhs: 'a, rhs: 'a})
 //│     'value :> ('value, 'value,)
 //│   <:  eval:
-//│ Expr['a] -> 'a
+//│ Expr[anything] -> nothing
 //│ ╔══[ERROR] Type mismatch in def definition:
 //│ ║  l.+1: 	rec def eval(e) = case e of
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -376,10 +376,10 @@ rec def eval(e) = case e of
   }
 //│ 'a -> 'value
 //│   where
-//│     'a <: (IntLit with {value: 'value}) | (Pair[?, ?] with {lhs: 'a, rhs: 'a}) | ~IntLit & ~Pair[?, ?]
+//│     'a <: (IntLit with {value: 'value}) | (Pair[anything, anything] with {lhs: 'a, rhs: 'a}) | ~IntLit & ~Pair[anything, anything]
 //│     'value :> ('value, 'value,)
 //│   <:  eval:
-//│ Expr['a] -> 'a
+//│ Expr[anything] -> nothing
 //│ ╔══[ERROR] Type mismatch in def definition:
 //│ ║  l.+1: 	rec def eval(e) = case e of
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/shared/src/test/diff/mlscript/Yuheng.mls
+++ b/shared/src/test/diff/mlscript/Yuheng.mls
@@ -109,7 +109,7 @@ rec def eval(e) = case e of
   }
 //│ eval: 'a -> 'value
 //│   where
-//│     'a <: (IntLit with {value: 'value}) | (Pair[anything, anything] with {lhs: 'a, rhs: 'a})
+//│     'a <: (IntLit with {value: 'value}) | (Pair[?, ?] with {lhs: 'a, rhs: 'a})
 //│     'value :> ('value, 'value,)
 //│     = [Function: eval]
 
@@ -120,7 +120,7 @@ rec def eval(e) = case e of
   }
 //│ eval: 'a -> 'value
 //│   where
-//│     'a <: (IntLit with {value: 'value}) | (Pair[anything, anything] with {lhs: 'a, rhs: 'a}) | ~IntLit & ~Pair[anything, anything]
+//│     'a <: (IntLit with {value: 'value}) | (Pair[?, ?] with {lhs: 'a, rhs: 'a}) | ~IntLit & ~Pair[?, ?]
 //│     'value :> ('value, 'value,)
 //│     = [Function: eval1]
 
@@ -143,7 +143,7 @@ p = Pair {
   rhs = Pair {
     lhs = IntLit { value = 2 };
     rhs = IntLit { value = 3 } } }
-//│ p: Pair[anything, anything] with {lhs: IntLit & {value: 1}, rhs: Pair[anything, anything] with {lhs: IntLit & {value: 2}, rhs: IntLit & {value: 3}}}
+//│ p: Pair[?, ?] with {lhs: IntLit & {value: 1}, rhs: Pair[?, ?] with {lhs: IntLit & {value: 2}, rhs: IntLit & {value: 3}}}
 //│  = Pair {
 //│      lhs: IntLit { value: 1 },
 //│      rhs: Pair { lhs: IntLit { value: 2 }, rhs: IntLit { value: 3 } }
@@ -248,7 +248,7 @@ eval (Pair {
 //│ ╙──      	                                   ^^^
 //│ res: 'a
 //│   where
-//│     'a :> ('a, 'a,) | 1 | (Pair[anything, anything] with {lhs: IntLit & {value: 2}, rhs: IntLit & {value: 3}})
+//│     'a :> ('a, 'a,) | 1 | (Pair[?, ?] with {lhs: IntLit & {value: 2}, rhs: IntLit & {value: 3}})
 
 
 p = Pair2 {
@@ -256,12 +256,12 @@ p = Pair2 {
   rhs = Pair2 {
     lhs = IntLit { value = 2 };
     rhs = IntLit { value = 3 } } }
-//│ p: Pair2[anything, anything] with {lhs: IntLit & {value: 1}, rhs: Pair2[anything, anything] with {lhs: IntLit & {value: 2}, rhs: IntLit & {value: 3}}}
+//│ p: Pair2[?, ?] with {lhs: IntLit & {value: 1}, rhs: Pair2[?, ?] with {lhs: IntLit & {value: 2}, rhs: IntLit & {value: 3}}}
 
 
 
 def eval: Expr['a] -> 'a
-//│ eval: Expr[anything] -> nothing
+//│ eval: Expr[?] -> nothing
 
 rec def eval(e) = case e of
   { IntLit -> e.value
@@ -269,10 +269,10 @@ rec def eval(e) = case e of
   }
 //│ 'a -> 'value
 //│   where
-//│     'a <: (IntLit with {value: 'value}) | (Pair[anything, anything] with {lhs: 'a, rhs: 'a})
+//│     'a <: (IntLit with {value: 'value}) | (Pair[?, ?] with {lhs: 'a, rhs: 'a})
 //│     'value :> ('value, 'value,)
 //│   <:  eval:
-//│ Expr[anything] -> nothing
+//│ Expr[?] -> nothing
 //│ ╔══[ERROR] Type mismatch in def definition:
 //│ ║  l.+1: 	rec def eval(e) = case e of
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -359,10 +359,10 @@ rec def eval(e) = case e of
   }
 //│ 'a -> 'value
 //│   where
-//│     'a <: (IntLit with {value: 'value}) | (Pair[anything, anything] with {lhs: 'a, rhs: 'a}) | ~IntLit & ~Pair[anything, anything]
+//│     'a <: (IntLit with {value: 'value}) | (Pair[?, ?] with {lhs: 'a, rhs: 'a}) | ~IntLit & ~Pair[?, ?]
 //│     'value :> ('value, 'value,)
 //│   <:  eval:
-//│ Expr[anything] -> nothing
+//│ Expr[?] -> nothing
 //│ ╔══[ERROR] Type mismatch in def definition:
 //│ ║  l.+1: 	rec def eval(e) = case e of
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/shared/src/test/diff/mlscript/Yuheng.mls
+++ b/shared/src/test/diff/mlscript/Yuheng.mls
@@ -236,7 +236,7 @@ eval (Pair {
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ║  l.+5: 	    rhs = IntLit { value = 3 } } } })
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── application of type `Pair[?A, ?B] with {lhs: ?lhs, rhs: ?rhs}` does not match type `int`
+//│ ╟── application of type `Pair[?, ?] with {Pair#A = ?A, Pair#B = ?B, lhs: ?lhs, rhs: ?rhs}` does not match type `int`
 //│ ║  l.+3: 	  rhs = IntLit { value = Pair {
 //│ ║        	                         ^^^^^^
 //│ ║  l.+4: 	    lhs = IntLit { value = 2 };
@@ -256,24 +256,7 @@ p = Pair2 {
   rhs = Pair2 {
     lhs = IntLit { value = 2 };
     rhs = IntLit { value = 3 } } }
-//│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.+1: 	p = Pair2 {
-//│ ║        	    ^^^^^^^
-//│ ║  l.+2: 	  lhs = IntLit { value = 1 };
-//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.+3: 	  rhs = Pair2 {
-//│ ║        	^^^^^^^^^^^^^^^
-//│ ║  l.+4: 	    lhs = IntLit { value = 2 };
-//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.+5: 	    rhs = IntLit { value = 3 } } }
-//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── type `int` is not a 2-element tuple
-//│ ║  l.90: 	class IntLit: Expr[int] & { value: int }
-//│ ║        	                   ^^^
-//│ ╟── Note: constraint arises from tuple type:
-//│ ║  l.181: 	class Pair2[A, B]: Expr[(A, B)] & { lhs: Expr[A]; rhs: Expr[A] }
-//│ ╙──       	                        ^^^^^^
-//│ p: error | (Pair2[anything, anything] with {lhs: IntLit & {value: 1}, rhs: Pair2[anything, anything] with {lhs: IntLit & {value: 2}, rhs: IntLit & {value: 3}}})
+//│ p: Pair2[anything, anything] with {lhs: IntLit & {value: 1}, rhs: Pair2[anything, anything] with {lhs: IntLit & {value: 2}, rhs: IntLit & {value: 3}}}
 
 
 
@@ -299,8 +282,8 @@ rec def eval(e) = case e of
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ║  l.+4: 	  }
 //│ ║        	^^^
-//│ ╟── type `Expr['a]` does not match type `IntLit & ?a | Pair[?, ?] & ?b`
-//│ ║  l.280: 	def eval: Expr['a] -> 'a
+//│ ╟── type `Expr[?]` does not match type `IntLit & ?a | Pair[?, ?] & ?b`
+//│ ║  l.263: 	def eval: Expr['a] -> 'a
 //│ ║         	          ^^^^^^^^
 //│ ╟── Note: constraint arises from reference:
 //│ ║  l.+1: 	rec def eval(e) = case e of
@@ -314,7 +297,7 @@ rec def eval(e) = case e of
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ║  l.+4: 	  }
 //│ ║        	^^^
-//│ ╟── expression of type `Expr['a] & ~intLit` does not have field 'rhs'
+//│ ╟── expression of type `Expr[?] & ~intLit` does not have field 'rhs'
 //│ ╟── Note: constraint arises from field selection:
 //│ ║  l.+3: 	  | Pair -> (eval e.lhs, eval e.rhs)
 //│ ║        	                              ^^^^^
@@ -330,7 +313,7 @@ rec def eval(e) = case e of
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ║  l.+4: 	  }
 //│ ║        	^^^
-//│ ╟── expression of type `Expr['a] & ~intLit` does not have field 'lhs'
+//│ ╟── expression of type `Expr[?] & ~intLit` does not have field 'lhs'
 //│ ╟── Note: constraint arises from field selection:
 //│ ║  l.+3: 	  | Pair -> (eval e.lhs, eval e.rhs)
 //│ ║        	                  ^^^^^
@@ -346,7 +329,7 @@ rec def eval(e) = case e of
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ║  l.+4: 	  }
 //│ ║        	^^^
-//│ ╟── expression of type `Expr['a] & ~pair | Expr['a] & ~?a` does not have field 'value'
+//│ ╟── expression of type `Expr[?] & ~pair | Expr[?] & ~?a` does not have field 'value'
 //│ ╟── Note: constraint arises from field selection:
 //│ ║  l.+2: 	  { IntLit -> e.value
 //│ ║        	              ^^^^^^^
@@ -366,7 +349,7 @@ rec def eval(e) = case e of
 //│ ║  l.+3: 	  | Pair -> (eval e.lhs, eval e.rhs)
 //│ ║        	            ^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type variable:
-//│ ║  l.280: 	def eval: Expr['a] -> 'a
+//│ ║  l.263: 	def eval: Expr['a] -> 'a
 //│ ╙──       	                      ^^
 
 rec def eval(e) = case e of
@@ -391,7 +374,7 @@ rec def eval(e) = case e of
 //│ ║        	^^^^^^^^^^^^^^
 //│ ║  l.+5: 	  }
 //│ ║        	^^^
-//│ ╟── expression of type `Expr['a] & ~intLit & ~?a | (Pair[?, ?]\lhs\rhs with {Expr#A = 'a})` does not have field 'rhs'
+//│ ╟── expression of type `Expr[?] & ~intLit & ~?a | Pair[?, ?]` does not have field 'rhs'
 //│ ╟── Note: constraint arises from field selection:
 //│ ║  l.+3: 	  | Pair -> (eval e.lhs, eval e.rhs)
 //│ ║        	                              ^^^^^
@@ -409,7 +392,7 @@ rec def eval(e) = case e of
 //│ ║        	^^^^^^^^^^^^^^
 //│ ║  l.+5: 	  }
 //│ ║        	^^^
-//│ ╟── expression of type `Expr['a] & ~intLit & ~?a | (Pair[?, ?]\lhs\rhs with {Expr#A = 'a})` does not have field 'lhs'
+//│ ╟── expression of type `Expr[?] & ~intLit & ~?a | Pair[?, ?]` does not have field 'lhs'
 //│ ╟── Note: constraint arises from field selection:
 //│ ║  l.+3: 	  | Pair -> (eval e.lhs, eval e.rhs)
 //│ ║        	                  ^^^^^
@@ -427,7 +410,7 @@ rec def eval(e) = case e of
 //│ ║        	^^^^^^^^^^^^^^
 //│ ║  l.+5: 	  }
 //│ ║        	^^^
-//│ ╟── expression of type `Expr['a] & ~pair & ~?a | (IntLit\value with {Expr#A = 'a}) | (Pair[?, ?]\lhs\rhs with {Expr#A = 'a}) & ~pair | ~?b & (Expr['a] & ~?a | (Pair[?, ?]\lhs\rhs with {Expr#A = 'a}))` does not have field 'value'
+//│ ╟── expression of type `Expr[?] & ~pair & ~?a | IntLit | Pair[?, ?] & ~pair | ~?b & (Expr[?] & ~?a | Pair[?, ?])` does not have field 'value'
 //│ ╟── Note: constraint arises from field selection:
 //│ ║  l.+2: 	  { IntLit -> e.value
 //│ ║        	              ^^^^^^^
@@ -449,5 +432,5 @@ rec def eval(e) = case e of
 //│ ║  l.+3: 	  | Pair -> (eval e.lhs, eval e.rhs)
 //│ ║        	            ^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from type variable:
-//│ ║  l.280: 	def eval: Expr['a] -> 'a
+//│ ║  l.263: 	def eval: Expr['a] -> 'a
 //│ ╙──       	                      ^^

--- a/shared/src/test/diff/typegen/TypegenTerms.mls
+++ b/shared/src/test/diff/typegen/TypegenTerms.mls
@@ -1,4 +1,5 @@
 :NoJS
+
 :ts
 { a = "hello"; b = "world" }
 1 + 2 - 5
@@ -75,19 +76,19 @@ def f: ('c -> 'a as 'a) -> 'c -> int
 1: ?
 { a = "hello" }: { a: string } & { b: int }
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.75: 	1: ?
+//│ ║  l.76: 	1: ?
 //│ ║        	^
 //│ ╟── integer literal of type `1` does not match type `nothing`
 //│ ╟── Note: constraint arises from type wildcard:
-//│ ║  l.75: 	1: ?
+//│ ║  l.76: 	1: ?
 //│ ╙──      	   ^
 //│ res: anything
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.76: 	{ a = "hello" }: { a: string } & { b: int }
+//│ ║  l.77: 	{ a = "hello" }: { a: string } & { b: int }
 //│ ║        	^^^^^^^^^^^^^^^
 //│ ╟── record literal of type `{a: "hello"}` does not have field 'b'
 //│ ╟── Note: constraint arises from intersection type:
-//│ ║  l.76: 	{ a = "hello" }: { a: string } & { b: int }
+//│ ║  l.77: 	{ a = "hello" }: { a: string } & { b: int }
 //│ ╙──      	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: {a: string, b: int}
 //│ // start ts

--- a/shared/src/test/diff/typegen/TypegenTypedefs.mls
+++ b/shared/src/test/diff/typegen/TypegenTypedefs.mls
@@ -85,7 +85,7 @@ def Some v = Some { value = v }
 //│ Defined type alias Option[+T]
 //│ Defined class LinkedList[=T]
 //│ Declared LinkedList.Append: LinkedList['T] -> 'T -> LinkedList['T]
-//│ Defined LinkedList.Append: (LinkedList['T] & 'this) -> ('T & 'head) -> (LinkedList['T] with {head: 'head, tail: Some[LinkedList['T]] with {value: LinkedList['T] & 'this}})
+//│ Defined LinkedList.Append: (LinkedList['T] & 'this) -> ('T & 'head) -> (LinkedList['T] with {head: 'head, tail: Some[LinkedList['T]] & {value: LinkedList['T] & 'this}})
 //│ None: None
 //│ Some: 'value -> Some['value]
 //│ // start ts

--- a/shared/src/test/diff/typegen/TypegenTypedefs.mls
+++ b/shared/src/test/diff/typegen/TypegenTypedefs.mls
@@ -195,7 +195,7 @@ class Prog[T]
 //│ ║  l.190: 	  method Run: Arg[T] -> number
 //│ ╙──       	              ^^^^^^
 //│ Defined class Prog[±T]
-//│ Declared Prog.Run: Prog[anything] -> error -> number
+//│ Declared Prog.Run: Prog[?] -> error -> number
 //│ ╔══[WARNING] Type definition Prog has bivariant type parameters:
 //│ ║  l.189: 	class Prog[T]
 //│ ║         	      ^^^^

--- a/shared/src/test/diff/typegen/TypegenTypedefs.mls
+++ b/shared/src/test/diff/typegen/TypegenTypedefs.mls
@@ -43,13 +43,13 @@ def Bank lock cash = Bank { lock = lock; cash = cash }
 let lockA = Lock 20 in let lockB = Lock 30 in (Bank lockA 2000).Better(Bank lockB 30000)
 //│ Defined class Lock[+T]
 //│ Declared Lock.Map: Lock['T] -> ('T -> 'a) -> Lock['a]
-//│ Defined Lock.Map: Lock['T] -> ('T -> ('pins & 'T0)) -> (Lock['T0] with {pins: 'pins})
+//│ Defined Lock.Map: Lock['T] -> ('T -> 'pins) -> Lock['pins]
 //│ Defined class Bank
 //│ Declared Bank.Potential: Bank -> int
 //│ Declared Bank.Better: Bank -> Bank -> bool
 //│ Defined Bank.Potential: Bank -> int
 //│ Defined Bank.Better: Bank -> Bank -> bool
-//│ Lock: ('pins & 'T) -> (Lock['T] with {pins: 'pins})
+//│ Lock: 'pins -> Lock['pins]
 //│ Bank: (Lock[int] & 'lock) -> (int & 'cash) -> (Bank with {cash: 'cash, lock: 'lock})
 //│ res: bool
 //│ // start ts
@@ -65,7 +65,7 @@ let lockA = Lock 20 in let lockB = Lock 30 in (Bank lockA 2000).Better(Bank lock
 //│     readonly Potential: int
 //│     Better(arg: Bank): bool
 //│ }
-//│ export declare const Lock<pins, T>: (arg: pins & T) => Omit<Lock<T>, "pins"> & {readonly pins: pins}
+//│ export declare const Lock<pins>: (arg: pins) => Lock<pins>
 //│ export declare const Bank<lock, cash>: (arg: Lock<int> & lock) => (arg1: int & cash) => Omit<Bank, "cash" | "lock"> & {readonly cash: cash, readonly lock: lock}
 //│ export declare const res: bool
 //│ // end ts
@@ -85,9 +85,9 @@ def Some v = Some { value = v }
 //│ Defined type alias Option[+T]
 //│ Defined class LinkedList[=T]
 //│ Declared LinkedList.Append: LinkedList['T] -> 'T -> LinkedList['T]
-//│ Defined LinkedList.Append: (LinkedList['T] & 'this) -> ('T & 'head) -> (LinkedList['T] with {head: 'head, tail: Some[LinkedList['T]] & {value: LinkedList['T] & 'this}})
+//│ Defined LinkedList.Append: (LinkedList['T] & 'this) -> ('T & 'head) -> (LinkedList['T] with {head: 'head, tail: Some[LinkedList['T]] with {value: LinkedList['T] & 'this}})
 //│ None: None
-//│ Some: ('value & 'T) -> (Some['T] with {value: 'value})
+//│ Some: 'value -> Some['value]
 //│ // start ts
 //│ export declare class None {
 //│     constructor(fields: {})
@@ -104,7 +104,7 @@ def Some v = Some { value = v }
 //│     Append(arg: T): LinkedList<T>
 //│ }
 //│ export declare const None: None
-//│ export declare const Some<value, T>: (arg: value & T) => Omit<Some<T>, "value"> & {readonly value: value}
+//│ export declare const Some<value>: (arg: value) => Some<value>
 //│ // end ts
 
 :ts
@@ -195,7 +195,7 @@ class Prog[T]
 //│ ║  l.190: 	  method Run: Arg[T] -> number
 //│ ╙──       	              ^^^^^^
 //│ Defined class Prog[±T]
-//│ Declared Prog.Run: Prog['T] -> error -> number
+//│ Declared Prog.Run: Prog[anything] -> error -> number
 //│ ╔══[WARNING] Type definition Prog has bivariant type parameters:
 //│ ║  l.189: 	class Prog[T]
 //│ ║         	      ^^^^

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -136,7 +136,10 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite with org.scalatest.Pa
         rec(ls, mode.copy(fixme = true))
       case line :: ls if line.startsWith(outputMarker) //|| line.startsWith(oldOutputMarker)
         => rec(ls, defaultMode)
-      case line :: ls if line.isEmpty || line.startsWith("//") =>
+      case line :: ls if line.isEmpty =>
+        out.println(line)
+        rec(ls, defaultMode)
+      case line :: ls if line.startsWith("//") =>
         out.println(line)
         rec(ls, mode)
       case line :: ls if line.startsWith(diffBegMarker) => // Check if there are unmerged git conflicts

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -324,10 +324,11 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite with org.scalatest.Pa
 
                 val tn = td.nme.name
                 val ttd = ctx.tyDefs(tn)
+                val tvv = ttd.tvarVariances.getOrElse(die)
 
                 // generate warnings for bivariant type variables
                 val bivariantTypeVars = ttd.tparamsargs.iterator.filter{ case (tname, tvar) =>
-                  ttd.tvarVariances.get.get(tvar).contains(typer.VarianceInfo.bi)
+                  tvv.get(tvar).contains(typer.VarianceInfo.bi)
                 }.map(_._1).toList
                 if (!bivariantTypeVars.isEmpty) {
                   varianceWarnings.put(td.nme, bivariantTypeVars)
@@ -335,7 +336,7 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite with org.scalatest.Pa
                 
                 val params = if (!ttd.tparamsargs.isEmpty)
                     SourceCode.horizontalArray(ttd.tparamsargs.map{ case (tname, tvar) =>
-                      val tvarVariance = ttd.tvarVariances.get.getOrElse(tvar, throw new Exception(
+                      val tvarVariance = tvv.getOrElse(tvar, throw new Exception(
                         s"Type variable $tvar not found in variance store ${ttd.tvarVariances} for $ttd"))
                       SourceCode(s"${tvarVariance.show}${tname.name}")
                     }.toList).toString()

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -283,14 +283,14 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite with org.scalatest.Pa
               if (mode.isDebugging) output(s"⬤ Typed as: $wty")
               if (mode.isDebugging) output(s" where: ${wty.showBounds}")
               typer.dbg = mode.dbgSimplif
-              if (mode.noSimplification) typer.expandType(wty)
+              if (mode.noSimplification) typer.expandType(wty)(ctx)
               else {
                 object SimplifyPipeline extends typer.SimplifyPipeline {
                   def debugOutput(msg: => Str): Unit =
                     if (mode.dbgSimplif) output(msg)
                 }
                 val sim = SimplifyPipeline(wty)(ctx)
-                val exp = typer.expandType(sim)
+                val exp = typer.expandType(sim)(ctx)
                 if (mode.dbgSimplif) output(s"⬤ Expanded: ${exp}")
                 exp
               }

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -324,7 +324,7 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite with org.scalatest.Pa
 
                 // generate warnings for bivariant type variables
                 val bivariantTypeVars = ttd.tparamsargs.iterator.filter{ case (tname, tvar) =>
-                  ttd.tvarVariances.get(tvar).contains(typer.VarianceInfo.bi)
+                  ttd.tvarVariances.get.get(tvar).contains(typer.VarianceInfo.bi)
                 }.map(_._1).toList
                 if (!bivariantTypeVars.isEmpty) {
                   varianceWarnings.put(td.nme, bivariantTypeVars)
@@ -332,8 +332,9 @@ class DiffTests extends org.scalatest.funsuite.AnyFunSuite with org.scalatest.Pa
                 
                 val params = if (!ttd.tparamsargs.isEmpty)
                     SourceCode.horizontalArray(ttd.tparamsargs.map{ case (tname, tvar) =>
-                      val tvarVariance = ttd.tvarVariances.getOrElse(tvar, throw new Exception(s"Type variable $tvar not found in variance store ${ttd.tvarVariances} for $ttd"))
-                      SourceCode(s"$tvarVariance${tname.name}")
+                      val tvarVariance = ttd.tvarVariances.get.getOrElse(tvar, throw new Exception(
+                        s"Type variable $tvar not found in variance store ${ttd.tvarVariances} for $ttd"))
+                      SourceCode(s"${tvarVariance.show}${tname.name}")
                     }.toList).toString()
                   else
                     SourceCode("")


### PR DESCRIPTION
Leverage the newly-calculated variance information to make type simplification and constraining better.