### PR TITLE
Display syntax errors and REPL history in `DiffTests`

### DIFF
--- a/shared/src/test/diff/codegen/ReplHost.mls
+++ b/shared/src/test/diff/codegen/ReplHost.mls
@@ -28,21 +28,23 @@ box0 = Box { inner = 0 }
 //│ │ │   }
 //│ │ └── Reply
 //│ │     undefined
-//│ ├─┬ Query 1/1
-//│ │ ├── Prelude: <empty>
-//│ │ └── Code: globalThis.box0 = new Box({ inner: 0 });
-//│ └── Reply 1/1: [success] Box { inner: 0 }
+//│ └─┬ Query 1/1
+//│   ├── Prelude: <empty>
+//│   ├── Code: globalThis.box0 = new Box({ inner: 0 });
+//│   ├── Intermediate: Box { inner: 0 }
+//│   └── Reply: [success] Box { inner: 0 }
 //│ box0: Box[0]
 //│     = Box { inner: 0 }
 
 :ShowRepl
 box1 = Box { inner = 1 }
-//│ Block [line: 39] [file: ReplHost]
+//│ Block [line: 40] [file: ReplHost]
 //│ ├── No prelude
-//│ ├─┬ Query 1/1
-//│ │ ├── Prelude: <empty>
-//│ │ └── Code: globalThis.box1 = new Box({ inner: 1 });
-//│ └── Reply 1/1: [success] Box { inner: 1 }
+//│ └─┬ Query 1/1
+//│   ├── Prelude: <empty>
+//│   ├── Code: globalThis.box1 = new Box({ inner: 1 });
+//│   ├── Intermediate: Box { inner: 1 }
+//│   └── Reply: [success] Box { inner: 1 }
 //│ box1: Box[1]
 //│     = Box { inner: 1 }
 
@@ -50,7 +52,7 @@ box1 = Box { inner = 1 }
 box1.Map (fun x -> add x 1)
 box1.Map (fun x -> add x 2)
 box1.Map (fun x -> Box { inner = x })
-//│ Block [line: 50] [file: ReplHost]
+//│ Block [line: 52] [file: ReplHost]
 //│ ├─┬ Prelude
 //│ │ ├── Code
 //│ │ │   function add(x, y) {
@@ -64,16 +66,19 @@ box1.Map (fun x -> Box { inner = x })
 //│ │     undefined
 //│ ├─┬ Query 1/3
 //│ │ ├── Prelude: <empty>
-//│ │ └── Code: res = box1.Map((x) => add(x)(1));
-//│ ├── Reply 1/3: [success] Box { inner: 2 }
+//│ │ ├── Code: res = box1.Map((x) => add(x)(1));
+//│ │ ├── Intermediate: Box { inner: 2 }
+//│ │ └── Reply: [success] Box { inner: 2 }
 //│ ├─┬ Query 2/3
 //│ │ ├── Prelude: <empty>
-//│ │ └── Code: res = box1.Map((x) => add(x)(2));
-//│ ├── Reply 2/3: [success] Box { inner: 3 }
-//│ ├─┬ Query 3/3
-//│ │ ├── Prelude: <empty>
-//│ │ └── Code: res = box1.Map((x) => new Box({ inner: x }));
-//│ └── Reply 3/3: [success] Box { inner: Box { inner: 1 } }
+//│ │ ├── Code: res = box1.Map((x) => add(x)(2));
+//│ │ ├── Intermediate: Box { inner: 3 }
+//│ │ └── Reply: [success] Box { inner: 3 }
+//│ └─┬ Query 3/3
+//│   ├── Prelude: <empty>
+//│   ├── Code: res = box1.Map((x) => new Box({ inner: x }));
+//│   ├── Intermediate: Box { inner: Box { inner: 1 } }
+//│   └── Reply: [success] Box { inner: Box { inner: 1 } }
 //│ res: Box[int]
 //│    = Box { inner: 2 }
 //│ res: Box[int]

--- a/shared/src/test/diff/codegen/ReplHost.mls
+++ b/shared/src/test/diff/codegen/ReplHost.mls
@@ -1,0 +1,82 @@
+
+:ShowRepl
+class Box[T]: { inner: T }
+  method Map: (T -> 'a) -> Box['a]
+  method Map f = Box { inner = f this.inner }
+  method Get = this.inner
+box0 = Box { inner = 0 }
+//│ Defined class Box[+T]
+//│ Declared Box.Map: Box['T] -> ('T -> 'a) -> Box['a]
+//│ Defined Box.Map: Box['T] -> ('T -> 'inner) -> Box['inner]
+//│ Defined Box.Get: Box['T] -> 'T
+//│ Block [line: 3] [file: ReplHost]
+//│ ├─┬ Prelude
+//│ │ ├── Code
+//│ │ │   let res;
+//│ │ │   class Box {
+//│ │ │     constructor(fields) {
+//│ │ │       this.inner = fields.inner;
+//│ │ │     }
+//│ │ │     Map(f) {
+//│ │ │       const self = this;
+//│ │ │       return new Box({ inner: f(self.inner) });
+//│ │ │     }
+//│ │ │     get Get() {
+//│ │ │       const self = this;
+//│ │ │       return self.inner;
+//│ │ │     }
+//│ │ │   }
+//│ │ └── Reply
+//│ │     undefined
+//│ ├─┬ Query 1/1
+//│ │ ├── Prelude: <empty>
+//│ │ └── Code: globalThis.box0 = new Box({ inner: 0 });
+//│ └── Reply 1/1: [success] Box { inner: 0 }
+//│ box0: Box[0]
+//│     = Box { inner: 0 }
+
+:ShowRepl
+box1 = Box { inner = 1 }
+//│ Block [line: 39] [file: ReplHost]
+//│ ├── No prelude
+//│ ├─┬ Query 1/1
+//│ │ ├── Prelude: <empty>
+//│ │ └── Code: globalThis.box1 = new Box({ inner: 1 });
+//│ └── Reply 1/1: [success] Box { inner: 1 }
+//│ box1: Box[1]
+//│     = Box { inner: 1 }
+
+:ShowRepl
+box1.Map (fun x -> add x 1)
+box1.Map (fun x -> add x 2)
+box1.Map (fun x -> Box { inner = x })
+//│ Block [line: 50] [file: ReplHost]
+//│ ├─┬ Prelude
+//│ │ ├── Code
+//│ │ │   function add(x, y) {
+//│ │ │     if (arguments.length === 2) {
+//│ │ │       return x + y;
+//│ │ │     } else {
+//│ │ │       return (y) => x + y;
+//│ │ │     }
+//│ │ │   }
+//│ │ └── Reply
+//│ │     undefined
+//│ ├─┬ Query 1/3
+//│ │ ├── Prelude: <empty>
+//│ │ └── Code: res = box1.Map((x) => add(x)(1));
+//│ ├── Reply 1/3: [success] Box { inner: 2 }
+//│ ├─┬ Query 2/3
+//│ │ ├── Prelude: <empty>
+//│ │ └── Code: res = box1.Map((x) => add(x)(2));
+//│ ├── Reply 2/3: [success] Box { inner: 3 }
+//│ ├─┬ Query 3/3
+//│ │ ├── Prelude: <empty>
+//│ │ └── Code: res = box1.Map((x) => new Box({ inner: x }));
+//│ └── Reply 3/3: [success] Box { inner: Box { inner: 1 } }
+//│ res: Box[int]
+//│    = Box { inner: 2 }
+//│ res: Box[int]
+//│    = Box { inner: 3 }
+//│ res: Box[Box[1]]
+//│    = Box { inner: Box { inner: 1 } }

--- a/shared/src/test/diff/codegen/ReplHost.mls
+++ b/shared/src/test/diff/codegen/ReplHost.mls
@@ -49,10 +49,22 @@ box1 = Box { inner = 1 }
 //│     = Box { inner: 1 }
 
 :ShowRepl
+case box1 of { Box -> 0 }
+//│ ┌ Block at ReplHost.mls:52
+//│ ├── No prelude
+//│ └─┬ Query 1/1
+//│   ├── Prelude: let a;
+//│   ├── Code: res = (a = box1, a instanceof Box ? 0 : (() => {  throw new Error("non-exhaustive case expression");})());
+//│   ├── Intermediate: 0
+//│   └── Reply: [success] 0
+//│ res: 0
+//│    = 0
+
+:ShowRepl
 box1.Map (fun x -> add x 1)
 box1.Map (fun x -> add x 2)
 box1.Map (fun x -> Box { inner = x })
-//│ ┌ Block at ReplHost.mls:52
+//│ ┌ Block at ReplHost.mls:64
 //│ ├─┬ Prelude
 //│ │ ├── Code
 //│ │ │   function add(x, y) {

--- a/shared/src/test/diff/codegen/ReplHost.mls
+++ b/shared/src/test/diff/codegen/ReplHost.mls
@@ -80,3 +80,7 @@ box1.Map (fun x -> Box { inner = x })
 //│    = Box { inner: 3 }
 //│ res: Box[Box[1]]
 //│    = Box { inner: Box { inner: 1 } }
+
+box1.Map (fun x -> Box { inner = x })
+//│ res: Box[Box[1]]
+//│    = Box { inner: Box { inner: 1 } }

--- a/shared/src/test/diff/codegen/ReplHost.mls
+++ b/shared/src/test/diff/codegen/ReplHost.mls
@@ -9,7 +9,7 @@ box0 = Box { inner = 0 }
 //│ Declared Box.Map: Box['T] -> ('T -> 'a) -> Box['a]
 //│ Defined Box.Map: Box['T] -> ('T -> 'inner) -> Box['inner]
 //│ Defined Box.Get: Box['T] -> 'T
-//│ Block [line: 3] [file: ReplHost]
+//│ ┌ Block at ReplHost.mls:3
 //│ ├─┬ Prelude
 //│ │ ├── Code
 //│ │ │   let res;
@@ -38,7 +38,7 @@ box0 = Box { inner = 0 }
 
 :ShowRepl
 box1 = Box { inner = 1 }
-//│ Block [line: 40] [file: ReplHost]
+//│ ┌ Block at ReplHost.mls:40
 //│ ├── No prelude
 //│ └─┬ Query 1/1
 //│   ├── Prelude: <empty>
@@ -52,7 +52,7 @@ box1 = Box { inner = 1 }
 box1.Map (fun x -> add x 1)
 box1.Map (fun x -> add x 2)
 box1.Map (fun x -> Box { inner = x })
-//│ Block [line: 52] [file: ReplHost]
+//│ ┌ Block at ReplHost.mls:52
 //│ ├─┬ Prelude
 //│ │ ├── Code
 //│ │ │   function add(x, y) {

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -15,6 +15,9 @@ import mlscript.JSTestBackend.TestCode
 import mlscript.codegen.typescript.TsTypegenCodeBuilder
 import org.scalatest.time._
 import org.scalatest.concurrent.{TimeLimitedTests, Signaler}
+import mlscript.DiffTests.ReplHost.Result
+import mlscript.DiffTests.ReplHost.Empty
+import mlscript.DiffTests.ReplHost.Unexecuted
 
 
 class DiffTests
@@ -414,15 +417,15 @@ class DiffTests
 
             final case class ExecutedResult(var replies: Ls[ReplHost.Reply]) extends JSTestBackend.Result {
               def showFirst(prefixLength: Int): Unit = replies match {
-                case ReplHost.Error(err) :: rest =>
+                case ReplHost.Error(isSyntaxError, content) :: rest =>
                   if (!(mode.expectTypeErrors
                       || mode.expectRuntimeErrors
                       || allowRuntimeErrors
                       || mode.fixme
                   )) failures += blockLineNum
                   totalRuntimeErrors += 1
-                  output("Runtime error:")
-                  err.split('\n') foreach { s => output("  " + s) }
+                  output((if (isSyntaxError) "Syntax" else "Runtime") + " error:")
+                  content.linesIterator.foreach { s => output("  " + s) }
                   replies = rest
                 case ReplHost.Unexecuted(reason) :: rest =>
                   output(" " * prefixLength + "= <no result>")
@@ -488,8 +491,14 @@ class DiffTests
                             output(s"│ │   $line")
                           }
                           output(s"│ └── Reply")
-                          preludeReply.linesIterator.zipWithIndex.foreach { case (line, index) =>
-                            output(s"│     $line")
+                          // Display successful results in multiple lines.
+                          // Display other results in single line.
+                          preludeReply match {
+                            case Result(content) =>
+                              content.linesIterator.zipWithIndex.foreach {
+                                case (line, index) => output(s"│     $line")
+                              }
+                            case other => output(s"│     $other")
                           }
                         }
                       }
@@ -765,35 +774,52 @@ object DiffTests {
     private val stdout = new BufferedReader(new InputStreamReader(proc.getInputStream))
     private val stderr = new BufferedReader(new InputStreamReader(proc.getErrorStream))
 
-    skipUntilPrompt()
+    // Skip the welcome message.
+    collectUntilPrompt()
 
     /**
      * This function simply collect output from Node.js until meet `"\n> "`.
+     * It is useful to skip the welcome message and collect REPL reply from
+     * interactive Node.js. It also filters out syntax errors.
      */
-    private def skipUntilPrompt(): Str = {
+    private def collectUntilPrompt(): ReplHost.Reply = {
       val buffer = new StringBuilder()
       while (!buffer.endsWith("\n> ")) {
         buffer.append(stdout.read().toChar)
       }
-      buffer.delete(buffer.length - 3, buffer.length)
-      buffer.toString
-    }
-
-    private def consumeUntilPrompt(): ReplHost.Reply = {
-      val buffer = new StringBuilder()
-      while (!buffer.endsWith("\n> ")) {
-        buffer.append(stdout.read().toChar)
-      }
+      // Remove the trailing `"\n> "`
       buffer.delete(buffer.length - 3, buffer.length)
       val reply = buffer.toString()
-      val begin = reply.indexOf(0x200B)
-      val end = reply.lastIndexOf(0x200B)
-      if (begin >= 0 && end >= 0)
-        // `console.log` inserts a space between every two arguments,
-        // so + 1 and - 1 is necessary to get correct length.
-        ReplHost.Error(reply.substring(begin + 1, end))
-      else
-        ReplHost.Result(reply)
+      reply.linesIterator.find(_.startsWith(ReplHost.syntaxErrorHead)) match {
+        case None => ReplHost.Result(reply)
+        case Some(syntaxErrorLine) =>
+          val message = syntaxErrorLine.substring(ReplHost.syntaxErrorHead.length)
+          ReplHost.Error(true, message)
+      }
+    }
+
+    /**
+     * Parse query results from collected output from Node.js.
+     * 
+     * - If there is line begins with `"Uncaught SyntaxError: "`, returns
+     *   the syntax error indicated in that line.
+     * - If character `0x200B` presents in the output, returns the trimmed
+     *   error message.
+     * - Otherwise, returns the result as a successfully reply.
+     */
+    private def parseQueryResult(): ReplHost.Reply = {
+      collectUntilPrompt().map { reply =>
+        // Find error boundaries.
+        val begin = reply.indexOf(0x200B)
+        val end = reply.lastIndexOf(0x200B)
+        // If there is an error, returns `ReplHost.Error`.
+        if (begin >= 0 && end >= 0)
+          // `console.log` inserts a space between every two arguments,
+          // so + 1 and - 1 is necessary to get correct length.
+          ReplHost.Error(false, reply.substring(begin + 1, end))
+        else
+          ReplHost.Result(reply)
+      }
     }
 
     private def send(code: Str, useEval: Bool = false): Unit = {
@@ -806,22 +832,25 @@ object DiffTests {
     }
 
     def query(prelude: Str, code: Str, res: Str): ReplHost.Reply = {
-      if (prelude.isEmpty && code.isEmpty) ReplHost.Empty
+      // For empty queries, returns empty.
+      if (prelude.isEmpty && code.isEmpty)
+        ReplHost.Empty
       else {
+        // Warp the code with `try`-`catch` block.
         val wrapped = s"$prelude try { $code } catch (e) { console.log('\\u200B' + e + '\\u200B'); }"
+        // Send the code
         send(wrapped)
-        consumeUntilPrompt() match {
-          case _: ReplHost.Result =>
-            send(if (res =:= "res") res else s"globalThis[\"${res}\"]")
-            consumeUntilPrompt()
-          case t => t
+        // If succeed, retrieve the result.
+        parseQueryResult().map { _ =>
+          send(if (res =:= "res") res else s"globalThis[\"${res}\"]")
+          parseQueryResult()
         }
       }
     }
 
-    def execute(code: Str): Str = {
+    def execute(code: Str): ReplHost.Reply = {
       send(code)
-      skipUntilPrompt()
+      collectUntilPrompt()
     }
 
     def terminate(): Unit = proc.destroy()
@@ -829,11 +858,25 @@ object DiffTests {
 
   object ReplHost {
     /**
+      * The syntax error beginning text.
+      */
+    private val syntaxErrorHead = "Uncaught SyntaxError: "
+
+    /**
       * The base class of all kinds of REPL replies.
       */
-    sealed abstract class Reply
+    sealed abstract class Reply {
+      /**
+        * Maps the successfuly part.
+        *
+        * @param f the function over
+        * @return
+        */
+      def map(f: Str => Reply): Reply
+    }
 
     final case class Result(content: Str) extends Reply {
+      override def map(f: Str => Reply): Reply = f(content)
       override def toString(): Str = s"[success] $content"
     }
 
@@ -841,6 +884,7 @@ object DiffTests {
       * If the query is `Empty`, we will receive this.
       */
     final object Empty extends Reply {
+      override def map(f: Str => Reply): Reply = this
       override def toString(): Str = "[empty]"
     }
 
@@ -848,14 +892,20 @@ object DiffTests {
       * If the query is `Unexecuted`, we will receive this.
       */
     final case class Unexecuted(message: Str) extends Reply {
+      override def map(f: Str => Reply): Reply = this
       override def toString(): Str = s"[unexecuted] $message"
     }
 
     /**
       * If the `ReplHost` captured errors, it will response with `Error`.
       */
-    final case class Error(message: Str) extends Reply {
-      override def toString(): Str = s"[error] $message"
+    final case class Error(syntax: Bool, message: Str) extends Reply {
+      override def map(f: Str => Reply): Reply = this
+      override def toString(): Str =
+        if (syntax)
+          s"[syntax error] $message"
+        else
+          s"[runtime error] $message"
     }
   }
 }

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -491,7 +491,7 @@ class DiffTests
                             case ReplHost.Result(content, intermediate) =>
                               intermediate.foreach { value =>
                                 output(s"│ ├── Intermediate")
-                                content.linesIterator.foreach { line => output(s"│ │   $line") }  
+                                value.linesIterator.foreach { line => output(s"│ │   $line") }  
                               }
                               output(s"│ └── Reply")
                               content.linesIterator.foreach { line => output(s"│     $line") }  

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -15,9 +15,6 @@ import mlscript.JSTestBackend.TestCode
 import mlscript.codegen.typescript.TsTypegenCodeBuilder
 import org.scalatest.time._
 import org.scalatest.concurrent.{TimeLimitedTests, Signaler}
-import mlscript.ReplHost.Result
-import mlscript.ReplHost.Empty
-import mlscript.ReplHost.Unexecuted
 
 
 class DiffTests
@@ -522,7 +519,7 @@ class DiffTests
                         if (mode.showRepl) {
                           // Show the intermediate reply if possible.
                           reply match {
-                            case Result(_, Some(intermediate)) =>
+                            case ReplHost.Result(_, Some(intermediate)) =>
                               output(s"$p0├── Intermediate: $intermediate")
                             case _ => ()
                           }

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -429,9 +429,9 @@ class DiffTests
                   output(" " * (prefixLength + 2) + reason)
                   replies = rest
                 case ReplHost.Result(result, _) :: rest =>
-                  result.split('\n').zipWithIndex foreach { case (s, i) =>
-                    if (i =:= 0) output(" " * prefixLength + "= " + s)
-                    else output(" " * (prefixLength + 2) + s)
+                  result.linesIterator.zipWithIndex.foreach { case (line, i) =>
+                    if (i =:= 0) output(" " * prefixLength + "= " + line)
+                    else output(" " * (prefixLength + 2) + line)
                   }
                   replies = rest
                 case ReplHost.Empty :: rest =>
@@ -484,18 +484,18 @@ class DiffTests
                         if (mode.showRepl) {
                           output(s"├─┬ Prelude")
                           output(s"│ ├── Code")
-                          lines.iterator.zipWithIndex.foreach { case (line, index) =>
-                            output(s"│ │   $line")
-                          }
-                          output(s"│ └── Reply")
+                          lines.iterator.foreach { line => output(s"│ │   $line") }
                           // Display successful results in multiple lines.
                           // Display other results in single line.
                           preludeReply match {
-                            case ReplHost.Result(content, _) =>
-                              content.linesIterator.zipWithIndex.foreach {
-                                case (line, index) => output(s"│     $line")
+                            case ReplHost.Result(content, intermediate) =>
+                              intermediate.foreach { value =>
+                                output(s"│ ├── Intermediate")
+                                content.linesIterator.foreach { line => output(s"│ │   $line") }  
                               }
-                            case other => output(s"│     $other")
+                              output(s"│ └── Reply")
+                              content.linesIterator.foreach { line => output(s"│     $line") }  
+                            case other => output(s"│ └── Reply $other")
                           }
                         }
                       }

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -468,7 +468,7 @@ class DiffTests
                   // Execute code.
                   if (!mode.noExecution) {
                     if (mode.showRepl) {
-                      output(s"Block [line: ${blockLineNum}] [file: ${file.baseName}]")
+                      output(s"┌ Block at ${file.last}:${blockLineNum}")
                     }
                     // Execute the prelude code.
                     prelude match {

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -15,9 +15,6 @@ import mlscript.JSTestBackend.TestCode
 import mlscript.codegen.typescript.TsTypegenCodeBuilder
 import org.scalatest.time._
 import org.scalatest.concurrent.{TimeLimitedTests, Signaler}
-import mlscript.DiffTests.ReplHost.Result
-import mlscript.DiffTests.ReplHost.Empty
-import mlscript.DiffTests.ReplHost.Unexecuted
 
 
 class DiffTests
@@ -494,7 +491,7 @@ class DiffTests
                           // Display successful results in multiple lines.
                           // Display other results in single line.
                           preludeReply match {
-                            case Result(content) =>
+                            case ReplHost.Result(content) =>
                               content.linesIterator.zipWithIndex.foreach {
                                 case (line, index) => output(s"│     $line")
                               }
@@ -760,152 +757,5 @@ object DiffTests {
   private val files = allFiles.filter { file =>
       val fileName = file.baseName
       validExt(file.ext) && filter(fileName)
-  }
-  
-  
-  /** Helper to run NodeJS on test input. */
-  final case class ReplHost() {
-    import java.io.{BufferedWriter, BufferedReader, InputStreamReader, OutputStreamWriter}
-    private val builder = new java.lang.ProcessBuilder()
-    builder.command("node", "--interactive")
-    private val proc = builder.start()
-
-    private val stdin = new BufferedWriter(new OutputStreamWriter(proc.getOutputStream))
-    private val stdout = new BufferedReader(new InputStreamReader(proc.getInputStream))
-    private val stderr = new BufferedReader(new InputStreamReader(proc.getErrorStream))
-
-    // Skip the welcome message.
-    collectUntilPrompt()
-
-    /**
-     * This function simply collect output from Node.js until meet `"\n> "`.
-     * It is useful to skip the welcome message and collect REPL reply from
-     * interactive Node.js. It also filters out syntax errors.
-     */
-    private def collectUntilPrompt(): ReplHost.Reply = {
-      val buffer = new StringBuilder()
-      while (!buffer.endsWith("\n> ")) {
-        buffer.append(stdout.read().toChar)
-      }
-      // Remove the trailing `"\n> "`
-      buffer.delete(buffer.length - 3, buffer.length)
-      val reply = buffer.toString()
-      reply.linesIterator.find(_.startsWith(ReplHost.syntaxErrorHead)) match {
-        case None => ReplHost.Result(reply)
-        case Some(syntaxErrorLine) =>
-          val message = syntaxErrorLine.substring(ReplHost.syntaxErrorHead.length)
-          ReplHost.Error(true, message)
-      }
-    }
-
-    /**
-     * Parse query results from collected output from Node.js.
-     * 
-     * - If there is line begins with `"Uncaught SyntaxError: "`, returns
-     *   the syntax error indicated in that line.
-     * - If character `0x200B` presents in the output, returns the trimmed
-     *   error message.
-     * - Otherwise, returns the result as a successfully reply.
-     */
-    private def parseQueryResult(): ReplHost.Reply = {
-      collectUntilPrompt().map { reply =>
-        // Find error boundaries.
-        val begin = reply.indexOf(0x200B)
-        val end = reply.lastIndexOf(0x200B)
-        // If there is an error, returns `ReplHost.Error`.
-        if (begin >= 0 && end >= 0)
-          // `console.log` inserts a space between every two arguments,
-          // so + 1 and - 1 is necessary to get correct length.
-          ReplHost.Error(false, reply.substring(begin + 1, end))
-        else
-          ReplHost.Result(reply)
-      }
-    }
-
-    private def send(code: Str, useEval: Bool = false): Unit = {
-      stdin.write(
-        if (useEval) "eval(" + JSLit.makeStringLiteral(code) + ")\n"
-        else if (code endsWith "\n") code
-        else code + "\n"
-      )
-      stdin.flush()
-    }
-
-    def query(prelude: Str, code: Str, res: Str): ReplHost.Reply = {
-      // For empty queries, returns empty.
-      if (prelude.isEmpty && code.isEmpty)
-        ReplHost.Empty
-      else {
-        // Warp the code with `try`-`catch` block.
-        val wrapped = s"$prelude try { $code } catch (e) { console.log('\\u200B' + e + '\\u200B'); }"
-        // Send the code
-        send(wrapped)
-        // If succeed, retrieve the result.
-        parseQueryResult().map { _ =>
-          send(if (res =:= "res") res else s"globalThis[\"${res}\"]")
-          parseQueryResult()
-        }
-      }
-    }
-
-    def execute(code: Str): ReplHost.Reply = {
-      send(code)
-      collectUntilPrompt()
-    }
-
-    def terminate(): Unit = proc.destroy()
-  }
-
-  object ReplHost {
-    /**
-      * The syntax error beginning text.
-      */
-    private val syntaxErrorHead = "Uncaught SyntaxError: "
-
-    /**
-      * The base class of all kinds of REPL replies.
-      */
-    sealed abstract class Reply {
-      /**
-        * Maps the successfuly part.
-        *
-        * @param f the function over
-        * @return
-        */
-      def map(f: Str => Reply): Reply
-    }
-
-    final case class Result(content: Str) extends Reply {
-      override def map(f: Str => Reply): Reply = f(content)
-      override def toString(): Str = s"[success] $content"
-    }
-
-    /**
-      * If the query is `Empty`, we will receive this.
-      */
-    final object Empty extends Reply {
-      override def map(f: Str => Reply): Reply = this
-      override def toString(): Str = "[empty]"
-    }
-
-    /**
-      * If the query is `Unexecuted`, we will receive this.
-      */
-    final case class Unexecuted(message: Str) extends Reply {
-      override def map(f: Str => Reply): Reply = this
-      override def toString(): Str = s"[unexecuted] $message"
-    }
-
-    /**
-      * If the `ReplHost` captured errors, it will response with `Error`.
-      */
-    final case class Error(syntax: Bool, message: Str) extends Reply {
-      override def map(f: Str => Reply): Reply = this
-      override def toString(): Str =
-        if (syntax)
-          s"[syntax error] $message"
-        else
-          s"[runtime error] $message"
-    }
   }
 }

--- a/shared/src/test/scala/mlscript/DiffTests.scala
+++ b/shared/src/test/scala/mlscript/DiffTests.scala
@@ -468,34 +468,34 @@ class DiffTests
                   // Execute code.
                   if (!mode.noExecution) {
                     if (mode.showRepl) {
-                      println(s"Block [line: ${blockLineNum}] [file: ${file.baseName}]")
+                      output(s"Block [line: ${blockLineNum}] [file: ${file.baseName}]")
                     }
                     // Execute the prelude code.
                     prelude match {
                       case Nil => {
                         if (mode.showRepl) {
-                          println(s"├── No prelude")
+                          output(s"├── No prelude")
                           if (queries.isEmpty)
-                            println(s"└── No queries")
+                            output(s"└── No queries")
                         }
                       }
                       case lines => {
                         val preludeReply = host.execute(lines mkString " ")
                         if (mode.showRepl) {
-                          println(s"├─┬ Prelude")
-                          println(s"│ ├── Code")
+                          output(s"├─┬ Prelude")
+                          output(s"│ ├── Code")
                           lines.iterator.zipWithIndex.foreach { case (line, index) =>
-                            println(s"│ │   $line")
+                            output(s"│ │   $line")
                           }
-                          println(s"│ └── Reply")
+                          output(s"│ └── Reply")
                           preludeReply.linesIterator.zipWithIndex.foreach { case (line, index) =>
-                            println(s"│     $line")
+                            output(s"│     $line")
                           }
                         }
                       }
                     }
                     if (mode.showRepl && queries.isEmpty) {
-                      println(s"└── No queries")
+                      output(s"└── No queries")
                     }
                     // Send queries to the host.
                     ExecutedResult(queries.zipWithIndex.map {
@@ -503,26 +503,26 @@ class DiffTests
                         val prelude = preludeLines.mkString
                         val code = codeLines.mkString
                         if (mode.showRepl) {
-                          println(s"├─┬ Query ${i + 1}/${queries.length}")
-                          println(s"│ ├── Prelude: ${if (preludeLines.isEmpty) "<empty>" else prelude}")
-                          println(s"│ └── Code: ${code}")
+                          output(s"├─┬ Query ${i + 1}/${queries.length}")
+                          output(s"│ ├── Prelude: ${if (preludeLines.isEmpty) "<empty>" else prelude}")
+                          output(s"│ └── Code: ${code}")
                         }
                         val reply = host.query(prelude, code, res)
                         if (mode.showRepl) {
                           val prefix = if (i + 1 == queries.length) "└──" else "├──"
-                          println(s"$prefix Reply ${i + 1}/${queries.length}: $reply")
+                          output(s"$prefix Reply ${i + 1}/${queries.length}: $reply")
                         }
                         reply
                       case (JSTestBackend.AbortedQuery(reason), i) =>
                         if (mode.showRepl) {
                           val prefix = if (i + 1 == queries.length) "└──" else "├──"
-                          println(s"$prefix Query ${i + 1}/${queries.length}: <aborted: $reason>")
+                          output(s"$prefix Query ${i + 1}/${queries.length}: <aborted: $reason>")
                         }
                         ReplHost.Unexecuted(reason)
                       case (JSTestBackend.EmptyQuery, i) =>
                         if (mode.showRepl) {
                           val prefix = if (i + 1 == queries.length) "└──" else "├──"
-                          println(s"$prefix Query ${i + 1}/${queries.length}: <empty>")
+                          output(s"$prefix Query ${i + 1}/${queries.length}: <empty>")
                         }
                         ReplHost.Empty
                     })

--- a/shared/src/test/scala/mlscript/ReplHost.scala
+++ b/shared/src/test/scala/mlscript/ReplHost.scala
@@ -1,0 +1,159 @@
+package mlscript
+
+import mlscript.utils.shorthands._
+
+/**
+ * Helper to run NodeJS on test input.
+ */
+final case class ReplHost() {
+  import java.io.{BufferedWriter, BufferedReader, InputStreamReader, OutputStreamWriter}
+  private val builder = new java.lang.ProcessBuilder()
+  builder.command("node", "--interactive")
+  private val proc = builder.start()
+
+  private val stdin = new BufferedWriter(new OutputStreamWriter(proc.getOutputStream))
+  private val stdout = new BufferedReader(new InputStreamReader(proc.getInputStream))
+  private val stderr = new BufferedReader(new InputStreamReader(proc.getErrorStream))
+
+  // Skip the welcome message.
+  collectUntilPrompt()
+
+  /**
+   * This function simply collect output from Node.js until meet `"\n> "`.
+   * It is useful to skip the welcome message and collect REPL reply from
+   * interactive Node.js. It also filters out syntax errors.
+   */
+  private def collectUntilPrompt(): ReplHost.Reply = {
+    val buffer = new StringBuilder()
+    while (!buffer.endsWith("\n> ")) {
+      buffer.append(stdout.read().toChar)
+    }
+    // Remove the trailing `"\n> "`
+    buffer.delete(buffer.length - 3, buffer.length)
+    val reply = buffer.toString()
+    reply.linesIterator.find(_.startsWith(ReplHost.syntaxErrorHead)) match {
+      case None => ReplHost.Result(reply)
+      case Some(syntaxErrorLine) =>
+        val message = syntaxErrorLine.substring(ReplHost.syntaxErrorHead.length)
+        ReplHost.Error(true, message)
+    }
+  }
+
+  /**
+   * Parse query results from collected output from Node.js.
+   * 
+   * - If there is line begins with `"Uncaught SyntaxError: "`, returns
+   *   the syntax error indicated in that line.
+   * - If character `0x200B` presents in the output, returns the trimmed
+   *   error message.
+   * - Otherwise, returns the result as a successfully reply.
+   */
+  private def parseQueryResult(): ReplHost.Reply = {
+    collectUntilPrompt().map { reply =>
+      // Find error boundaries.
+      val begin = reply.indexOf(0x200b)
+      val end = reply.lastIndexOf(0x200b)
+      // If there is an error, returns `ReplHost.Error`.
+      if (begin >= 0 && end >= 0)
+        // `console.log` inserts a space between every two arguments,
+        // so + 1 and - 1 is necessary to get correct length.
+        ReplHost.Error(false, reply.substring(begin + 1, end))
+      else
+        ReplHost.Result(reply)
+    }
+  }
+
+  /**
+    * Send code to Node.js process.
+    *
+    * @param code
+    * @param useEval whether warp
+    */
+  private def send(code: Str, useEval: Bool = false): Unit = {
+    stdin.write(
+      if (useEval) "eval(" + JSLit.makeStringLiteral(code) + ")\n"
+      else if (code endsWith "\n") code
+      else code + "\n"
+    )
+    stdin.flush()
+  }
+
+  def query(prelude: Str, code: Str, res: Str): ReplHost.Reply = {
+    // For empty queries, returns empty.
+    if (prelude.isEmpty && code.isEmpty)
+      ReplHost.Empty
+    else {
+      // Warp the code with `try`-`catch` block.
+      val wrapped = s"$prelude try { $code } catch (e) { console.log('\\u200B' + e + '\\u200B'); }"
+      // Send the code
+      send(wrapped)
+      // If succeed, retrieve the result.
+      parseQueryResult().map { _ =>
+        send(if (res == "res") res else s"globalThis[\"${res}\"]")
+        parseQueryResult()
+      }
+    }
+  }
+
+  def execute(code: Str): ReplHost.Reply = {
+    send(code)
+    collectUntilPrompt()
+  }
+
+  def terminate(): Unit = proc.destroy()
+}
+
+object ReplHost {
+
+  /**
+    * The syntax error beginning text.
+    */
+  private val syntaxErrorHead = "Uncaught SyntaxError: "
+
+  /**
+    * The base class of all kinds of REPL replies.
+    */
+  sealed abstract class Reply {
+
+    /**
+      * Maps the successfuly part.
+      *
+      * @param f the function over
+      * @return
+      */
+    def map(f: Str => Reply): Reply
+  }
+
+  final case class Result(content: Str) extends Reply {
+    override def map(f: Str => Reply): Reply = f(content)
+    override def toString(): Str = s"[success] $content"
+  }
+
+  /**
+    * If the query is `Empty`, we will receive this.
+    */
+  final object Empty extends Reply {
+    override def map(f: Str => Reply): Reply = this
+    override def toString(): Str = "[empty]"
+  }
+
+  /**
+    * If the query is `Unexecuted`, we will receive this.
+    */
+  final case class Unexecuted(message: Str) extends Reply {
+    override def map(f: Str => Reply): Reply = this
+    override def toString(): Str = s"[unexecuted] $message"
+  }
+
+  /**
+    * If the `ReplHost` captured errors, it will response with `Error`.
+    */
+  final case class Error(syntax: Bool, message: Str) extends Reply {
+    override def map(f: Str => Reply): Reply = this
+    override def toString(): Str =
+      if (syntax)
+        s"[syntax error] $message"
+      else
+        s"[runtime error] $message"
+  }
+}

--- a/shared/src/test/scala/mlscript/ReplHost.scala
+++ b/shared/src/test/scala/mlscript/ReplHost.scala
@@ -3,7 +3,7 @@ package mlscript
 import mlscript.utils.shorthands._
 
 /**
- * A helper class manipulate an interactive Node.js process.
+ * A helper class to manipulate an interactive Node.js process.
  */
 final case class ReplHost() {
   import java.io.{BufferedWriter, BufferedReader, InputStreamReader, OutputStreamWriter}

--- a/shared/src/test/scala/mlscript/ReplHost.scala
+++ b/shared/src/test/scala/mlscript/ReplHost.scala
@@ -3,7 +3,7 @@ package mlscript
 import mlscript.utils.shorthands._
 
 /**
- * A helper class holding a Node.js process and runs 
+ * A helper class manipulate an interactive Node.js process.
  */
 final case class ReplHost() {
   import java.io.{BufferedWriter, BufferedReader, InputStreamReader, OutputStreamWriter}


### PR DESCRIPTION
This PR makes several improvements on code generation error reporting.

- When `:ShowRepl` is on, shows history in test files rather than `stdout`.
- The reply to preludes (classes) is not shown previously because `consumeUntilPrompt` discarded the output. Now it shows.
- Now we extract syntax errors from the Node.js output and display them.

By the way, I need some examples that legally cause syntax errors.