### PR TITLE
Replace triggerBy with dependsOn

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Running the main MLscript tests only requires the Scala Build Tool installed.
 In the terminal, run `sbt mlscriptJVM/test`.
 
 Running the ts2mls MLscript tests requires NodeJS, and TypeScript in addition.
-In the terminal, run `sbt ts2mlsJS/test`.
+In the terminal, run `sbt ts2mlsTest/test`.
 
 You can also run all tests simultaneously.
 In the terminal, run `sbt test`.

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / organization     := "io.lptk"
 ThisBuild / organizationName := "LPTK"
 
 lazy val root = project.in(file("."))
-  .aggregate(mlscriptJS, mlscriptJVM, ts2mlsJS, compilerJVM)
+  .aggregate(mlscriptJS, mlscriptJVM, ts2mlsTest, compilerJVM)
   .settings(
     publish := {},
     publishLocal := {},
@@ -73,11 +73,11 @@ lazy val ts2mls = crossProject(JSPlatform, JVMPlatform).in(file("ts2mls"))
 lazy val ts2mlsJS = ts2mls.js
 lazy val ts2mlsJVM = ts2mls.jvm
 
-val tsTypeDiffTests = taskKey[Unit]("")
-
-tsTypeDiffTests := (Def.task{
-  (ts2mlsJVM / Test / test).value
-} triggeredBy (ts2mlsJS / Test / test)).value
+lazy val ts2mlsTest = project.in(file("ts2mls"))
+  .settings(
+    scalaVersion := "2.13.8",
+    Test / test := ((ts2mlsJVM / Test / test) dependsOn (ts2mlsJS / Test / test)).value
+  )
 
 lazy val compiler = crossProject(JSPlatform, JVMPlatform).in(file("compiler"))
   .settings(


### PR DESCRIPTION
It seems that `triggerBy` in `build.sbt` would not exit with an error code even if sub tasks fail. I updated the `build.sbt` by using `dependsOn`, which could generate correct results in GitHub Actions.