### PR TITLE
Fix trait parents handling

### DIFF
--- a/shared/src/main/scala/mlscript/JSBackend.scala
+++ b/shared/src/main/scala/mlscript/JSBackend.scala
@@ -505,7 +505,6 @@ class JSBackend(allowUnresolvedSymbols: Boolean) {
   protected def translateLocalNewType(typeDef: NuTypeDef)(implicit scope: Scope): JSConstDecl = {
     // TODO: support traitSymbols
     val (traitSymbols, classSymbols, mixinSymbols, moduleSymbols) = declareNewTypeDefs(typeDef :: Nil, false)
-    if (!traitSymbols.isEmpty) throw CodeGenError("traits are not supported yet.")
 
     val sym = classSymbols match {
       case s :: _ => S(s)
@@ -579,21 +578,16 @@ class JSBackend(allowUnresolvedSymbols: Boolean) {
   }
 
   private def translateParents(superFields: Ls[Term], constructorScope: Scope)(implicit scope: Scope): Opt[JSExpr] = {
-    val bases = superFields.map {
-      case App(lhs, _) => translateTerm(App(lhs, Tup(Ls())))(constructorScope)
-      case t => translateTerm(t)(constructorScope)
-    }
-
-    def translateParent(current: JSExpr, base: JSExpr, mixinOnly: Bool): JSExpr = {
-      val name = current match {
-        case JSIdent(nme) => nme
-        case JSInvoke(JSIdent(nme), _) => nme
-        case JSNew(JSIdent(nme)) => nme
-        case JSInvoke(JSNew(JSIdent(nme)), _) => nme 
-        case f: JSField => f.property.name
-        case JSInvoke(f: JSField, _) => f.property.name
+    def translateParent(current: Term, base: JSExpr, mixinOnly: Bool): JSExpr = {
+      def resolveName(term: Term): Str = term match {
+        case App(lhs, _) => resolveName(lhs)
+        case Var(name) => name
+        case Sel(_, Var(fieldName)) => fieldName
+        case TyApp(lhs, _) => resolveName(lhs)
         case _ => throw CodeGenError("unsupported parents.")
       }
+
+      val name = resolveName(current)
 
       scope.resolveValue(name) match {
         case Some(CapturedSymbol(_, _: TraitSymbol)) => base // TODO:
@@ -619,7 +613,7 @@ class JSBackend(allowUnresolvedSymbols: Boolean) {
 
     // for non-first parent classes, they must be mixins or we would get more than one parent classes,
     // which is not allowed in JS
-    bases match {
+    superFields match {
       case head :: tail => S(tail.foldLeft(
         translateParent(head, JSIdent("Object"), false)
       )((res, next) => translateParent(next, res, true)))
@@ -732,7 +726,6 @@ class JSBackend(allowUnresolvedSymbols: Boolean) {
 
     // TODO: support traitSymbols
     val (traitSymbols, classSymbols, mixinSymbols, moduleSymbols) = declareNewTypeDefs(sym.nested, true)(nuTypeScope)
-    if (!traitSymbols.isEmpty) throw CodeGenError("traits are not supported yet.")
 
     if (keepTopLevelScope) // also declare in the top level for diff tests
       declareNewTypeDefs(sym.nested, false)(topLevelScope)

--- a/shared/src/test/diff/nu/ParamOverride.mls
+++ b/shared/src/test/diff/nu/ParamOverride.mls
@@ -11,7 +11,7 @@ class Derived0(n: int) extends Base
 //│ ╙──     	                               ^^^^
 //│ class Derived0(n: int)
 //│ Code generation encountered an error:
-//│   unresolved symbol Base
+//│   unresolved parent Base.
 
 
 mixin Base1(n: number) {


### PR DESCRIPTION
Ignore traits in inheritance clauses correctly and fix `translateParents`:
```ts
:js
trait A
class B() extends A
//│ trait A
//│ class B()
//│ // Prelude
//│ class TypingUnit15 {
//│   #B;
//│   constructor() {
//│   }
//│   get B() {
//│     const outer = this;
//│     if (this.#B === undefined) {
//│       class B extends Object {
//│         constructor() {
//│           super();
//│         }
//│       };
//│       this.#B = (() => Object.freeze(new B()));
//│       this.#B.class = B;
//│     }
//│     return this.#B;
//│   }
//│ }
//│ const typing_unit15 = new TypingUnit15;
//│ globalThis.A = typing_unit15.A;
//│ globalThis.B = typing_unit15.B;
//│ // End of generated code
```