### PR TITLE
Fix `this` being captured by immediately invoked functions

### DIFF
--- a/shared/src/main/scala/mlscript/JSBackend.scala
+++ b/shared/src/main/scala/mlscript/JSBackend.scala
@@ -411,7 +411,6 @@ class JSBackend {
       case _ => scope.derive(s"getter $name")
     }
     // Declare the alias for `this` before declaring parameters.
-    // TODO: Remove this after we don't use IIFEs.
     val selfSymbol = memberScope.declareThisAlias()
     // Declare parameters.
     val (memberParams, body) = method.rhs.value match {

--- a/shared/src/main/scala/mlscript/JSBackend.scala
+++ b/shared/src/main/scala/mlscript/JSBackend.scala
@@ -5,6 +5,7 @@ import mlscript.codegen.Helpers._
 import mlscript.codegen._
 import scala.collection.mutable.ListBuffer
 import mlscript.{JSField, JSLit}
+import scala.collection.mutable.{Set => MutSet}
 
 class JSBackend {
   /**
@@ -16,6 +17,8 @@ class JSBackend {
     * The prelude code manager.
     */
   protected val polyfill = Polyfill()
+
+  protected val visitedSymbols = MutSet[ValueSymbol]()
 
   /**
     * This function translates parameter destructions in `def` declarations.
@@ -82,7 +85,7 @@ class JSBackend {
         else
           throw new UnimplementedError(sym)
       case S(sym: ValueSymbol) =>
-        sym.accessed = true
+        visitedSymbols += sym
         JSIdent(sym.runtimeName)
       case S(sym: ClassSymbol) =>
         if (isCallee)
@@ -375,7 +378,12 @@ class JSBackend {
       classSymbol: ClassSymbol,
       baseClassSymbol: Opt[ClassSymbol]
   )(implicit scope: Scope): JSClassDecl = {
-    val members = classSymbol.methods.map { translateClassMember(_) }
+    // Translate class methods and getters.
+    val classScope = scope.derive(s"class ${classSymbol.lexicalName}")
+    val members = classSymbol.methods.map {
+      translateClassMember(_)(classScope)
+    }
+    // Collect class fields.
     val fields = classSymbol.body.collectFields ++
       classSymbol.body.collectTypeNames.flatMap(resolveTraitFields)
     val base = baseClassSymbol.map { sym => JSIdent(sym.runtimeName) }
@@ -394,25 +402,31 @@ class JSBackend {
    * Translate class methods and getters.
    */
   private def translateClassMember(
-      method: MethodDef[Left[Term, Type]]
+      method: MethodDef[Left[Term, Type]],
   )(implicit scope: Scope): JSClassMemberDecl = {
     val name = method.nme.name
-    // Collect parameters and create the member scope.
-    val (memberParams, memberScope, body) = method.rhs.value match {
-      case Lam(params, body) =>
-        val methodScope = scope.derive("method $name")
-        val methodParams = translateParams(params)(methodScope)
-        (S(methodParams), methodScope, body)
-      case term =>
-        (N, scope.derive(s"Getter $name"), term)
+    // Create the method/getter scope.
+    val memberScope = method.rhs.value match {
+      case _: Lam => scope.derive(s"method $name")
+      case _ => scope.derive(s"getter $name")
     }
-    // Declare a value symbol for `this`.
-    val thisSymbol = memberScope.declareThis()
+    // Declare the alias for `this` before declaring parameters.
+    // TODO: Remove this after we don't use IIFEs.
+    val selfSymbol = memberScope.declareThisAlias()
+    // Declare parameters.
+    val (memberParams, body) = method.rhs.value match {
+      case Lam(params, body) =>
+        val methodParams = translateParams(params)(memberScope)
+        (S(methodParams), body)
+      case term =>
+        (N, term)
+    }
     // Translate class member body.
     val bodyResult = translateTerm(body)(memberScope).`return`
     // If `this` is accessed, add `const self = this`.
-    val bodyStmts = if (thisSymbol.accessed) {
-      val thisDecl = JSConstDecl(thisSymbol.runtimeName, JSIdent("this"))
+    val bodyStmts = if (visitedSymbols(selfSymbol)) {
+      val thisDecl = JSConstDecl(selfSymbol.runtimeName, JSIdent("this"))
+      visitedSymbols -= selfSymbol
       R(thisDecl :: bodyResult :: Nil)
     } else {
       R(bodyResult :: Nil)

--- a/shared/src/main/scala/mlscript/codegen/Scope.scala
+++ b/shared/src/main/scala/mlscript/codegen/Scope.scala
@@ -51,6 +51,16 @@ class Scope(name: Str, enclosing: Opt[Scope]) {
     }
   }
 
+  /**
+    * Shorthands for creating function scopes.
+    */
+  def this(name: Str, params: Ls[Str], enclosing: Scope) = {
+    this(name, Opt(enclosing))
+    params foreach { param =>
+      declareValue(param)
+    }
+  }
+
   private val allocateRuntimeNameIter = for {
     i <- (1 to Int.MaxValue).iterator
     c <- Scope.nameAlphabet.combinations(i)
@@ -228,7 +238,7 @@ class Scope(name: Str, enclosing: Opt[Scope]) {
     symbol
   }
   
-  def declareThis(): ValueSymbol = {
+  def declareThisAlias(): ValueSymbol = {
     val runtimeName = allocateRuntimeName("self")
     val symbol = ValueSymbol("this", runtimeName)
     register(symbol)

--- a/shared/src/main/scala/mlscript/codegen/Scope.scala
+++ b/shared/src/main/scala/mlscript/codegen/Scope.scala
@@ -227,6 +227,13 @@ class Scope(name: Str, enclosing: Opt[Scope]) {
     register(symbol)
     symbol
   }
+  
+  def declareThis(): ValueSymbol = {
+    val runtimeName = allocateRuntimeName("self")
+    val symbol = ValueSymbol("this", runtimeName)
+    register(symbol)
+    symbol
+  }
 
   def declareValue(lexicalName: Str): ValueSymbol = {
     val runtimeName = lexicalValueSymbols.get(lexicalName) match {

--- a/shared/src/main/scala/mlscript/codegen/Scope.scala
+++ b/shared/src/main/scala/mlscript/codegen/Scope.scala
@@ -51,16 +51,6 @@ class Scope(name: Str, enclosing: Opt[Scope]) {
     }
   }
 
-  /**
-    * Shorthands for creating function scopes.
-    */
-  def this(name: Str, params: Ls[Str], enclosing: Scope) = {
-    this(name, Opt(enclosing))
-    params foreach { param =>
-      declareValue(param)
-    }
-  }
-
   private val allocateRuntimeNameIter = for {
     i <- (1 to Int.MaxValue).iterator
     c <- Scope.nameAlphabet.combinations(i)

--- a/shared/src/main/scala/mlscript/codegen/Scope.scala
+++ b/shared/src/main/scala/mlscript/codegen/Scope.scala
@@ -299,12 +299,21 @@ class Scope(name: Str, enclosing: Opt[Scope]) {
     name
   }
 
+  /**
+    * This function declares a parameter in current scope and returns the 
+    * symbol's runtime name.
+    *
+    * @param name
+    * @return
+    */
   def declareParameter(name: Str): Str = {
-    val prefix = if (JSField.isValidIdentifier(name)) name
-      else if (Symbol.isKeyword(name)) name + "$" else Scope.replaceTicks(name)
-    val symbol = ValueSymbol(name, prefix)
-    register(symbol)
-    symbol.runtimeName
+    val prefix =
+      if (JSField.isValidIdentifier(name)) name
+      else if (Symbol.isKeyword(name)) name + "$"
+      else Scope.replaceTicks(name)
+    val runtimeName = allocateRuntimeName(prefix)
+    register(ValueSymbol(name, runtimeName))
+    runtimeName
   }
 
   def existsRuntimeSymbol(name: Str): Bool = runtimeSymbols.contains(name)

--- a/shared/src/main/scala/mlscript/codegen/Symbol.scala
+++ b/shared/src/main/scala/mlscript/codegen/Symbol.scala
@@ -28,11 +28,6 @@ sealed trait TypeSymbol extends LexicalSymbol {
 
 sealed class ValueSymbol(val lexicalName: Str, val runtimeName: Str) extends RuntimeSymbol {
   override def toString: Str = s"value $lexicalName"
-
-  /**
-   * Whether this `ValueSymbol` has touched by `translateVar` or not.
-   */
-  var accessed: Bool = false
 }
 
 object ValueSymbol {
@@ -130,7 +125,7 @@ object Symbol {
     "return",
     "super",
     "switch",
-    // "this",
+    "this",
     "throw",
     "try",
     "typeof",

--- a/shared/src/main/scala/mlscript/codegen/Symbol.scala
+++ b/shared/src/main/scala/mlscript/codegen/Symbol.scala
@@ -28,6 +28,11 @@ sealed trait TypeSymbol extends LexicalSymbol {
 
 sealed class ValueSymbol(val lexicalName: Str, val runtimeName: Str) extends RuntimeSymbol {
   override def toString: Str = s"value $lexicalName"
+
+  /**
+   * Whether this `ValueSymbol` has touched by `translateVar` or not.
+   */
+  var accessed: Bool = false
 }
 
 object ValueSymbol {

--- a/shared/src/test/diff/codegen/Classes.mls
+++ b/shared/src/test/diff/codegen/Classes.mls
@@ -184,6 +184,68 @@ f = f0
 //│  = [Function: f0]
 
 
+// The following test ensures `const self = this` is generated correctly.
+
+:js
+class Point: { x: int; y: int }
+  method Zero = 0
+  method Move (dx: int, dy: int) =
+    Point { x = this.x + dx; y = this.y + dy }
+  method Average self =
+    Point { x = (this.x + self.x) / 2; y = (this.y + self.y) / 2 }
+  method Shadow this = Point { x = this.x + 1; y = this.y + 1 }
+  method Shadow2 ((this,)) = Point { x = this.x + 1; y = this.y + 1 }
+  method Shadow3 { this } = Point { x = this.x + 1; y = this.y + 1 }
+//│ Defined class Point
+//│ Defined Point.Zero: Point -> 0
+//│ Defined Point.Move: Point -> (int, int,) -> Point
+//│ Defined Point.Average: Point -> {x: int, y: int} -> Point
+//│ Defined Point.Shadow: Point -> {x: int, y: int} -> Point
+//│ Defined Point.Shadow2: Point -> {x: int, y: int} -> Point
+//│ Defined Point.Shadow3: Point -> {this: {x: int, y: int}} -> Point
+//│ // Prelude
+//│ class Point {
+//│   constructor(fields) {
+//│     this.x = fields.x;
+//│     this.y = fields.y;
+//│   }
+//│   get Zero() {
+//│     return 0;
+//│   }
+//│   Move(dx, dy) {
+//│     const self = this;
+//│     return (new Point({
+//│       x: self.x + dx,
+//│       y: self.y + dy
+//│     }));
+//│   }
+//│   Average(self1) {
+//│     const self = this;
+//│     return (new Point({
+//│       x: (self.x + self1.x) / 2,
+//│       y: (self.y + self1.y) / 2
+//│     }));
+//│   }
+//│   Shadow(this1) {
+//│     return (new Point({
+//│       x: this1.x + 1,
+//│       y: this1.y + 1
+//│     }));
+//│   }
+//│   Shadow2([this1]) {
+//│     return (new Point({
+//│       x: this1.x + 1,
+//│       y: this1.y + 1
+//│     }));
+//│   }
+//│   Shadow3({ this: this1 }) {
+//│     return (new Point({
+//│       x: this1.x + 1,
+//│       y: this1.y + 1
+//│     }));
+//│   }
+//│ }
+//│ // End of generated code
 
 //  Some simplification tests:
 

--- a/shared/src/test/diff/codegen/Classes.mls
+++ b/shared/src/test/diff/codegen/Classes.mls
@@ -191,15 +191,15 @@ class Point: { x: int; y: int }
   method Zero = 0
   method Move (dx: int, dy: int) =
     Point { x = this.x + dx; y = this.y + dy }
-  method Average self =
-    Point { x = (this.x + self.x) / 2; y = (this.y + self.y) / 2 }
+  method Sum self =
+    Point { x = this.x + self.x; y = this.y + self.y }
   method Shadow this = Point { x = this.x + 1; y = this.y + 1 }
   method Shadow2 ((this,)) = Point { x = this.x + 1; y = this.y + 1 }
   method Shadow3 { this } = Point { x = this.x + 1; y = this.y + 1 }
 //│ Defined class Point
 //│ Defined Point.Zero: Point -> 0
 //│ Defined Point.Move: Point -> (int, int,) -> Point
-//│ Defined Point.Average: Point -> {x: int, y: int} -> Point
+//│ Defined Point.Sum: Point -> {x: int, y: int} -> Point
 //│ Defined Point.Shadow: Point -> {x: int, y: int} -> Point
 //│ Defined Point.Shadow2: Point -> {x: int, y: int} -> Point
 //│ Defined Point.Shadow3: Point -> {this: {x: int, y: int}} -> Point
@@ -219,29 +219,29 @@ class Point: { x: int; y: int }
 //│       y: self.y + dy
 //│     }));
 //│   }
-//│   Average(self1) {
+//│   Sum(self1) {
 //│     const self = this;
 //│     return (new Point({
-//│       x: (self.x + self1.x) / 2,
-//│       y: (self.y + self1.y) / 2
+//│       x: self.x + self1.x,
+//│       y: self.y + self1.y
 //│     }));
 //│   }
-//│   Shadow(this1) {
+//│   Shadow(this$) {
 //│     return (new Point({
-//│       x: this1.x + 1,
-//│       y: this1.y + 1
+//│       x: this$.x + 1,
+//│       y: this$.y + 1
 //│     }));
 //│   }
-//│   Shadow2([this1]) {
+//│   Shadow2([this$]) {
 //│     return (new Point({
-//│       x: this1.x + 1,
-//│       y: this1.y + 1
+//│       x: this$.x + 1,
+//│       y: this$.y + 1
 //│     }));
 //│   }
-//│   Shadow3({ this: this1 }) {
+//│   Shadow3({ "this": this$ }) {
 //│     return (new Point({
-//│       x: this1.x + 1,
-//│       y: this1.y + 1
+//│       x: this$.x + 1,
+//│       y: this$.y + 1
 //│     }));
 //│   }
 //│ }

--- a/shared/src/test/diff/codegen/Classes.mls
+++ b/shared/src/test/diff/codegen/Classes.mls
@@ -19,10 +19,12 @@ class Box[T]: { inner: T }
 //│     this.inner = fields.inner;
 //│   }
 //│   Map(f) {
-//│     return new Box({ inner: f(this.inner) });
+//│     const self = this;
+//│     return new Box({ inner: f(self.inner) });
 //│   }
 //│   get Get() {
-//│     return this.inner;
+//│     const self = this;
+//│     return self.inner;
 //│   }
 //│ }
 //│ // End of generated code
@@ -73,12 +75,14 @@ def MyBox inner info = MyBox { inner; info }
 //│     this.info = fields.info;
 //│   }
 //│   Map(f) {
-//│     return withConstruct(Box1(f(this.inner)), { info: this.info });
+//│     const self = this;
+//│     return withConstruct(Box1(f(self.inner)), { info: self.info });
 //│   }
 //│   get Inc() {
+//│     const self = this;
 //│     return (new MyBox({
-//│       inner: this.inner + 1,
-//│       info: this.info
+//│       inner: self.inner + 1,
+//│       info: self.info
 //│     }));
 //│   }
 //│ }
@@ -161,13 +165,13 @@ def f: Box[?] -> int
 :e
 f(Box{})
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.162: 	f(Box{})
+//│ ║  l.166: 	f(Box{})
 //│ ║         	^^^^^^^^
 //│ ╟── record literal of type `anything` does not match type `nothing`
-//│ ║  l.162: 	f(Box{})
+//│ ║  l.166: 	f(Box{})
 //│ ║         	     ^^
 //│ ╟── Note: constraint arises from type wildcard:
-//│ ║  l.157: 	def f: Box[?] -> int
+//│ ║  l.161: 	def f: Box[?] -> int
 //│ ╙──       	           ^
 //│ res: error | int
 //│    = <no result>

--- a/shared/src/test/diff/codegen/Inheritance.mls
+++ b/shared/src/test/diff/codegen/Inheritance.mls
@@ -34,7 +34,8 @@ class Y: X
 //│     this.x = fields.x;
 //│   }
 //│   get MX() {
-//│     return this.x;
+//│     const self = this;
+//│     return self.x;
 //│   }
 //│ }
 //│ // End of generated code

--- a/shared/src/test/diff/codegen/ParameterPattern.mls
+++ b/shared/src/test/diff/codegen/ParameterPattern.mls
@@ -1,0 +1,40 @@
+// This test file ensures that parameter destruction patterns are translated correctly.
+()
+//│ res: ()
+//│    = []
+
+:js
+def volatile ((this, break)) = this + break
+//│ // Query 1
+//│ globalThis.volatile1 = function volatile1([
+//│   this1,
+//│   break1
+//│ ]) {
+//│   return this1 + break1;
+//│ };
+//│ // End of generated code
+//│ volatile: (int, int,) -> int
+//│         = [Function: volatile1]
+
+:js
+def volatile1 { debugger; continue } = debugger + continue
+//│ // Query 1
+//│ globalThis.volatile11 = function volatile11({
+//│   debugger: debugger1,
+//│   continue: continue1
+//│ }) {
+//│   return debugger1 + continue1;
+//│ };
+//│ // End of generated code
+//│ volatile1: {continue: int, debugger: int} -> int
+//│          = [Function: volatile11]
+
+:js
+def volatile2 export = export + 2
+//│ // Query 1
+//│ globalThis.volatile2 = function volatile2(export1) {
+//│   return export1 + 2;
+//│ };
+//│ // End of generated code
+//│ volatile2: int -> int
+//│          = [Function: volatile2]

--- a/shared/src/test/diff/codegen/ParameterPattern.mls
+++ b/shared/src/test/diff/codegen/ParameterPattern.mls
@@ -7,10 +7,10 @@
 def volatile ((this, break)) = this + break
 //│ // Query 1
 //│ globalThis.volatile1 = function volatile1([
-//│   this1,
-//│   break1
+//│   this$,
+//│   break$
 //│ ]) {
-//│   return this1 + break1;
+//│   return this$ + break$;
 //│ };
 //│ // End of generated code
 //│ volatile: (int, int,) -> int
@@ -20,10 +20,10 @@ def volatile ((this, break)) = this + break
 def volatile1 { debugger; continue } = debugger + continue
 //│ // Query 1
 //│ globalThis.volatile11 = function volatile11({
-//│   debugger: debugger1,
-//│   continue: continue1
+//│   "debugger": debugger$,
+//│   "continue": continue$
 //│ }) {
-//│   return debugger1 + continue1;
+//│   return debugger$ + continue$;
 //│ };
 //│ // End of generated code
 //│ volatile1: {continue: int, debugger: int} -> int
@@ -32,8 +32,8 @@ def volatile1 { debugger; continue } = debugger + continue
 :js
 def volatile2 export = export + 2
 //│ // Query 1
-//│ globalThis.volatile2 = function volatile2(export1) {
-//│   return export1 + 2;
+//│ globalThis.volatile2 = function volatile2(export$) {
+//│   return export$ + 2;
 //│ };
 //│ // End of generated code
 //│ volatile2: int -> int

--- a/shared/src/test/diff/codegen/Parentheses.mls
+++ b/shared/src/test/diff/codegen/Parentheses.mls
@@ -60,7 +60,7 @@ x > 0 && x < 0
 1 + (if (case x + 1 of { int -> 8 | string -> 9 }) == 3 then 2 else 3)
 //│ // Query 1
 //│ let a;
-//│ res = 1 + ((a = x + 1, Number.isInteger(a) ? 8 : a.constructor === String ? 9 : (function () {
+//│ res = 1 + ((a = x + 1, Number.isInteger(a) ? 8 : a.constructor === String ? 9 : (() => {
 //│   throw new Error("non-exhaustive case expression");
 //│ })()) == 3 ? 2 : 3);
 //│ // End of generated code
@@ -71,7 +71,7 @@ x > 0 && x < 0
 case x of { int -> 1 | string -> 0 }
 //│ // Query 1
 //│ let b;
-//│ res = (b = x, Number.isInteger(b) ? 1 : b.constructor === String ? 0 : (function () {
+//│ res = (b = x, Number.isInteger(b) ? 1 : b.constructor === String ? 0 : (() => {
 //│   throw new Error("non-exhaustive case expression");
 //│ })());
 //│ // End of generated code
@@ -85,10 +85,10 @@ case x of { int -> 1 | string -> 0 }
 //│ // Query 1
 //│ let c, d;
 //│ res = [
-//│   (c = x, Number.isInteger(c) ? 1 : c.constructor === String ? 0 : (function () {
+//│   (c = x, Number.isInteger(c) ? 1 : c.constructor === String ? 0 : (() => {
 //│     throw new Error("non-exhaustive case expression");
 //│   })()),
-//│   (d = x, Number.isInteger(d) ? 1 : d.constructor === String ? 0 : (function () {
+//│   (d = x, Number.isInteger(d) ? 1 : d.constructor === String ? 0 : (() => {
 //│     throw new Error("non-exhaustive case expression");
 //│   })())
 //│ ];

--- a/shared/src/test/diff/codegen/Recursion.mls
+++ b/shared/src/test/diff/codegen/Recursion.mls
@@ -24,9 +24,7 @@ def pow1 x =
   in go
 //│ // Query 1
 //│ globalThis.pow1 = function pow1(x) {
-//│   return ((function (go) {
-//│     return go;
-//│   })(function go(n) {
+//│   return (((go) => go)(function go(n) {
 //│     return n > 0 ? go(n - 1) * x : 1;
 //│   }));
 //│ };

--- a/shared/src/test/diff/codegen/Terms.mls
+++ b/shared/src/test/diff/codegen/Terms.mls
@@ -228,9 +228,7 @@ f 0
 :js
 let x = 0 in x + 1
 //│ // Query 1
-//│ res = (function (x) {
-//│   return x + 1;
-//│ })(0);
+//│ res = ((x) => x + 1)(0);
 //│ // End of generated code
 //│ res: int
 //│    = 1
@@ -243,7 +241,7 @@ def f x = case x of { }
 //│ // Query 1
 //│ globalThis.f1 = function f1(x) {
 //│   let a;
-//│   return (a = x, (function () {
+//│   return (a = x, (() => {
 //│     throw new Error("non-exhaustive case expression");
 //│   })());
 //│ };
@@ -294,7 +292,7 @@ case A { a = 0 } of
   }
 //│ // Query 1
 //│ let b;
-//│ res = (b = new A({ a: 0 }), b instanceof A ? "A" : b instanceof B ? "B" : (function () {
+//│ res = (b = new A({ a: 0 }), b instanceof A ? "A" : b instanceof B ? "B" : (() => {
 //│   throw new Error("non-exhaustive case expression");
 //│ })());
 //│ // End of generated code

--- a/shared/src/test/diff/codegen/TrickyTerms.mls
+++ b/shared/src/test/diff/codegen/TrickyTerms.mls
@@ -33,7 +33,7 @@ def f x = case 1 of { 1 -> x }
 //│ // Query 1
 //│ globalThis.f = function f(x) {
 //│   let a;
-//│   return (a = 1, a === 1 ? x : (function () {
+//│   return (a = 1, a === 1 ? x : (() => {
 //│     throw new Error("non-exhaustive case expression");
 //│   })());
 //│ };
@@ -65,15 +65,9 @@ let t = tmp in let tmp = 1 in t tmp
 //│   return tmp;
 //│ };
 //│ // Query 2
-//│ res = tmp2((function (tmp) {
-//│   return tmp;
-//│ })(1));
+//│ res = tmp2(((tmp) => tmp)(1));
 //│ // Query 3
-//│ res = (function (t) {
-//│   return ((function (tmp) {
-//│     return t(tmp);
-//│   })(1));
-//│ })(tmp2);
+//│ res = ((t) => ((tmp) => t(tmp))(1))(tmp2);
 //│ // End of generated code
 //│ tmp: 'a -> 'a
 //│    = [Function: tmp2]

--- a/shared/src/test/diff/mlscript/Mohammad.mls
+++ b/shared/src/test/diff/mlscript/Mohammad.mls
@@ -22,7 +22,7 @@ def useCls c = case c of { Class -> c.x | int -> "oops" }
 //│ // Query 1
 //│ globalThis.useCls = function useCls(c) {
 //│   let a;
-//│   return (a = c, a instanceof Class ? c.x : Number.isInteger(a) ? "oops" : (function () {
+//│   return (a = c, a instanceof Class ? c.x : Number.isInteger(a) ? "oops" : (() => {
 //│     throw new Error("non-exhaustive case expression");
 //│   })());
 //│ };
@@ -235,7 +235,7 @@ oo = Oops 2
 case oo of { Oops -> 1 }
 //│ // Query 1
 //│ let a;
-//│ res = (a = oo, Oops.is(a) ? 1 : (function () {
+//│ res = (a = oo, Oops.is(a) ? 1 : (() => {
 //│   throw new Error("non-exhaustive case expression");
 //│ })());
 //│ // End of generated code

--- a/shared/src/test/diff/mlscript/RecursiveTypes.mls
+++ b/shared/src/test/diff/mlscript/RecursiveTypes.mls
@@ -6,13 +6,9 @@ let rec l = fun a -> fun a -> fun a -> l in let rec r = fun a -> fun a -> r in i
 //│ // Prelude
 //│ let res;
 //│ // Query 1
-//│ res = (function (l) {
-//│   return ((function (r) {
-//│     return true ? l : r;
-//│   })(function r(a) {
-//│     return (a) => r;
-//│   }));
-//│ })(function l(a) {
+//│ res = ((l) => ((r) => true ? l : r)(function r(a) {
+//│   return (a) => r;
+//│ }))(function l(a) {
 //│   return (a) => (a) => l;
 //│ });
 //│ // End of generated code
@@ -359,16 +355,16 @@ bar2_ty2 = bar_ty2
 //│   where
 //│     'r :> {x: 'r}
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.353: 	bar2_ty2 = bar_ty2
+//│ ║  l.349: 	bar2_ty2 = bar_ty2
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── type `C[?r]` does not match type `{x: ?r0} | 'r`
-//│ ║  l.286: 	def bar_ty2: C['r] as 'r
+//│ ║  l.282: 	def bar_ty2: C['r] as 'r
 //│ ║         	             ^^^^^
 //│ ╟── but it flows into reference with expected type `{x: ?r1} | 'r`
-//│ ║  l.353: 	bar2_ty2 = bar_ty2
+//│ ║  l.349: 	bar2_ty2 = bar_ty2
 //│ ║         	           ^^^^^^^
 //│ ╟── Note: constraint arises from local type binding:
-//│ ║  l.333: 	def bar2_ty2: { x: 'r } as 'r
+//│ ║  l.329: 	def bar2_ty2: { x: 'r } as 'r
 //│ ╙──       	              ^^^^^^^^^
 
 :e
@@ -381,40 +377,40 @@ bar_ty2 = bar2_ty2
 //│   where
 //│     'r :> C['r]
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.375: 	bar_ty2 = bar2_ty2
+//│ ║  l.371: 	bar_ty2 = bar2_ty2
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── type `{x: ?r}` does not match type `C[?r0] | 'r`
-//│ ║  l.333: 	def bar2_ty2: { x: 'r } as 'r
+//│ ║  l.329: 	def bar2_ty2: { x: 'r } as 'r
 //│ ║         	              ^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `C[?r1] | 'r`
-//│ ║  l.375: 	bar_ty2 = bar2_ty2
+//│ ║  l.371: 	bar_ty2 = bar2_ty2
 //│ ║         	          ^^^^^^^^
 //│ ╟── Note: constraint arises from local type binding:
-//│ ║  l.286: 	def bar_ty2: C['r] as 'r
+//│ ║  l.282: 	def bar_ty2: C['r] as 'r
 //│ ╙──       	             ^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.375: 	bar_ty2 = bar2_ty2
+//│ ║  l.371: 	bar_ty2 = bar2_ty2
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── type `{x: ?r}` does not match type `C[?r0] | 'r`
-//│ ║  l.333: 	def bar2_ty2: { x: 'r } as 'r
+//│ ║  l.329: 	def bar2_ty2: { x: 'r } as 'r
 //│ ║         	              ^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `C[?r1] | 'r`
-//│ ║  l.375: 	bar_ty2 = bar2_ty2
+//│ ║  l.371: 	bar_ty2 = bar2_ty2
 //│ ║         	          ^^^^^^^^
 //│ ╟── Note: constraint arises from local type binding:
-//│ ║  l.286: 	def bar_ty2: C['r] as 'r
+//│ ║  l.282: 	def bar_ty2: C['r] as 'r
 //│ ╙──       	             ^^^^^
 //│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.375: 	bar_ty2 = bar2_ty2
+//│ ║  l.371: 	bar_ty2 = bar2_ty2
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── type `{x: ?r}` does not match type `C[?r0] | 'r`
-//│ ║  l.333: 	def bar2_ty2: { x: 'r } as 'r
+//│ ║  l.329: 	def bar2_ty2: { x: 'r } as 'r
 //│ ║         	              ^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `C[?r1] | 'r`
-//│ ║  l.375: 	bar_ty2 = bar2_ty2
+//│ ║  l.371: 	bar_ty2 = bar2_ty2
 //│ ║         	          ^^^^^^^^
 //│ ╟── Note: constraint arises from local type binding:
-//│ ║  l.286: 	def bar_ty2: C['r] as 'r
+//│ ║  l.282: 	def bar_ty2: C['r] as 'r
 //│ ╙──       	             ^^^^^
 
 
@@ -468,13 +464,13 @@ f
 :e
 f 1
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.469: 	f 1
+//│ ║  l.465: 	f 1
 //│ ║         	^^^
 //│ ╟── operator application of type `int` does not have field 'a'
-//│ ║  l.438: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.434: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ║         	                                             ^^^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.438: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.434: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ╙──       	                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error | int | 'a\a & {a: int}
 //│   where
@@ -483,13 +479,13 @@ f 1
 :e
 f { a = 1 }
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.484: 	f { a = 1 }
+//│ ║  l.480: 	f { a = 1 }
 //│ ║         	^^^^^^^^^^^
 //│ ╟── operator application of type `int` does not have field 'a'
-//│ ║  l.438: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.434: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ║         	                                             ^^^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.438: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.434: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ╙──       	                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error
 
@@ -506,13 +502,13 @@ f ainf
 //│   where
 //│     'ainf :> {a: 'ainf}
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.504: 	f ainf
+//│ ║  l.500: 	f ainf
 //│ ║         	^^^^^^
 //│ ╟── operator application of type `int` does not have field 'a'
-//│ ║  l.438: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.434: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ║         	                                             ^^^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.438: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.434: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ╙──       	                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error
 
@@ -523,13 +519,13 @@ f infina
 //│   where
 //│     'infina :> 0 & {a: 'infina}
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.521: 	f infina
+//│ ║  l.517: 	f infina
 //│ ║         	^^^^^^^^
 //│ ╟── operator application of type `int` does not have field 'a'
-//│ ║  l.438: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.434: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ║         	                                             ^^^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.438: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
+//│ ║  l.434: 	rec def f x = if x > 0 then (f (x with { a = x - 1 })).a else x
 //│ ╙──       	                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: error | 'infina | int | 'a\a & {a: int}
 //│   where
@@ -546,16 +542,16 @@ def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as
 :e
 f_manual 1
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.547: 	f_manual 1
+//│ ║  l.543: 	f_manual 1
 //│ ║         	^^^^^^^^^^
 //│ ╟── integer literal of type `1` does not have field 'a'
-//│ ║  l.547: 	f_manual 1
+//│ ║  l.543: 	f_manual 1
 //│ ║         	         ^
 //│ ╟── Note: constraint arises from record type:
-//│ ║  l.540: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
+//│ ║  l.536: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
 //│ ║         	                ^^^^^^^^^^^^^^^^^
 //│ ╟── from intersection type:
-//│ ║  l.540: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
+//│ ║  l.536: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
 //│ ╙──       	              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ res: 'e | error
 //│   where
@@ -564,16 +560,16 @@ f_manual 1
 :e
 f_manual { a = 1 }
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.565: 	f_manual { a = 1 }
+//│ ║  l.561: 	f_manual { a = 1 }
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── integer literal of type `1` does not have field 'a'
-//│ ║  l.565: 	f_manual { a = 1 }
+//│ ║  l.561: 	f_manual { a = 1 }
 //│ ║         	               ^
 //│ ╟── Note: constraint arises from record type:
-//│ ║  l.540: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
+//│ ║  l.536: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
 //│ ║         	                ^^^^^^^^^^^^^^^^^
 //│ ╟── from intersection type:
-//│ ║  l.540: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
+//│ ║  l.536: 	def f_manual: (({a: 'b & 'a & 'c} as 'a) & 'd) -> ('c | ('d | 'e\a & {a: int} as 'e))
 //│ ╙──       	                    ^^^^^^^^^^^^
 //│ res: 'e | 1 | error
 //│   where
@@ -605,16 +601,16 @@ def f_manual_ns: 'a | ('b & (({a: 'd & 'c} as 'c) | ~{a: 'e | int} | ~{})\a & ((
 :e
 f_manual_ns ainf
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.606: 	f_manual_ns ainf
+//│ ║  l.602: 	f_manual_ns ainf
 //│ ║         	^^^^^^^^^^^^^^^^
 //│ ╟── type `int` does not have field 'a'
-//│ ║  l.597: 	def f_manual_ns: 'a | ('b & (({a: 'd & 'c} as 'c) | ~{a: 'e | int} | ~{})\a & (({a: 'd & 'c} as 'c) | ~{a: 'e | int})\a & (({a: 'f} as 'c) as 'f) & (int | ~{a: 'e | int} | ~{})\a & (int | ~{a: 'e | int})\a & int & int) -> ('g | 'd | ('b | 'h\a & {a: 'e | int} as 'h))
+//│ ║  l.593: 	def f_manual_ns: 'a | ('b & (({a: 'd & 'c} as 'c) | ~{a: 'e | int} | ~{})\a & (({a: 'd & 'c} as 'c) | ~{a: 'e | int})\a & (({a: 'f} as 'c) as 'f) & (int | ~{a: 'e | int} | ~{})\a & (int | ~{a: 'e | int})\a & int & int) -> ('g | 'd | ('b | 'h\a & {a: 'e | int} as 'h))
 //│ ║         	                                                              ^^^
 //│ ╟── Note: constraint arises from record type:
-//│ ║  l.597: 	def f_manual_ns: 'a | ('b & (({a: 'd & 'c} as 'c) | ~{a: 'e | int} | ~{})\a & (({a: 'd & 'c} as 'c) | ~{a: 'e | int})\a & (({a: 'f} as 'c) as 'f) & (int | ~{a: 'e | int} | ~{})\a & (int | ~{a: 'e | int})\a & int & int) -> ('g | 'd | ('b | 'h\a & {a: 'e | int} as 'h))
+//│ ║  l.593: 	def f_manual_ns: 'a | ('b & (({a: 'd & 'c} as 'c) | ~{a: 'e | int} | ~{})\a & (({a: 'd & 'c} as 'c) | ~{a: 'e | int})\a & (({a: 'f} as 'c) as 'f) & (int | ~{a: 'e | int} | ~{})\a & (int | ~{a: 'e | int})\a & int & int) -> ('g | 'd | ('b | 'h\a & {a: 'e | int} as 'h))
 //│ ║         	                              ^^^^^^^^^^^^
 //│ ╟── from intersection type:
-//│ ║  l.597: 	def f_manual_ns: 'a | ('b & (({a: 'd & 'c} as 'c) | ~{a: 'e | int} | ~{})\a & (({a: 'd & 'c} as 'c) | ~{a: 'e | int})\a & (({a: 'f} as 'c) as 'f) & (int | ~{a: 'e | int} | ~{})\a & (int | ~{a: 'e | int})\a & int & int) -> ('g | 'd | ('b | 'h\a & {a: 'e | int} as 'h))
+//│ ║  l.593: 	def f_manual_ns: 'a | ('b & (({a: 'd & 'c} as 'c) | ~{a: 'e | int} | ~{})\a & (({a: 'd & 'c} as 'c) | ~{a: 'e | int})\a & (({a: 'f} as 'c) as 'f) & (int | ~{a: 'e | int} | ~{})\a & (int | ~{a: 'e | int})\a & int & int) -> ('g | 'd | ('b | 'h\a & {a: 'e | int} as 'h))
 //│ ╙──       	                                  ^^^^^^^
 //│ res: error
 
@@ -655,13 +651,13 @@ r + 1
 :e
 r.a
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.656: 	r.a
+//│ ║  l.652: 	r.a
 //│ ║         	^^^
 //│ ╟── integer literal of type `1` does not have field 'a'
-//│ ║  l.647: 	r = f 1
+//│ ║  l.643: 	r = f 1
 //│ ║         	      ^
 //│ ╟── but it flows into reference with expected type `{a: ?a}`
-//│ ║  l.656: 	r.a
+//│ ║  l.652: 	r.a
 //│ ╙──       	^
 //│ res: error | int
 

--- a/shared/src/test/diff/mlscript/Ticks.mls
+++ b/shared/src/test/diff/mlscript/Ticks.mls
@@ -64,7 +64,8 @@ class A'[B'] : {x': B'}
 //│     this["x'"] = fields["x'"];
 //│   }
 //│   get "C'"() {
-//│     return this["x'"];
+//│     const self = this;
+//│     return self["x'"];
 //│   }
 //│ }
 //│ // End of generated code
@@ -85,10 +86,12 @@ mm.P' f'
 //│     this["x'"] = fields["x'"];
 //│   }
 //│   get "N'"() {
-//│     return this["x'"];
+//│     const self = this;
+//│     return self["x'"];
 //│   }
 //│   "P'"(y$) {
-//│     return this["x'"] + y$;
+//│     const self = this;
+//│     return self["x'"] + y$;
 //│   }
 //│ }
 //│ // Query 1
@@ -218,9 +221,7 @@ def g' x' = x' with { c' = 24 }
 :js
 gg' = let w' = 2 in w' + w'
 //│ // Query 1
-//│ globalThis.gg$ = (function (w$) {
-//│   return w$ + w$;
-//│ })(2);
+//│ globalThis.gg$ = ((w$) => w$ + w$)(2);
 //│ // End of generated code
 //│ gg': int
 //│    = 4
@@ -279,13 +280,13 @@ trait T : {x': int}
 //│       if (!("N'" in instance)) {
 //│         Object.defineProperty(instance, "N'", {
 //│           get: function () {
-//│             return this["x'"];
+//│             return this1["x'"];
 //│           }
 //│         });
 //│       }
 //│       if (!("P'" in instance)) {
 //│         instance["P'"] = function (y$) {
-//│           return this["x'"] + y$;
+//│           return this1["x'"] + y$;
 //│         };
 //│       }
 //│       if (!("Q" in instance)) {
@@ -293,7 +294,7 @@ trait T : {x': int}
 //│           y$,
 //│           { "z'": z$ }
 //│         ]) {
-//│           return this["x'"] + y$ + z$;
+//│           return this1["x'"] + y$ + z$;
 //│         };
 //│       }
 //│     },
@@ -314,9 +315,7 @@ trait T : {x': int}
 :js
 let f' = fun x -> x + 1 in f' 2
 //│ // Query 1
-//│ res = (function (f$) {
-//│   return f$(2);
-//│ })((x) => x + 1);
+//│ res = ((f$) => f$(2))((x) => x + 1);
 //│ // End of generated code
 //│ res: int
 //│    = 3

--- a/shared/src/test/diff/mlscript/TypeClasses.mls
+++ b/shared/src/test/diff/mlscript/TypeClasses.mls
@@ -1,4 +1,3 @@
-
 class Monoid[A]
   method Empty: A
   method Add: A -> A -> A
@@ -98,10 +97,10 @@ cmi = ComplexMonoid { base = IntMonoid }
 //│ ║  l.+1: 	cmi = ComplexMonoid { base = IntMonoid }
 //│ ║        	                    ^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.37: 	class ComplexMonoid[A]: Monoid[Complex[A]] & { base: Monoid[A] }
+//│ ║  l.36: 	class ComplexMonoid[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║        	                                                     ^^^^^^^^^
 //│ ╟── from reference:
-//│ ║  l.52: 	def ComplexMonoid base = ComplexMonoid { base }
+//│ ║  l.51: 	def ComplexMonoid base = ComplexMonoid { base }
 //│ ╙──      	                                         ^^^^
 //│ cmi: (ComplexMonoid['A] with {base: {base: IntMonoid}}) | error
 
@@ -114,7 +113,7 @@ class ComplexMonoid_bad_0[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base }
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` is not an instance of type `Complex`
-//│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
+//│ ║  l.30: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into application with expected type `Complex[?]`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base }
@@ -123,28 +122,28 @@ class ComplexMonoid_bad_0[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.+1: 	class ComplexMonoid_bad_0[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║        	                                     ^^^^^^^^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.3: 	  method Empty: A
+//│ ║  l.2: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base }
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` is not a record (expected a record with fields: real, imaginary)
-//│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
+//│ ║  l.30: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into application with expected type `{imaginary: A, real: A}`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from record type:
-//│ ║  l.29: 	class Complex[A]: { real: A; imaginary: A }
+//│ ║  l.28: 	class Complex[A]: { real: A; imaginary: A }
 //│ ║        	                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.3: 	  method Empty: A
+//│ ║  l.2: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base }
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not have field 'Complex#A'
-//│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
+//│ ║  l.30: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into application with expected type `{Complex#A <: A}`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base }
@@ -153,7 +152,7 @@ class ComplexMonoid_bad_0[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.+1: 	class ComplexMonoid_bad_0[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║        	                                     ^^^^^^^^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.3: 	  method Empty: A
+//│ ║  l.2: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ Defined class ComplexMonoid_bad_0[=A]
 //│ Defined ComplexMonoid_bad_0.Empty: ComplexMonoid_bad_0['A] -> 'imaginary -> (Complex['imaginary | {real: Monoid['A]}] & {real: {real: Monoid['A]}})
@@ -173,7 +172,7 @@ class ComplexMonoid_bad_1[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base.Empty; imaginary = this.imaginary.Empty }
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` is not an instance of type `Complex`
-//│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
+//│ ║  l.30: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into application with expected type `Complex[?]`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base.Empty; imaginary = this.imaginary.Empty }
@@ -182,28 +181,28 @@ class ComplexMonoid_bad_1[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.+1: 	class ComplexMonoid_bad_1[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║        	                                     ^^^^^^^^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.3: 	  method Empty: A
+//│ ║  l.2: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base.Empty; imaginary = this.imaginary.Empty }
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` is not a record (expected a record with fields: real, imaginary)
-//│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
+//│ ║  l.30: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into application with expected type `{imaginary: A, real: A}`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base.Empty; imaginary = this.imaginary.Empty }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from record type:
-//│ ║  l.29: 	class Complex[A]: { real: A; imaginary: A }
+//│ ║  l.28: 	class Complex[A]: { real: A; imaginary: A }
 //│ ║        	                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.3: 	  method Empty: A
+//│ ║  l.2: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base.Empty; imaginary = this.imaginary.Empty }
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not have field 'Complex#A'
-//│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
+//│ ║  l.30: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into application with expected type `{Complex#A <: A}`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base.Empty; imaginary = this.imaginary.Empty }
@@ -212,7 +211,7 @@ class ComplexMonoid_bad_1[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.+1: 	class ComplexMonoid_bad_1[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║        	                                     ^^^^^^^^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.3: 	  method Empty: A
+//│ ║  l.2: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ Defined class ComplexMonoid_bad_1[=A]
 //│ Defined ComplexMonoid_bad_1.Empty: ComplexMonoid_bad_1['A] -> 'imaginary -> (Complex['imaginary | {imaginary: error, real: 'A}] & {real: {imaginary: error, real: 'A}})

--- a/shared/src/test/diff/mlscript/TypeClasses.mls
+++ b/shared/src/test/diff/mlscript/TypeClasses.mls
@@ -98,10 +98,10 @@ cmi = ComplexMonoid { base = IntMonoid }
 //│ ║  l.+1: 	cmi = ComplexMonoid { base = IntMonoid }
 //│ ║        	                    ^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.36: 	class ComplexMonoid[A]: Monoid[Complex[A]] & { base: Monoid[A] }
+//│ ║  l.37: 	class ComplexMonoid[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║        	                                                     ^^^^^^^^^
 //│ ╟── from reference:
-//│ ║  l.51: 	def ComplexMonoid base = ComplexMonoid { base }
+//│ ║  l.52: 	def ComplexMonoid base = ComplexMonoid { base }
 //│ ╙──      	                                         ^^^^
 //│ cmi: (ComplexMonoid['A] with {base: {base: IntMonoid}}) | error
 
@@ -114,7 +114,7 @@ class ComplexMonoid_bad_0[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base }
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` is not an instance of type `Complex`
-//│ ║  l.30: 	def Complex real imaginary = Complex { real; imaginary }
+//│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into application with expected type `Complex[?]`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base }
@@ -123,28 +123,28 @@ class ComplexMonoid_bad_0[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.+1: 	class ComplexMonoid_bad_0[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║        	                                     ^^^^^^^^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.2: 	  method Empty: A
+//│ ║  l.3: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base }
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` is not a record (expected a record with fields: real, imaginary)
-//│ ║  l.30: 	def Complex real imaginary = Complex { real; imaginary }
+//│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into application with expected type `{imaginary: A, real: A}`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from record type:
-//│ ║  l.28: 	class Complex[A]: { real: A; imaginary: A }
+//│ ║  l.29: 	class Complex[A]: { real: A; imaginary: A }
 //│ ║        	                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.2: 	  method Empty: A
+//│ ║  l.3: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base }
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not have field 'Complex#A'
-//│ ║  l.30: 	def Complex real imaginary = Complex { real; imaginary }
+//│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into application with expected type `{Complex#A <: A}`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base }
@@ -153,7 +153,7 @@ class ComplexMonoid_bad_0[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.+1: 	class ComplexMonoid_bad_0[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║        	                                     ^^^^^^^^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.2: 	  method Empty: A
+//│ ║  l.3: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ Defined class ComplexMonoid_bad_0[=A]
 //│ Defined ComplexMonoid_bad_0.Empty: ComplexMonoid_bad_0['A] -> 'imaginary -> (Complex['imaginary | {real: Monoid['A]}] & {real: {real: Monoid['A]}})
@@ -173,7 +173,7 @@ class ComplexMonoid_bad_1[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base.Empty; imaginary = this.imaginary.Empty }
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` is not an instance of type `Complex`
-//│ ║  l.30: 	def Complex real imaginary = Complex { real; imaginary }
+//│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into application with expected type `Complex[?]`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base.Empty; imaginary = this.imaginary.Empty }
@@ -182,28 +182,28 @@ class ComplexMonoid_bad_1[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.+1: 	class ComplexMonoid_bad_1[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║        	                                     ^^^^^^^^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.2: 	  method Empty: A
+//│ ║  l.3: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base.Empty; imaginary = this.imaginary.Empty }
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` is not a record (expected a record with fields: real, imaginary)
-//│ ║  l.30: 	def Complex real imaginary = Complex { real; imaginary }
+//│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into application with expected type `{imaginary: A, real: A}`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base.Empty; imaginary = this.imaginary.Empty }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from record type:
-//│ ║  l.28: 	class Complex[A]: { real: A; imaginary: A }
+//│ ║  l.29: 	class Complex[A]: { real: A; imaginary: A }
 //│ ║        	                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.2: 	  method Empty: A
+//│ ║  l.3: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ ╔══[ERROR] Type mismatch in method definition:
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base.Empty; imaginary = this.imaginary.Empty }
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── function of type `?a -> ?b` does not have field 'Complex#A'
-//│ ║  l.30: 	def Complex real imaginary = Complex { real; imaginary }
+//│ ║  l.31: 	def Complex real imaginary = Complex { real; imaginary }
 //│ ║        	                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into application with expected type `{Complex#A <: A}`
 //│ ║  l.+2: 	  method Empty = Complex { real = this.base.Empty; imaginary = this.imaginary.Empty }
@@ -212,7 +212,7 @@ class ComplexMonoid_bad_1[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║  l.+1: 	class ComplexMonoid_bad_1[A]: Monoid[Complex[A]] & { base: Monoid[A] }
 //│ ║        	                                     ^^^^^^^^^^
 //│ ╟── from inherited method declaration:
-//│ ║  l.2: 	  method Empty: A
+//│ ║  l.3: 	  method Empty: A
 //│ ╙──     	         ^^^^^^^^
 //│ Defined class ComplexMonoid_bad_1[=A]
 //│ Defined ComplexMonoid_bad_1.Empty: ComplexMonoid_bad_1['A] -> 'imaginary -> (Complex['imaginary | {imaginary: error, real: 'A}] & {real: {imaginary: error, real: 'A}})

--- a/shared/src/test/diff/mlscript/TypeClasses.mls
+++ b/shared/src/test/diff/mlscript/TypeClasses.mls
@@ -1,3 +1,4 @@
+
 class Monoid[A]
   method Empty: A
   method Add: A -> A -> A

--- a/shared/src/test/diff/mlscript/Under.mls
+++ b/shared/src/test/diff/mlscript/Under.mls
@@ -44,26 +44,24 @@ def foo { _ } = { _ }
 //│ res: 1
 //│    = 1
 
-// * This code leads to a syntax error in NodeJS: "Duplicate parameter name not allowed in this context",
-// *  so we got an undefined result here.
 :e
 def foo { _ ; _ } = 1
 //│ ╔══[ERROR] Multiple declarations of field name _ in record literal
-//│ ║  l.50: 	def foo { _ ; _ } = 1
+//│ ║  l.48: 	def foo { _ ; _ } = 1
 //│ ║        	        ^^^^^^^^^
 //│ ╟── Declared at
-//│ ║  l.50: 	def foo { _ ; _ } = 1
+//│ ║  l.48: 	def foo { _ ; _ } = 1
 //│ ║        	          ^
 //│ ╟── Declared at
-//│ ║  l.50: 	def foo { _ ; _ } = 1
+//│ ║  l.48: 	def foo { _ ; _ } = 1
 //│ ╙──      	              ^
 //│ foo: {_: anything, _: anything} -> 1
-//│    = undefined
+//│    = [Function: foo5]
 
 // :js
 def foo { _ = _ ; __ = _ } = 1
 //│ foo: {_: anything, __: anything} -> 1
-//│    = undefined
+//│    = [Function: foo6]
 
 rec def _ = 1
 //│ _: 1


### PR DESCRIPTION
This is mentioned in #65 .

```
:js
class A: { x: int }
  method MA = let _ = 1 in this.x
//│ Defined class A
//│ Defined A.MA: A -> int
//│ // Prelude
//│ class A {
//│   constructor(fields) {
//│     this.x = fields.x;
//│   }
//│   get MA() {
//│     return ((function (_) {
//│       return this.x;
//│     })(1));
//│   }
//│ }
//│ // End of generated code

(A { x = 1 }).MA
//│ res: int
//│ Runtime error:
//│   TypeError: Cannot read properties of undefined (reading 'x')
```