### PR TITLE
Allow selecting tuple by integer indices

### DIFF
--- a/shared/src/main/scala/mlscript/MLParser.scala
+++ b/shared/src/main/scala/mlscript/MLParser.scala
@@ -41,7 +41,7 @@ class MLParser(origin: Origin, indent: Int = 0, recordLocations: Bool = true) {
   def number[p: P]: P[Int] = P( CharIn("0-9").repX(1).!.map(_.toInt) )
   def ident[p: P]: P[String] =
     P( (letter | "_") ~~ (letter | digit | "_" | "'").repX ).!.filter(!keywords(_))
-  def field[p: P]: P[String] = P( ident | number.map(_.toString) )
+  def index[p: P]: P[String] = P( "0" | CharIn("1-9") ~~ digit.repX ).!.map(_.toString)
   
   def termOrAssign[p: P]: P[Statement] = P( term ~ ("=" ~ term).? ).map {
     case (expr, N) => expr
@@ -59,7 +59,7 @@ class MLParser(origin: Origin, indent: Int = 0, recordLocations: Bool = true) {
     | P(kw("undefined")).map(x => UnitLit(true)) | P(kw("null")).map(x => UnitLit(false)))
   
   def variable[p: P]: P[Var] = locate(ident.map(Var))
-  def fieldName[p: P]: P[Var] = locate(field.map(Var))
+  def fieldName[p: P]: P[Var] = locate( (ident | index).map(Var) )
 
   def parenCell[p: P]: P[Either[Term, (Term, Boolean)]] = (("..." | kw("mut")).!.? ~ term).map {
     case (Some("..."), t) => Left(t)

--- a/shared/src/main/scala/mlscript/NewLexer.scala
+++ b/shared/src/main/scala/mlscript/NewLexer.scala
@@ -176,7 +176,11 @@ class NewLexer(origin: Origin, raise: Diagnostic => Unit, dbg: Bool) {
             // go(k, SELECT(name))
             lex(k, ind, next(k, SELECT(name)))
           }
-          else if (isDigit(nc)) {
+          else if (
+            // The first character is '0' and the next character is not a digit
+            (nc === '0' && !(j + 1 < length && isDigit(bytes(j + 1)))) ||
+            ('0' < nc && nc <= '9') // The first character is a digit other than '0'
+          ) {
             val (name, k) = takeWhile(j)(isDigit)
             // go(k, SELECT(name))
             lex(k, ind, next(k, SELECT(name)))

--- a/shared/src/main/scala/mlscript/NewLexer.scala
+++ b/shared/src/main/scala/mlscript/NewLexer.scala
@@ -169,10 +169,19 @@ class NewLexer(origin: Origin, raise: Diagnostic => Unit, dbg: Bool) {
         lex(j, ind, next(j, if (keywords.contains(n)) KEYWORD(n) else IDENT(n, isAlphaOp(n))))
       case _ if isOpChar(c) =>
         val (n, j) = takeWhile(i)(isOpChar)
-        if (n === "." && j < length && isIdentFirstChar(bytes(j))) {
-          val (name, k) = takeWhile(j)(isIdentChar)
-          // go(k, SELECT(name))
-          lex(k, ind, next(k, SELECT(name)))
+        if (n === "." && j < length) {
+          val nc = bytes(j)
+          if (isIdentFirstChar(nc)) {
+            val (name, k) = takeWhile(j)(isIdentChar)
+            // go(k, SELECT(name))
+            lex(k, ind, next(k, SELECT(name)))
+          }
+          else if (isDigit(nc)) {
+            val (name, k) = takeWhile(j)(isDigit)
+            // go(k, SELECT(name))
+            lex(k, ind, next(k, SELECT(name)))
+          }
+          else lex(j, ind, next(j, if (isSymKeyword.contains(n)) KEYWORD(n) else IDENT(n, true)))
         }
         // else go(j, if (isSymKeyword.contains(n)) KEYWORD(n) else IDENT(n, true))
         else lex(j, ind, next(j, if (isSymKeyword.contains(n)) KEYWORD(n) else IDENT(n, true)))

--- a/shared/src/main/scala/mlscript/NewParser.scala
+++ b/shared/src/main/scala/mlscript/NewParser.scala
@@ -614,7 +614,7 @@ abstract class NewParser(origin: Origin, tokens: Ls[Stroken -> Loc], newDefs: Bo
         exprCont(Var(opStr).withLoc(S(l1)), prec, allowNewlines = false)
       case (br @ BRACKETS(bk @ (Round | Square | Curly), toks), loc) :: _ =>
         consume
-        val res = rec(toks, S(br.innerLoc), br.describe).concludeWith(_.argsMaybeIndented(bk == Curly))
+        val res = rec(toks, S(br.innerLoc), br.describe).concludeWith(_.argsMaybeIndented(bk === Curly))
         val bra = (bk, res) match {
           case (Curly, _) =>
             Bra(true, Rcd(res.map {

--- a/shared/src/main/scala/mlscript/NewParser.scala
+++ b/shared/src/main/scala/mlscript/NewParser.scala
@@ -552,7 +552,7 @@ abstract class NewParser(origin: Origin, tokens: Ls[Stroken -> Loc], newDefs: Bo
       case Nil => Nil
       case (KEYWORD("of"), _) :: _ =>
         consume
-        Tup(args(false) // TODO
+        Tup(args(false, false) // TODO
           ) :: funParams
       case (br @ BRACKETS(Round, toks), loc) :: _ =>
         consume
@@ -614,7 +614,7 @@ abstract class NewParser(origin: Origin, tokens: Ls[Stroken -> Loc], newDefs: Bo
         exprCont(Var(opStr).withLoc(S(l1)), prec, allowNewlines = false)
       case (br @ BRACKETS(bk @ (Round | Square | Curly), toks), loc) :: _ =>
         consume
-        val res = rec(toks, S(br.innerLoc), br.describe).concludeWith(_.argsMaybeIndented())
+        val res = rec(toks, S(br.innerLoc), br.describe).concludeWith(_.argsMaybeIndented(bk == Curly))
         val bra = (bk, res) match {
           case (Curly, _) =>
             Bra(true, Rcd(res.map {
@@ -1094,8 +1094,8 @@ abstract class NewParser(origin: Origin, tokens: Ls[Stroken -> Loc], newDefs: Bo
       case _ => f(this, false)
     }
   
-  final def argsMaybeIndented()(implicit fe: FoundErr, et: ExpectThen): Ls[Opt[Var] -> Fld] =
-    maybeIndented(_.args(_))
+  final def argsMaybeIndented(inRecord: Bool = false)(implicit fe: FoundErr, et: ExpectThen): Ls[Opt[Var] -> Fld] =
+    maybeIndented(_.args(inRecord, _))
   // final def argsMaybeIndented()(implicit fe: FoundErr, et: ExpectThen): Ls[Opt[Var] -> Fld] =
   //   cur match {
   //     case (br @ BRACKETS(Indent, toks), _) :: _ if (toks.headOption match {
@@ -1108,9 +1108,9 @@ abstract class NewParser(origin: Origin, tokens: Ls[Stroken -> Loc], newDefs: Bo
   //   }
   
   // TODO support comma-less arg blocks...?
-  final def args(allowNewlines: Bool, prec: Int = NoElsePrec)(implicit fe: FoundErr, et: ExpectThen): Ls[Opt[Var] -> Fld] =
+  final def args(inRecord: Bool, allowNewlines: Bool, prec: Int = NoElsePrec)(implicit fe: FoundErr, et: ExpectThen): Ls[Opt[Var] -> Fld] =
     // argsOrIf(Nil).map{case (_, L(x))=> ???; case (n, R(x))=>n->x} // TODO
-    argsOrIf(Nil, Nil, allowNewlines, prec).flatMap{case (n, L(x))=> 
+    argsOrIf(Nil, Nil, inRecord, allowNewlines, prec).flatMap{case (n, L(x))=> 
         err(msg"Unexpected 'then'/'else' clause" -> x.toLoc :: Nil)
         n->Fld(FldFlags.empty, errExpr)::Nil
       case (n, R(x))=>n->x::Nil} // TODO
@@ -1125,7 +1125,7 @@ abstract class NewParser(origin: Origin, tokens: Ls[Stroken -> Loc], newDefs: Bo
     }
   }
   */
-  final def argsOrIf(acc: Ls[Opt[Var] -> (IfBody \/ Fld)], seqAcc: Ls[Statement], allowNewlines: Bool, prec: Int = NoElsePrec)
+  final def argsOrIf(acc: Ls[Opt[Var] -> (IfBody \/ Fld)], seqAcc: Ls[Statement], inRecord: Bool, allowNewlines: Bool, prec: Int = NoElsePrec)
         (implicit fe: FoundErr, et: ExpectThen): Ls[Opt[Var] -> (IfBody \/ Fld)] =
       wrap(acc, seqAcc) { l =>
     
@@ -1139,7 +1139,7 @@ abstract class NewParser(origin: Origin, tokens: Ls[Stroken -> Loc], newDefs: Bo
         }
       case (SPACE, _) :: _ =>
         consume
-        argsOrIf(acc, seqAcc, allowNewlines, prec)
+        argsOrIf(acc, seqAcc, inRecord, allowNewlines, prec)
       case (NEWLINE, _) :: _ => // TODO: | ...
         assert(seqAcc.isEmpty)
         acc.reverse
@@ -1173,6 +1173,10 @@ abstract class NewParser(origin: Origin, tokens: Ls[Stroken -> Loc], newDefs: Bo
         consume
         consume
         S(Var(idStr).withLoc(S(l0)))
+      case (LITVAL(IntLit(i)), l0) :: (KEYWORD(":"), _) :: _ if inRecord => // TODO: | ...
+        consume
+        consume
+        S(Var(i.toString).withLoc(S(l0)))
       case _ => N
     }
     // val e = expr(NoElsePrec) -> argMut.isDefined
@@ -1188,10 +1192,10 @@ abstract class NewParser(origin: Origin, tokens: Ls[Stroken -> Loc], newDefs: Bo
       case (COMMA, l0) :: (NEWLINE, l1) :: _ =>
         consume
         consume
-        argsOrIf(mkSeq :: acc, Nil, allowNewlines)
+        argsOrIf(mkSeq :: acc, Nil, inRecord, allowNewlines)
       case (COMMA, l0) :: _ =>
         consume
-        argsOrIf(mkSeq :: acc, Nil, allowNewlines)
+        argsOrIf(mkSeq :: acc, Nil, inRecord, allowNewlines)
       case (NEWLINE, l1) :: _ if allowNewlines =>
         consume
         argName match {
@@ -1202,7 +1206,7 @@ abstract class NewParser(origin: Origin, tokens: Ls[Stroken -> Loc], newDefs: Bo
         e match {
           case L(_) => ???
           case R(Fld(FldFlags(false, false, _), res)) =>
-            argsOrIf(acc, res :: seqAcc, allowNewlines)
+            argsOrIf(acc, res :: seqAcc, false, allowNewlines)
           case R(_) => ???
         }
       case _ =>

--- a/shared/src/main/scala/mlscript/Parser.scala
+++ b/shared/src/main/scala/mlscript/Parser.scala
@@ -39,13 +39,18 @@ class Parser(origin: Origin, indent: Int = 0, recordLocations: Bool = true) {
   
   def NAME[p: P]: P[Var] = locate(ident.map(Var(_)))
   
-  def ident[p: P] = Lexer.identifier | "(" ~ operator.! ~ ")"
+  def ident[p: P]: P[String] = Lexer.identifier | "(" ~ operator.! ~ ")"
   
   def NUMBER[p: P]: P[Lit] = locate(
     P( Lexer.longinteger | Lexer.integer ).map(IntLit) |
     P( Lexer.floatnumber ).map(DecLit)
   )
   def STRING[p: P]: P[StrLit] = locate(Lexer.stringliteral.map(StrLit(_)))
+
+  def FIELD[p: P]: P[Var] = locate(
+    P( Lexer.identifier ).map(Var(_)) |
+    P( Lexer.decimalinteger ).map(n => Var(n.toString))
+  )
   
   def expr[p: P]: P[Term] = P( ite | basicExpr ).opaque("expression")
   
@@ -174,7 +179,7 @@ class Parser(origin: Origin, indent: Int = 0, recordLocations: Bool = true) {
     case (as, ao) => (as ++ ao.toList).reduceLeft((f, a) => App(f, toParams(a)))
   }
   
-  def atomOrSelect[p: P]: P[Term] = P(atom ~ (Index ~~ "." ~ NAME ~~ Index).rep).map {
+  def atomOrSelect[p: P]: P[Term] = P(atom ~ (Index ~~ "." ~ FIELD ~~ Index).rep).map {
     case (lhs, sels) => sels.foldLeft(lhs) {
       case (acc, (i0,str,i1)) => Sel(lhs, str).withLoc(i0, i1, origin)
     }

--- a/shared/src/main/scala/mlscript/TypeSimplifier.scala
+++ b/shared/src/main/scala/mlscript/TypeSimplifier.scala
@@ -411,13 +411,7 @@ trait TypeSimplifier { self: Typer =>
                     val arity = fs.size
                     val (componentFields, rcdFields) = rcd.fields
                       .filterNot(traitPrefixes contains _._1.name.takeWhile(_ =/= '#'))
-                      .partitionMap(f =>
-                        if (f._1.name.forall(_.isDigit)) {
-                          val index = f._1.name.toInt
-                          if (0 <= index && index < arity) L(index -> f._2)
-                          else R(f)
-                        } else R(f)
-                      )
+                      .partitionMap(f => f._1.toIndexOption.filter((0 until arity).contains).map(_ -> f._2).toLeft(f))
                     val componentFieldsMap = componentFields.toMap
                     val tupleComponents = fs.iterator.zipWithIndex.map { case ((nme, ty), i) =>
                       nme -> (ty && componentFieldsMap.getOrElse(i, TopType.toUpper(noProv))).update(go(_, pol.map(!_)), go(_, pol))

--- a/shared/src/main/scala/mlscript/TypeSimplifier.scala
+++ b/shared/src/main/scala/mlscript/TypeSimplifier.scala
@@ -430,7 +430,7 @@ trait TypeSimplifier { self: Typer =>
                       )
                     val componentFieldsMap = componentFields.toMap
                     val tupleComponents = fs.iterator.zipWithIndex.map { case ((nme, ty), i) =>
-                      nme -> (ty && componentFieldsMap.getOrElse(i + 1, TopType.toUpper(noProv))).update(go(_, pol.map(!_)), go(_, pol))
+                      nme -> (ty && componentFieldsMap.getOrElse(i, TopType.toUpper(noProv))).update(go(_, pol.map(!_)), go(_, pol))
                     }.toList
                     S(TupleType(tupleComponents)(tt.prov)) -> rcdFields.mapValues(_.update(go(_, pol.map(!_)), go(_, pol)))
                   case S(ct: ClassTag) => S(ct) -> nFields

--- a/shared/src/main/scala/mlscript/TypeSimplifier.scala
+++ b/shared/src/main/scala/mlscript/TypeSimplifier.scala
@@ -412,15 +412,21 @@ trait TypeSimplifier { self: Typer =>
                     val (componentFields, rcdFields) = rcd.fields
                       .filterNot(traitPrefixes contains _._1.name.takeWhile(_ =/= '#'))
                       .partitionMap(f =>
-                        if (f._1.name.length > 1 && f._1.name.startsWith("_")) {
-                          val namePostfix = f._1.name.tail
-                          if (namePostfix.forall(_.isDigit)) {
-                            val index = namePostfix.toInt
-                            if (index <= arity && index > 0) L(index -> f._2)
-                            else R(f)
-                          }
+                        if (f._1.name.forall(_.isDigit)) {
+                          val index = f._1.name.toInt
+                          if (0 <= index && index < arity) L(index -> f._2)
                           else R(f)
                         } else R(f)
+                        // // With old tuple field names:
+                        // if (f._1.name.length > 1 && f._1.name.startsWith("_")) {
+                        //   val namePostfix = f._1.name.tail
+                        //   if (namePostfix.forall(_.isDigit)) {
+                        //     val index = namePostfix.toInt
+                        //     if (index <= arity && index > 0) L(index -> f._2)
+                        //     else R(f)
+                        //   }
+                        //   else R(f)
+                        // } else R(f)
                       )
                     val componentFieldsMap = componentFields.toMap
                     val tupleComponents = fs.iterator.zipWithIndex.map { case ((nme, ty), i) =>

--- a/shared/src/main/scala/mlscript/TypeSimplifier.scala
+++ b/shared/src/main/scala/mlscript/TypeSimplifier.scala
@@ -417,16 +417,6 @@ trait TypeSimplifier { self: Typer =>
                           if (0 <= index && index < arity) L(index -> f._2)
                           else R(f)
                         } else R(f)
-                        // // With old tuple field names:
-                        // if (f._1.name.length > 1 && f._1.name.startsWith("_")) {
-                        //   val namePostfix = f._1.name.tail
-                        //   if (namePostfix.forall(_.isDigit)) {
-                        //     val index = namePostfix.toInt
-                        //     if (index <= arity && index > 0) L(index -> f._2)
-                        //     else R(f)
-                        //   }
-                        //   else R(f)
-                        // } else R(f)
                       )
                     val componentFieldsMap = componentFields.toMap
                     val tupleComponents = fs.iterator.zipWithIndex.map { case ((nme, ty), i) =>

--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -1101,7 +1101,7 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool, val ne
         //   Returns a function expecting an additional argument of type `Class` before the method arguments
         def rcdSel(obj: Term, fieldName: Var) = {
           val o_ty = typeMonomorphicTerm(obj)
-          val res = freshVar(prov, N, Opt.when(!fieldName.name.startsWith("_"))(fieldName.name))
+          val res = freshVar(prov, N, Opt.when(!fieldName.name.startsWith("_") && !fieldName.isIndex)(fieldName.name))
           val obj_ty = mkProxy(o_ty, tp(obj.toCoveringLoc, "receiver"))
           val rcd_ty = RecordType.mk(
             fieldName -> res.toUpper(tp(fieldName.toLoc, "field selector")) :: Nil)(prov)

--- a/shared/src/main/scala/mlscript/TyperDatatypes.scala
+++ b/shared/src/main/scala/mlscript/TyperDatatypes.scala
@@ -269,7 +269,7 @@ abstract class TyperDatatypes extends TyperHelpers { Typer: Typer =>
     lazy val toArray: ArrayType = ArrayType(inner)(prov)  // upcast to array
     override lazy val toRecord: RecordType =
       RecordType(
-        fields.zipWithIndex.map { case ((_, t), i) => (Var("_"+(i+1)), t) }
+        fields.zipWithIndex.map { case ((_, t), i) => (Var(i.toString), t) }
         // Note: In line with TypeScript, tuple field names are pure type system fictions,
         //    with no runtime existence. Therefore, they should not be included in the record type
         //    corresponding to this tuple type.

--- a/shared/src/main/scala/mlscript/TyperHelpers.scala
+++ b/shared/src/main/scala/mlscript/TyperHelpers.scala
@@ -604,14 +604,19 @@ abstract class TyperHelpers { Typer: Typer =>
       case t @ RecordType(fs) => RecordType(fs.filter(nt => !names(nt._1)))(t.prov)
       case t @ TupleType(fs) =>
         val relevantNames = names.filter(n =>
-          n.name.startsWith("_")
-            && {
-              val t = n.name.tail
-              t.forall(_.isDigit) && {
-                val n = t.toInt
-                1 <= n && n <= fs.length
-              }
-            })
+          !n.name.isEmpty && n.name.forall(_.isDigit) && {
+            val index = n.name.toInt
+            0 <= index && index < fs.length
+          })
+          // // With old tuple field names:
+          // n.name.startsWith("_")
+          //   && {
+          //     val t = n.name.tail
+          //     t.forall(_.isDigit) && {
+          //       val n = t.toInt
+          //       1 <= n && n <= fs.length
+          //     }
+          //   })
         if (relevantNames.isEmpty) t
         else {
           val rcd = t.toRecord

--- a/shared/src/main/scala/mlscript/TyperHelpers.scala
+++ b/shared/src/main/scala/mlscript/TyperHelpers.scala
@@ -604,19 +604,7 @@ abstract class TyperHelpers { Typer: Typer =>
       case t @ RecordType(fs) => RecordType(fs.filter(nt => !names(nt._1)))(t.prov)
       case t @ TupleType(fs) =>
         val relevantNames = names.filter(n =>
-          !n.name.isEmpty && n.name.forall(_.isDigit) && {
-            val index = n.name.toInt
-            0 <= index && index < fs.length
-          })
-          // // With old tuple field names:
-          // n.name.startsWith("_")
-          //   && {
-          //     val t = n.name.tail
-          //     t.forall(_.isDigit) && {
-          //       val n = t.toInt
-          //       1 <= n && n <= fs.length
-          //     }
-          //   })
+          n.toIndexOption.exists((0 until fs.length).contains))
         if (relevantNames.isEmpty) t
         else {
           val rcd = t.toRecord

--- a/shared/src/main/scala/mlscript/codegen/Codegen.scala
+++ b/shared/src/main/scala/mlscript/codegen/Codegen.scala
@@ -605,9 +605,11 @@ class JSField(`object`: JSExpr, val property: JSIdent) extends JSMember(`object`
     ) ++ SourceCode(
       if (JSField.isValidFieldName(property.name)) {
         s".${property.name}"
-      } else {
-        s"[${JSLit.makeStringLiteral(property.name)}]"
-      }
+      } else
+        property.name.toIntOption match {
+          case S(index) => s"[$index]"
+          case N => s"[${JSLit.makeStringLiteral(property.name)}]"
+        }
     )
 }
 

--- a/shared/src/main/scala/mlscript/helpers.scala
+++ b/shared/src/main/scala/mlscript/helpers.scala
@@ -715,6 +715,12 @@ trait LitImpl { self: Lit =>
 }
 
 trait VarImpl { self: Var =>
+  /** Check if the variable name is an integer. */
+  def isIndex: Bool = name.headOption match {
+    case S('0') => name.length === 1
+    case S(_) => name.forall(_.isDigit)
+    case N => false
+  }
   def isPatVar: Bool =
     (name.head.isLetter && name.head.isLower || name.head === '_' || name.head === '$') && name =/= "true" && name =/= "false"
   def toVar: Var = this

--- a/shared/src/main/scala/mlscript/helpers.scala
+++ b/shared/src/main/scala/mlscript/helpers.scala
@@ -721,6 +721,8 @@ trait VarImpl { self: Var =>
     case S(_) => name.forall(_.isDigit)
     case N => false
   }
+  /** Get the integer if it's a valid index. */
+  def toIndexOption: Opt[Int] = if (isIndex) name.toIntOption else N
   def isPatVar: Bool =
     (name.head.isLetter && name.head.isLower || name.head === '_' || name.head === '$') && name =/= "true" && name =/= "false"
   def toVar: Var = this

--- a/shared/src/test/diff/basics/Intersections.fun
+++ b/shared/src/test/diff/basics/Intersections.fun
@@ -6,11 +6,11 @@ let foo = _ as (_: (Int => Int) & (Bool => Bool))
 
 :ns
 let foo = _ as (_: (Int => Int) & (Bool => Bool))
-let foo = (_ as (_: (Int => Int) & (Bool => Bool)))._1
+let foo = (_ as (_: (Int => Int) & (Bool => Bool))).0
 //│ foo: forall 'a. (_: 'a,)
 //│   where
 //│     'a <: int -> int & bool -> bool
-//│ foo: forall 'a. 'a
+//│ foo: forall '0. '0
 
 foo(1)
 //│ res: nothing

--- a/shared/src/test/diff/basics/Intersections.fun
+++ b/shared/src/test/diff/basics/Intersections.fun
@@ -10,7 +10,7 @@ let foo = (_ as (_: (Int => Int) & (Bool => Bool))).0
 //│ foo: forall 'a. (_: 'a,)
 //│   where
 //│     'a <: int -> int & bool -> bool
-//│ foo: forall '0. '0
+//│ foo: forall 'a. 'a
 
 foo(1)
 //│ res: nothing

--- a/shared/src/test/diff/basics/Tuples.fun
+++ b/shared/src/test/diff/basics/Tuples.fun
@@ -15,40 +15,26 @@ let t = x: 1, y: 2, z: 3
 //│ t: (1, y: 2, 3,)
 //│ t: (x: 1, y: 2, z: 3,)
 
-(1, true, "hey")._2
-(1, true, "hey")._3
+(1, true, "hey").1
+(1, true, "hey").2
 //│ res: true
 //│ res: "hey"
 
 :e
-(1, true, "hey")._4
+(1, true, "hey").3
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.24: 	(1, true, "hey")._4
-//│ ║        	                ^^^
-//│ ╟── tuple of type `{_1: 1, _2: true, _3: "hey"}` does not have field '_4'
-//│ ║  l.24: 	(1, true, "hey")._4
+//│ ║  l.24: 	(1, true, "hey").3
+//│ ║        	                ^^
+//│ ╟── tuple of type `{0: 1, 1: true, 2: "hey"}` does not have field '3'
+//│ ║  l.24: 	(1, true, "hey").3
 //│ ║        	 ^^^^^^^^^^^^^^
-//│ ╟── but it flows into receiver with expected type `{_4: ?a}`
-//│ ║  l.24: 	(1, true, "hey")._4
+//│ ╟── but it flows into receiver with expected type `{3: ?3}`
+//│ ║  l.24: 	(1, true, "hey").3
 //│ ╙──      	^^^^^^^^^^^^^^^^
 //│ res: error
 
-:p
-:e
-(1, true, "hey").2
-//│ Parsed: '(' {[1, true, "hey",]} ')'(...0.2);
-//│ Desugared: '(' {[1, true, "hey",]} ')'(...0.2)
-//│ AST: App(Bra(rcd = false, Blk(...)), DecLit(0.2))
-//│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.38: 	(1, true, "hey").2
-//│ ║        	^^^^^^^^^^^^^^^^^^
-//│ ╟── tuple of type `(1, true, "hey",)` is not a function
-//│ ║  l.38: 	(1, true, "hey").2
-//│ ║        	 ^^^^^^^^^^^^^^
-//│ ╟── but it flows into applied expression with expected type `0.2 -> ?a`
-//│ ║  l.38: 	(1, true, "hey").2
-//│ ╙──      	^^^^^^^^^^^^^^^^
-//│ res: error
+(1, true, "hey").1
+//│ res: true
 
 :w
 let not-tup = (
@@ -56,7 +42,7 @@ let not-tup = (
   2
 )
 //│ ╔══[WARNING] Pure expression does nothing in statement position.
-//│ ║  l.55: 	  1
+//│ ║  l.41: 	  1
 //│ ╙──      	  ^
 //│ not-tup: 2
 
@@ -66,7 +52,7 @@ let tup = (
   2
 )
 //│ ╔══[WARNING] Previous field definitions are discarded by this returned expression.
-//│ ║  l.66: 	  2
+//│ ║  l.52: 	  2
 //│ ╙──      	  ^
 //│ tup: 2
 
@@ -76,7 +62,7 @@ let tup =
   2,
   3
 //│ ╔══[WARNING] Previous field definitions are discarded by this returned expression.
-//│ ║  l.77: 	  3
+//│ ║  l.63: 	  3
 //│ ╙──      	  ^
 //│ tup: 3
 

--- a/shared/src/test/diff/basics/Tuples.fun
+++ b/shared/src/test/diff/basics/Tuples.fun
@@ -28,7 +28,7 @@ let t = x: 1, y: 2, z: 3
 //│ ╟── tuple of type `{0: 1, 1: true, 2: "hey"}` does not have field '3'
 //│ ║  l.24: 	(1, true, "hey").3
 //│ ║        	 ^^^^^^^^^^^^^^
-//│ ╟── but it flows into receiver with expected type `{3: ?3}`
+//│ ╟── but it flows into receiver with expected type `{3: ?a}`
 //│ ║  l.24: 	(1, true, "hey").3
 //│ ╙──      	^^^^^^^^^^^^^^^^
 //│ res: error

--- a/shared/src/test/diff/basics/Unions.fun
+++ b/shared/src/test/diff/basics/Unions.fun
@@ -146,7 +146,7 @@ x => foo { v: x }
 
 // Notice that in MLscript, `(0, 0) | (1, 1)` is equivalent to `(0 | 1, 0 | 1)`
 let bar(r: (0, 0) | (1, 1)) = if r.0 < 1 then r.0 else r.1
-//│ bar: (r: ('a & (0 | 1), 0 | 1,),) -> 'a
+//│ bar: (r: ('a & (0 | 1), 'a & (0 | 1),),) -> 'a
 
 bar(0, 1)
 //│ res: 0 | 1
@@ -261,7 +261,7 @@ x => baz(x, x)
 
 
 let baz(r: (0, 0) | (1, _)) = if r.0 < 1 then r.0 else r.1
-//│ baz: (r: ('a & (0 | 1), anything,),) -> 'a
+//│ baz: (r: ('a & (0 | 1), 'a,),) -> 'a
 
 :e
 baz(0)

--- a/shared/src/test/diff/basics/Unions.fun
+++ b/shared/src/test/diff/basics/Unions.fun
@@ -232,7 +232,7 @@ baz(0)
 //│ ╟── integer literal of type `0` does not have field '1'
 //│ ║  l.228: 	baz(0)
 //│ ║         	    ^
-//│ ╟── but it flows into argument with expected type `{1: ?1}`
+//│ ╟── but it flows into argument with expected type `{1: ?a}`
 //│ ║  l.228: 	baz(0)
 //│ ║         	   ^^^
 //│ ╟── Note: constraint arises from field selection:
@@ -272,7 +272,7 @@ baz(0, 1)
 //│ ╟── integer literal of type `0` does not have field '1'
 //│ ║  l.267: 	baz(0)
 //│ ║         	    ^
-//│ ╟── but it flows into argument with expected type `{1: ?1}`
+//│ ╟── but it flows into argument with expected type `{1: ?a}`
 //│ ║  l.267: 	baz(0)
 //│ ║         	   ^^^
 //│ ╟── Note: constraint arises from field selection:

--- a/shared/src/test/diff/basics/Unions.fun
+++ b/shared/src/test/diff/basics/Unions.fun
@@ -146,7 +146,7 @@ x => foo { v: x }
 
 // Notice that in MLscript, `(0, 0) | (1, 1)` is equivalent to `(0 | 1, 0 | 1)`
 let bar(r: (0, 0) | (1, 1)) = if r.0 < 1 then r.0 else r.1
-//│ bar: (r: (0 | 1, 0 | 1,) & {0: number & 'a, 1: 'a},) -> 'a
+//│ bar: (r: ('a & (0 | 1), 0 | 1,),) -> 'a
 
 bar(0, 1)
 //│ res: 0 | 1
@@ -261,7 +261,7 @@ x => baz(x, x)
 
 
 let baz(r: (0, 0) | (1, _)) = if r.0 < 1 then r.0 else r.1
-//│ baz: (r: (0 | 1, anything,) & {0: number & 'a, 1: 'a},) -> 'a
+//│ baz: (r: ('a & (0 | 1), anything,),) -> 'a
 
 :e
 baz(0)

--- a/shared/src/test/diff/basics/Unions.fun
+++ b/shared/src/test/diff/basics/Unions.fun
@@ -145,8 +145,8 @@ x => foo { v: x }
 
 
 // Notice that in MLscript, `(0, 0) | (1, 1)` is equivalent to `(0 | 1, 0 | 1)`
-let bar(r: (0, 0) | (1, 1)) = if r._1 < 1 then r._1 else r._2
-//│ bar: (r: ('a & (0 | 1), 'a & (0 | 1),),) -> 'a
+let bar(r: (0, 0) | (1, 1)) = if r.0 < 1 then r.0 else r.1
+//│ bar: (r: (0 | 1, 0 | 1,) & {0: number & 'a, 1: 'a},) -> 'a
 
 bar(0, 1)
 //│ res: 0 | 1
@@ -221,25 +221,25 @@ x => bar(bar(x, 1), 0)
 //│ res: ('a & (0 | 1), 'a & (0 | 1),) -> (0 | 'a)
 
 
-let baz(r: (0, 0) | _) = if r._1 < 1 then r._1 else r._2
-//│ baz: (r: {_1: number & 'a, _2: 'a},) -> 'a
+let baz(r: (0, 0) | _) = if r.0 < 1 then r.0 else r.1
+//│ baz: (r: {0: number & 'a, 1: 'a},) -> 'a
 
 :e
 baz(0)
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.228: 	baz(0)
 //│ ║         	^^^^^^
-//│ ╟── integer literal of type `0` does not have field '_2'
+//│ ╟── integer literal of type `0` does not have field '1'
 //│ ║  l.228: 	baz(0)
 //│ ║         	    ^
-//│ ╟── but it flows into argument with expected type `{_2: ?a}`
+//│ ╟── but it flows into argument with expected type `{1: ?1}`
 //│ ║  l.228: 	baz(0)
 //│ ║         	   ^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.224: 	let baz(r: (0, 0) | _) = if r._1 < 1 then r._1 else r._2
-//│ ║         	                                                     ^^^
+//│ ║  l.224: 	let baz(r: (0, 0) | _) = if r.0 < 1 then r.0 else r.1
+//│ ║         	                                                   ^^
 //│ ╟── from binding:
-//│ ║  l.224: 	let baz(r: (0, 0) | _) = if r._1 < 1 then r._1 else r._2
+//│ ║  l.224: 	let baz(r: (0, 0) | _) = if r.0 < 1 then r.0 else r.1
 //│ ╙──       	        ^^^^^^^^^^^^^
 //│ res: error
 
@@ -260,8 +260,8 @@ x => baz(x, x)
 //│ res: (number & 'a, 'a,) -> 'a
 
 
-let baz(r: (0, 0) | (1, _)) = if r._1 < 1 then r._1 else r._2
-//│ baz: (r: ('a & (0 | 1), 'a,),) -> 'a
+let baz(r: (0, 0) | (1, _)) = if r.0 < 1 then r.0 else r.1
+//│ baz: (r: (0 | 1, anything,) & {0: number & 'a, 1: 'a},) -> 'a
 
 :e
 baz(0)
@@ -269,17 +269,17 @@ baz(0, 1)
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.267: 	baz(0)
 //│ ║         	^^^^^^
-//│ ╟── integer literal of type `0` does not have field '_2'
+//│ ╟── integer literal of type `0` does not have field '1'
 //│ ║  l.267: 	baz(0)
 //│ ║         	    ^
-//│ ╟── but it flows into argument with expected type `{_2: ?a}`
+//│ ╟── but it flows into argument with expected type `{1: ?1}`
 //│ ║  l.267: 	baz(0)
 //│ ║         	   ^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.263: 	let baz(r: (0, 0) | (1, _)) = if r._1 < 1 then r._1 else r._2
-//│ ║         	                                                          ^^^
+//│ ║  l.263: 	let baz(r: (0, 0) | (1, _)) = if r.0 < 1 then r.0 else r.1
+//│ ║         	                                                        ^^
 //│ ╟── from binding:
-//│ ║  l.263: 	let baz(r: (0, 0) | (1, _)) = if r._1 < 1 then r._1 else r._2
+//│ ║  l.263: 	let baz(r: (0, 0) | (1, _)) = if r.0 < 1 then r.0 else r.1
 //│ ╙──       	        ^^^^^^^^^^^^^^^^^^
 //│ res: error
 //│ res: 0 | 1

--- a/shared/src/test/diff/codegen/Terms.mls
+++ b/shared/src/test/diff/codegen/Terms.mls
@@ -413,15 +413,15 @@ t1 = (mut "hello", mut true)
 //│   = [ 'hello', true ]
 
 :js
-t1._1 <- "bye"
-t1._1
+t1.1 <- "bye"
+t1.1
 //│ // Query 1
-//│ res = (t1["_1"] = "bye", []);
+//│ res = (t1["1"] = "bye", []);
 //│ // Query 2
-//│ res = t1["_1"];
+//│ res = t1["1"];
 //│ // End of generated code
 //│ = []
-//│ res: "hello"
+//│ res: true
 //│    = 'bye'
 
 :js
@@ -480,20 +480,20 @@ xpp a1
 
 :js
 tu = (mut (), mut 2)
-tu._1 <- (tu._2 <- 3)
-tu._1
-tu._2
+tu.0 <- (tu.1 <- 3)
+tu.0
+tu.1
 //│ // Query 1
 //│ globalThis.tu = [
 //│   [],
 //│   2
 //│ ];
 //│ // Query 2
-//│ res = (tu["_1"] = (tu["_2"] = 3, []), []);
+//│ res = (tu["0"] = (tu["1"] = 3, []), []);
 //│ // Query 3
-//│ res = tu["_1"];
+//│ res = tu["0"];
 //│ // Query 4
-//│ res = tu["_2"];
+//│ res = tu["1"];
 //│ // End of generated code
 //│ tu: (mut 'a, mut 'b,)
 //│   where

--- a/shared/src/test/diff/codegen/Terms.mls
+++ b/shared/src/test/diff/codegen/Terms.mls
@@ -413,15 +413,15 @@ t1 = (mut "hello", mut true)
 //│   = [ 'hello', true ]
 
 :js
-t1.1 <- "bye"
-t1.1
+t1.0 <- "bye"
+t1.0
 //│ // Query 1
-//│ res = (t1["1"] = "bye", []);
+//│ res = (t1["0"] = "bye", []);
 //│ // Query 2
-//│ res = t1["1"];
+//│ res = t1["0"];
 //│ // End of generated code
 //│ = []
-//│ res: true
+//│ res: "hello"
 //│    = 'bye'
 
 :js

--- a/shared/src/test/diff/codegen/Terms.mls
+++ b/shared/src/test/diff/codegen/Terms.mls
@@ -416,9 +416,9 @@ t1 = (mut "hello", mut true)
 t1.0 <- "bye"
 t1.0
 //│ // Query 1
-//│ res = (t1["0"] = "bye", []);
+//│ res = (t1[0] = "bye", []);
 //│ // Query 2
-//│ res = t1["0"];
+//│ res = t1[0];
 //│ // End of generated code
 //│ = []
 //│ res: "hello"
@@ -489,11 +489,11 @@ tu.1
 //│   2
 //│ ];
 //│ // Query 2
-//│ res = (tu["0"] = (tu["1"] = 3, []), []);
+//│ res = (tu[0] = (tu[1] = 3, []), []);
 //│ // Query 3
-//│ res = tu["0"];
+//│ res = tu[0];
 //│ // Query 4
-//│ res = tu["1"];
+//│ res = tu[1];
 //│ // End of generated code
 //│ tu: (mut 'a, mut 'b,)
 //│   where

--- a/shared/src/test/diff/ecoop23/PolymorphicVariants.mls
+++ b/shared/src/test/diff/ecoop23/PolymorphicVariants.mls
@@ -22,10 +22,10 @@ class Success[out A](result: A)
 fun list_assoc(s, l) =
   if l is
     Cons(h, t) then
-      if s === h._1 then Success(h._2)
+      if s === h.0 then Success(h.1)
       else list_assoc(s, t)
     Nil then NotFound()
-//│ fun list_assoc: forall 'a 'A. (Eql['a], Cons[{_1: 'a, _2: 'A}] | Nil) -> (NotFound | Success['A])
+//│ fun list_assoc: forall 'a 'A. (Eql['a], Cons[{0: 'a, 1: 'A}] | Nil) -> (NotFound | Success['A])
 
 // fun list_assoc(s: Str, l: Cons[{ _1: Str, _2: 'b }] | Nil): NotFound | Success['b]
 
@@ -40,7 +40,7 @@ mixin EvalVar {
         Success(r) then r
 }
 //│ mixin EvalVar() {
-//│   fun eval: (Cons[{_1: anything, _2: 'a}] | Nil, Var) -> (Var | 'a)
+//│   fun eval: (Cons[{0: anything, 1: 'a}] | Nil, Var) -> (Var | 'a)
 //│ }
 
 class Abs[A](x: Str, t: A)
@@ -80,7 +80,7 @@ mixin EvalLambda {
 
 module Test1 extends EvalVar, EvalLambda
 //│ module Test1 {
-//│   fun eval: (Cons[{_1: anything, _2: 'a}] | Nil, Abs['b] | App['c] | Var) -> 'a
+//│   fun eval: (Cons[{0: anything, 1: 'a}] | Nil, Abs['b] | App['c] | Var) -> 'a
 //│ }
 //│ where
 //│   'b <: Abs['b] | App['c] | Var
@@ -123,7 +123,7 @@ Test1.eval(Cons(["c", Abs("d", Var("d"))], Nil), App(Abs("b", Var("b")), Var("c"
 //│     'A0 :> 'a
 //│     'A :> 'a
 //│ res
-//│     = Var {}
+//│     = Abs {}
 
 class Numb(n: Int)
 class Add[A](l: A, r: A)
@@ -158,7 +158,7 @@ mixin EvalExpr {
 
 module Test2 extends EvalVar, EvalExpr
 //│ module Test2 {
-//│   fun eval: forall 'a. (Cons[{_1: anything, _2: Object & 'b}] | Nil, 'a & (Add['c] | Mul['c] | Numb | Var)) -> (Numb | Var | 'b | 'a | 'c)
+//│   fun eval: forall 'a. (Cons[{0: anything, 1: Object & 'b}] | Nil, 'a & (Add['c] | Mul['c] | Numb | Var)) -> (Numb | Var | 'b | 'a | 'c)
 //│ }
 //│ where
 //│   'c <: Add['c] | Mul['c] | Numb | Var
@@ -176,7 +176,7 @@ Test2.eval(Cons(["c", Abs("d", Var("d"))], Nil), Var("a"))
 Test2.eval(Cons(["a", Numb(1)], Nil), Var("a"))
 //│ Numb | Var
 //│ res
-//│     = Var {}
+//│     = Numb {}
 
 // * This expected error shows that Test2 does not handle Abs expression inputs
 :e
@@ -205,7 +205,7 @@ Test2.eval(Cons(["a", Abs("d", Var("d"))], Nil), Add(Numb(1), Var("a")))
 
 module Test3 extends EvalVar, EvalExpr, EvalLambda
 //│ module Test3 {
-//│   fun eval: (Cons[{_1: anything, _2: 'a}] | Nil, Abs['b] | App['c] | Object & 'd & ~#Abs & ~#App) -> 'e
+//│   fun eval: (Cons[{0: anything, 1: 'a}] | Nil, Abs['b] | App['c] | Object & 'd & ~#Abs & ~#App) -> 'e
 //│ }
 //│ where
 //│   'a :> 'e
@@ -233,12 +233,12 @@ Test3.eval(Cons(["c", Abs("d", Var("d"))], Nil), App(Abs("a", Var("a")), Add(Num
 //│     'A0 :> 'a
 //│     'A :> 'a
 //│ res
-//│     = Var {}
+//│     = Add {}
 
 // * Incorrect version, for regression testing – EvalLambda should be mixed in after EvalExpr
 module Test3 extends EvalVar, EvalLambda, EvalExpr
 //│ module Test3 {
-//│   fun eval: (Cons[{_1: anything, _2: 'a}] | Nil, 'a & (Add['b] | Mul['b] | Numb | Var)) -> ('a | 'b | 'c)
+//│   fun eval: (Cons[{0: anything, 1: 'a}] | Nil, 'a & (Add['b] | Mul['b] | Numb | Var)) -> ('a | 'b | 'c)
 //│ }
 //│ where
 //│   'a :> 'c | 'b

--- a/shared/src/test/diff/fcp/PolyParams.mls
+++ b/shared/src/test/diff/fcp/PolyParams.mls
@@ -10,12 +10,12 @@ fooid = foo id
 //│ fooid: (1, true,)
 //│      = [ 1, true ]
 
-fooid._1
-fooid._2
+fooid.0
+fooid.1
 //│ res: 1
-//│    = undefined
+//│    = 1
 //│ res: true
-//│    = undefined
+//│    = true
 
 def foo(f: (forall 'A. 'A -> 'A) -> (forall 'B. 'B -> 'B)) =
   id f id (f id)

--- a/shared/src/test/diff/fcp/Skolems2.mls
+++ b/shared/src/test/diff/fcp/Skolems2.mls
@@ -198,7 +198,7 @@ f 42
 //│ [Function (anonymous)]
 
 // * Note: parser parses this the same as `oops((f, 0)._1)`
-def extrude f = oops((f, 0))._1
+def extrude f = oops((f, 0)).0
 //│ extrude: (forall 'c. ('c -> 'c, 0,)) -> 'c0 -> 'c0
 //│        = [Function: extrude1]
 
@@ -209,9 +209,9 @@ def extrude f = oops((f, 0))._1
 
 
 def oops (i: forall 'c. ('c -> 'c, 0)) =
-  let _ = (i._1 id) "hello"
-  in i._1
-//│ oops: (forall 'c. ('c -> 'c, 0,)) -> 'c0 -> 'c0
+  let _ = (i.0 id) "hello"
+  in i.1
+//│ oops: (forall 'c. ('c -> 'c, 0,)) -> 0
 //│     = [Function: oops1]
 
 def oops (i: forall 'c. ('c -> 'c, 0)) =

--- a/shared/src/test/diff/fcp/Skolems2.mls
+++ b/shared/src/test/diff/fcp/Skolems2.mls
@@ -210,8 +210,8 @@ def extrude f = oops((f, 0)).0
 
 def oops (i: forall 'c. ('c -> 'c, 0)) =
   let _ = (i.0 id) "hello"
-  in i.1
-//│ oops: (forall 'c. ('c -> 'c, 0,)) -> 0
+  in i.0
+//│ oops: (forall 'c. ('c -> 'c, 0,)) -> 'c0 -> 'c0
 //│     = [Function: oops1]
 
 def oops (i: forall 'c. ('c -> 'c, 0)) =

--- a/shared/src/test/diff/mlf-examples/variations_ex_hashtbl.mls
+++ b/shared/src/test/diff/mlf-examples/variations_ex_hashtbl.mls
@@ -72,10 +72,10 @@ table = hashtbl_add table "one" (fun f -> fun x -> f x)
 
 rec def find table key =
   match_list table none (fun h -> fun t ->
-    if eq h._1 key then some h._2
+    if eq h.0 key then some h.1
     else find t key
   )
-//│ find: List[{_1: anything, _2: 'val}] -> anything -> (None | Some['val])
+//│ find: List[{0: anything, 1: 'val}] -> anything -> (None | Some['val])
 
 def nfind table key =
   let opt = find table key in
@@ -83,10 +83,10 @@ def nfind table key =
   { None -> fun f -> fun x -> x
   | Some -> opt.val
   }
-//│ nfind: List[{_1: anything, _2: 'val}] -> anything -> (anything -> 'a -> 'a | 'val)
+//│ nfind: List[{0: anything, 1: 'val}] -> anything -> (anything -> 'a -> 'a | 'val)
 
-def nfind: List[{_1: anything; _2: 'val}] -> anything -> (anything -> 'a -> 'a | 'val)
-//│ nfind: List[{_1: anything, _2: 'val}] -> anything -> ('val | anything -> 'a -> 'a)
+def nfind: List[{0: anything; 1: 'val}] -> anything -> (anything -> 'a -> 'a | 'val)
+//│ nfind: List[{0: anything, 1: 'val}] -> anything -> ('val | anything -> 'a -> 'a)
 
 // * Alternative
 // def nfind table key =

--- a/shared/src/test/diff/mlscript/DavidB.mls
+++ b/shared/src/test/diff/mlscript/DavidB.mls
@@ -10,7 +10,7 @@ tuple2 = (4, 5)
 //│       = [ 4, 5 ]
 
 if true then tuple1 else tuple2
-//│ res: Array[1 | 2 | 3 | 4 | 5] & {_1: 1 | 4, _2: 2 | 5}
+//│ res: Array[1 | 2 | 3 | 4 | 5] & {0: 1 | 4, 1: 2 | 5}
 //│    = [ 1, 2, 3 ]
 
 arr = tuple1 : Array[int]

--- a/shared/src/test/diff/mlscript/LetPolym.mls
+++ b/shared/src/test/diff/mlscript/LetPolym.mls
@@ -136,18 +136,15 @@ def test f =
 //│ test: ((1 | 2) -> int) -> (int -> int, int -> int,)
 //│     = [Function: test11]
 
-:re // TODO
 f_g = test succ
-f_g._1 42
-f_g._2 42
+f_g.0 42
+f_g.1 42
 //│ f_g: (int -> int, int -> int,)
 //│    = [ [Function (anonymous)], [Function (anonymous)] ]
 //│ res: int
-//│ Runtime error:
-//│   TypeError: f_g._1 is not a function
+//│    = 44
 //│ res: int
-//│ Runtime error:
-//│   TypeError: f_g._2 is not a function
+//│    = 45
 
 
 def test f =
@@ -159,10 +156,10 @@ def test f =
 :e
 test succ
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.160: 	test succ
+//│ ║  l.157: 	test succ
 //│ ║         	^^^^^^^^^
 //│ ╟── string literal of type `"ok"` is not an instance of type `int`
-//│ ║  l.155: 	  in (local add 1, local concat "ok")
+//│ ║  l.152: 	  in (local add 1, local concat "ok")
 //│ ╙──       	                                ^^^^
 //│ res: error | (int -> int, string -> string,)
 //│    = [ [Function (anonymous)], [Function (anonymous)] ]
@@ -201,16 +198,16 @@ fun f -> fun x ->
 :e
 res add "1"
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.202: 	res add "1"
+//│ ║  l.199: 	res add "1"
 //│ ║         	^^^^^^^^^^^
 //│ ╟── string literal of type `"1"` is not an instance of type `int`
-//│ ║  l.202: 	res add "1"
+//│ ║  l.199: 	res add "1"
 //│ ║         	        ^^^
 //│ ╟── Note: constraint arises from reference:
-//│ ║  l.196: 	  let local = (fun y -> f y) x
+//│ ║  l.193: 	  let local = (fun y -> f y) x
 //│ ║         	                          ^
 //│ ╟── from reference:
-//│ ║  l.196: 	  let local = (fun y -> f y) x
+//│ ║  l.193: 	  let local = (fun y -> f y) x
 //│ ╙──       	                             ^
 //│ res: error | ()
 //│    = []
@@ -224,16 +221,16 @@ fun f -> fun x ->
 :e
 res add "1"
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.225: 	res add "1"
+//│ ║  l.222: 	res add "1"
 //│ ║         	^^^^^^^^^^^
 //│ ╟── string literal of type `"1"` is not an instance of type `int`
-//│ ║  l.225: 	res add "1"
+//│ ║  l.222: 	res add "1"
 //│ ║         	        ^^^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.219: 	  let local = f ((fun y -> y) x)
+//│ ║  l.216: 	  let local = f ((fun y -> y) x)
 //│ ║         	                 ^^^^^^^^^^^^^^
 //│ ╟── from reference:
-//│ ║  l.219: 	  let local = f ((fun y -> y) x)
+//│ ║  l.216: 	  let local = f ((fun y -> y) x)
 //│ ╙──       	                              ^
 //│ res: error | ()
 //│    = []
@@ -254,17 +251,17 @@ fun f -> fun x ->
     let tmp = add x 1 in x
   )) (fun f -> f true)
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.253: 	(fun k -> k (fun x ->
+//│ ║  l.250: 	(fun k -> k (fun x ->
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.254: 	    let tmp = add x 1 in x
+//│ ║  l.251: 	    let tmp = add x 1 in x
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.255: 	  )) (fun f -> f true)
+//│ ║  l.252: 	  )) (fun f -> f true)
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── reference of type `true` is not an instance of type `int`
-//│ ║  l.255: 	  )) (fun f -> f true)
+//│ ║  l.252: 	  )) (fun f -> f true)
 //│ ║         	                 ^^^^
 //│ ╟── Note: constraint arises from reference:
-//│ ║  l.254: 	    let tmp = add x 1 in x
+//│ ║  l.251: 	    let tmp = add x 1 in x
 //│ ╙──       	                  ^
 //│ res: error | true
 //│    = true
@@ -276,21 +273,21 @@ fun f -> fun x ->
     ) in test
   ) (fun f -> f true)
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.273: 	(fun k ->
+//│ ║  l.270: 	(fun k ->
 //│ ║         	^^^^^^^^^
-//│ ║  l.274: 	    let test = k (fun x ->
+//│ ║  l.271: 	    let test = k (fun x ->
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.275: 	      let tmp = add x 1 in x
+//│ ║  l.272: 	      let tmp = add x 1 in x
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.276: 	    ) in test
+//│ ║  l.273: 	    ) in test
 //│ ║         	^^^^^^^^^^^^^
-//│ ║  l.277: 	  ) (fun f -> f true)
+//│ ║  l.274: 	  ) (fun f -> f true)
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── reference of type `true` is not an instance of type `int`
-//│ ║  l.277: 	  ) (fun f -> f true)
+//│ ║  l.274: 	  ) (fun f -> f true)
 //│ ║         	                ^^^^
 //│ ╟── Note: constraint arises from reference:
-//│ ║  l.275: 	      let tmp = add x 1 in x
+//│ ║  l.272: 	      let tmp = add x 1 in x
 //│ ╙──       	                    ^
 //│ res: error | true
 //│    = true
@@ -349,16 +346,16 @@ foo (fun x -> (x, x))
 :e
 foo (fun x -> (0, x + 1))
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.350: 	foo (fun x -> (0, x + 1))
+//│ ║  l.347: 	foo (fun x -> (0, x + 1))
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── type `'a` is not an instance of type `int`
-//│ ║  l.339: 	def foo (f: forall 'a. 'a -> ('a, 'a)) =
+//│ ║  l.336: 	def foo (f: forall 'a. 'a -> ('a, 'a)) =
 //│ ║         	                       ^^
 //│ ╟── Note: constraint arises from reference:
-//│ ║  l.350: 	foo (fun x -> (0, x + 1))
+//│ ║  l.347: 	foo (fun x -> (0, x + 1))
 //│ ║         	                  ^
 //│ ╟── Note: quantified type variable 'a is defined at:
-//│ ║  l.339: 	def foo (f: forall 'a. 'a -> ('a, 'a)) =
+//│ ║  l.336: 	def foo (f: forall 'a. 'a -> ('a, 'a)) =
 //│ ╙──       	                   ^^
 //│ res: error | int
 //│    = 43

--- a/shared/src/test/diff/mlscript/MLTuples.mls
+++ b/shared/src/test/diff/mlscript/MLTuples.mls
@@ -27,7 +27,7 @@ Hey t
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.26: 	Hey t
 //│ ║        	^^^^^
-//│ ╟── tuple literal of type `{_1: 1, _2: 2, _3: 3}` does not have field 'x'
+//│ ╟── tuple literal of type `{0: 1, 1: 2, 2: 3}` does not have field 'x'
 //│ ║  l.2: 	t = (1, 2, 3)
 //│ ║       	    ^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `{x: int}`
@@ -102,10 +102,10 @@ f htx
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.73: 	f htx
 //│ ║        	^^^^^
-//│ ╟── `with` extension of type `(1, 2, 3,) & {x: 1}` does not match type `(?a, ?b,) | ~#Hey`
+//│ ╟── `with` extension of type `(1, 2, 3,) & {x: 1}` does not match type `(?a, ?b,) & {0: ?a, 1: ?b} | ~#Hey`
 //│ ║  l.11: 	tx = t with { x = 1 }
 //│ ║        	     ^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `(?c, ?d,) | ~#Hey`
+//│ ╟── but it flows into reference with expected type `(?c, ?d,) & {0: ?c, 1: ?d} | ~#Hey`
 //│ ║  l.73: 	f htx
 //│ ║        	  ^^^
 //│ ╟── Note: constraint arises from tuple literal:
@@ -143,7 +143,7 @@ g tx
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.142: 	g tx
 //│ ║         	^^^^
-//│ ╟── expression of type `(1, 2, 3,) & {x: 1} & ~#Hey` does not have field 'y'
+//│ ╟── expression of type `(1, 2, 3,) & {0: 1, 1: 2, 2: 3, x: 1} & ~#Hey` does not have field 'y'
 //│ ╟── Note: constraint arises from field selection:
 //│ ║  l.130: 	g arg = case arg of { Hey -> arg.x | _ -> arg.y }
 //│ ╙──       	                                          ^^^^^
@@ -158,13 +158,13 @@ if bool then (1,) else (2,)
 
 :ge
 if bool then (1,) else (2, 3)
-//│ res: Array[1 | 2 | 3] & {_1: 1 | 2}
+//│ res: Array[1 | 2 | 3] & {0: 1 | 2}
 //│ Code generation encountered an error:
 //│   type alias bool is not a valid expression
 
 :ge
 if bool then (1,) with { a = 1; b = 2 } else (2, 3) with { b = 3; c = 4 }
-//│ res: Array[1 | 2 | 3] & {_1: 1 | 2, b: 2 | 3}
+//│ res: Array[1 | 2 | 3] & {0: 1 | 2, b: 2 | 3}
 //│ Code generation encountered an error:
 //│   type alias bool is not a valid expression
 
@@ -176,12 +176,12 @@ if bool then (1,) else fun x -> x
 
 
 
-t._1
-t._2
-//│ res: 1
-//│    = undefined
+t.1
+t.2
 //│ res: 2
-//│    = undefined
+//│    = 2
+//│ res: 3
+//│    = 3
 
 
 t = (1, 2, 3) with {x = 1}
@@ -193,35 +193,35 @@ t.x
 //│ res: 1
 //│    = 1
 
-t._1
-t._2
-//│ res: 1
-//│    = undefined
+t.1
+t.2
 //│ res: 2
-//│    = undefined
+//│    = 2
+//│ res: 3
+//│    = 3
 
 
 t = (1, 2, 3) with {_1 = "oops"}
-//│ t: {_1: "oops", _2: 2, _3: 3}
+//│ t: {0: 1, 1: 2, 2: 3, _1: "oops"}
 //│  = [ 1, 2, 3, _1: 'oops' ]
 
 // TODO (https://github.com/hkust-taco/mlscript/issues/69)
 :e
-(t: ("oops",int,int,))._1
+(t: ("oops",int,int,)).1
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.210: 	(t: ("oops",int,int,))._1
+//│ ║  l.210: 	(t: ("oops",int,int,)).1
 //│ ║         	 ^
-//│ ╟── `with` extension of type `{_1: "oops", _2: 2, _3: 3}` is not a 3-element tuple
+//│ ╟── `with` extension of type `{0: 1, 1: 2, 2: 3, _1: "oops"}` is not a 3-element tuple
 //│ ║  l.204: 	t = (1, 2, 3) with {_1 = "oops"}
 //│ ║         	    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `("oops", int, int,)`
-//│ ║  l.210: 	(t: ("oops",int,int,))._1
+//│ ║  l.210: 	(t: ("oops",int,int,)).1
 //│ ║         	 ^
 //│ ╟── Note: constraint arises from tuple type:
-//│ ║  l.210: 	(t: ("oops",int,int,))._1
+//│ ║  l.210: 	(t: ("oops",int,int,)).1
 //│ ╙──       	    ^^^^^^^^^^^^^^^^^
-//│ res: "oops"
-//│    = 'oops'
+//│ res: int
+//│    = 2
 
 
 def f: (1, 2, 3) & (2, 2 | 3, 3 | 4)

--- a/shared/src/test/diff/mlscript/MLTuples.mls
+++ b/shared/src/test/diff/mlscript/MLTuples.mls
@@ -193,12 +193,12 @@ t.x
 //│ res: 1
 //│    = 1
 
+t.0
 t.1
-t.2
+//│ res: 1
+//│    = 1
 //│ res: 2
 //│    = 2
-//│ res: 3
-//│    = 3
 
 
 t = (1, 2, 3) with {_1 = "oops"}
@@ -207,21 +207,21 @@ t = (1, 2, 3) with {_1 = "oops"}
 
 // TODO (https://github.com/hkust-taco/mlscript/issues/69)
 :e
-(t: ("oops",int,int,)).1
+(t: ("oops",int,int,)).0
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.210: 	(t: ("oops",int,int,)).1
+//│ ║  l.210: 	(t: ("oops",int,int,)).0
 //│ ║         	 ^
 //│ ╟── `with` extension of type `{0: 1, 1: 2, 2: 3, _1: "oops"}` is not a 3-element tuple
 //│ ║  l.204: 	t = (1, 2, 3) with {_1 = "oops"}
 //│ ║         	    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `("oops", int, int,)`
-//│ ║  l.210: 	(t: ("oops",int,int,)).1
+//│ ║  l.210: 	(t: ("oops",int,int,)).0
 //│ ║         	 ^
 //│ ╟── Note: constraint arises from tuple type:
-//│ ║  l.210: 	(t: ("oops",int,int,)).1
+//│ ║  l.210: 	(t: ("oops",int,int,)).0
 //│ ╙──       	    ^^^^^^^^^^^^^^^^^
-//│ res: int
-//│    = 2
+//│ res: "oops"
+//│    = 1
 
 
 def f: (1, 2, 3) & (2, 2 | 3, 3 | 4)

--- a/shared/src/test/diff/mlscript/MLTuples.mls
+++ b/shared/src/test/diff/mlscript/MLTuples.mls
@@ -176,12 +176,12 @@ if bool then (1,) else fun x -> x
 
 
 
+t.0
 t.1
-t.2
+//│ res: 1
+//│    = 1
 //│ res: 2
 //│    = 2
-//│ res: 3
-//│    = 3
 
 
 t = (1, 2, 3) with {x = 1}

--- a/shared/src/test/diff/mlscript/MLTuples.mls
+++ b/shared/src/test/diff/mlscript/MLTuples.mls
@@ -201,9 +201,9 @@ t.1
 //│    = 2
 
 
-t = (1, 2, 3) with {_1 = "oops"}
-//│ t: {0: 1, 1: 2, 2: 3, _1: "oops"}
-//│  = [ 1, 2, 3, _1: 'oops' ]
+t = (1, 2, 3) with {0 = "oops"}
+//│ t: {0: "oops", 1: 2, 2: 3}
+//│  = [ 'oops', 2, 3 ]
 
 // TODO (https://github.com/hkust-taco/mlscript/issues/69)
 :e
@@ -211,9 +211,9 @@ t = (1, 2, 3) with {_1 = "oops"}
 //│ ╔══[ERROR] Type mismatch in type ascription:
 //│ ║  l.210: 	(t: ("oops",int,int,)).0
 //│ ║         	 ^
-//│ ╟── `with` extension of type `{0: 1, 1: 2, 2: 3, _1: "oops"}` is not a 3-element tuple
-//│ ║  l.204: 	t = (1, 2, 3) with {_1 = "oops"}
-//│ ║         	    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── `with` extension of type `{0: "oops", 1: 2, 2: 3}` is not a 3-element tuple
+//│ ║  l.204: 	t = (1, 2, 3) with {0 = "oops"}
+//│ ║         	    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `("oops", int, int,)`
 //│ ║  l.210: 	(t: ("oops",int,int,)).0
 //│ ║         	 ^
@@ -221,7 +221,7 @@ t = (1, 2, 3) with {_1 = "oops"}
 //│ ║  l.210: 	(t: ("oops",int,int,)).0
 //│ ╙──       	    ^^^^^^^^^^^^^^^^^
 //│ res: "oops"
-//│    = 1
+//│    = 'oops'
 
 
 def f: (1, 2, 3) & (2, 2 | 3, 3 | 4)

--- a/shared/src/test/diff/mlscript/MLTuples.mls
+++ b/shared/src/test/diff/mlscript/MLTuples.mls
@@ -102,10 +102,10 @@ f htx
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.73: 	f htx
 //│ ║        	^^^^^
-//│ ╟── `with` extension of type `(1, 2, 3,) & {x: 1}` does not match type `(?a & ?b, ?b,) | ~#Hey`
+//│ ╟── `with` extension of type `(1, 2, 3,) & {x: 1}` does not match type `(?a, ?b,) | ~#Hey`
 //│ ║  l.11: 	tx = t with { x = 1 }
 //│ ║        	     ^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `(?c & ?d, ?d,) | ~#Hey`
+//│ ╟── but it flows into reference with expected type `(?c, ?d,) | ~#Hey`
 //│ ║  l.73: 	f htx
 //│ ║        	  ^^^
 //│ ╟── Note: constraint arises from tuple literal:
@@ -143,7 +143,7 @@ g tx
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.142: 	g tx
 //│ ║         	^^^^
-//│ ╟── expression of type `(nothing, nothing, 3,) & {x: 1} & ~#Hey` does not have field 'y'
+//│ ╟── expression of type `(1, 2, 3,) & {x: 1} & ~#Hey` does not have field 'y'
 //│ ╟── Note: constraint arises from field selection:
 //│ ║  l.130: 	g arg = case arg of { Hey -> arg.x | _ -> arg.y }
 //│ ╙──       	                                          ^^^^^

--- a/shared/src/test/diff/mlscript/MLTuples.mls
+++ b/shared/src/test/diff/mlscript/MLTuples.mls
@@ -102,10 +102,10 @@ f htx
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.73: 	f htx
 //│ ║        	^^^^^
-//│ ╟── `with` extension of type `(1, 2, 3,) & {x: 1}` does not match type `(?a, ?b,) & {0: ?a, 1: ?b} | ~#Hey`
+//│ ╟── `with` extension of type `(1, 2, 3,) & {x: 1}` does not match type `(?a & ?b, ?b,) | ~#Hey`
 //│ ║  l.11: 	tx = t with { x = 1 }
 //│ ║        	     ^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `(?c, ?d,) & {0: ?c, 1: ?d} | ~#Hey`
+//│ ╟── but it flows into reference with expected type `(?c & ?d, ?d,) | ~#Hey`
 //│ ║  l.73: 	f htx
 //│ ║        	  ^^^
 //│ ╟── Note: constraint arises from tuple literal:
@@ -143,7 +143,7 @@ g tx
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.142: 	g tx
 //│ ║         	^^^^
-//│ ╟── expression of type `(1, 2, 3,) & {0: 1, 1: 2, 2: 3, x: 1} & ~#Hey` does not have field 'y'
+//│ ╟── expression of type `(nothing, nothing, 3,) & {x: 1} & ~#Hey` does not have field 'y'
 //│ ╟── Note: constraint arises from field selection:
 //│ ║  l.130: 	g arg = case arg of { Hey -> arg.x | _ -> arg.y }
 //│ ╙──       	                                          ^^^^^

--- a/shared/src/test/diff/mlscript/Mut.mls
+++ b/shared/src/test/diff/mlscript/Mut.mls
@@ -543,20 +543,26 @@ mt3[1] <- mt1.0
 
 :e
 :ge
-mt1.0 <- mt1.2
+mt1.0 <- mt1.1
 mt1.1 <- 1
 mt1.0 <- (b1.t <- 4)
 (mt1.0 <- b1.t) <- 4
 b1.x <- 1 + 2 <- 4
-//│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.546: 	mt1.0 <- mt1.2
-//│ ║         	         ^^^^^
-//│ ╟── type `{mut 0: int, mut 1: bool}` does not have field '2'
+//│ ╔══[ERROR] Type mismatch in assignment:
+//│ ║  l.546: 	mt1.0 <- mt1.1
+//│ ║         	^^^^^^^^^^^^^^
+//│ ╟── type `bool` is not an instance of `int`
 //│ ║  l.381: 	def mt1: (mut int, mut bool)
-//│ ║         	         ^^^^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{2: ?2}`
-//│ ║  l.546: 	mt1.0 <- mt1.2
-//│ ╙──       	         ^^^
+//│ ║         	                       ^^^^
+//│ ╟── but it flows into field selection with expected type `int`
+//│ ║  l.546: 	mt1.0 <- mt1.1
+//│ ║         	         ^^^^^
+//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.381: 	def mt1: (mut int, mut bool)
+//│ ║         	              ^^^
+//│ ╟── from assigned selection:
+//│ ║  l.546: 	mt1.0 <- mt1.1
+//│ ╙──       	^^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
 //│ ║  l.547: 	mt1.1 <- 1
 //│ ║         	^^^^^^^^^^
@@ -628,7 +634,7 @@ f mt1 1
 :e
 f mt2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.629: 	f mt2
+//│ ║  l.635: 	f mt2
 //│ ║         	^^^^^
 //│ ╟── tuple field of type `int` is not mutable
 //│ ║  l.382: 	def mt2: (int, int)
@@ -640,10 +646,10 @@ f mt2
 :e
 g (1, true) 2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.641: 	g (1, true) 2
+//│ ║  l.647: 	g (1, true) 2
 //│ ║         	^^^^^^^^^^^
 //│ ╟── argument of type `1` is not mutable
-//│ ║  l.641: 	g (1, true) 2
+//│ ║  l.647: 	g (1, true) 2
 //│ ╙──       	   ^
 //│ res: error | unit
 //│    = <no result>
@@ -652,10 +658,10 @@ g (1, true) 2
 // TODO forbid `mut` here
 g (mut 1, true) 2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.653: 	g (mut 1, true) 2
+//│ ║  l.659: 	g (mut 1, true) 2
 //│ ║         	^^^^^^^^^^^^^^^
 //│ ╟── argument of type `1` is not mutable
-//│ ║  l.653: 	g (mut 1, true) 2
+//│ ║  l.659: 	g (mut 1, true) 2
 //│ ╙──       	       ^
 //│ res: error | unit
 //│    = <no result>
@@ -699,13 +705,13 @@ st2.0 <- 8
 :e
 st1.0 <- 9
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.700: 	st1.0 <- 9
+//│ ║  l.706: 	st1.0 <- 9
 //│ ║         	^^^^^^^^^^
 //│ ╟── tuple field of type `int` is not mutable
-//│ ║  l.676: 	def st1 : (int, )
+//│ ║  l.682: 	def st1 : (int, )
 //│ ║         	           ^^^
 //│ ╟── but it flows into assigned field with expected type `?0`
-//│ ║  l.700: 	st1.0 <- 9
+//│ ║  l.706: 	st1.0 <- 9
 //│ ╙──       	    ^
 //│ = []
 
@@ -730,20 +736,20 @@ foreach am1 (fun y -> y.0 <- 2)
 (1,2,3)[0] <- true
 (1,2,3).0 <- "hello"
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.730: 	(1,2,3)[0] <- true
+//│ ║  l.736: 	(1,2,3)[0] <- true
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── tuple literal of type `(1, 2, 3,)` does not match type `MutArray[?a]`
-//│ ║  l.730: 	(1,2,3)[0] <- true
+//│ ║  l.736: 	(1,2,3)[0] <- true
 //│ ╙──       	^^^^^^^
 //│ = []
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.731: 	(1,2,3).0 <- "hello"
+//│ ║  l.737: 	(1,2,3).0 <- "hello"
 //│ ║         	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── tuple field of type `1` is not mutable
-//│ ║  l.731: 	(1,2,3).0 <- "hello"
+//│ ║  l.737: 	(1,2,3).0 <- "hello"
 //│ ║         	 ^
 //│ ╟── but it flows into assigned field with expected type `?0`
-//│ ║  l.731: 	(1,2,3).0 <- "hello"
+//│ ║  l.737: 	(1,2,3).0 <- "hello"
 //│ ╙──       	        ^
 //│ = []
 
@@ -751,18 +757,18 @@ foreach am1 (fun y -> y.0 <- 2)
 (0,)["oops"]
 (mut 0,)["oops"] <- 1
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.751: 	(0,)["oops"]
+//│ ║  l.757: 	(0,)["oops"]
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` is not an instance of type `int`
-//│ ║  l.751: 	(0,)["oops"]
+//│ ║  l.757: 	(0,)["oops"]
 //│ ╙──       	     ^^^^^^
 //│ res: 0 | undefined
 //│    = undefined
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.752: 	(mut 0,)["oops"] <- 1
+//│ ║  l.758: 	(mut 0,)["oops"] <- 1
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` is not an instance of type `int`
-//│ ║  l.752: 	(mut 0,)["oops"] <- 1
+//│ ║  l.758: 	(mut 0,)["oops"] <- 1
 //│ ╙──       	         ^^^^^^
 //│ = []
 
@@ -779,24 +785,24 @@ arr = (mut 0,)
 arr[oops]
 arr[oops] <- 1
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.779: 	arr[oops]
+//│ ║  l.785: 	arr[oops]
 //│ ║         	^^^^^^^^^
 //│ ╟── string literal of type `"oops"` is not an instance of type `int`
-//│ ║  l.769: 	oops = "oops"
+//│ ║  l.775: 	oops = "oops"
 //│ ║         	       ^^^^^^
 //│ ╟── but it flows into reference with expected type `int`
-//│ ║  l.779: 	arr[oops]
+//│ ║  l.785: 	arr[oops]
 //│ ╙──       	    ^^^^
 //│ res: 0 | undefined
 //│    = undefined
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.780: 	arr[oops] <- 1
+//│ ║  l.786: 	arr[oops] <- 1
 //│ ║         	^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` is not an instance of type `int`
-//│ ║  l.769: 	oops = "oops"
+//│ ║  l.775: 	oops = "oops"
 //│ ║         	       ^^^^^^
 //│ ╟── but it flows into reference with expected type `int`
-//│ ║  l.780: 	arr[oops] <- 1
+//│ ║  l.786: 	arr[oops] <- 1
 //│ ╙──       	    ^^^^
 //│ = []
 
@@ -810,10 +816,10 @@ x = 1
 :e
 x <- 2
 //│ ╔══[ERROR] Illegal assignment
-//│ ║  l.811: 	x <- 2
+//│ ║  l.817: 	x <- 2
 //│ ║         	^^^^^^
 //│ ╟── cannot assign to reference
-//│ ║  l.811: 	x <- 2
+//│ ║  l.817: 	x <- 2
 //│ ╙──       	^
 //│ res: error
 //│    = []
@@ -843,16 +849,16 @@ foo { mut a = 1 } 2 add
 :e
 foo { mut a = 1 } 2 3
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.844: 	foo { mut a = 1 } 2 3
+//│ ║  l.850: 	foo { mut a = 1 } 2 3
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── integer literal of type `3` is not a function
-//│ ║  l.844: 	foo { mut a = 1 } 2 3
+//│ ║  l.850: 	foo { mut a = 1 } 2 3
 //│ ║         	                    ^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.835: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
+//│ ║  l.841: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
 //│ ║         	                                                   ^^^^^
 //│ ╟── from reference:
-//│ ║  l.835: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
+//│ ║  l.841: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
 //│ ╙──       	                                                   ^
 //│ res: error | (unit, int, 0 | 1 | 2, unit, nothing,)
 //│ Runtime error:
@@ -862,24 +868,24 @@ foo { mut a = 1 } 2 3
 foo { mut a = "oops" } 2
 foo { a = 1 } 2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.862: 	foo { mut a = "oops" } 2
+//│ ║  l.868: 	foo { mut a = "oops" } 2
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` is not an instance of type `int`
-//│ ║  l.862: 	foo { mut a = "oops" } 2
+//│ ║  l.868: 	foo { mut a = "oops" } 2
 //│ ║         	              ^^^^^^
 //│ ╟── but it flows into mutable record field with expected type `int`
-//│ ║  l.862: 	foo { mut a = "oops" } 2
+//│ ║  l.868: 	foo { mut a = "oops" } 2
 //│ ║         	          ^^^^^^^^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.835: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
+//│ ║  l.841: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
 //│ ╙──       	                           ^^^
 //│ res: error | (("oops" | 0 | 2) -> 'a) -> (unit, int, "oops" | 0 | 2, unit, 'a,)
 //│    = [Function (anonymous)]
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.863: 	foo { a = 1 } 2
+//│ ║  l.869: 	foo { a = 1 } 2
 //│ ║         	^^^^^^^^^^^^^
 //│ ╟── record field of type `1` is not mutable
-//│ ║  l.863: 	foo { a = 1 } 2
+//│ ║  l.869: 	foo { a = 1 } 2
 //│ ╙──       	      ^^^^^
 //│ res: error | (1 -> 'a) -> (unit, int, 1, unit, 'a,)
 //│    = [Function (anonymous)]

--- a/shared/src/test/diff/mlscript/Mut.mls
+++ b/shared/src/test/diff/mlscript/Mut.mls
@@ -108,7 +108,7 @@ immtpl[0]
 
 :e
 immrcd.x <- 0
-immtpl.1 <- 0
+immtpl.0 <- 0
 immtpl[0] <- 0
 //│ ╔══[ERROR] Type mismatch in assignment:
 //│ ║  l.110: 	immrcd.x <- 0
@@ -121,14 +121,14 @@ immtpl[0] <- 0
 //│ ╙──       	       ^
 //│ = []
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.111: 	immtpl.1 <- 0
+//│ ║  l.111: 	immtpl.0 <- 0
 //│ ║         	^^^^^^^^^^^^^
-//│ ╟── reference of type `{0: int}` does not have field '1'
-//│ ║  l.111: 	immtpl.1 <- 0
-//│ ║         	^^^^^^
-//│ ╟── Note: constraint arises from assigned selection:
-//│ ║  l.111: 	immtpl.1 <- 0
-//│ ╙──       	^^^^^^^^
+//│ ╟── tuple field of type `int` is not mutable
+//│ ║  l.93: 	immtpl = (1: int,)
+//│ ║        	          ^
+//│ ╟── but it flows into assigned field with expected type `?0`
+//│ ║  l.111: 	immtpl.0 <- 0
+//│ ╙──       	       ^
 //│ = []
 //│ ╔══[ERROR] Type mismatch in assignment:
 //│ ║  l.112: 	immtpl[0] <- 0
@@ -543,61 +543,61 @@ mt3[1] <- mt1.0
 
 :e
 :ge
-mt1.1 <- mt1.2
-mt1.2 <- 1
-mt1.1 <- (b1.t <- 4)
-(mt1.1 <- b1.t) <- 4
+mt1.0 <- mt1.2
+mt1.1 <- 1
+mt1.0 <- (b1.t <- 4)
+(mt1.0 <- b1.t) <- 4
 b1.x <- 1 + 2 <- 4
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.546: 	mt1.1 <- mt1.2
+//│ ║  l.546: 	mt1.0 <- mt1.2
 //│ ║         	         ^^^^^
 //│ ╟── type `{mut 0: int, mut 1: bool}` does not have field '2'
 //│ ║  l.381: 	def mt1: (mut int, mut bool)
 //│ ║         	         ^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `{2: ?2}`
-//│ ║  l.546: 	mt1.1 <- mt1.2
+//│ ║  l.546: 	mt1.0 <- mt1.2
 //│ ╙──       	         ^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.547: 	mt1.2 <- 1
+//│ ║  l.547: 	mt1.1 <- 1
 //│ ║         	^^^^^^^^^^
-//│ ╟── type `{mut 0: int, mut 1: bool}` does not have field '2'
+//│ ╟── integer literal of type `1` is not an instance of type `bool`
+//│ ║  l.547: 	mt1.1 <- 1
+//│ ║         	         ^
+//│ ╟── Note: constraint arises from type reference:
 //│ ║  l.381: 	def mt1: (mut int, mut bool)
-//│ ║         	         ^^^^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{mut 2: in ?2}`
-//│ ║  l.547: 	mt1.2 <- 1
-//│ ║         	^^^
-//│ ╟── Note: constraint arises from assigned selection:
-//│ ║  l.547: 	mt1.2 <- 1
+//│ ║         	                       ^^^^
+//│ ╟── from assigned selection:
+//│ ║  l.547: 	mt1.1 <- 1
 //│ ╙──       	^^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.548: 	mt1.1 <- (b1.t <- 4)
+//│ ║  l.548: 	mt1.0 <- (b1.t <- 4)
 //│ ║         	          ^^^^^^^^^
 //│ ╟── type `B` does not have field 't'
 //│ ║  l.265: 	def b1 : B
 //│ ║         	         ^
 //│ ╟── but it flows into reference with expected type `{mut t: in ?t}`
-//│ ║  l.548: 	mt1.1 <- (b1.t <- 4)
+//│ ║  l.548: 	mt1.0 <- (b1.t <- 4)
 //│ ║         	          ^^
 //│ ╟── Note: constraint arises from assigned selection:
-//│ ║  l.548: 	mt1.1 <- (b1.t <- 4)
+//│ ║  l.548: 	mt1.0 <- (b1.t <- 4)
 //│ ╙──       	          ^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.548: 	mt1.1 <- (b1.t <- 4)
+//│ ║  l.548: 	mt1.0 <- (b1.t <- 4)
 //│ ║         	^^^^^^^^^^^^^^^^^^^^
-//│ ╟── assignment of type `unit` is not an instance of type `bool`
-//│ ║  l.548: 	mt1.1 <- (b1.t <- 4)
+//│ ╟── assignment of type `unit` is not an instance of type `int`
+//│ ║  l.548: 	mt1.0 <- (b1.t <- 4)
 //│ ║         	          ^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.381: 	def mt1: (mut int, mut bool)
-//│ ║         	                       ^^^^
+//│ ║         	              ^^^
 //│ ╟── from assigned selection:
-//│ ║  l.548: 	mt1.1 <- (b1.t <- 4)
+//│ ║  l.548: 	mt1.0 <- (b1.t <- 4)
 //│ ╙──       	^^^^^
 //│ ╔══[ERROR] Illegal assignment
-//│ ║  l.549: 	(mt1.1 <- b1.t) <- 4
+//│ ║  l.549: 	(mt1.0 <- b1.t) <- 4
 //│ ║         	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── cannot assign to assignment
-//│ ║  l.549: 	(mt1.1 <- b1.t) <- 4
+//│ ║  l.549: 	(mt1.0 <- b1.t) <- 4
 //│ ╙──       	^^^^^^^^^^^^^^^
 //│ res: error
 //│ ╔══[ERROR] Illegal assignment
@@ -607,7 +607,7 @@ b1.x <- 1 + 2 <- 4
 //│ ║  l.550: 	b1.x <- 1 + 2 <- 4
 //│ ╙──       	            ^
 //│ Code generation encountered an error:
-//│   illegal assignemnt left-hand side: Bra(rcd = false, Assign(Sel(Var(mt1), 1), Sel(Var(b1), t)))
+//│   illegal assignemnt left-hand side: Bra(rcd = false, Assign(Sel(Var(mt1), 0), Sel(Var(b1), t)))
 
 def f : {mut 0 : int} -> int -> unit
 def g : (mut int, bool) -> int -> unit
@@ -697,19 +697,16 @@ st2.0 <- 8
 //│ = []
 
 :e
-st1.1 <- 9
+st1.0 <- 9
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.700: 	st1.1 <- 9
+//│ ║  l.700: 	st1.0 <- 9
 //│ ║         	^^^^^^^^^^
-//│ ╟── type `{0: int}` does not have field '1'
+//│ ╟── tuple field of type `int` is not mutable
 //│ ║  l.676: 	def st1 : (int, )
-//│ ║         	          ^^^^^^^
-//│ ╟── but it flows into reference with expected type `{mut 1: in ?1}`
-//│ ║  l.700: 	st1.1 <- 9
-//│ ║         	^^^
-//│ ╟── Note: constraint arises from assigned selection:
-//│ ║  l.700: 	st1.1 <- 9
-//│ ╙──       	^^^^^
+//│ ║         	           ^^^
+//│ ╟── but it flows into assigned field with expected type `?0`
+//│ ║  l.700: 	st1.0 <- 9
+//│ ╙──       	    ^
 //│ = []
 
 def am1 : Array[(mut int)]
@@ -731,22 +728,22 @@ foreach am1 (fun y -> y.0 <- 2)
 
 :e
 (1,2,3)[0] <- true
-(1,2,3).1 <- "hello"
+(1,2,3).0 <- "hello"
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.733: 	(1,2,3)[0] <- true
+//│ ║  l.730: 	(1,2,3)[0] <- true
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── tuple literal of type `(1, 2, 3,)` does not match type `MutArray[?a]`
-//│ ║  l.733: 	(1,2,3)[0] <- true
+//│ ║  l.730: 	(1,2,3)[0] <- true
 //│ ╙──       	^^^^^^^
 //│ = []
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.734: 	(1,2,3).1 <- "hello"
+//│ ║  l.731: 	(1,2,3).0 <- "hello"
 //│ ║         	^^^^^^^^^^^^^^^^^^^^
-//│ ╟── tuple field of type `2` is not mutable
-//│ ║  l.734: 	(1,2,3).1 <- "hello"
-//│ ║         	   ^
-//│ ╟── but it flows into assigned field with expected type `?1`
-//│ ║  l.734: 	(1,2,3).1 <- "hello"
+//│ ╟── tuple field of type `1` is not mutable
+//│ ║  l.731: 	(1,2,3).0 <- "hello"
+//│ ║         	 ^
+//│ ╟── but it flows into assigned field with expected type `?0`
+//│ ║  l.731: 	(1,2,3).0 <- "hello"
 //│ ╙──       	        ^
 //│ = []
 
@@ -754,18 +751,18 @@ foreach am1 (fun y -> y.0 <- 2)
 (0,)["oops"]
 (mut 0,)["oops"] <- 1
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.754: 	(0,)["oops"]
+//│ ║  l.751: 	(0,)["oops"]
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` is not an instance of type `int`
-//│ ║  l.754: 	(0,)["oops"]
+//│ ║  l.751: 	(0,)["oops"]
 //│ ╙──       	     ^^^^^^
 //│ res: 0 | undefined
 //│    = undefined
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.755: 	(mut 0,)["oops"] <- 1
+//│ ║  l.752: 	(mut 0,)["oops"] <- 1
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` is not an instance of type `int`
-//│ ║  l.755: 	(mut 0,)["oops"] <- 1
+//│ ║  l.752: 	(mut 0,)["oops"] <- 1
 //│ ╙──       	         ^^^^^^
 //│ = []
 
@@ -782,24 +779,24 @@ arr = (mut 0,)
 arr[oops]
 arr[oops] <- 1
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.782: 	arr[oops]
+//│ ║  l.779: 	arr[oops]
 //│ ║         	^^^^^^^^^
 //│ ╟── string literal of type `"oops"` is not an instance of type `int`
-//│ ║  l.772: 	oops = "oops"
+//│ ║  l.769: 	oops = "oops"
 //│ ║         	       ^^^^^^
 //│ ╟── but it flows into reference with expected type `int`
-//│ ║  l.782: 	arr[oops]
+//│ ║  l.779: 	arr[oops]
 //│ ╙──       	    ^^^^
 //│ res: 0 | undefined
 //│    = undefined
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.783: 	arr[oops] <- 1
+//│ ║  l.780: 	arr[oops] <- 1
 //│ ║         	^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` is not an instance of type `int`
-//│ ║  l.772: 	oops = "oops"
+//│ ║  l.769: 	oops = "oops"
 //│ ║         	       ^^^^^^
 //│ ╟── but it flows into reference with expected type `int`
-//│ ║  l.783: 	arr[oops] <- 1
+//│ ║  l.780: 	arr[oops] <- 1
 //│ ╙──       	    ^^^^
 //│ = []
 
@@ -813,10 +810,10 @@ x = 1
 :e
 x <- 2
 //│ ╔══[ERROR] Illegal assignment
-//│ ║  l.814: 	x <- 2
+//│ ║  l.811: 	x <- 2
 //│ ║         	^^^^^^
 //│ ╟── cannot assign to reference
-//│ ║  l.814: 	x <- 2
+//│ ║  l.811: 	x <- 2
 //│ ╙──       	^
 //│ res: error
 //│    = []
@@ -846,16 +843,16 @@ foo { mut a = 1 } 2 add
 :e
 foo { mut a = 1 } 2 3
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.847: 	foo { mut a = 1 } 2 3
+//│ ║  l.844: 	foo { mut a = 1 } 2 3
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── integer literal of type `3` is not a function
-//│ ║  l.847: 	foo { mut a = 1 } 2 3
+//│ ║  l.844: 	foo { mut a = 1 } 2 3
 //│ ║         	                    ^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.838: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
+//│ ║  l.835: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
 //│ ║         	                                                   ^^^^^
 //│ ╟── from reference:
-//│ ║  l.838: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
+//│ ║  l.835: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
 //│ ╙──       	                                                   ^
 //│ res: error | (unit, int, 0 | 1 | 2, unit, nothing,)
 //│ Runtime error:
@@ -865,24 +862,24 @@ foo { mut a = 1 } 2 3
 foo { mut a = "oops" } 2
 foo { a = 1 } 2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.865: 	foo { mut a = "oops" } 2
+//│ ║  l.862: 	foo { mut a = "oops" } 2
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` is not an instance of type `int`
-//│ ║  l.865: 	foo { mut a = "oops" } 2
+//│ ║  l.862: 	foo { mut a = "oops" } 2
 //│ ║         	              ^^^^^^
 //│ ╟── but it flows into mutable record field with expected type `int`
-//│ ║  l.865: 	foo { mut a = "oops" } 2
+//│ ║  l.862: 	foo { mut a = "oops" } 2
 //│ ║         	          ^^^^^^^^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.838: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
+//│ ║  l.835: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
 //│ ╙──       	                           ^^^
 //│ res: error | (("oops" | 0 | 2) -> 'a) -> (unit, int, "oops" | 0 | 2, unit, 'a,)
 //│    = [Function (anonymous)]
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.866: 	foo { a = 1 } 2
+//│ ║  l.863: 	foo { a = 1 } 2
 //│ ║         	^^^^^^^^^^^^^
 //│ ╟── record field of type `1` is not mutable
-//│ ║  l.866: 	foo { a = 1 } 2
+//│ ║  l.863: 	foo { a = 1 } 2
 //│ ╙──       	      ^^^^^
 //│ res: error | (1 -> 'a) -> (unit, int, 1, unit, 'a,)
 //│    = [Function (anonymous)]

--- a/shared/src/test/diff/mlscript/Mut.mls
+++ b/shared/src/test/diff/mlscript/Mut.mls
@@ -97,18 +97,18 @@ immtpl = (1: int,)
 //│       = [ 1 ]
 
 immrcd.x
-immtpl._1
+immtpl.0
 immtpl[0]
 //│ res: int
 //│    = 1
 //│ res: int
-//│    = undefined
+//│    = 1
 //│ res: int | undefined
 //│    = 1
 
 :e
 immrcd.x <- 0
-immtpl._1 <- 0
+immtpl.1 <- 0
 immtpl[0] <- 0
 //│ ╔══[ERROR] Type mismatch in assignment:
 //│ ║  l.110: 	immrcd.x <- 0
@@ -121,14 +121,14 @@ immtpl[0] <- 0
 //│ ╙──       	       ^
 //│ = []
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.111: 	immtpl._1 <- 0
-//│ ║         	^^^^^^^^^^^^^^
-//│ ╟── tuple field of type `int` is not mutable
-//│ ║  l.93: 	immtpl = (1: int,)
-//│ ║        	          ^
-//│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.111: 	immtpl._1 <- 0
-//│ ╙──       	       ^^
+//│ ║  l.111: 	immtpl.1 <- 0
+//│ ║         	^^^^^^^^^^^^^
+//│ ╟── reference of type `{0: int}` does not have field '1'
+//│ ║  l.111: 	immtpl.1 <- 0
+//│ ║         	^^^^^^
+//│ ╟── Note: constraint arises from assigned selection:
+//│ ║  l.111: 	immtpl.1 <- 0
+//│ ╙──       	^^^^^^^^
 //│ = []
 //│ ╔══[ERROR] Type mismatch in assignment:
 //│ ║  l.112: 	immtpl[0] <- 0
@@ -404,7 +404,7 @@ mt1 : (int, bool)
 //│      mt1 is not implemented
 
 def emt: (mut int)
-emt._1
+emt.0
 //│ emt: (mut int,)
 //│    = <missing implementation>
 //│ res: int
@@ -412,7 +412,7 @@ emt._1
 //│      emt is not implemented
 
 k1 = (mut 233, "hello", mut true)
-k1._1 <- k1._1 + 1
+k1.0 <- k1.0 + 1
 //│ k1: (mut 'a, "hello", mut 'b,)
 //│   where
 //│     'b :> true
@@ -421,19 +421,19 @@ k1._1 <- k1._1 + 1
 //│ = []
 
 :e
-k1._2 <- 233
+k1.1 <- 233
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.424: 	k1._2 <- 233
-//│ ║         	^^^^^^^^^^^^
-//│ ╟── tuple literal of type `forall ?a ?b. (mut ?a, "hello", mut ?b,)` does not have field '_2'
+//│ ║  l.424: 	k1.1 <- 233
+//│ ║         	^^^^^^^^^^^
+//│ ╟── tuple literal of type `forall ?a ?b. (mut ?a, "hello", mut ?b,)` does not have field '1'
 //│ ║  l.414: 	k1 = (mut 233, "hello", mut true)
 //│ ║         	     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{mut _2: in ?c}`
-//│ ║  l.424: 	k1._2 <- 233
+//│ ╟── but it flows into reference with expected type `{mut 1: in ?1}`
+//│ ║  l.424: 	k1.1 <- 233
 //│ ║         	^^
 //│ ╟── Note: constraint arises from assigned selection:
-//│ ║  l.424: 	k1._2 <- 233
-//│ ╙──       	^^^^^
+//│ ║  l.424: 	k1.1 <- 233
+//│ ╙──       	^^^^
 //│ = []
 
 mt1 = (mut 3, mut false)
@@ -474,7 +474,7 @@ amf mt4
 
 :e
 a1[0] <- 1
-mt1[0] <- mt2._1
+mt1[0] <- mt2.0
 mt4[3] <- true
 //│ ╔══[ERROR] Type mismatch in assignment:
 //│ ║  l.476: 	a1[0] <- 1
@@ -488,8 +488,8 @@ mt4[3] <- true
 //│ = <no result>
 //│   a1 is not implemented
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.477: 	mt1[0] <- mt2._1
-//│ ║         	^^^^^^^^^^^^^^^^
+//│ ║  l.477: 	mt1[0] <- mt2.0
+//│ ║         	^^^^^^^^^^^^^^^
 //│ ╟── type `int` is not an instance of `bool`
 //│ ║  l.381: 	def mt1: (mut int, mut bool)
 //│ ║         	              ^^^
@@ -497,22 +497,22 @@ mt4[3] <- true
 //│ ║  l.381: 	def mt1: (mut int, mut bool)
 //│ ║         	                       ^^^^
 //│ ╟── from assigned array element:
-//│ ║  l.477: 	mt1[0] <- mt2._1
+//│ ║  l.477: 	mt1[0] <- mt2.0
 //│ ╙──       	^^^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.477: 	mt1[0] <- mt2._1
-//│ ║         	^^^^^^^^^^^^^^^^
+//│ ║  l.477: 	mt1[0] <- mt2.0
+//│ ║         	^^^^^^^^^^^^^^^
 //│ ╟── type `int` is not an instance of `bool`
 //│ ║  l.382: 	def mt2: (int, int)
 //│ ║         	          ^^^
 //│ ╟── but it flows into field selection with expected type `bool`
-//│ ║  l.477: 	mt1[0] <- mt2._1
-//│ ║         	          ^^^^^^
+//│ ║  l.477: 	mt1[0] <- mt2.0
+//│ ║         	          ^^^^^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.381: 	def mt1: (mut int, mut bool)
 //│ ║         	                       ^^^^
 //│ ╟── from assigned array element:
-//│ ║  l.477: 	mt1[0] <- mt2._1
+//│ ║  l.477: 	mt1[0] <- mt2.0
 //│ ╙──       	^^^^^^
 //│ = <no result>
 //│   mt2 is not implemented
@@ -527,11 +527,11 @@ mt4[3] <- true
 //│ ╙──       	^^^
 //│ = []
 
-mt1._1 <- mt2._1
-mt1._1 <- mt1._1 * 2
-mt1._2 <- false
+mt1.0 <- mt2.0
+mt1.0 <- mt1.0 * 2
+mt1.1 <- false
 mt3[0] <- let tmp = mt3[1] in case tmp of { undefined -> 0 | _ -> tmp }
-mt3[1] <- mt1._1
+mt3[1] <- mt1.0
 //│ = <no result>
 //│   mt2 is not implemented
 //│ = []
@@ -543,68 +543,62 @@ mt3[1] <- mt1._1
 
 :e
 :ge
-mt1._1 <- mt1._2
-mt1._2 <- 1
-mt1._1 <- (b1.t <- 4)
-(mt1._1 <- b1.t) <- 4
+mt1.1 <- mt1.2
+mt1.2 <- 1
+mt1.1 <- (b1.t <- 4)
+(mt1.1 <- b1.t) <- 4
 b1.x <- 1 + 2 <- 4
-//│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.546: 	mt1._1 <- mt1._2
-//│ ║         	^^^^^^^^^^^^^^^^
-//│ ╟── type `bool` is not an instance of `int`
+//│ ╔══[ERROR] Type mismatch in field selection:
+//│ ║  l.546: 	mt1.1 <- mt1.2
+//│ ║         	         ^^^^^
+//│ ╟── type `{mut 0: int, mut 1: bool}` does not have field '2'
 //│ ║  l.381: 	def mt1: (mut int, mut bool)
-//│ ║         	                       ^^^^
-//│ ╟── but it flows into field selection with expected type `int`
-//│ ║  l.546: 	mt1._1 <- mt1._2
-//│ ║         	          ^^^^^^
-//│ ╟── Note: constraint arises from type reference:
-//│ ║  l.381: 	def mt1: (mut int, mut bool)
-//│ ║         	              ^^^
-//│ ╟── from assigned selection:
-//│ ║  l.546: 	mt1._1 <- mt1._2
-//│ ╙──       	^^^^^^
+//│ ║         	         ^^^^^^^^^^^^^^^^^^^
+//│ ╟── but it flows into reference with expected type `{2: ?2}`
+//│ ║  l.546: 	mt1.1 <- mt1.2
+//│ ╙──       	         ^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.547: 	mt1._2 <- 1
-//│ ║         	^^^^^^^^^^^
-//│ ╟── integer literal of type `1` is not an instance of type `bool`
-//│ ║  l.547: 	mt1._2 <- 1
-//│ ║         	          ^
-//│ ╟── Note: constraint arises from type reference:
+//│ ║  l.547: 	mt1.2 <- 1
+//│ ║         	^^^^^^^^^^
+//│ ╟── type `{mut 0: int, mut 1: bool}` does not have field '2'
 //│ ║  l.381: 	def mt1: (mut int, mut bool)
-//│ ║         	                       ^^^^
-//│ ╟── from assigned selection:
-//│ ║  l.547: 	mt1._2 <- 1
-//│ ╙──       	^^^^^^
+//│ ║         	         ^^^^^^^^^^^^^^^^^^^
+//│ ╟── but it flows into reference with expected type `{mut 2: in ?2}`
+//│ ║  l.547: 	mt1.2 <- 1
+//│ ║         	^^^
+//│ ╟── Note: constraint arises from assigned selection:
+//│ ║  l.547: 	mt1.2 <- 1
+//│ ╙──       	^^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.548: 	mt1._1 <- (b1.t <- 4)
-//│ ║         	           ^^^^^^^^^
+//│ ║  l.548: 	mt1.1 <- (b1.t <- 4)
+//│ ║         	          ^^^^^^^^^
 //│ ╟── type `B` does not have field 't'
 //│ ║  l.265: 	def b1 : B
 //│ ║         	         ^
 //│ ╟── but it flows into reference with expected type `{mut t: in ?t}`
-//│ ║  l.548: 	mt1._1 <- (b1.t <- 4)
-//│ ║         	           ^^
+//│ ║  l.548: 	mt1.1 <- (b1.t <- 4)
+//│ ║         	          ^^
 //│ ╟── Note: constraint arises from assigned selection:
-//│ ║  l.548: 	mt1._1 <- (b1.t <- 4)
-//│ ╙──       	           ^^^^
+//│ ║  l.548: 	mt1.1 <- (b1.t <- 4)
+//│ ╙──       	          ^^^^
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.548: 	mt1._1 <- (b1.t <- 4)
-//│ ║         	^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── assignment of type `unit` is not an instance of type `int`
-//│ ║  l.548: 	mt1._1 <- (b1.t <- 4)
-//│ ║         	           ^^^^^^^^^
+//│ ║  l.548: 	mt1.1 <- (b1.t <- 4)
+//│ ║         	^^^^^^^^^^^^^^^^^^^^
+//│ ╟── assignment of type `unit` is not an instance of type `bool`
+//│ ║  l.548: 	mt1.1 <- (b1.t <- 4)
+//│ ║         	          ^^^^^^^^^
 //│ ╟── Note: constraint arises from type reference:
 //│ ║  l.381: 	def mt1: (mut int, mut bool)
-//│ ║         	              ^^^
+//│ ║         	                       ^^^^
 //│ ╟── from assigned selection:
-//│ ║  l.548: 	mt1._1 <- (b1.t <- 4)
-//│ ╙──       	^^^^^^
+//│ ║  l.548: 	mt1.1 <- (b1.t <- 4)
+//│ ╙──       	^^^^^
 //│ ╔══[ERROR] Illegal assignment
-//│ ║  l.549: 	(mt1._1 <- b1.t) <- 4
-//│ ║         	^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.549: 	(mt1.1 <- b1.t) <- 4
+//│ ║         	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── cannot assign to assignment
-//│ ║  l.549: 	(mt1._1 <- b1.t) <- 4
-//│ ╙──       	^^^^^^^^^^^^^^^^
+//│ ║  l.549: 	(mt1.1 <- b1.t) <- 4
+//│ ╙──       	^^^^^^^^^^^^^^^
 //│ res: error
 //│ ╔══[ERROR] Illegal assignment
 //│ ║  l.550: 	b1.x <- 1 + 2 <- 4
@@ -613,19 +607,19 @@ b1.x <- 1 + 2 <- 4
 //│ ║  l.550: 	b1.x <- 1 + 2 <- 4
 //│ ╙──       	            ^
 //│ Code generation encountered an error:
-//│   illegal assignemnt left-hand side: Bra(rcd = false, Assign(Sel(Var(mt1), _1), Sel(Var(b1), t)))
+//│   illegal assignemnt left-hand side: Bra(rcd = false, Assign(Sel(Var(mt1), 1), Sel(Var(b1), t)))
 
-def f : {mut _1 : int} -> int -> unit
+def f : {mut 0 : int} -> int -> unit
 def g : (mut int, bool) -> int -> unit
-//│ f: {mut _1: int} -> int -> unit
+//│ f: {mut 0: int} -> int -> unit
 //│  = <missing implementation>
 //│ g: (mut int, bool,) -> int -> unit
 //│  = <missing implementation>
 
-def f a n = a._1 <- n
-//│ {mut _1: in 'a} -> 'a -> unit
+def f a n = a.0 <- n
+//│ {mut 0: in '0} -> '0 -> unit
 //│   <:  f:
-//│ {mut _1: int} -> int -> unit
+//│ {mut 0: int} -> int -> unit
 //│  = [Function: f]
 
 f mt1 1
@@ -634,7 +628,7 @@ f mt1 1
 :e
 f mt2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.635: 	f mt2
+//│ ║  l.629: 	f mt2
 //│ ║         	^^^^^
 //│ ╟── tuple field of type `int` is not mutable
 //│ ║  l.382: 	def mt2: (int, int)
@@ -646,10 +640,10 @@ f mt2
 :e
 g (1, true) 2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.647: 	g (1, true) 2
+//│ ║  l.641: 	g (1, true) 2
 //│ ║         	^^^^^^^^^^^
 //│ ╟── argument of type `1` is not mutable
-//│ ║  l.647: 	g (1, true) 2
+//│ ║  l.641: 	g (1, true) 2
 //│ ╙──       	   ^
 //│ res: error | unit
 //│    = <no result>
@@ -658,10 +652,10 @@ g (1, true) 2
 // TODO forbid `mut` here
 g (mut 1, true) 2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.659: 	g (mut 1, true) 2
+//│ ║  l.653: 	g (mut 1, true) 2
 //│ ║         	^^^^^^^^^^^^^^^
 //│ ╟── argument of type `1` is not mutable
-//│ ║  l.659: 	g (mut 1, true) 2
+//│ ║  l.653: 	g (mut 1, true) 2
 //│ ╙──       	       ^
 //│ res: error | unit
 //│    = <no result>
@@ -699,20 +693,23 @@ st2 = (mut 4,)
 //│ (mut int,)
 //│    = [ 4 ]
 
-st2._1 <- 8
+st2.0 <- 8
 //│ = []
 
 :e
-st1._1 <- 9
+st1.1 <- 9
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.706: 	st1._1 <- 9
-//│ ║         	^^^^^^^^^^^
-//│ ╟── tuple field of type `int` is not mutable
-//│ ║  l.682: 	def st1 : (int, )
-//│ ║         	           ^^^
-//│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.706: 	st1._1 <- 9
-//│ ╙──       	    ^^
+//│ ║  l.700: 	st1.1 <- 9
+//│ ║         	^^^^^^^^^^
+//│ ╟── type `{0: int}` does not have field '1'
+//│ ║  l.676: 	def st1 : (int, )
+//│ ║         	          ^^^^^^^
+//│ ╟── but it flows into reference with expected type `{mut 1: in ?1}`
+//│ ║  l.700: 	st1.1 <- 9
+//│ ║         	^^^
+//│ ╟── Note: constraint arises from assigned selection:
+//│ ║  l.700: 	st1.1 <- 9
+//│ ╙──       	^^^^^
 //│ = []
 
 def am1 : Array[(mut int)]
@@ -724,7 +721,7 @@ def foreach : Array['a] -> ('a -> unit) -> Array['a]
 //│        = <missing implementation>
 
 foreach am1 (fun x -> x[0] <- 1)
-foreach am1 (fun y -> y._1 <- 2)
+foreach am1 (fun y -> y.0 <- 2)
 //│ res: Array[(mut int,)]
 //│    = <no result>
 //│      foreach is not implemented
@@ -734,41 +731,41 @@ foreach am1 (fun y -> y._1 <- 2)
 
 :e
 (1,2,3)[0] <- true
-(1,2,3)._1 <- "hello"
+(1,2,3).1 <- "hello"
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.736: 	(1,2,3)[0] <- true
+//│ ║  l.733: 	(1,2,3)[0] <- true
 //│ ║         	^^^^^^^^^^^^^^^^^^
 //│ ╟── tuple literal of type `(1, 2, 3,)` does not match type `MutArray[?a]`
-//│ ║  l.736: 	(1,2,3)[0] <- true
+//│ ║  l.733: 	(1,2,3)[0] <- true
 //│ ╙──       	^^^^^^^
 //│ = []
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.737: 	(1,2,3)._1 <- "hello"
-//│ ║         	^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── tuple field of type `1` is not mutable
-//│ ║  l.737: 	(1,2,3)._1 <- "hello"
-//│ ║         	 ^
-//│ ╟── but it flows into assigned field with expected type `?a`
-//│ ║  l.737: 	(1,2,3)._1 <- "hello"
-//│ ╙──       	        ^^
+//│ ║  l.734: 	(1,2,3).1 <- "hello"
+//│ ║         	^^^^^^^^^^^^^^^^^^^^
+//│ ╟── tuple field of type `2` is not mutable
+//│ ║  l.734: 	(1,2,3).1 <- "hello"
+//│ ║         	   ^
+//│ ╟── but it flows into assigned field with expected type `?1`
+//│ ║  l.734: 	(1,2,3).1 <- "hello"
+//│ ╙──       	        ^
 //│ = []
 
 :e
 (0,)["oops"]
 (mut 0,)["oops"] <- 1
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.757: 	(0,)["oops"]
+//│ ║  l.754: 	(0,)["oops"]
 //│ ║         	^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` is not an instance of type `int`
-//│ ║  l.757: 	(0,)["oops"]
+//│ ║  l.754: 	(0,)["oops"]
 //│ ╙──       	     ^^^^^^
 //│ res: 0 | undefined
 //│    = undefined
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.758: 	(mut 0,)["oops"] <- 1
+//│ ║  l.755: 	(mut 0,)["oops"] <- 1
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` is not an instance of type `int`
-//│ ║  l.758: 	(mut 0,)["oops"] <- 1
+//│ ║  l.755: 	(mut 0,)["oops"] <- 1
 //│ ╙──       	         ^^^^^^
 //│ = []
 
@@ -785,24 +782,24 @@ arr = (mut 0,)
 arr[oops]
 arr[oops] <- 1
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.785: 	arr[oops]
+//│ ║  l.782: 	arr[oops]
 //│ ║         	^^^^^^^^^
 //│ ╟── string literal of type `"oops"` is not an instance of type `int`
-//│ ║  l.775: 	oops = "oops"
+//│ ║  l.772: 	oops = "oops"
 //│ ║         	       ^^^^^^
 //│ ╟── but it flows into reference with expected type `int`
-//│ ║  l.785: 	arr[oops]
+//│ ║  l.782: 	arr[oops]
 //│ ╙──       	    ^^^^
 //│ res: 0 | undefined
 //│    = undefined
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.786: 	arr[oops] <- 1
+//│ ║  l.783: 	arr[oops] <- 1
 //│ ║         	^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` is not an instance of type `int`
-//│ ║  l.775: 	oops = "oops"
+//│ ║  l.772: 	oops = "oops"
 //│ ║         	       ^^^^^^
 //│ ╟── but it flows into reference with expected type `int`
-//│ ║  l.786: 	arr[oops] <- 1
+//│ ║  l.783: 	arr[oops] <- 1
 //│ ╙──       	    ^^^^
 //│ = []
 
@@ -816,10 +813,10 @@ x = 1
 :e
 x <- 2
 //│ ╔══[ERROR] Illegal assignment
-//│ ║  l.817: 	x <- 2
+//│ ║  l.814: 	x <- 2
 //│ ║         	^^^^^^
 //│ ╟── cannot assign to reference
-//│ ║  l.817: 	x <- 2
+//│ ║  l.814: 	x <- 2
 //│ ╙──       	^
 //│ res: error
 //│    = []
@@ -849,16 +846,16 @@ foo { mut a = 1 } 2 add
 :e
 foo { mut a = 1 } 2 3
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.850: 	foo { mut a = 1 } 2 3
+//│ ║  l.847: 	foo { mut a = 1 } 2 3
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── integer literal of type `3` is not a function
-//│ ║  l.850: 	foo { mut a = 1 } 2 3
+//│ ║  l.847: 	foo { mut a = 1 } 2 3
 //│ ║         	                    ^
 //│ ╟── Note: constraint arises from application:
-//│ ║  l.841: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
+//│ ║  l.838: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
 //│ ║         	                                                   ^^^^^
 //│ ╟── from reference:
-//│ ║  l.841: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
+//│ ║  l.838: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
 //│ ╙──       	                                                   ^
 //│ res: error | (unit, int, 0 | 1 | 2, unit, nothing,)
 //│ Runtime error:
@@ -868,24 +865,24 @@ foo { mut a = 1 } 2 3
 foo { mut a = "oops" } 2
 foo { a = 1 } 2
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.868: 	foo { mut a = "oops" } 2
+//│ ║  l.865: 	foo { mut a = "oops" } 2
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── string literal of type `"oops"` is not an instance of type `int`
-//│ ║  l.868: 	foo { mut a = "oops" } 2
+//│ ║  l.865: 	foo { mut a = "oops" } 2
 //│ ║         	              ^^^^^^
 //│ ╟── but it flows into mutable record field with expected type `int`
-//│ ║  l.868: 	foo { mut a = "oops" } 2
+//│ ║  l.865: 	foo { mut a = "oops" } 2
 //│ ║         	          ^^^^^^^^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.841: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
+//│ ║  l.838: 	def foo x y z = (x.a <- 0, x.a + 1, x.a, x.a <- y, z x.a)
 //│ ╙──       	                           ^^^
 //│ res: error | (("oops" | 0 | 2) -> 'a) -> (unit, int, "oops" | 0 | 2, unit, 'a,)
 //│    = [Function (anonymous)]
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.869: 	foo { a = 1 } 2
+//│ ║  l.866: 	foo { a = 1 } 2
 //│ ║         	^^^^^^^^^^^^^
 //│ ╟── record field of type `1` is not mutable
-//│ ║  l.869: 	foo { a = 1 } 2
+//│ ║  l.866: 	foo { a = 1 } 2
 //│ ╙──       	      ^^^^^
 //│ res: error | (1 -> 'a) -> (unit, int, 1, unit, 'a,)
 //│    = [Function (anonymous)]

--- a/shared/src/test/diff/mlscript/Mut2.mls
+++ b/shared/src/test/diff/mlscript/Mut2.mls
@@ -11,18 +11,17 @@
 //│     'a :> 1 | 2
 //│    = [ 1, 2 ]
 
-((fun t -> let tmp = t._1 <- 3 in t) ((mut 1, mut 2))): MutArray['a]
+((fun t -> let tmp = t.1 <- 3 in t) ((mut 1, mut 2))): MutArray['a]
 //│ res: MutArray['a]
 //│   where
 //│     'a :> 1 | 2 | 3
-//│    = [ 1, 2, _1: 3 ]
+//│    = [ 1, 3 ]
 
-((fun t -> let tmp = t._1 + 1 in t) ((mut 1, mut 2))): MutArray['a]
-//│ res: MutArray[in 'a & 'b out 'b]
+((fun t -> let tmp = t.1 + 1 in t) ((mut 1, mut 2))): MutArray['a]
+//│ res: MutArray['a]
 //│   where
-//│     'a <: int & 'b
-//│     'b :> 1 | 2
-//│        <: 'a
+//│     'a :> 1 | 2
+//│        <: int
 //│    = [ 1, 2 ]
 
 if true then (mut 1,) else (mut 2,)
@@ -48,16 +47,16 @@ r = if true then t1 else t2
 :e
 r._1 <- 1
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.49: 	r._1 <- 1
+//│ ║  l.48: 	r._1 <- 1
 //│ ║        	^^^^^^^^^
-//│ ╟── integer literal of type `1` does not match type `3`
-//│ ║  l.49: 	r._1 <- 1
-//│ ║        	        ^
-//│ ╟── Note: constraint arises from literal type:
-//│ ║  l.37: 	def t2: (mut 3, mut 4)
-//│ ║        	             ^
-//│ ╟── from assigned selection:
-//│ ║  l.49: 	r._1 <- 1
+//│ ╟── type `{mut 0: 1, mut 1: 2}` does not have field '_1'
+//│ ║  l.35: 	def t1: (mut 1, mut 2)
+//│ ║        	        ^^^^^^^^^^^^^^
+//│ ╟── but it flows into reference with expected type `{mut _1: in ?a}`
+//│ ║  l.48: 	r._1 <- 1
+//│ ║        	^
+//│ ╟── Note: constraint arises from assigned selection:
+//│ ║  l.48: 	r._1 <- 1
 //│ ╙──      	^^^^
 //│ = <no result>
 //│   r and t1 are not implemented
@@ -75,26 +74,26 @@ r = if true then t1 else t2
 //│  = <no result>
 //│    t1 is not implemented
 
-r._1 <- if true then 2 else 3
+r.0 <- if true then 2 else 3
 //│ = <no result>
 //│   r and t1 are not implemented
 
 :e
-r._1 <- if true then 2 else 1
+r.0 <- if true then 2 else 1
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.83: 	r._1 <- if true then 2 else 1
-//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.82: 	r.0 <- if true then 2 else 1
+//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── integer literal of type `1` does not match type `2 | 3 | 4`
-//│ ║  l.83: 	r._1 <- if true then 2 else 1
-//│ ║        	                            ^
+//│ ║  l.82: 	r.0 <- if true then 2 else 1
+//│ ║        	                           ^
 //│ ╟── but it flows into application with expected type `2 | 3 | 4`
-//│ ║  l.83: 	r._1 <- if true then 2 else 1
-//│ ║        	           ^^^^^^^^^^^^^^^^^^
+//│ ║  l.82: 	r.0 <- if true then 2 else 1
+//│ ║        	          ^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from union type:
-//│ ║  l.67: 	def t2: (mut 2 | 3 | 4)
+//│ ║  l.66: 	def t2: (mut 2 | 3 | 4)
 //│ ║        	             ^^^^^^^^^
 //│ ╟── from assigned selection:
-//│ ║  l.83: 	r._1 <- if true then 2 else 1
-//│ ╙──      	^^^^
+//│ ║  l.82: 	r.0 <- if true then 2 else 1
+//│ ╙──      	^^^
 //│ = <no result>
 //│   r and t1 are not implemented

--- a/shared/src/test/diff/mlscript/Mut2.mls
+++ b/shared/src/test/diff/mlscript/Mut2.mls
@@ -11,17 +11,18 @@
 //│     'a :> 1 | 2
 //│    = [ 1, 2 ]
 
-((fun t -> let tmp = t.1 <- 3 in t) ((mut 1, mut 2))): MutArray['a]
+((fun t -> let tmp = t.0 <- 3 in t) ((mut 1, mut 2))): MutArray['a]
 //│ res: MutArray['a]
 //│   where
 //│     'a :> 1 | 2 | 3
-//│    = [ 1, 3 ]
+//│    = [ 3, 2 ]
 
-((fun t -> let tmp = t.1 + 1 in t) ((mut 1, mut 2))): MutArray['a]
-//│ res: MutArray['a]
+((fun t -> let tmp = t.0 + 1 in t) ((mut 1, mut 2))): MutArray['a]
+//│ res: MutArray[in 'a & 'b out 'b]
 //│   where
-//│     'a :> 1 | 2
-//│        <: int
+//│     'a <: int & 'b
+//│     'b :> 1 | 2
+//│        <: 'a
 //│    = [ 1, 2 ]
 
 if true then (mut 1,) else (mut 2,)
@@ -45,19 +46,19 @@ r = if true then t1 else t2
 //│    t1 is not implemented
 
 :e
-r._1 <- 1
+r.0 <- 1
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.48: 	r._1 <- 1
-//│ ║        	^^^^^^^^^
-//│ ╟── type `{mut 0: 1, mut 1: 2}` does not have field '_1'
-//│ ║  l.35: 	def t1: (mut 1, mut 2)
-//│ ║        	        ^^^^^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{mut _1: in ?a}`
-//│ ║  l.48: 	r._1 <- 1
-//│ ║        	^
-//│ ╟── Note: constraint arises from assigned selection:
-//│ ║  l.48: 	r._1 <- 1
-//│ ╙──      	^^^^
+//│ ║  l.49: 	r.0 <- 1
+//│ ║        	^^^^^^^^
+//│ ╟── integer literal of type `1` does not match type `3`
+//│ ║  l.49: 	r.0 <- 1
+//│ ║        	       ^
+//│ ╟── Note: constraint arises from literal type:
+//│ ║  l.37: 	def t2: (mut 3, mut 4)
+//│ ║        	             ^
+//│ ╟── from assigned selection:
+//│ ║  l.49: 	r.0 <- 1
+//│ ╙──      	^^^
 //│ = <no result>
 //│   r and t1 are not implemented
 
@@ -81,19 +82,19 @@ r.0 <- if true then 2 else 3
 :e
 r.0 <- if true then 2 else 1
 //│ ╔══[ERROR] Type mismatch in assignment:
-//│ ║  l.82: 	r.0 <- if true then 2 else 1
+//│ ║  l.83: 	r.0 <- if true then 2 else 1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── integer literal of type `1` does not match type `2 | 3 | 4`
-//│ ║  l.82: 	r.0 <- if true then 2 else 1
+//│ ║  l.83: 	r.0 <- if true then 2 else 1
 //│ ║        	                           ^
 //│ ╟── but it flows into application with expected type `2 | 3 | 4`
-//│ ║  l.82: 	r.0 <- if true then 2 else 1
+//│ ║  l.83: 	r.0 <- if true then 2 else 1
 //│ ║        	          ^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from union type:
-//│ ║  l.66: 	def t2: (mut 2 | 3 | 4)
+//│ ║  l.67: 	def t2: (mut 2 | 3 | 4)
 //│ ║        	             ^^^^^^^^^
 //│ ╟── from assigned selection:
-//│ ║  l.82: 	r.0 <- if true then 2 else 1
+//│ ║  l.83: 	r.0 <- if true then 2 else 1
 //│ ╙──      	^^^
 //│ = <no result>
 //│   r and t1 are not implemented

--- a/shared/src/test/diff/mlscript/PolyVariantCodeReuse.mls
+++ b/shared/src/test/diff/mlscript/PolyVariantCodeReuse.mls
@@ -53,13 +53,13 @@ def eq: string -> string -> bool
 
 rec def list_assoc s l = case l of {
   | Cons ->
-      if eq l.head._1 s then Success l.head._2
+      if eq l.head.0 s then Success l.head.1
       else list_assoc s l.tail
   | Nil -> NotFound
   }
 //│ list_assoc: string -> 'a -> (NotFound | (Success with {result: 'result}))
 //│   where
-//│     'a <: (Cons[?] with {head: {_1: string, _2: 'result}, tail: 'a}) | Nil
+//│     'a <: (Cons[?] with {head: {0: string, 1: 'result}, tail: 'a}) | Nil
 //│           = <no result>
 //│             eq is not implemented
 
@@ -86,7 +86,7 @@ def eval_var sub v = case v of {
   }
 //│ eval_var: (Cons[?] & 'a | Nil) -> (Var & 'result) -> 'result
 //│   where
-//│     'a <: {head: {_1: string, _2: 'result}, tail: Cons[?] & 'a | Nil}
+//│     'a <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'a | Nil}
 //│         = <no result>
 //│           list_assoc and eq are not implemented
 
@@ -125,13 +125,13 @@ def eval_lambda eval_rec subst v = case v of {
     | Abs -> eval_rec (Cons (Tuple l1.name l2) Nil) l1.body
     | _ -> App { lhs = l1; rhs = l2 }
     }
-  | Abs -> let new_name = int_to_string ((gensym ())._2.a) in
+  | Abs -> let new_name = int_to_string ((gensym ()).1.a) in
     Abs { name = new_name;
           body = eval_rec (Cons (Tuple v.name (Var { name = new_name })) subst) v.body }
   }
-//│ eval_lambda: (((Cons[('a, Var | 'body,) | 'A] with {head: ('a, Var | 'body,), tail: Nil | 'tail}) | 'tail) -> 'lhs -> ('body & 'result & ((Abs[?] with {body: 'lhs, name: 'a}) | 'lhs0 & ~#Abs))) -> (List['A] & (Cons[?] & 'b | Nil) & 'tail) -> ((Abs[?] with {body: 'lhs, name: 'a}) | App[?] & {lhs: 'lhs, rhs: 'lhs} | Var & 'result) -> (Abs['body] | (App['lhs0 | 'body] with {lhs: 'lhs0, rhs: 'body}) | 'result)
+//│ eval_lambda: (((Cons[('a, Var | 'body,) & {0: 'a, 1: Var | 'body} | 'A] with {head: ('a, Var | 'body,), tail: Nil | 'tail}) | 'tail) -> 'lhs -> ('body & 'result & ((Abs[?] with {body: 'lhs, name: 'a}) | 'lhs0 & ~#Abs))) -> (List['A] & (Cons[?] & 'b | Nil) & 'tail) -> ((Abs[?] with {body: 'lhs, name: 'a}) | App[?] & {lhs: 'lhs, rhs: 'lhs} | Var & 'result) -> (Abs['body] | (App['lhs0 | 'body] with {lhs: 'lhs0, rhs: 'body}) | 'result)
 //│   where
-//│     'b <: {head: {_1: string, _2: 'result}, tail: Cons[?] & 'b | Nil}
+//│     'b <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'b | Nil}
 //│            = <no result>
 //│              eval_var, list_assoc and eq are not implemented
 
@@ -139,7 +139,7 @@ rec def eval1 subst = eval_lambda eval1 subst
 //│ eval1: ('tail & (Cons[?] & List[?] & 'b | Nil & List[?])) -> 'c -> 'd
 //│   where
 //│     'tail <: Cons[?] & 'b | Nil
-//│     'b <: {head: {_1: string, _2: 'result}, tail: 'tail}
+//│     'b <: {head: {0: string, 1: 'result}, tail: 'tail}
 //│     'result :> 'd
 //│             <: Abs[?] & 'e & 'f | 'lhs & (Abs[?] & 'f & ~#Abs | App[?] & 'g | Var & 'h)
 //│     'd :> 'result | 'i | App['a]\lhs\rhs & {lhs: 'lhs, rhs: 'rhs} | Abs['d]
@@ -213,7 +213,7 @@ rec def eval_expr eval_rec subst v =
     }
 //│ eval_expr: ('a -> 'rhs -> 'rhs0) -> ('a & (Cons[?] & 'b | Nil)) -> (Add[?] & {lhs: 'rhs, rhs: 'rhs} | Mul[?] & {lhs: 'rhs, rhs: 'rhs} | Numb & 'result | Var & 'result) -> (Add['rhs0] | Mul['rhs0] | Numb | 'result)
 //│   where
-//│     'b <: {head: {_1: string, _2: 'result}, tail: Cons[?] & 'b | Nil}
+//│     'b <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'b | Nil}
 //│          = <no result>
 //│            eval_var, list_assoc and eq are not implemented
 
@@ -221,7 +221,7 @@ rec def eval2 subst = eval_expr eval2 subst
 //│ eval2: (Cons[?] & 'a | Nil) -> 'b -> (Numb | 'result)
 //│   where
 //│     'b <: Add[?] & {lhs: 'b, rhs: 'b} | Mul[?] & {lhs: 'b, rhs: 'b} | Numb & 'result | Var & 'result
-//│     'a <: {head: {_1: string, _2: 'result & (Numb | ~#Numb)}, tail: Cons[?] & 'a | Nil}
+//│     'a <: {head: {0: string, 1: 'result & (Numb | ~#Numb)}, tail: Cons[?] & 'a | Nil}
 //│     'result :> Mul[Numb | 'result] | Add[Numb | 'result]
 //│      = <no result>
 //│        eval_expr, eval_var, list_assoc and eq are not implemented
@@ -259,10 +259,10 @@ def eval_lexpr eval_rec subst v = case v of {
   | Lambda -> eval_lambda eval_rec subst v
   | Expr -> eval_expr eval_rec subst v
   }
-//│ eval_lexpr: ((Cons[('a, Var | 'body,) | 'A]\head\tail & {head: ('a, Var | 'body,), tail: Nil | 'tail} | 'tail) -> 'lhs -> ('body & 'result & (Abs[?]\body\name & {body: 'lhs, name: 'a} | 'lhs0 & ~#Abs))) -> (List['A] & (Cons[?] & 'b | Nil) & (Cons[?] & 'c | Nil) & 'tail) -> (Abs[?]\body\name & {body: 'lhs, name: 'a} | Add[?] & {lhs: 'lhs, rhs: 'lhs} | App[?] & {lhs: 'lhs, rhs: 'lhs} | Mul[?] & {lhs: 'lhs, rhs: 'lhs} | Numb & 'result | Var & 'result) -> (Abs['body] | Add['body] | App['lhs0 | 'body]\lhs\rhs & {lhs: 'lhs0, rhs: 'body} | Mul['body] | Numb | 'result)
+//│ eval_lexpr: ((Cons[('a, Var | 'body,) & {0: 'a, 1: Var | 'body} | 'A]\head\tail & {head: ('a, Var | 'body,), tail: Nil | 'tail} | 'tail) -> 'lhs -> ('body & 'result & (Abs[?]\body\name & {body: 'lhs, name: 'a} | 'lhs0 & ~#Abs))) -> (List['A] & (Cons[?] & 'b | Nil) & (Cons[?] & 'c | Nil) & 'tail) -> (Abs[?]\body\name & {body: 'lhs, name: 'a} | Add[?] & {lhs: 'lhs, rhs: 'lhs} | App[?] & {lhs: 'lhs, rhs: 'lhs} | Mul[?] & {lhs: 'lhs, rhs: 'lhs} | Numb & 'result | Var & 'result) -> (Abs['body] | Add['body] | App['lhs0 | 'body]\lhs\rhs & {lhs: 'lhs0, rhs: 'body} | Mul['body] | Numb | 'result)
 //│   where
-//│     'c <: {head: {_1: string, _2: 'result}, tail: Cons[?] & 'c | Nil}
-//│     'b <: {head: {_1: string, _2: 'result}, tail: Cons[?] & 'b | Nil}
+//│     'c <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'c | Nil}
+//│     'b <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'b | Nil}
 //│           = <no result>
 //│             eval_lambda, eval_var, list_assoc and eq are not implemented
 
@@ -270,9 +270,9 @@ rec def eval3 subst = eval_lexpr eval3 subst
 //│ eval3: ('tail & 'tail0 & (Cons[?] & List[?] & 'b & 'c | Nil & List[?])) -> 'd -> 'e
 //│   where
 //│     'tail0 <: Cons[?] & 'c | Nil
-//│     'c <: {head: {_1: string, _2: 'result}, tail: 'tail0}
+//│     'c <: {head: {0: string, 1: 'result}, tail: 'tail0}
 //│     'tail <: Cons[?] & 'b | Nil
-//│     'b <: {head: {_1: string, _2: 'result}, tail: 'tail}
+//│     'b <: {head: {0: string, 1: 'result}, tail: 'tail}
 //│     'result :> Var | 'e | Numb
 //│             <: Abs[?] & 'f & 'g | 'lhs & (Lambda & 'f & ~#Abs | 'h & (Expr & ~#Numb | Numb))
 //│     'e :> Abs['e] | (App['a] with {lhs: 'lhs, rhs: 'rhs}) | 'result | 'i | 'j | (Add['e] with {lhs: 'e, rhs: 'e}) | (Mul['e] with {lhs: 'e, rhs: 'e})
@@ -403,14 +403,14 @@ def eval_lexpr' eval_rec subst v = case v of {
   | Add -> eval_expr eval_rec subst v
   | Mul -> eval_expr eval_rec subst v
   }
-//│ eval_lexpr': ((Cons[('b, Var | 'body,) | 'A]\head\tail & {head: ('b, Var | 'body,), tail: Nil | 'tail} | 'tail) -> 'body0 -> ('body & 'result & (Abs[?]\body\name & {body: 'body0, name: 'b} | 'lhs & 'a & (Abs[?]\body\name & {body: 'body0, name: 'b} & ~#Abs | 'lhs & 'a & ~#Abs)))) -> (List['A] & (Cons[?] & 'c | Nil) & (Cons[?] & 'd | Nil) & (Cons[?] & 'e | Nil) & (Cons[?] & 'f | Nil) & (Cons[?] & 'g | Nil) & 'tail & (Cons[?] & 'h | Nil)) -> (Abs[?]\body\name & {body: 'body0, name: 'b} | Add[?] & {lhs: 'body0, rhs: 'body0} | App[?] & {lhs: 'body0, rhs: 'body0} | Mul[?] & {lhs: 'body0, rhs: 'body0} | Numb & 'result | Var & 'result) -> (Abs['body] | Add['body] | App['a | 'body]\lhs\rhs & {lhs: 'lhs, rhs: 'body} | Mul['body] | Numb | 'result)
+//│ eval_lexpr': ((Cons[('b, Var | 'body,) & {0: 'b, 1: Var | 'body} | 'A]\head\tail & {head: ('b, Var | 'body,), tail: Nil | 'tail} | 'tail) -> 'body0 -> ('body & 'result & (Abs[?]\body\name & {body: 'body0, name: 'b} | 'lhs & 'a & (Abs[?]\body\name & {body: 'body0, name: 'b} & ~#Abs | 'lhs & 'a & ~#Abs)))) -> (List['A] & (Cons[?] & 'c | Nil) & (Cons[?] & 'd | Nil) & (Cons[?] & 'e | Nil) & (Cons[?] & 'f | Nil) & (Cons[?] & 'g | Nil) & 'tail & (Cons[?] & 'h | Nil)) -> (Abs[?]\body\name & {body: 'body0, name: 'b} | Add[?] & {lhs: 'body0, rhs: 'body0} | App[?] & {lhs: 'body0, rhs: 'body0} | Mul[?] & {lhs: 'body0, rhs: 'body0} | Numb & 'result | Var & 'result) -> (Abs['body] | Add['body] | App['a | 'body]\lhs\rhs & {lhs: 'lhs, rhs: 'body} | Mul['body] | Numb | 'result)
 //│   where
-//│     'h <: {head: {_1: string, _2: 'result}, tail: Cons[?] & 'h | Nil}
-//│     'g <: {head: {_1: string, _2: 'result}, tail: Cons[?] & 'g | Nil}
-//│     'f <: {head: {_1: string, _2: 'result}, tail: Cons[?] & 'f | Nil}
-//│     'e <: {head: {_1: string, _2: 'result}, tail: Cons[?] & 'e | Nil}
-//│     'd <: {head: {_1: string, _2: 'result}, tail: Cons[?] & 'd | Nil}
-//│     'c <: {head: {_1: string, _2: 'result}, tail: Cons[?] & 'c | Nil}
+//│     'h <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'h | Nil}
+//│     'g <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'g | Nil}
+//│     'f <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'f | Nil}
+//│     'e <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'e | Nil}
+//│     'd <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'd | Nil}
+//│     'c <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'c | Nil}
 //│            = <no result>
 //│              eval_var, list_assoc and eq are not implemented
 
@@ -423,32 +423,32 @@ rec def eval4 subst = eval_lexpr' eval4 subst
 //│ eval4: ('tail & 'tail0 & 'tail1 & 'tail2 & 'tail3 & 'tail4 & (Cons[?] & List[?] & 'a & 'b & 'c & 'd & 'e & 'f | Nil & List[?])) -> 'g -> (App[nothing] | 'result | 'h)
 //│   where
 //│     'tail4 <: Cons[?] & 'f | Nil
-//│     'f <: {head: {_1: string, _2: 'result0}, tail: 'tail4}
+//│     'f <: {head: {0: string, 1: 'result0}, tail: 'tail4}
 //│     'tail3 <: Cons[?] & 'e | Nil
-//│     'e <: {head: {_1: string, _2: 'result0}, tail: 'tail3}
+//│     'e <: {head: {0: string, 1: 'result0}, tail: 'tail3}
 //│     'tail2 <: Cons[?] & 'd | Nil
-//│     'd <: {head: {_1: string, _2: 'result & (Numb | ~#Numb)}, tail: 'tail2}
+//│     'd <: {head: {0: string, 1: 'result & (Numb | ~#Numb)}, tail: 'tail2}
 //│     'tail1 <: Cons[?] & 'c | Nil
 //│     'c <: {
 //│       head: {
-//│         _1: string,
-//│         _2: 'result & (Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)))
+//│         0: string,
+//│         1: 'result & (Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)))
 //│       },
 //│       tail: 'tail1
 //│     }
 //│     'tail0 <: Cons[?] & 'b | Nil
 //│     'b <: {
 //│       head: {
-//│         _1: string,
-//│         _2: 'result & (Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)))
+//│         0: string,
+//│         1: 'result & (Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)))
 //│       },
 //│       tail: 'tail0
 //│     }
 //│     'tail <: Cons[?] & 'a | Nil
 //│     'a <: {
 //│       head: {
-//│         _1: string,
-//│         _2: 'result & (Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)))
+//│         0: string,
+//│         1: 'result & (Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)))
 //│       },
 //│       tail: 'tail
 //│     }
@@ -477,17 +477,17 @@ rec def eval4 subst = eval_lexpr' eval4 subst
 //│ eval4: ('tail & 'tail0 & 'tail1 & 'tail2 & 'tail3 & 'tail4 & (Cons[?] & List[?] & 'b & 'c & 'd & 'e & 'f & 'g | Nil & List[?])) -> 'h -> 'i
 //│   where
 //│     'tail4 <: Cons[?] & 'd | Nil
-//│     'd <: {head: {_1: string, _2: 'result}, tail: 'tail4}
+//│     'd <: {head: {0: string, 1: 'result}, tail: 'tail4}
 //│     'tail3 <: Cons[?] & 'c | Nil
-//│     'c <: {head: {_1: string, _2: 'result0}, tail: 'tail3}
+//│     'c <: {head: {0: string, 1: 'result0}, tail: 'tail3}
 //│     'tail2 <: Cons[?] & 'b | Nil
-//│     'b <: {head: {_1: string, _2: 'result0}, tail: 'tail2}
+//│     'b <: {head: {0: string, 1: 'result0}, tail: 'tail2}
 //│     'tail1 <: Cons[?] & 'g | Nil
-//│     'g <: {head: {_1: string, _2: 'result0}, tail: 'tail1}
+//│     'g <: {head: {0: string, 1: 'result0}, tail: 'tail1}
 //│     'tail0 <: Cons[?] & 'f | Nil
-//│     'f <: {head: {_1: string, _2: 'result}, tail: 'tail0}
+//│     'f <: {head: {0: string, 1: 'result}, tail: 'tail0}
 //│     'tail <: Cons[?] & 'e | Nil
-//│     'e <: {head: {_1: string, _2: 'result}, tail: 'tail}
+//│     'e <: {head: {0: string, 1: 'result}, tail: 'tail}
 //│     'result :> Var | 'i | Numb
 //│             <: Abs[?] & 'j & 'k & 'l | 'lhs & 'lhs0 & (Add[?] & 'm | App[?] & 'n | Mul[?] & 'o | Var & 'p | 'q & (Numb | Numb & ~#Numb))
 //│     'i :> 'result0 | 'r | Abs['i] | App['a]\lhs\rhs & {lhs: 'lhs0, rhs: 'rhs} | 'result | 's | Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0]\lhs\rhs & {lhs: 'lhs, rhs: 'rhs0}

--- a/shared/src/test/diff/mlscript/PolyVariantCodeReuse.mls
+++ b/shared/src/test/diff/mlscript/PolyVariantCodeReuse.mls
@@ -129,9 +129,9 @@ def eval_lambda eval_rec subst v = case v of {
     Abs { name = new_name;
           body = eval_rec (Cons (Tuple v.name (Var { name = new_name })) subst) v.body }
   }
-//│ eval_lambda: (((Cons[('a, Var | 'body,) & {0: 'a, 1: Var | 'body} | 'A] with {head: ('a, Var | 'body,), tail: Nil | 'tail}) | 'tail) -> 'lhs -> ('body & 'result & ((Abs[?] with {body: 'lhs, name: 'a}) | 'lhs0 & ~#Abs))) -> (List['A] & (Cons[?] & 'b | Nil) & 'tail) -> ((Abs[?] with {body: 'lhs, name: 'a}) | App[?] & {lhs: 'lhs, rhs: 'lhs} | Var & 'result) -> (Abs['body] | (App['lhs0 | 'body] with {lhs: 'lhs0, rhs: 'body}) | 'result)
+//│ eval_lambda: (((Cons[('a & (Var | 'body) | 'b & (Var | 'body), Var | 'body,) | 'A] with {head: ('b | 'a, Var | 'body,), tail: Nil | 'tail}) | 'tail) -> 'lhs -> ('body & 'result & ((Abs[?] with {body: 'lhs, name: 'b}) | 'lhs0 & ~#Abs))) -> (List['A] & (Cons[?] & 'c | Nil) & 'tail) -> ((Abs[?] with {body: 'lhs, name: 'a}) | App[?] & {lhs: 'lhs, rhs: 'lhs} | Var & 'result) -> (Abs['body] | (App['lhs0 | 'body] with {lhs: 'lhs0, rhs: 'body}) | 'result)
 //│   where
-//│     'b <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'b | Nil}
+//│     'c <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'c | Nil}
 //│            = <no result>
 //│              eval_var, list_assoc and eq are not implemented
 
@@ -259,10 +259,10 @@ def eval_lexpr eval_rec subst v = case v of {
   | Lambda -> eval_lambda eval_rec subst v
   | Expr -> eval_expr eval_rec subst v
   }
-//│ eval_lexpr: ((Cons[('a, Var | 'body,) & {0: 'a, 1: Var | 'body} | 'A]\head\tail & {head: ('a, Var | 'body,), tail: Nil | 'tail} | 'tail) -> 'lhs -> ('body & 'result & (Abs[?]\body\name & {body: 'lhs, name: 'a} | 'lhs0 & ~#Abs))) -> (List['A] & (Cons[?] & 'b | Nil) & (Cons[?] & 'c | Nil) & 'tail) -> (Abs[?]\body\name & {body: 'lhs, name: 'a} | Add[?] & {lhs: 'lhs, rhs: 'lhs} | App[?] & {lhs: 'lhs, rhs: 'lhs} | Mul[?] & {lhs: 'lhs, rhs: 'lhs} | Numb & 'result | Var & 'result) -> (Abs['body] | Add['body] | App['lhs0 | 'body]\lhs\rhs & {lhs: 'lhs0, rhs: 'body} | Mul['body] | Numb | 'result)
+//│ eval_lexpr: ((Cons[('a & (Var | 'body) | 'b & (Var | 'body), Var | 'body,) | 'A]\head\tail & {head: ('b | 'a, Var | 'body,), tail: Nil | 'tail} | 'tail) -> 'lhs -> ('body & 'result & (Abs[?]\body\name & {body: 'lhs, name: 'b} | 'lhs0 & ~#Abs))) -> (List['A] & (Cons[?] & 'c | Nil) & (Cons[?] & 'd | Nil) & 'tail) -> (Abs[?]\body\name & {body: 'lhs, name: 'a} | Add[?] & {lhs: 'lhs, rhs: 'lhs} | App[?] & {lhs: 'lhs, rhs: 'lhs} | Mul[?] & {lhs: 'lhs, rhs: 'lhs} | Numb & 'result | Var & 'result) -> (Abs['body] | Add['body] | App['lhs0 | 'body]\lhs\rhs & {lhs: 'lhs0, rhs: 'body} | Mul['body] | Numb | 'result)
 //│   where
+//│     'd <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'd | Nil}
 //│     'c <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'c | Nil}
-//│     'b <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'b | Nil}
 //│           = <no result>
 //│             eval_lambda, eval_var, list_assoc and eq are not implemented
 
@@ -403,14 +403,14 @@ def eval_lexpr' eval_rec subst v = case v of {
   | Add -> eval_expr eval_rec subst v
   | Mul -> eval_expr eval_rec subst v
   }
-//│ eval_lexpr': ((Cons[('b, Var | 'body,) & {0: 'b, 1: Var | 'body} | 'A]\head\tail & {head: ('b, Var | 'body,), tail: Nil | 'tail} | 'tail) -> 'body0 -> ('body & 'result & (Abs[?]\body\name & {body: 'body0, name: 'b} | 'lhs & 'a & (Abs[?]\body\name & {body: 'body0, name: 'b} & ~#Abs | 'lhs & 'a & ~#Abs)))) -> (List['A] & (Cons[?] & 'c | Nil) & (Cons[?] & 'd | Nil) & (Cons[?] & 'e | Nil) & (Cons[?] & 'f | Nil) & (Cons[?] & 'g | Nil) & 'tail & (Cons[?] & 'h | Nil)) -> (Abs[?]\body\name & {body: 'body0, name: 'b} | Add[?] & {lhs: 'body0, rhs: 'body0} | App[?] & {lhs: 'body0, rhs: 'body0} | Mul[?] & {lhs: 'body0, rhs: 'body0} | Numb & 'result | Var & 'result) -> (Abs['body] | Add['body] | App['a | 'body]\lhs\rhs & {lhs: 'lhs, rhs: 'body} | Mul['body] | Numb | 'result)
+//│ eval_lexpr': ((Cons[(Var & 'b | Var & 'c | Var & 'd | 'body & ('b | 'c | 'd) | 'body & ('c | 'd | 'b), Var | 'body,) | 'A]\head\tail & {head: ('b | 'c | 'd, Var | 'body,), tail: Nil | 'tail} | 'tail) -> 'body0 -> ('body & 'result & (Abs[?]\body\name & {body: 'body0, name: 'b & 'd} | 'lhs & 'a & (Abs[?]\body\name & {body: 'body0, name: 'd} & ~#Abs | 'lhs & 'a & ~#Abs)))) -> (List['A] & (Cons[?] & 'e | Nil) & (Cons[?] & 'f | Nil) & (Cons[?] & 'g | Nil) & (Cons[?] & 'h | Nil) & (Cons[?] & 'i | Nil) & 'tail & (Cons[?] & 'j | Nil)) -> (Abs[?]\body\name & {body: 'body0, name: 'c} | Add[?] & {lhs: 'body0, rhs: 'body0} | App[?] & {lhs: 'body0, rhs: 'body0} | Mul[?] & {lhs: 'body0, rhs: 'body0} | Numb & 'result | Var & 'result) -> (Abs['body] | Add['body] | App['a | 'body]\lhs\rhs & {lhs: 'lhs, rhs: 'body} | Mul['body] | Numb | 'result)
 //│   where
+//│     'j <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'j | Nil}
+//│     'i <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'i | Nil}
 //│     'h <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'h | Nil}
 //│     'g <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'g | Nil}
 //│     'f <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'f | Nil}
 //│     'e <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'e | Nil}
-//│     'd <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'd | Nil}
-//│     'c <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'c | Nil}
 //│            = <no result>
 //│              eval_var, list_assoc and eq are not implemented
 
@@ -422,51 +422,51 @@ rec def eval4 subst = eval_lexpr' eval4 subst
 //│ ╙── Note: use flag `:ex` to see internal error info.
 //│ eval4: ('tail & 'tail0 & 'tail1 & 'tail2 & 'tail3 & 'tail4 & (Cons[?] & List[?] & 'a & 'b & 'c & 'd & 'e & 'f | Nil & List[?])) -> 'g -> (App[nothing] | 'result | 'h)
 //│   where
-//│     'tail4 <: Cons[?] & 'f | Nil
-//│     'f <: {head: {0: string, 1: 'result0}, tail: 'tail4}
-//│     'tail3 <: Cons[?] & 'e | Nil
-//│     'e <: {head: {0: string, 1: 'result0}, tail: 'tail3}
-//│     'tail2 <: Cons[?] & 'd | Nil
-//│     'd <: {head: {0: string, 1: 'result & (Numb | ~#Numb)}, tail: 'tail2}
-//│     'tail1 <: Cons[?] & 'c | Nil
+//│     'tail4 <: Cons[?] & 'e | Nil
+//│     'e <: {head: {0: string, 1: 'result0}, tail: 'tail4}
+//│     'tail3 <: Cons[?] & 'd | Nil
+//│     'd <: {head: {0: string, 1: 'result & (Numb | ~#Numb)}, tail: 'tail3}
+//│     'tail2 <: Cons[?] & 'c | Nil
 //│     'c <: {
+//│       head: {
+//│         0: string,
+//│         1: 'result & (Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)))
+//│       },
+//│       tail: 'tail2
+//│     }
+//│     'tail1 <: Cons[?] & 'b | Nil
+//│     'b <: {
 //│       head: {
 //│         0: string,
 //│         1: 'result & (Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)))
 //│       },
 //│       tail: 'tail1
 //│     }
-//│     'tail0 <: Cons[?] & 'b | Nil
-//│     'b <: {
+//│     'tail0 <: Cons[?] & 'a | Nil
+//│     'a <: {
 //│       head: {
 //│         0: string,
 //│         1: 'result & (Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)))
 //│       },
 //│       tail: 'tail0
 //│     }
-//│     'tail <: Cons[?] & 'a | Nil
-//│     'a <: {
-//│       head: {
-//│         0: string,
-//│         1: 'result & (Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)))
-//│       },
-//│       tail: 'tail
-//│     }
-//│     'result :> Abs[Abs[nothing] | App[nothing] | 'result | 'h] | App['lhs] & {lhs: 'lhs, rhs: nothing} | 'h | Numb | Var | Add[Abs[nothing] | App[nothing] | 'result | 'h] | Mul[Abs[nothing] | App[nothing] | 'result | 'h] | 'result0 | 'p
+//│     'tail <: Cons[?] & 'f | Nil
+//│     'f <: {head: {0: string, 1: 'result0}, tail: 'tail}
+//│     'result0 :> Var | Numb
+//│              <: Abs[?] & 'j | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)
+//│     'j <: Abs[?] | App[?] | Var & 'h
 //│     'h :> Var
 //│        <: Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & {name: string} & 'k | App[?] & {name: string} & 'l | Mul[?] & {name: string} & 'm | Var & 'n | 'o & (Numb & {name: string} | Numb & {name: string} & ~#Numb))
-//│     'lhs :> App['lhs] & {lhs: 'lhs, rhs: nothing} | Var
 //│     'i <: {body: 'g, name: string}
 //│     'g <: Abs[?] & 'j | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Numb & 'o | Var & 'n
 //│     'k <: Add[?] & {lhs: 'g, rhs: 'g} | Mul[?] & {lhs: 'g, rhs: 'g} | Numb & 'result | Var & 'p
+//│     'result :> Abs[Abs[nothing] | App[nothing] | 'result | 'h] | App['lhs] & {lhs: 'lhs, rhs: nothing} | 'h | Numb | Var | Add[Abs[nothing] | App[nothing] | 'result | 'h] | Mul[Abs[nothing] | App[nothing] | 'result | 'h] | 'result0 | 'p
 //│     'p <: Var & (Abs[?] & 'j | Add[?] & {name: string} & 'k | App[?] & {name: string} & 'l | Mul[?] & {name: string} & 'm | Var & 'n | 'o & (Numb & {name: string} | Numb & {name: string} & ~#Numb))
 //│     'o <: Add[?] & {lhs: 'g, rhs: 'g} | Mul[?] & {lhs: 'g, rhs: 'g} | Numb & 'result0 | Var & 'p
-//│     'result0 :> Var | Numb
-//│              <: Abs[?] & 'j | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)
 //│     'n <: Var & 'h
 //│     'm <: Add[?] & {lhs: 'g, rhs: 'g} | Mul[?] & {lhs: 'g, rhs: 'g} | Numb & 'result | Var
 //│     'l <: Abs[?] & {body: 'g} | App[?] & {rhs: 'g} | Var & 'h
-//│     'j <: Abs[?] | App[?] | Var & 'h
+//│     'lhs :> App['lhs] & {lhs: 'lhs, rhs: nothing} | Var
 //│      = <no result>
 //│        eval_lexpr', eval_var, list_assoc and eq are not implemented
 
@@ -476,55 +476,55 @@ rec def eval4 subst = eval_lexpr' eval4 subst
 rec def eval4 subst = eval_lexpr' eval4 subst
 //│ eval4: ('tail & 'tail0 & 'tail1 & 'tail2 & 'tail3 & 'tail4 & (Cons[?] & List[?] & 'b & 'c & 'd & 'e & 'f & 'g | Nil & List[?])) -> 'h -> 'i
 //│   where
-//│     'tail4 <: Cons[?] & 'd | Nil
-//│     'd <: {head: {0: string, 1: 'result}, tail: 'tail4}
-//│     'tail3 <: Cons[?] & 'c | Nil
-//│     'c <: {head: {0: string, 1: 'result0}, tail: 'tail3}
-//│     'tail2 <: Cons[?] & 'b | Nil
-//│     'b <: {head: {0: string, 1: 'result0}, tail: 'tail2}
-//│     'tail1 <: Cons[?] & 'g | Nil
-//│     'g <: {head: {0: string, 1: 'result0}, tail: 'tail1}
-//│     'tail0 <: Cons[?] & 'f | Nil
-//│     'f <: {head: {0: string, 1: 'result}, tail: 'tail0}
-//│     'tail <: Cons[?] & 'e | Nil
-//│     'e <: {head: {0: string, 1: 'result}, tail: 'tail}
-//│     'result :> Var | 'i | Numb
-//│             <: Abs[?] & 'j & 'k & 'l | 'lhs & 'lhs0 & (Add[?] & 'm | App[?] & 'n | Mul[?] & 'o | Var & 'p | 'q & (Numb | Numb & ~#Numb))
-//│     'i :> 'result0 | 'r | Abs['i] | App['a]\lhs\rhs & {lhs: 'lhs0, rhs: 'rhs} | 'result | 's | Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0]\lhs\rhs & {lhs: 'lhs, rhs: 'rhs0}
-//│     'result0 :> 'i
-//│              <: Abs[?] & 'j & 'k & 'l | 'lhs0 & (Abs[?] & 'k & 'l & ~#Abs | 'lhs & (Add[?] & 'm | App[?] & 'n | Mul[?] & 'o | Var & 'p | 'q & (Numb | Numb & ~#Numb)))
+//│     'tail4 <: Cons[?] & 'g | Nil
+//│     'g <: {head: {0: string, 1: 'result}, tail: 'tail4}
+//│     'tail3 <: Cons[?] & 'f | Nil
+//│     'f <: {head: {0: string, 1: 'result0}, tail: 'tail3}
+//│     'tail2 <: Cons[?] & 'e | Nil
+//│     'e <: {head: {0: string, 1: 'result0}, tail: 'tail2}
+//│     'tail1 <: Cons[?] & 'd | Nil
+//│     'd <: {head: {0: string, 1: 'result0}, tail: 'tail1}
+//│     'tail0 <: Cons[?] & 'c | Nil
+//│     'c <: {head: {0: string, 1: 'result}, tail: 'tail0}
+//│     'tail <: Cons[?] & 'b | Nil
+//│     'b <: {head: {0: string, 1: 'result}, tail: 'tail}
+//│     'result :> 'i
+//│             <: Abs[?] & 'j & 'k & 'l | 'lhs & (Abs[?] & 'k & 'l & ~#Abs | 'lhs0 & (Add[?] & 'm | App[?] & 'n | Mul[?] & 'o | Var & 'p | 'q & (Numb | Numb & ~#Numb)))
+//│     'i :> 'result | 'r | Abs['i] | App['a]\lhs\rhs & {lhs: 'lhs, rhs: 'rhs} | 'result0 | 's | Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0]\lhs\rhs & {lhs: 'lhs0, rhs: 'rhs0}
+//│     'r :> Var
+//│        <: Abs[?] & 'j & 'k & 'l | 'lhs & (Abs[?] & 'k & 'l & ~#Abs | 'lhs0 & (Add[?] & {name: string} & 'm | App[?] & {name: string} & 'n | Mul[?] & {name: string} & 'o | Var & 'p | 'q & (Numb & {name: string} | Numb & {name: string} & ~#Numb)))
 //│     'j <: {body: 'h, name: string}
 //│     'h <: Abs[?] & 'k | Add[?] & 'm | App[?] & 'n | Mul[?] & 'o | Numb & 'q | Var & 'p
-//│     'k <: Abs[?] & {body: 'h} | App[?] & {lhs: 'h, rhs: 'h} | Var & 'r
-//│     'r :> Var
-//│        <: Abs[?] & 'j & 'k & 'l | 'lhs0 & (Abs[?] & 'k & 'l & ~#Abs | 'lhs & (Add[?] & {name: string} & 'm | App[?] & {name: string} & 'n | Mul[?] & {name: string} & 'o | Var & 'p | 'q & (Numb & {name: string} | Numb & {name: string} & ~#Numb)))
-//│     'm <: Add[?] & {lhs: 'h, rhs: 'h} | Mul[?] & {lhs: 'h, rhs: 'h} | Numb & 'result | Var & 's
+//│     'm <: Add[?] & {lhs: 'h, rhs: 'h} | Mul[?] & {lhs: 'h, rhs: 'h} | Numb & 'result0 | Var & 's
+//│     'result0 :> Var | 'i | Numb
+//│              <: Abs[?] & 'j & 'k & 'l | 'lhs & 'lhs0 & (Add[?] & 'm | App[?] & 'n | Mul[?] & 'o | Var & 'p | 'q & (Numb | Numb & ~#Numb))
+//│     'o <: Add[?] & {lhs: 'h, rhs: 'h} | Mul[?] & {lhs: 'h, rhs: 'h} | Numb & 'result0 | Var & 's
 //│     's <: Var & (Abs[?] & 'j & 'k & 'l | 'lhs & 'lhs0 & (Add[?] & {name: string} & 'm | App[?] & {name: string} & 'n | Mul[?] & {name: string} & 'o | Var & 'p | 'q & (Numb & {name: string} | Numb & {name: string} & ~#Numb)))
-//│     'q <: Add[?] & {lhs: 'h, rhs: 'h} | Mul[?] & {lhs: 'h, rhs: 'h} | Numb & 'result | Var & 's
+//│     'q <: Add[?] & {lhs: 'h, rhs: 'h} | Mul[?] & {lhs: 'h, rhs: 'h} | Numb & 'result0 | Var & 's
 //│     'p <: Var & 'r
-//│     'o <: Add[?] & {lhs: 'h, rhs: 'h} | Mul[?] & {lhs: 'h, rhs: 'h} | Numb & 'result | Var & 's
 //│     'n <: Abs[?] & {body: 'h} | App[?] & {lhs: 'h, rhs: 'h} | Var & 'r
-//│     'lhs0 :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs0 | 'lhs, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | Numb | Var
-//│           <: 'h & 'a
-//│     'a0 :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs0 | 'lhs, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | 'i
-//│     'a :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs0 | 'lhs, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | 'i
-//│     'lhs :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs0 | 'lhs, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | Numb | Var
-//│          <: 'h & 'a0
+//│     'lhs :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs | 'lhs0, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | Numb | Var
+//│          <: 'h & 'a
+//│     'a0 :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs | 'lhs0, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | 'i
+//│     'a :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs | 'lhs0, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | 'i
+//│     'lhs0 :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs | 'lhs0, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | Numb | Var
+//│           <: 'h & 'a0
 //│     'rhs :> 'i
 //│     'rhs0 :> 'i
 //│     'l <: {body: 'h, name: string}
+//│     'k <: Abs[?] & {body: 'h} | App[?] & {lhs: 'h, rhs: 'h} | Var & 'r
 //│      = <no result>
 //│        eval_lexpr', eval_var, list_assoc and eq are not implemented
 //│ constrain calls  : 16185
 //│ annoying  calls  : 2300
-//│ subtyping calls  : 602211
+//│ subtyping calls  : 602229
 
 :ResetFuel
 
 eval4 Nil (Abs { name = "s"; body = Add { lhs = Var { name = "s" }; rhs = Numb { num = 1 } } })
 //│ res: 'b
 //│   where
-//│     'b :> Var | Abs['b] | (App['a] with {lhs: 'lhs, rhs: 'rhs}) | Numb | (Add['b] with {lhs: 'b, rhs: 'b}) | (Mul['b] with {lhs: 'b, rhs: 'b})
+//│     'b :> Var | (Mul['b] with {lhs: 'b, rhs: 'b}) | Abs['b] | (App['a] with {lhs: 'lhs, rhs: 'rhs}) | Numb | (Add['b] with {lhs: 'b, rhs: 'b})
 //│     'a :> 'lhs | 'b
 //│     'lhs :> (Add['b] with {lhs: 'b, rhs: 'b}) | (App['a] with {lhs: 'lhs, rhs: 'rhs}) | (Mul['b] with {lhs: 'b, rhs: 'b}) | Numb | Var
 //│     'rhs :> 'b

--- a/shared/src/test/diff/mlscript/PolyVariantCodeReuse.mls
+++ b/shared/src/test/diff/mlscript/PolyVariantCodeReuse.mls
@@ -129,9 +129,9 @@ def eval_lambda eval_rec subst v = case v of {
     Abs { name = new_name;
           body = eval_rec (Cons (Tuple v.name (Var { name = new_name })) subst) v.body }
   }
-//│ eval_lambda: (((Cons[('a & (Var | 'body) | 'b & (Var | 'body), Var | 'body,) | 'A] with {head: ('b | 'a, Var | 'body,), tail: Nil | 'tail}) | 'tail) -> 'lhs -> ('body & 'result & ((Abs[?] with {body: 'lhs, name: 'b}) | 'lhs0 & ~#Abs))) -> (List['A] & (Cons[?] & 'c | Nil) & 'tail) -> ((Abs[?] with {body: 'lhs, name: 'a}) | App[?] & {lhs: 'lhs, rhs: 'lhs} | Var & 'result) -> (Abs['body] | (App['lhs0 | 'body] with {lhs: 'lhs0, rhs: 'body}) | 'result)
+//│ eval_lambda: (((Cons[('a, Var | 'body,) | 'A] with {head: ('a, Var | 'body,), tail: Nil | 'tail}) | 'tail) -> 'lhs -> ('body & 'result & ((Abs[?] with {body: 'lhs, name: 'a}) | 'lhs0 & ~#Abs))) -> (List['A] & (Cons[?] & 'b | Nil) & 'tail) -> ((Abs[?] with {body: 'lhs, name: 'a}) | App[?] & {lhs: 'lhs, rhs: 'lhs} | Var & 'result) -> (Abs['body] | (App['lhs0 | 'body] with {lhs: 'lhs0, rhs: 'body}) | 'result)
 //│   where
-//│     'c <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'c | Nil}
+//│     'b <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'b | Nil}
 //│            = <no result>
 //│              eval_var, list_assoc and eq are not implemented
 
@@ -259,10 +259,10 @@ def eval_lexpr eval_rec subst v = case v of {
   | Lambda -> eval_lambda eval_rec subst v
   | Expr -> eval_expr eval_rec subst v
   }
-//│ eval_lexpr: ((Cons[('a & (Var | 'body) | 'b & (Var | 'body), Var | 'body,) | 'A]\head\tail & {head: ('b | 'a, Var | 'body,), tail: Nil | 'tail} | 'tail) -> 'lhs -> ('body & 'result & (Abs[?]\body\name & {body: 'lhs, name: 'b} | 'lhs0 & ~#Abs))) -> (List['A] & (Cons[?] & 'c | Nil) & (Cons[?] & 'd | Nil) & 'tail) -> (Abs[?]\body\name & {body: 'lhs, name: 'a} | Add[?] & {lhs: 'lhs, rhs: 'lhs} | App[?] & {lhs: 'lhs, rhs: 'lhs} | Mul[?] & {lhs: 'lhs, rhs: 'lhs} | Numb & 'result | Var & 'result) -> (Abs['body] | Add['body] | App['lhs0 | 'body]\lhs\rhs & {lhs: 'lhs0, rhs: 'body} | Mul['body] | Numb | 'result)
+//│ eval_lexpr: ((Cons[('a, Var | 'body,) | 'A]\head\tail & {head: ('a, Var | 'body,), tail: Nil | 'tail} | 'tail) -> 'lhs -> ('body & 'result & (Abs[?]\body\name & {body: 'lhs, name: 'a} | 'lhs0 & ~#Abs))) -> (List['A] & (Cons[?] & 'b | Nil) & (Cons[?] & 'c | Nil) & 'tail) -> (Abs[?]\body\name & {body: 'lhs, name: 'a} | Add[?] & {lhs: 'lhs, rhs: 'lhs} | App[?] & {lhs: 'lhs, rhs: 'lhs} | Mul[?] & {lhs: 'lhs, rhs: 'lhs} | Numb & 'result | Var & 'result) -> (Abs['body] | Add['body] | App['lhs0 | 'body]\lhs\rhs & {lhs: 'lhs0, rhs: 'body} | Mul['body] | Numb | 'result)
 //│   where
-//│     'd <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'd | Nil}
 //│     'c <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'c | Nil}
+//│     'b <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'b | Nil}
 //│           = <no result>
 //│             eval_lambda, eval_var, list_assoc and eq are not implemented
 
@@ -403,14 +403,14 @@ def eval_lexpr' eval_rec subst v = case v of {
   | Add -> eval_expr eval_rec subst v
   | Mul -> eval_expr eval_rec subst v
   }
-//│ eval_lexpr': ((Cons[(Var & 'b | Var & 'c | Var & 'd | 'body & ('b | 'c | 'd) | 'body & ('c | 'd | 'b), Var | 'body,) | 'A]\head\tail & {head: ('b | 'c | 'd, Var | 'body,), tail: Nil | 'tail} | 'tail) -> 'body0 -> ('body & 'result & (Abs[?]\body\name & {body: 'body0, name: 'b & 'd} | 'lhs & 'a & (Abs[?]\body\name & {body: 'body0, name: 'd} & ~#Abs | 'lhs & 'a & ~#Abs)))) -> (List['A] & (Cons[?] & 'e | Nil) & (Cons[?] & 'f | Nil) & (Cons[?] & 'g | Nil) & (Cons[?] & 'h | Nil) & (Cons[?] & 'i | Nil) & 'tail & (Cons[?] & 'j | Nil)) -> (Abs[?]\body\name & {body: 'body0, name: 'c} | Add[?] & {lhs: 'body0, rhs: 'body0} | App[?] & {lhs: 'body0, rhs: 'body0} | Mul[?] & {lhs: 'body0, rhs: 'body0} | Numb & 'result | Var & 'result) -> (Abs['body] | Add['body] | App['a | 'body]\lhs\rhs & {lhs: 'lhs, rhs: 'body} | Mul['body] | Numb | 'result)
+//│ eval_lexpr': ((Cons[('b, Var | 'body,) | 'A]\head\tail & {head: ('b, Var | 'body,), tail: Nil | 'tail} | 'tail) -> 'body0 -> ('body & 'result & (Abs[?]\body\name & {body: 'body0, name: 'b} | 'lhs & 'a & (Abs[?]\body\name & {body: 'body0, name: 'b} & ~#Abs | 'lhs & 'a & ~#Abs)))) -> (List['A] & (Cons[?] & 'c | Nil) & (Cons[?] & 'd | Nil) & (Cons[?] & 'e | Nil) & (Cons[?] & 'f | Nil) & (Cons[?] & 'g | Nil) & 'tail & (Cons[?] & 'h | Nil)) -> (Abs[?]\body\name & {body: 'body0, name: 'b} | Add[?] & {lhs: 'body0, rhs: 'body0} | App[?] & {lhs: 'body0, rhs: 'body0} | Mul[?] & {lhs: 'body0, rhs: 'body0} | Numb & 'result | Var & 'result) -> (Abs['body] | Add['body] | App['a | 'body]\lhs\rhs & {lhs: 'lhs, rhs: 'body} | Mul['body] | Numb | 'result)
 //│   where
-//│     'j <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'j | Nil}
-//│     'i <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'i | Nil}
 //│     'h <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'h | Nil}
 //│     'g <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'g | Nil}
 //│     'f <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'f | Nil}
 //│     'e <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'e | Nil}
+//│     'd <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'd | Nil}
+//│     'c <: {head: {0: string, 1: 'result}, tail: Cons[?] & 'c | Nil}
 //│            = <no result>
 //│              eval_var, list_assoc and eq are not implemented
 
@@ -422,51 +422,51 @@ rec def eval4 subst = eval_lexpr' eval4 subst
 //│ ╙── Note: use flag `:ex` to see internal error info.
 //│ eval4: ('tail & 'tail0 & 'tail1 & 'tail2 & 'tail3 & 'tail4 & (Cons[?] & List[?] & 'a & 'b & 'c & 'd & 'e & 'f | Nil & List[?])) -> 'g -> (App[nothing] | 'result | 'h)
 //│   where
-//│     'tail4 <: Cons[?] & 'e | Nil
-//│     'e <: {head: {0: string, 1: 'result0}, tail: 'tail4}
-//│     'tail3 <: Cons[?] & 'd | Nil
-//│     'd <: {head: {0: string, 1: 'result & (Numb | ~#Numb)}, tail: 'tail3}
-//│     'tail2 <: Cons[?] & 'c | Nil
+//│     'tail4 <: Cons[?] & 'f | Nil
+//│     'f <: {head: {0: string, 1: 'result0}, tail: 'tail4}
+//│     'tail3 <: Cons[?] & 'e | Nil
+//│     'e <: {head: {0: string, 1: 'result0}, tail: 'tail3}
+//│     'tail2 <: Cons[?] & 'd | Nil
+//│     'd <: {head: {0: string, 1: 'result & (Numb | ~#Numb)}, tail: 'tail2}
+//│     'tail1 <: Cons[?] & 'c | Nil
 //│     'c <: {
-//│       head: {
-//│         0: string,
-//│         1: 'result & (Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)))
-//│       },
-//│       tail: 'tail2
-//│     }
-//│     'tail1 <: Cons[?] & 'b | Nil
-//│     'b <: {
 //│       head: {
 //│         0: string,
 //│         1: 'result & (Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)))
 //│       },
 //│       tail: 'tail1
 //│     }
-//│     'tail0 <: Cons[?] & 'a | Nil
-//│     'a <: {
+//│     'tail0 <: Cons[?] & 'b | Nil
+//│     'b <: {
 //│       head: {
 //│         0: string,
 //│         1: 'result & (Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)))
 //│       },
 //│       tail: 'tail0
 //│     }
-//│     'tail <: Cons[?] & 'f | Nil
-//│     'f <: {head: {0: string, 1: 'result0}, tail: 'tail}
-//│     'result0 :> Var | Numb
-//│              <: Abs[?] & 'j | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)
-//│     'j <: Abs[?] | App[?] | Var & 'h
+//│     'tail <: Cons[?] & 'a | Nil
+//│     'a <: {
+//│       head: {
+//│         0: string,
+//│         1: 'result & (Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)))
+//│       },
+//│       tail: 'tail
+//│     }
+//│     'result :> Abs[Abs[nothing] | App[nothing] | 'result | 'h] | App['lhs] & {lhs: 'lhs, rhs: nothing} | 'h | Numb | Var | Add[Abs[nothing] | App[nothing] | 'result | 'h] | Mul[Abs[nothing] | App[nothing] | 'result | 'h] | 'result0 | 'p
 //│     'h :> Var
 //│        <: Abs[?] & 'i & 'j | 'lhs & (Abs[?] & 'j & ~#Abs | Add[?] & {name: string} & 'k | App[?] & {name: string} & 'l | Mul[?] & {name: string} & 'm | Var & 'n | 'o & (Numb & {name: string} | Numb & {name: string} & ~#Numb))
+//│     'lhs :> App['lhs] & {lhs: 'lhs, rhs: nothing} | Var
 //│     'i <: {body: 'g, name: string}
 //│     'g <: Abs[?] & 'j | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Numb & 'o | Var & 'n
 //│     'k <: Add[?] & {lhs: 'g, rhs: 'g} | Mul[?] & {lhs: 'g, rhs: 'g} | Numb & 'result | Var & 'p
-//│     'result :> Abs[Abs[nothing] | App[nothing] | 'result | 'h] | App['lhs] & {lhs: 'lhs, rhs: nothing} | 'h | Numb | Var | Add[Abs[nothing] | App[nothing] | 'result | 'h] | Mul[Abs[nothing] | App[nothing] | 'result | 'h] | 'result0 | 'p
 //│     'p <: Var & (Abs[?] & 'j | Add[?] & {name: string} & 'k | App[?] & {name: string} & 'l | Mul[?] & {name: string} & 'm | Var & 'n | 'o & (Numb & {name: string} | Numb & {name: string} & ~#Numb))
 //│     'o <: Add[?] & {lhs: 'g, rhs: 'g} | Mul[?] & {lhs: 'g, rhs: 'g} | Numb & 'result0 | Var & 'p
+//│     'result0 :> Var | Numb
+//│              <: Abs[?] & 'j | Add[?] & 'k | App[?] & 'l | Mul[?] & 'm | Var & 'n | 'o & (Numb | Numb & ~#Numb)
 //│     'n <: Var & 'h
 //│     'm <: Add[?] & {lhs: 'g, rhs: 'g} | Mul[?] & {lhs: 'g, rhs: 'g} | Numb & 'result | Var
 //│     'l <: Abs[?] & {body: 'g} | App[?] & {rhs: 'g} | Var & 'h
-//│     'lhs :> App['lhs] & {lhs: 'lhs, rhs: nothing} | Var
+//│     'j <: Abs[?] | App[?] | Var & 'h
 //│      = <no result>
 //│        eval_lexpr', eval_var, list_assoc and eq are not implemented
 
@@ -476,55 +476,55 @@ rec def eval4 subst = eval_lexpr' eval4 subst
 rec def eval4 subst = eval_lexpr' eval4 subst
 //│ eval4: ('tail & 'tail0 & 'tail1 & 'tail2 & 'tail3 & 'tail4 & (Cons[?] & List[?] & 'b & 'c & 'd & 'e & 'f & 'g | Nil & List[?])) -> 'h -> 'i
 //│   where
-//│     'tail4 <: Cons[?] & 'g | Nil
-//│     'g <: {head: {0: string, 1: 'result}, tail: 'tail4}
-//│     'tail3 <: Cons[?] & 'f | Nil
-//│     'f <: {head: {0: string, 1: 'result0}, tail: 'tail3}
-//│     'tail2 <: Cons[?] & 'e | Nil
-//│     'e <: {head: {0: string, 1: 'result0}, tail: 'tail2}
-//│     'tail1 <: Cons[?] & 'd | Nil
-//│     'd <: {head: {0: string, 1: 'result0}, tail: 'tail1}
-//│     'tail0 <: Cons[?] & 'c | Nil
-//│     'c <: {head: {0: string, 1: 'result}, tail: 'tail0}
-//│     'tail <: Cons[?] & 'b | Nil
-//│     'b <: {head: {0: string, 1: 'result}, tail: 'tail}
-//│     'result :> 'i
-//│             <: Abs[?] & 'j & 'k & 'l | 'lhs & (Abs[?] & 'k & 'l & ~#Abs | 'lhs0 & (Add[?] & 'm | App[?] & 'n | Mul[?] & 'o | Var & 'p | 'q & (Numb | Numb & ~#Numb)))
-//│     'i :> 'result | 'r | Abs['i] | App['a]\lhs\rhs & {lhs: 'lhs, rhs: 'rhs} | 'result0 | 's | Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0]\lhs\rhs & {lhs: 'lhs0, rhs: 'rhs0}
-//│     'r :> Var
-//│        <: Abs[?] & 'j & 'k & 'l | 'lhs & (Abs[?] & 'k & 'l & ~#Abs | 'lhs0 & (Add[?] & {name: string} & 'm | App[?] & {name: string} & 'n | Mul[?] & {name: string} & 'o | Var & 'p | 'q & (Numb & {name: string} | Numb & {name: string} & ~#Numb)))
+//│     'tail4 <: Cons[?] & 'd | Nil
+//│     'd <: {head: {0: string, 1: 'result}, tail: 'tail4}
+//│     'tail3 <: Cons[?] & 'c | Nil
+//│     'c <: {head: {0: string, 1: 'result0}, tail: 'tail3}
+//│     'tail2 <: Cons[?] & 'b | Nil
+//│     'b <: {head: {0: string, 1: 'result0}, tail: 'tail2}
+//│     'tail1 <: Cons[?] & 'g | Nil
+//│     'g <: {head: {0: string, 1: 'result0}, tail: 'tail1}
+//│     'tail0 <: Cons[?] & 'f | Nil
+//│     'f <: {head: {0: string, 1: 'result}, tail: 'tail0}
+//│     'tail <: Cons[?] & 'e | Nil
+//│     'e <: {head: {0: string, 1: 'result}, tail: 'tail}
+//│     'result :> Var | 'i | Numb
+//│             <: Abs[?] & 'j & 'k & 'l | 'lhs & 'lhs0 & (Add[?] & 'm | App[?] & 'n | Mul[?] & 'o | Var & 'p | 'q & (Numb | Numb & ~#Numb))
+//│     'i :> 'result0 | 'r | Abs['i] | App['a]\lhs\rhs & {lhs: 'lhs0, rhs: 'rhs} | 'result | 's | Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0]\lhs\rhs & {lhs: 'lhs, rhs: 'rhs0}
+//│     'result0 :> 'i
+//│              <: Abs[?] & 'j & 'k & 'l | 'lhs0 & (Abs[?] & 'k & 'l & ~#Abs | 'lhs & (Add[?] & 'm | App[?] & 'n | Mul[?] & 'o | Var & 'p | 'q & (Numb | Numb & ~#Numb)))
 //│     'j <: {body: 'h, name: string}
 //│     'h <: Abs[?] & 'k | Add[?] & 'm | App[?] & 'n | Mul[?] & 'o | Numb & 'q | Var & 'p
-//│     'm <: Add[?] & {lhs: 'h, rhs: 'h} | Mul[?] & {lhs: 'h, rhs: 'h} | Numb & 'result0 | Var & 's
-//│     'result0 :> Var | 'i | Numb
-//│              <: Abs[?] & 'j & 'k & 'l | 'lhs & 'lhs0 & (Add[?] & 'm | App[?] & 'n | Mul[?] & 'o | Var & 'p | 'q & (Numb | Numb & ~#Numb))
-//│     'o <: Add[?] & {lhs: 'h, rhs: 'h} | Mul[?] & {lhs: 'h, rhs: 'h} | Numb & 'result0 | Var & 's
+//│     'k <: Abs[?] & {body: 'h} | App[?] & {lhs: 'h, rhs: 'h} | Var & 'r
+//│     'r :> Var
+//│        <: Abs[?] & 'j & 'k & 'l | 'lhs0 & (Abs[?] & 'k & 'l & ~#Abs | 'lhs & (Add[?] & {name: string} & 'm | App[?] & {name: string} & 'n | Mul[?] & {name: string} & 'o | Var & 'p | 'q & (Numb & {name: string} | Numb & {name: string} & ~#Numb)))
+//│     'm <: Add[?] & {lhs: 'h, rhs: 'h} | Mul[?] & {lhs: 'h, rhs: 'h} | Numb & 'result | Var & 's
 //│     's <: Var & (Abs[?] & 'j & 'k & 'l | 'lhs & 'lhs0 & (Add[?] & {name: string} & 'm | App[?] & {name: string} & 'n | Mul[?] & {name: string} & 'o | Var & 'p | 'q & (Numb & {name: string} | Numb & {name: string} & ~#Numb)))
-//│     'q <: Add[?] & {lhs: 'h, rhs: 'h} | Mul[?] & {lhs: 'h, rhs: 'h} | Numb & 'result0 | Var & 's
+//│     'q <: Add[?] & {lhs: 'h, rhs: 'h} | Mul[?] & {lhs: 'h, rhs: 'h} | Numb & 'result | Var & 's
 //│     'p <: Var & 'r
+//│     'o <: Add[?] & {lhs: 'h, rhs: 'h} | Mul[?] & {lhs: 'h, rhs: 'h} | Numb & 'result | Var & 's
 //│     'n <: Abs[?] & {body: 'h} | App[?] & {lhs: 'h, rhs: 'h} | Var & 'r
-//│     'lhs :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs | 'lhs0, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | Numb | Var
-//│          <: 'h & 'a
-//│     'a0 :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs | 'lhs0, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | 'i
-//│     'a :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs | 'lhs0, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | 'i
-//│     'lhs0 :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs | 'lhs0, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | Numb | Var
-//│           <: 'h & 'a0
+//│     'lhs0 :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs0 | 'lhs, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | Numb | Var
+//│           <: 'h & 'a
+//│     'a0 :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs0 | 'lhs, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | 'i
+//│     'a :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs0 | 'lhs, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | 'i
+//│     'lhs :> Add['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | App['a0 | 'a]\lhs\rhs & {lhs: 'lhs0 | 'lhs, rhs: 'rhs0 | 'rhs} | Mul['i]\lhs\rhs & {lhs: 'i, rhs: 'i} | Numb | Var
+//│          <: 'h & 'a0
 //│     'rhs :> 'i
 //│     'rhs0 :> 'i
 //│     'l <: {body: 'h, name: string}
-//│     'k <: Abs[?] & {body: 'h} | App[?] & {lhs: 'h, rhs: 'h} | Var & 'r
 //│      = <no result>
 //│        eval_lexpr', eval_var, list_assoc and eq are not implemented
 //│ constrain calls  : 16185
 //│ annoying  calls  : 2300
-//│ subtyping calls  : 602229
+//│ subtyping calls  : 602211
 
 :ResetFuel
 
 eval4 Nil (Abs { name = "s"; body = Add { lhs = Var { name = "s" }; rhs = Numb { num = 1 } } })
 //│ res: 'b
 //│   where
-//│     'b :> Var | (Mul['b] with {lhs: 'b, rhs: 'b}) | Abs['b] | (App['a] with {lhs: 'lhs, rhs: 'rhs}) | Numb | (Add['b] with {lhs: 'b, rhs: 'b})
+//│     'b :> Var | Abs['b] | (App['a] with {lhs: 'lhs, rhs: 'rhs}) | Numb | (Add['b] with {lhs: 'b, rhs: 'b}) | (Mul['b] with {lhs: 'b, rhs: 'b})
 //│     'a :> 'lhs | 'b
 //│     'lhs :> (Add['b] with {lhs: 'b, rhs: 'b}) | (App['a] with {lhs: 'lhs, rhs: 'rhs}) | (Mul['b] with {lhs: 'b, rhs: 'b}) | Numb | Var
 //│     'rhs :> 'b

--- a/shared/src/test/diff/mlscript/SelfNeg.mls
+++ b/shared/src/test/diff/mlscript/SelfNeg.mls
@@ -120,7 +120,7 @@ r
 //│    = <no result>
 //│      r and bar are not implemented
 
-r._1 : nothing
+r.0 : nothing
 //│ res: nothing
 //│    = <no result>
 //│      r and bar are not implemented

--- a/shared/src/test/diff/mlscript/SelfNegs.mls
+++ b/shared/src/test/diff/mlscript/SelfNegs.mls
@@ -12,9 +12,9 @@ def foo(fa: ((~'a) -> 'a, 'a)) =
 
 :ns
 foo
-//│ res: forall 'a '1 'b. ((~'a -> 'a, 'a,),) -> 'b
+//│ res: forall 'a 'b 'c. ((~'a -> 'a, 'a,),) -> 'c
 //│   where
-//│     'a <: 'b & '1
-//│     '1 <: ~'a
+//│     'a <: 'c & 'b
+//│     'b <: ~'a
 //│    = [Function: foo1]
 

--- a/shared/src/test/diff/mlscript/SelfNegs.mls
+++ b/shared/src/test/diff/mlscript/SelfNegs.mls
@@ -6,15 +6,15 @@ def foo(f: (~'a) -> 'a, a: 'a) =
 //│    = [Function: foo]
 
 def foo(fa: ((~'a) -> 'a, 'a)) =
-  fa._1 fa._2
+  fa.0 fa.1
 //│ foo: ((~'a -> 'a, 'a,),) -> 'a
 //│    = [Function: foo1]
 
 :ns
 foo
-//│ res: forall 'a 'b 'c. ((~'a -> 'a, 'a,),) -> 'c
+//│ res: forall 'a '1 'b. ((~'a -> 'a, 'a,),) -> 'b
 //│   where
-//│     'a <: 'c & 'b
-//│     'b <: ~'a
+//│     'a <: 'b & '1
+//│     '1 <: ~'a
 //│    = [Function: foo1]
 

--- a/shared/src/test/diff/mlscript/This.mls
+++ b/shared/src/test/diff/mlscript/This.mls
@@ -155,21 +155,15 @@ NewDerivedDerived.NewQuz
 
 :e
 class NewDerivedDerivedDerived: NewDerivedDerived
-  method NewQux = this.NewBar.1
-//│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.158: 	  method NewQux = this.NewBar.1
-//│ ║         	                  ^^^^^^^^^^^^^
-//│ ╟── field selection of type `{0: ?a}` does not have field '1'
-//│ ║  l.158: 	  method NewQux = this.NewBar.1
-//│ ╙──       	                  ^^^^^^^^^^^
+  method NewQux = this.NewBar.0
 //│ ╔══[ERROR] Overriding method NewDerived.NewQux without explicit declaration is not allowed.
-//│ ║  l.158: 	  method NewQux = this.NewBar.1
+//│ ║  l.158: 	  method NewQux = this.NewBar.0
 //│ ║         	         ^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: method definition inherited from
 //│ ║  l.130: 	  method NewQux = this.NewBar.0
 //│ ╙──       	         ^^^^^^^^^^^^^^^^^^^^^^
 //│ Defined class NewDerivedDerivedDerived
-//│ Defined NewDerivedDerivedDerived.NewQux: NewDerivedDerivedDerived -> error
+//│ Defined NewDerivedDerivedDerived.NewQux: (NewDerivedDerivedDerived & 'this) -> (NewDerivedDerivedDerived & NewBase & 'this)
 
 // Test methods of NewDerivedDerivedDerived
 NewDerivedDerivedDerived.NewBar
@@ -179,7 +173,7 @@ NewDerivedDerivedDerived.NewQux
 //│ res: (NewDerivedDerivedDerived & 'this) -> (NewBase & 'this,)
 //│ res: (NewDerivedDerivedDerived & 'this) -> (NewBase & 'this)
 //│ res: (NewDerivedDerivedDerived & 'this) -> (NewDerivedDerived & NewBase & NewDerived & 'this)
-//│ res: NewDerivedDerivedDerived -> error
+//│ res: (NewDerivedDerivedDerived & 'this) -> (NewDerivedDerivedDerived & NewBase & 'this)
 
 
 

--- a/shared/src/test/diff/mlscript/This.mls
+++ b/shared/src/test/diff/mlscript/This.mls
@@ -103,7 +103,7 @@ class Base2
 class Derived2: Base2
   method Foo3 = (this.Foo2,)
 class DerivedDerived2: Derived2
-  method Foo2 = this.Foo3._1
+  method Foo2 = this.Foo3.0
 //│ Defined class Base2
 //│ Declared Base2.Foo2: (Base2 & 'this) -> (Base2 & 'this)
 //│ Defined class Derived2
@@ -127,7 +127,7 @@ class NewBase
 //│ Defined NewBase.NewBar: (NewBase & 'this) -> (NewBase & 'this,)
 
 class NewDerived: NewBase
-  method NewQux = this.NewBar._1
+  method NewQux = this.NewBar.0
 //│ Defined class NewDerived
 //│ Defined NewDerived.NewQux: (NewDerived & 'this) -> (NewDerived & NewBase & 'this)
 
@@ -155,15 +155,21 @@ NewDerivedDerived.NewQuz
 
 :e
 class NewDerivedDerivedDerived: NewDerivedDerived
-  method NewQux = this.NewBar._1
+  method NewQux = this.NewBar.1
+//│ ╔══[ERROR] Type mismatch in field selection:
+//│ ║  l.158: 	  method NewQux = this.NewBar.1
+//│ ║         	                  ^^^^^^^^^^^^^
+//│ ╟── field selection of type `{0: ?a}` does not have field '1'
+//│ ║  l.158: 	  method NewQux = this.NewBar.1
+//│ ╙──       	                  ^^^^^^^^^^^
 //│ ╔══[ERROR] Overriding method NewDerived.NewQux without explicit declaration is not allowed.
-//│ ║  l.158: 	  method NewQux = this.NewBar._1
-//│ ║         	         ^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.158: 	  method NewQux = this.NewBar.1
+//│ ║         	         ^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── Note: method definition inherited from
-//│ ║  l.130: 	  method NewQux = this.NewBar._1
-//│ ╙──       	         ^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.130: 	  method NewQux = this.NewBar.0
+//│ ╙──       	         ^^^^^^^^^^^^^^^^^^^^^^
 //│ Defined class NewDerivedDerivedDerived
-//│ Defined NewDerivedDerivedDerived.NewQux: (NewDerivedDerivedDerived & 'this) -> (NewDerivedDerivedDerived & NewBase & 'this)
+//│ Defined NewDerivedDerivedDerived.NewQux: NewDerivedDerivedDerived -> error
 
 // Test methods of NewDerivedDerivedDerived
 NewDerivedDerivedDerived.NewBar
@@ -173,7 +179,7 @@ NewDerivedDerivedDerived.NewQux
 //│ res: (NewDerivedDerivedDerived & 'this) -> (NewBase & 'this,)
 //│ res: (NewDerivedDerivedDerived & 'this) -> (NewBase & 'this)
 //│ res: (NewDerivedDerivedDerived & 'this) -> (NewDerivedDerived & NewBase & NewDerived & 'this)
-//│ res: (NewDerivedDerivedDerived & 'this) -> (NewDerivedDerivedDerived & NewBase & 'this)
+//│ res: NewDerivedDerivedDerived -> error
 
 
 

--- a/shared/src/test/diff/mlscript/TrickyExtrusion.mls
+++ b/shared/src/test/diff/mlscript/TrickyExtrusion.mls
@@ -53,46 +53,46 @@ test f =
 //│     = [Function: test2]
 
 :e // * Due to lack of precision
-(test id)._1 + 1
+(test id).1 + 1
 //│ ╔══[ERROR] Type mismatch in operator application:
-//│ ║  l.56: 	(test id)._1 + 1
-//│ ║        	^^^^^^^^^^^^^^
+//│ ║  l.56: 	(test id).1 + 1
+//│ ║        	^^^^^^^^^^^^^
 //│ ╟── reference of type `true` is not an instance of type `int`
 //│ ║  l.4: 	True = true
 //│ ║       	       ^^^^
 //│ ╟── but it flows into field selection with expected type `int`
-//│ ║  l.56: 	(test id)._1 + 1
-//│ ╙──      	^^^^^^^^^^^^
+//│ ║  l.56: 	(test id).1 + 1
+//│ ╙──      	^^^^^^^^^^^
 //│ res: error | int
-//│    = NaN
+//│    = 2
 
 :e // * Due to lack of precision
-not (test id)._2
-//│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.70: 	not (test id)._2
-//│ ║        	^^^^^^^^^^^^^^^^
-//│ ╟── integer literal of type `0` is not an instance of type `bool`
+not (test id).2
+//│ ╔══[ERROR] Type mismatch in field selection:
+//│ ║  l.70: 	not (test id).2
+//│ ║        	    ^^^^^^^^^^^
+//│ ╟── tuple literal of type `forall ?a ?b. (?a, ?b,)` does not have field '2'
 //│ ║  l.51: 	  in (r 0, r True)
-//│ ║        	        ^
-//│ ╟── but it flows into field selection with expected type `bool`
-//│ ║  l.70: 	not (test id)._2
-//│ ╙──      	    ^^^^^^^^^^^^
-//│ res: bool | error
+//│ ║        	     ^^^^^^^^^^^^^
+//│ ╟── but it flows into application with expected type `{2: ?2}`
+//│ ║  l.70: 	not (test id).2
+//│ ╙──      	     ^^^^^^^
+//│ res: bool
 //│    = true
 
 :e // * Legit
-not (test id)._1
+not (test id).1
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.84: 	not (test id)._1
-//│ ║        	^^^^^^^^^^^^^^^^
+//│ ║  l.84: 	not (test id).1
+//│ ║        	^^^^^^^^^^^^^^^
 //│ ╟── integer literal of type `0` is not an instance of type `bool`
 //│ ║  l.51: 	  in (r 0, r True)
 //│ ║        	        ^
 //│ ╟── but it flows into field selection with expected type `bool`
-//│ ║  l.84: 	not (test id)._1
-//│ ╙──      	    ^^^^^^^^^^^^
+//│ ║  l.84: 	not (test id).1
+//│ ╙──      	    ^^^^^^^^^^^
 //│ res: bool | error
-//│    = true
+//│    = false
 
 
 
@@ -110,13 +110,13 @@ not (test id)._1
 test f =
   let r x = f x
   in (r 0, r True)
-//│ test: forall 'a 'b 'c 'd 'e 'f 'g. 'c -> ('e, 'f,)
+//│ test: forall 'a 'b 'c 'd 'e 'f 'g. 'b -> ('f, 'd,)
 //│   where
-//│     'c <: 'g -> 'a & 'b -> 'd
-//│     'd <: 'e
-//│     'b :> 0
-//│     'a <: 'f
-//│     'g :> true
+//│     'b <: 'e -> 'g & 'a -> 'c
+//│     'c <: 'f
+//│     'a :> 0
+//│     'g <: 'd
+//│     'e :> true
 //│     = [Function: test3]
 
 // * Q: why does this type *appear* approximated after simplification?
@@ -126,25 +126,25 @@ test
 
 // * We can tell the type is still precise enough because these work:
 
-(test id)._1 + 1
+(test id).0 + 1
 //│ res: int
-//│    = NaN
+//│    = 1
 
-not (test id)._2
+not (test id).1
 //│ res: bool
-//│    = true
+//│    = false
 
 :e // * Legit
-not (test id)._1
+not (test id).0
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.138: 	not (test id)._1
-//│ ║         	^^^^^^^^^^^^^^^^
+//│ ║  l.138: 	not (test id).0
+//│ ║         	^^^^^^^^^^^^^^^
 //│ ╟── integer literal of type `0` is not an instance of type `bool`
 //│ ║  l.112: 	  in (r 0, r True)
 //│ ║         	        ^
 //│ ╟── but it flows into field selection with expected type `bool`
-//│ ║  l.138: 	not (test id)._1
-//│ ╙──       	    ^^^^^^^^^^^^
+//│ ║  l.138: 	not (test id).0
+//│ ╙──       	    ^^^^^^^^^^^
 //│ res: bool | error
 //│    = true
 

--- a/shared/src/test/diff/mlscript/TrickyExtrusion.mls
+++ b/shared/src/test/diff/mlscript/TrickyExtrusion.mls
@@ -53,46 +53,46 @@ test f =
 //│     = [Function: test2]
 
 :e // * Due to lack of precision
-(test id).1 + 1
+(test id).0 + 1
 //│ ╔══[ERROR] Type mismatch in operator application:
-//│ ║  l.56: 	(test id).1 + 1
+//│ ║  l.56: 	(test id).0 + 1
 //│ ║        	^^^^^^^^^^^^^
 //│ ╟── reference of type `true` is not an instance of type `int`
 //│ ║  l.4: 	True = true
 //│ ║       	       ^^^^
 //│ ╟── but it flows into field selection with expected type `int`
-//│ ║  l.56: 	(test id).1 + 1
+//│ ║  l.56: 	(test id).0 + 1
 //│ ╙──      	^^^^^^^^^^^
 //│ res: error | int
-//│    = 2
+//│    = 1
 
 :e // * Due to lack of precision
-not (test id).2
-//│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.70: 	not (test id).2
-//│ ║        	    ^^^^^^^^^^^
-//│ ╟── tuple literal of type `forall ?a ?b. (?a, ?b,)` does not have field '2'
-//│ ║  l.51: 	  in (r 0, r True)
-//│ ║        	     ^^^^^^^^^^^^^
-//│ ╟── but it flows into application with expected type `{2: ?2}`
-//│ ║  l.70: 	not (test id).2
-//│ ╙──      	     ^^^^^^^
-//│ res: bool
-//│    = true
-
-:e // * Legit
 not (test id).1
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.84: 	not (test id).1
+//│ ║  l.70: 	not (test id).1
 //│ ║        	^^^^^^^^^^^^^^^
 //│ ╟── integer literal of type `0` is not an instance of type `bool`
 //│ ║  l.51: 	  in (r 0, r True)
 //│ ║        	        ^
 //│ ╟── but it flows into field selection with expected type `bool`
-//│ ║  l.84: 	not (test id).1
+//│ ║  l.70: 	not (test id).1
 //│ ╙──      	    ^^^^^^^^^^^
 //│ res: bool | error
 //│    = false
+
+:e // * Legit
+not (test id).0
+//│ ╔══[ERROR] Type mismatch in application:
+//│ ║  l.84: 	not (test id).0
+//│ ║        	^^^^^^^^^^^^^^^
+//│ ╟── integer literal of type `0` is not an instance of type `bool`
+//│ ║  l.51: 	  in (r 0, r True)
+//│ ║        	        ^
+//│ ╟── but it flows into field selection with expected type `bool`
+//│ ║  l.84: 	not (test id).0
+//│ ╙──      	    ^^^^^^^^^^^
+//│ res: bool | error
+//│    = true
 
 
 
@@ -110,13 +110,13 @@ not (test id).1
 test f =
   let r x = f x
   in (r 0, r True)
-//│ test: forall 'a 'b 'c 'd 'e 'f 'g. 'b -> ('f, 'd,)
+//│ test: forall 'a 'b 'c 'd 'e 'f 'g. 'c -> ('e, 'f,)
 //│   where
-//│     'b <: 'e -> 'g & 'a -> 'c
-//│     'c <: 'f
-//│     'a :> 0
-//│     'g <: 'd
-//│     'e :> true
+//│     'c <: 'g -> 'a & 'b -> 'd
+//│     'd <: 'e
+//│     'b :> 0
+//│     'a <: 'f
+//│     'g :> true
 //│     = [Function: test3]
 
 // * Q: why does this type *appear* approximated after simplification?

--- a/shared/src/test/diff/mlscript/TupleArray.mls
+++ b/shared/src/test/diff/mlscript/TupleArray.mls
@@ -49,43 +49,31 @@ r = {b = "a", c = 1}
 //│ ╙──      	       ^^^^^^^^^^^^^^^^^^^
 //│  = { b: 'a', c: 1 }
 
-(1,2,3) with { _4 = "oops" }
-//│ res: (1, 2, 3,) & {_4: "oops"}
-//│    = [ 1, 2, 3, _4: 'oops' ]
+(1,2,3) with { 4 = "oops" }
+//│ res: (1, 2, 3,) & {4: "oops"}
+//│    = [ 1, 2, 3, <1 empty item>, 'oops' ]
 
-(1,2,3) with { _1 = "oops" }
-//│ res: {_1: "oops", _2: 2, _3: 3}
-//│    = [ 1, 2, 3, _1: 'oops' ]
+(1,2,3) with { 1 = "oops" }
+//│ res: (1, 2, 3,) & {1: "oops"}
+//│    = [ 1, 'oops', 3 ]
 
-:e
-(res: (int,int,int,))._1
-//│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.61: 	(res: (int,int,int,))._1
-//│ ║        	 ^^^
-//│ ╟── `with` extension of type `{_1: "oops", _2: 2, _3: 3}` is not a 3-element tuple
-//│ ║  l.56: 	(1,2,3) with { _1 = "oops" }
-//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `(int, int, int,)`
-//│ ║  l.61: 	(res: (int,int,int,))._1
-//│ ║        	 ^^^
-//│ ╟── Note: constraint arises from tuple type:
-//│ ║  l.61: 	(res: (int,int,int,))._1
-//│ ╙──      	      ^^^^^^^^^^^^^^
+// :e TODO
+(res: (int,int,int,)).1
 //│ res: int
 //│    = 'oops'
 
 
-def r: int \ _1
-//│ r: int\_1
+def r: int \ 1
+//│ r: int\1
 //│  = <missing implementation>
 
-def r: (1,2,3) \ _1
-//│ r: in (1, 2, 3,)\_1 out {_2: 2, _3: 3}
+def r: (1,2,3) \ 1
+//│ r: in (1, 2, 3,)\1 out (1, 2, 3,)
 //│  = <missing implementation>
-// (1,2,3).toRecord \ _1
+// (1,2,3).toRecord \ 1
 
-def r: (1,2,3) \ _12345
-//│ r: in (1, 2, 3,)\_12345 out (1, 2, 3,)
+def r: (1,2,3) \ 12345
+//│ r: in (1, 2, 3,)\12345 out (1, 2, 3,)
 //│  = <missing implementation>
 
 def arr: Array[int]
@@ -107,18 +95,18 @@ fr : Array[int] & {b: int}
 //│      fr and r are not implemented
 
 :e
-arr._1
+arr.1
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.110: 	arr._1
-//│ ║         	^^^^^^
-//│ ╟── type `Array[int]` does not have field '_1'
-//│ ║  l.91: 	def arr: Array[int]
+//│ ║  l.98: 	arr.1
+//│ ║        	^^^^^
+//│ ╟── type `Array[int]` does not have field '1'
+//│ ║  l.79: 	def arr: Array[int]
 //│ ║        	         ^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{_1: ?a}`
-//│ ║  l.110: 	arr._1
-//│ ╙──       	^^^
+//│ ╟── but it flows into reference with expected type `{1: ?1}`
+//│ ║  l.98: 	arr.1
+//│ ╙──      	^^^
 //│ res: error
-//│    = undefined
+//│    = 2
 
 rr = arr with { x = 1 }
 //│ rr: Array[int] & {x: 1}
@@ -138,13 +126,13 @@ t = (1, 2, 3) with {x = 1}
 //│ t: (1, 2, 3,) & {x: 1}
 //│  = [ 1, 2, 3, x: 1 ]
 
-t._1
-t._2
+t.1
+t.2
 t.x
-//│ res: 1
-//│    = undefined
 //│ res: 2
-//│    = undefined
+//│    = 2
+//│ res: 3
+//│    = 3
 //│ res: 1
 //│    = 1
 
@@ -170,10 +158,10 @@ def test: {x: 1} & (1, 2, 3)
 :e
 f(1,2,3) : 1 | 2 | 3
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.171: 	f(1,2,3) : 1 | 2 | 3
+//│ ║  l.159: 	f(1,2,3) : 1 | 2 | 3
 //│ ║         	^^^^^^^^
 //│ ╟── argument list of type `(1, 2, 3,)` does not match type `(?a,)`
-//│ ║  l.171: 	f(1,2,3) : 1 | 2 | 3
+//│ ║  l.159: 	f(1,2,3) : 1 | 2 | 3
 //│ ╙──       	 ^^^^^^^
 //│ res: 1 | 2 | 3
 //│    = [Number: 1] { b: 2 }
@@ -181,19 +169,19 @@ f(1,2,3) : 1 | 2 | 3
 :e
 (arr[0])[1][2]
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.182: 	(arr[0])[1][2]
+//│ ║  l.170: 	(arr[0])[1][2]
 //│ ║         	^^^^^^^^^^^
 //│ ╟── type `int` does not match type `Array[?a]`
-//│ ║  l.91: 	def arr: Array[int]
+//│ ║  l.79: 	def arr: Array[int]
 //│ ║        	               ^^^
 //│ ╟── but it flows into array access with expected type `Array[?b]`
-//│ ║  l.182: 	(arr[0])[1][2]
+//│ ║  l.170: 	(arr[0])[1][2]
 //│ ╙──       	 ^^^^^^
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.182: 	(arr[0])[1][2]
+//│ ║  l.170: 	(arr[0])[1][2]
 //│ ║         	^^^^^^^^^^^^^^
 //│ ╟── possibly-undefined array access of type `undefined` does not match type `Array[?a]`
-//│ ║  l.182: 	(arr[0])[1][2]
+//│ ║  l.170: 	(arr[0])[1][2]
 //│ ╙──       	^^^^^^^^^^^
 //│ res: error | undefined
 //│ Runtime error:
@@ -211,14 +199,14 @@ def myval: A & { x: anything }
 // //│ myval: A with {x: string}
 
 
-def tuuu: (1 | 2, true) & {_1: 2 | 3}
-//│ tuuu: (2, true,)
+def tuuu: (1 | 2, true) & {1: 2 | 3}
+//│ tuuu: (1 | 2, true,) & {1: 2 | 3}
 //│     = <missing implementation>
 // tuuu: ((1 | 2) & (2 | 3), true,)
 // tuuu: (2, true,)
 
 // (S, T, U)
-// Array[S | T | U] & { _1: S; _2: T; _3: U }
+// Array[S | T | U] & { 1: S; 2: T; 3: U }
 
 def f(x: int, y: string) = x
 //│ f: (int, string,) -> int
@@ -282,43 +270,43 @@ res: { x: int }
 //│ res: (1, 2, (true, false, ("hello", "world", "bye",),),)
 //│    = [ 1, 2, [ true, false, [ 'hello', 'world', 'bye' ] ] ]
 
-k1 = (6, "hi", false) with {_5=5; _6=true}
-k1._1
-k1._3
-//│ k1: (6, "hi", false,) & {_5: 5, _6: true}
-//│   = [ 6, 'hi', false, _5: 5, _6: true ]
+k1 = (6, "hi", false) with {5=5; 6=true}
+k1.0
+k1.2
+//│ k1: (6, "hi", false,) & {5: 5, 6: true}
+//│   = [ 6, 'hi', false, <2 empty items>, 5, true ]
 //│ res: 6
-//│    = undefined
+//│    = 6
 //│ res: false
-//│    = undefined
+//│    = false
 
-(1,2,3) with {_2 = "hello"; _a = true; _4 = 4}
-//│ res: {_1: 1, _2: "hello", _3: 3, _4: 4, _a: true}
-//│    = [ 1, 2, 3, _2: 'hello', _a: true, _4: 4 ]
+(1,2,3) with {2 = "hello"; _a = true; 4 = 4}
+//│ res: (1, 2, 3,) & {2: "hello", 4: 4, _a: true}
+//│    = [ 1, 2, 'hello', <1 empty item>, 4, _a: true ]
 
-(1,2,3) with {_1 = true; _0 = 233}
-//│ res: {_0: 233, _1: true, _2: 2, _3: 3}
-//│    = [ 1, 2, 3, _1: true, _0: 233 ]
+(1,2,3) with {1 = true; 0 = 233}
+//│ res: (1, 2, 3,) & {0: 233, 1: true}
+//│    = [ 233, true, 3 ]
 
-(1, 2, true) with {_0 = "hello"}
-//│ res: (1, 2, true,) & {_0: "hello"}
-//│    = [ 1, 2, true, _0: 'hello' ]
+(1, 2, true) with {0 = "hello"}
+//│ res: (1, 2, true,) & {0: "hello"}
+//│    = [ 'hello', 2, true ]
 
 ta1 = (5, 6, true, false, "hahaha")
-ta2 = ta1 with {x = 123; _7 = "bye"; _1 = 0}
-ta1._1
-ta2._2
-ta2._3
+ta2 = ta1 with {x = 123; 7 = "bye"; 1 = 0}
+ta1.1
+ta2.2
+ta2.3
 //│ ta1: (5, 6, true, false, "hahaha",)
 //│    = [ 5, 6, true, false, 'hahaha' ]
-//│ ta2: {_1: 0, _2: 6, _3: true, _4: false, _5: "hahaha", _7: "bye", x: 123}
-//│    = [ 5, 6, true, false, 'hahaha', x: 123, _7: 'bye', _1: 0 ]
-//│ res: 5
-//│    = undefined
+//│ ta2: (5, 6, true, false, "hahaha",) & {1: 0, 7: "bye", x: 123}
+//│    = [ 5, 0, true, false, 'hahaha', <2 empty items>, 'bye', x: 123 ]
 //│ res: 6
-//│    = undefined
+//│    = 6
 //│ res: true
-//│    = undefined
+//│    = true
+//│ res: false
+//│    = false
 
 def rep5: 'a -> Array['a]
 def rep5 x = (x,x,x,x,x)
@@ -329,69 +317,69 @@ def rep5 x = (x,x,x,x,x)
 //│ 'a -> Array['a]
 //│     = [Function: rep5]
 
-rep5 1 with {_1 = 10}
-a2 = rep5 2 with {_2 = true; x = "haha"}
-a2._2
+rep5 1 with {1 = 10}
+a2 = rep5 2 with {2 = true; x = "haha"}
+a2.2
 a2.x
-//│ res: Array[1] & {_1: 10}
-//│    = [ 1, 1, 1, 1, 1, _1: 10 ]
-//│ a2: Array[2] & {_2: true, x: "haha"}
-//│   = [ 2, 2, 2, 2, 2, _2: true, x: 'haha' ]
+//│ res: Array[1] & {1: 10}
+//│    = [ 1, 10, 1, 1, 1 ]
+//│ a2: Array[2] & {2: true, x: "haha"}
+//│   = [ 2, 2, true, 2, 2, x: 'haha' ]
 //│ res: true
 //│    = true
 //│ res: "haha"
 //│    = 'haha'
 
 :e
-a2._1
+a2.1
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.346: 	a2._1
-//│ ║         	^^^^^
-//│ ╟── type `Array['a]` does not match type `{_1: ?a} | ~{_2: true, x: "haha"}`
-//│ ║  l.323: 	def rep5: 'a -> Array['a]
+//│ ║  l.334: 	a2.1
+//│ ║         	^^^^
+//│ ╟── type `Array['a]` does not match type `{1: ?1} | ~{2: true, x: "haha"}`
+//│ ║  l.311: 	def rep5: 'a -> Array['a]
 //│ ║         	                ^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{_1: ?a} | ~{_2: true, x: "haha"}`
-//│ ║  l.346: 	a2._1
+//│ ╟── but it flows into reference with expected type `{1: ?1} | ~{2: true, x: "haha"}`
+//│ ║  l.334: 	a2.1
 //│ ╙──       	^^
 //│ res: error
-//│    = undefined
+//│    = 2
 
 (1,2,3,true) with {_a = 1; _b1 = false}
 //│ res: (1, 2, 3, true,) & {_a: 1, _b1: false}
 //│    = [ 1, 2, 3, true, _a: 1, _b1: false ]
 
-ht1 = (1,2,false) with {_1 = 'a'; _2 = 'hello'; _3 = false}
-ht1._1
-//│ ht1: {_1: "a", _2: "hello", _3: false}
-//│    = [ 1, 2, false, _1: 'a', _2: 'hello', _3: false ]
-//│ res: "a"
+ht1 = (1,2,false) with {1 = 'a'; 2 = 'hello'; 3 = false}
+ht1.1
+//│ ht1: (1, 2, false,) & {1: "a", 2: "hello", 3: false}
+//│    = [ 1, 'a', 'hello', false ]
+//│ res: nothing
 //│    = 'a'
 
-def hg1 t = (t._1, t._2)
+def hg1 t = (t.0, t.1)
 hg1 ht1
 hg1 ((5,5,5))
-(hg1 ht1)._2
-//│ hg1: {_1: 'a, _2: 'b} -> ('a, 'b,)
+(hg1 ht1).1
+//│ hg1: {0: '0, 1: '1} -> ('0, '1,)
 //│    = [Function: hg1]
-//│ res: ("a", "hello",)
-//│    = [ 'a', 'hello' ]
+//│ res: (1, nothing,)
+//│    = [ 1, 'a' ]
 //│ res: (5, 5,)
-//│    = [ undefined, undefined ]
-//│ res: "hello"
-//│    = undefined
+//│    = [ 5, 5 ]
+//│ res: nothing
+//│    = 'a'
 
 def ta1: Array[int] | (int, bool)
-def test: (string, 1) & { _1: "hello" }
-def test2: (string, 1) & { _1: "hello"; _3: int }
+def test: (string, 1) & { 1: "hello" }
+def test2: (string, 1) & { 1: "hello"; 3: int }
 //│ ta1: Array[bool | int]
 //│    = <missing implementation>
-//│ test: ("hello", 1,)
+//│ test: (string, 1,) & {1: "hello"}
 //│     = <missing implementation>
-//│ test2: ("hello", 1,) & {_3: int}
+//│ test2: (string, 1,) & {1: "hello", 3: int}
 //│      = <missing implementation>
 
-test: { _1: 'a }
-//│ res: {_1: "hello"}
+test: { 1: 'a }
+//│ res: {1: nothing}
 //│    = <no result>
 //│      test is not implemented
 
@@ -403,9 +391,9 @@ test: ('a, 1)
 //│    = <no result>
 //│      test is not implemented
 
-// TODO in principe, we could narrow the refinement to ` & { _1: 1 }` here...
-def test3: Array[1] & { _1: int }
-//│ test3: Array[1] & {_1: int}
+// TODO in principe, we could narrow the refinement to ` & { 1: 1 }` here...
+def test3: Array[1] & { 1: int }
+//│ test3: Array[1] & {1: int}
 //│      = <missing implementation>
 
 def fta1: Array[int | bool] -> int
@@ -420,7 +408,7 @@ fta1 r1
 //│ res: int
 //│    = <no result>
 //│      fta1 is not implemented
-//│ r1: Array[1 | 2 | 3] & {_1: 1, _2: 2}
+//│ r1: Array[1 | 2 | 3] & {0: 1, 1: 2}
 //│   = [ 1, 2, 3 ]
 //│ res: int
 //│    = <no result>
@@ -429,9 +417,9 @@ fta1 r1
 :NoJS
 def p1: T | Array[bool] | (int, string) | (true, 3)
 def p2: T | (string, bool) | Array[int] | (2, 4)
-def pf t = (t[1], t._1)
+def pf t = (t[1], t.1)
 pf((1,2,3))
 //│ p1: Array[bool | int | string] | T
 //│ p2: Array[bool | int | string] | T
-//│ pf: (Array['a & ~undefined] & {_1: 'b}) -> (undefined | 'a, 'b,)
-//│ res: (1 | 2 | 3 | undefined, 1,)
+//│ pf: (Array['a & ~undefined] & {1: '1}) -> (undefined | 'a, '1,)
+//│ res: (1 | 2 | 3 | undefined, 2,)

--- a/shared/src/test/diff/mlscript/TupleArray.mls
+++ b/shared/src/test/diff/mlscript/TupleArray.mls
@@ -54,7 +54,7 @@ r = {b = "a", c = 1}
 //│    = [ 1, 2, 3, 'oops' ]
 
 (1,2,3) with { 0 = "oops" }
-//│ res: (1, 2, 3,) & {0: "oops"}
+//│ res: (1, 2, 3,)
 //│    = [ 'oops', 2, 3 ]
 
 // :e TODO
@@ -200,7 +200,7 @@ def myval: A & { x: anything }
 
 
 def tuuu: (1 | 2, true) & {0: 2 | 3}
-//│ tuuu: (1 | 2, true,) & {0: 2 | 3}
+//│ tuuu: (1 | 2, true,)
 //│     = <missing implementation>
 // tuuu: ((1 | 2) & (2 | 3), true,)
 // tuuu: (2, true,)
@@ -281,15 +281,15 @@ k1.2
 //│    = false
 
 (1,2,3) with {1 = "hello"; _a = true; 3 = 4}
-//│ res: (1, 2, 3,) & {1: "hello", 3: 4, _a: true}
+//│ res: (nothing, 2, 3,) & {3: 4, _a: true}
 //│    = [ 1, 'hello', 3, 4, _a: true ]
 
 (1,2,3) with {1 = true; 0 = 233}
-//│ res: (1, 2, 3,) & {0: 233, 1: true}
+//│ res: (nothing, 2, 3,)
 //│    = [ 233, true, 3 ]
 
 (1, 2, true) with {0 = "hello"}
-//│ res: (1, 2, true,) & {0: "hello"}
+//│ res: (1, 2, true,)
 //│    = [ 'hello', 2, true ]
 
 ta1 = (5, 6, true, false, "hahaha")
@@ -299,7 +299,7 @@ ta2.1
 ta2.2
 //│ ta1: (5, 6, true, false, "hahaha",)
 //│    = [ 5, 6, true, false, 'hahaha' ]
-//│ ta2: (5, 6, true, false, "hahaha",) & {0: 0, 7: "bye", x: 123}
+//│ ta2: (5, 6, true, false, "hahaha",) & {7: "bye", x: 123}
 //│    = [ 0, 6, true, false, 'hahaha', <2 empty items>, 'bye', x: 123 ]
 //│ res: 5
 //│    = 5
@@ -350,7 +350,7 @@ a2.0
 
 ht1 = (1,2,false) with {0 = 'a'; 1 = 'hello'; 2 = false}
 ht1.0
-//│ ht1: (1, 2, false,) & {0: "a", 1: "hello", 2: false}
+//│ ht1: (nothing, nothing, false,)
 //│    = [ 'a', 'hello', false ]
 //│ res: nothing
 //│    = 'a'
@@ -373,9 +373,9 @@ def test: (string, 1) & { 0: "hello" }
 def test2: (string, 1) & { 0: "hello"; 2: int }
 //│ ta1: Array[bool | int]
 //│    = <missing implementation>
-//│ test: (string, 1,) & {0: "hello"}
+//│ test: (string, 1,)
 //│     = <missing implementation>
-//│ test2: (string, 1,) & {0: "hello", 2: int}
+//│ test2: (string, 1,) & {2: int}
 //│      = <missing implementation>
 
 test: { 0: 'a }

--- a/shared/src/test/diff/mlscript/TupleArray.mls
+++ b/shared/src/test/diff/mlscript/TupleArray.mls
@@ -114,7 +114,7 @@ arr.0
 //│ ╟── type `Array[int]` does not have field '0'
 //│ ║  l.91: 	def arr: Array[int]
 //│ ║        	         ^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{0: ?0}`
+//│ ╟── but it flows into reference with expected type `{0: ?a}`
 //│ ║  l.110: 	arr.0
 //│ ╙──       	^^^
 //│ res: error
@@ -347,10 +347,10 @@ a2.0
 //│ ╔══[ERROR] Type mismatch in field selection:
 //│ ║  l.346: 	a2.0
 //│ ║         	^^^^
-//│ ╟── type `Array['a]` does not match type `{0: ?0} | ~{1: true, x: "haha"}`
+//│ ╟── type `Array['a]` does not match type `{0: ?a} | ~{1: true, x: "haha"}`
 //│ ║  l.323: 	def rep5: 'a -> Array['a]
 //│ ║         	                ^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{0: ?0} | ~{1: true, x: "haha"}`
+//│ ╟── but it flows into reference with expected type `{0: ?a} | ~{1: true, x: "haha"}`
 //│ ║  l.346: 	a2.0
 //│ ╙──       	^^
 //│ res: error
@@ -371,7 +371,7 @@ def hg1 t = (t.0, t.1)
 hg1 ht1
 hg1 ((5,5,5))
 (hg1 ht1).1
-//│ hg1: {0: '0, 1: '1} -> ('0, '1,)
+//│ hg1: {0: 'a, 1: 'b} -> ('a, 'b,)
 //│    = [Function: hg1]
 //│ res: ("a", "hello",)
 //│    = [ 'a', 'hello' ]
@@ -433,5 +433,5 @@ def pf t = (t[1], t.0)
 pf((1,2,3))
 //│ p1: Array[bool | int | string] | T
 //│ p2: Array[bool | int | string] | T
-//│ pf: (Array['a & ~undefined] & {0: '0}) -> (undefined | 'a, '0,)
+//│ pf: (Array['a & ~undefined] & {0: 'b}) -> (undefined | 'a, 'b,)
 //│ res: (1 | 2 | 3 | undefined, 1,)

--- a/shared/src/test/diff/mlscript/TupleArray.mls
+++ b/shared/src/test/diff/mlscript/TupleArray.mls
@@ -293,18 +293,18 @@ k1.2
 //│    = [ 'hello', 2, true ]
 
 ta1 = (5, 6, true, false, "hahaha")
-ta2 = ta1 with {x = 123; 7 = "bye"; 1 = 0}
+ta2 = ta1 with {x = 123; 7 = "bye"; 0 = 0}
 ta1.0
 ta2.1
 ta2.2
 //│ ta1: (5, 6, true, false, "hahaha",)
 //│    = [ 5, 6, true, false, 'hahaha' ]
-//│ ta2: (5, 6, true, false, "hahaha",) & {1: 0, 7: "bye", x: 123}
-//│    = [ 5, 0, true, false, 'hahaha', <2 empty items>, 'bye', x: 123 ]
+//│ ta2: (5, 6, true, false, "hahaha",) & {0: 0, 7: "bye", x: 123}
+//│    = [ 0, 6, true, false, 'hahaha', <2 empty items>, 'bye', x: 123 ]
 //│ res: 5
 //│    = 5
-//│ res: nothing
-//│    = 0
+//│ res: 6
+//│    = 6
 //│ res: true
 //│    = true
 

--- a/shared/src/test/diff/mlscript/TupleArray.mls
+++ b/shared/src/test/diff/mlscript/TupleArray.mls
@@ -49,26 +49,26 @@ r = {b = "a", c = 1}
 //│ ╙──      	       ^^^^^^^^^^^^^^^^^^^
 //│  = { b: 'a', c: 1 }
 
-(1,2,3) with { 4 = "oops" }
-//│ res: (1, 2, 3,) & {4: "oops"}
-//│    = [ 1, 2, 3, <1 empty item>, 'oops' ]
+(1,2,3) with { 3 = "oops" }
+//│ res: (1, 2, 3,) & {3: "oops"}
+//│    = [ 1, 2, 3, 'oops' ]
 
-(1,2,3) with { 1 = "oops" }
-//│ res: (1, 2, 3,) & {1: "oops"}
-//│    = [ 1, 'oops', 3 ]
+(1,2,3) with { 0 = "oops" }
+//│ res: (1, 2, 3,) & {0: "oops"}
+//│    = [ 'oops', 2, 3 ]
 
 // :e TODO
 (res: (int,int,int,)).1
 //│ res: int
-//│    = 'oops'
+//│    = 2
 
 
-def r: int \ 1
-//│ r: int\1
+def r: int \ 0
+//│ r: int\0
 //│  = <missing implementation>
 
-def r: (1,2,3) \ 1
-//│ r: in (1, 2, 3,)\1 out (1, 2, 3,)
+def r: (1,2,3) \ 0
+//│ r: in (1, 2, 3,)\0 out (1, 2, 3,)
 //│  = <missing implementation>
 // (1,2,3).toRecord \ 1
 
@@ -95,18 +95,18 @@ fr : Array[int] & {b: int}
 //│      fr and r are not implemented
 
 :e
-arr.1
+arr.0
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.98: 	arr.1
+//│ ║  l.98: 	arr.0
 //│ ║        	^^^^^
-//│ ╟── type `Array[int]` does not have field '1'
+//│ ╟── type `Array[int]` does not have field '0'
 //│ ║  l.79: 	def arr: Array[int]
 //│ ║        	         ^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{1: ?1}`
-//│ ║  l.98: 	arr.1
+//│ ╟── but it flows into reference with expected type `{0: ?0}`
+//│ ║  l.98: 	arr.0
 //│ ╙──      	^^^
 //│ res: error
-//│    = 2
+//│    = 1
 
 rr = arr with { x = 1 }
 //│ rr: Array[int] & {x: 1}
@@ -126,13 +126,13 @@ t = (1, 2, 3) with {x = 1}
 //│ t: (1, 2, 3,) & {x: 1}
 //│  = [ 1, 2, 3, x: 1 ]
 
+t.0
 t.1
-t.2
 t.x
+//│ res: 1
+//│    = 1
 //│ res: 2
 //│    = 2
-//│ res: 3
-//│    = 3
 //│ res: 1
 //│    = 1
 
@@ -199,8 +199,8 @@ def myval: A & { x: anything }
 // //│ myval: A with {x: string}
 
 
-def tuuu: (1 | 2, true) & {1: 2 | 3}
-//│ tuuu: (1 | 2, true,) & {1: 2 | 3}
+def tuuu: (1 | 2, true) & {0: 2 | 3}
+//│ tuuu: (1 | 2, true,) & {0: 2 | 3}
 //│     = <missing implementation>
 // tuuu: ((1 | 2) & (2 | 3), true,)
 // tuuu: (2, true,)
@@ -270,19 +270,19 @@ res: { x: int }
 //│ res: (1, 2, (true, false, ("hello", "world", "bye",),),)
 //│    = [ 1, 2, [ true, false, [ 'hello', 'world', 'bye' ] ] ]
 
-k1 = (6, "hi", false) with {5=5; 6=true}
+k1 = (6, "hi", false) with {4=5; 5=true}
 k1.0
 k1.2
-//│ k1: (6, "hi", false,) & {5: 5, 6: true}
-//│   = [ 6, 'hi', false, <2 empty items>, 5, true ]
+//│ k1: (6, "hi", false,) & {4: 5, 5: true}
+//│   = [ 6, 'hi', false, <1 empty item>, 5, true ]
 //│ res: 6
 //│    = 6
 //│ res: false
 //│    = false
 
-(1,2,3) with {2 = "hello"; _a = true; 4 = 4}
-//│ res: (1, 2, 3,) & {2: "hello", 4: 4, _a: true}
-//│    = [ 1, 2, 'hello', <1 empty item>, 4, _a: true ]
+(1,2,3) with {1 = "hello"; _a = true; 3 = 4}
+//│ res: (1, 2, 3,) & {1: "hello", 3: 4, _a: true}
+//│    = [ 1, 'hello', 3, 4, _a: true ]
 
 (1,2,3) with {1 = true; 0 = 233}
 //│ res: (1, 2, 3,) & {0: 233, 1: true}
@@ -294,19 +294,19 @@ k1.2
 
 ta1 = (5, 6, true, false, "hahaha")
 ta2 = ta1 with {x = 123; 7 = "bye"; 1 = 0}
-ta1.1
+ta1.0
+ta2.1
 ta2.2
-ta2.3
 //│ ta1: (5, 6, true, false, "hahaha",)
 //│    = [ 5, 6, true, false, 'hahaha' ]
 //│ ta2: (5, 6, true, false, "hahaha",) & {1: 0, 7: "bye", x: 123}
 //│    = [ 5, 0, true, false, 'hahaha', <2 empty items>, 'bye', x: 123 ]
-//│ res: 6
-//│    = 6
+//│ res: 5
+//│    = 5
+//│ res: nothing
+//│    = 0
 //│ res: true
 //│    = true
-//│ res: false
-//│    = false
 
 def rep5: 'a -> Array['a]
 def rep5 x = (x,x,x,x,x)
@@ -317,29 +317,29 @@ def rep5 x = (x,x,x,x,x)
 //│ 'a -> Array['a]
 //│     = [Function: rep5]
 
-rep5 1 with {1 = 10}
-a2 = rep5 2 with {2 = true; x = "haha"}
-a2.2
+rep5 1 with {0 = 10}
+a2 = rep5 2 with {1 = true; x = "haha"}
+a2.1
 a2.x
-//│ res: Array[1] & {1: 10}
-//│    = [ 1, 10, 1, 1, 1 ]
-//│ a2: Array[2] & {2: true, x: "haha"}
-//│   = [ 2, 2, true, 2, 2, x: 'haha' ]
+//│ res: Array[1] & {0: 10}
+//│    = [ 10, 1, 1, 1, 1 ]
+//│ a2: Array[2] & {1: true, x: "haha"}
+//│   = [ 2, true, 2, 2, 2, x: 'haha' ]
 //│ res: true
 //│    = true
 //│ res: "haha"
 //│    = 'haha'
 
 :e
-a2.1
+a2.0
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.334: 	a2.1
+//│ ║  l.334: 	a2.0
 //│ ║         	^^^^
-//│ ╟── type `Array['a]` does not match type `{1: ?1} | ~{2: true, x: "haha"}`
+//│ ╟── type `Array['a]` does not match type `{0: ?0} | ~{1: true, x: "haha"}`
 //│ ║  l.311: 	def rep5: 'a -> Array['a]
 //│ ║         	                ^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{1: ?1} | ~{2: true, x: "haha"}`
-//│ ║  l.334: 	a2.1
+//│ ╟── but it flows into reference with expected type `{0: ?0} | ~{1: true, x: "haha"}`
+//│ ║  l.334: 	a2.0
 //│ ╙──       	^^
 //│ res: error
 //│    = 2
@@ -348,10 +348,10 @@ a2.1
 //│ res: (1, 2, 3, true,) & {_a: 1, _b1: false}
 //│    = [ 1, 2, 3, true, _a: 1, _b1: false ]
 
-ht1 = (1,2,false) with {1 = 'a'; 2 = 'hello'; 3 = false}
-ht1.1
-//│ ht1: (1, 2, false,) & {1: "a", 2: "hello", 3: false}
-//│    = [ 1, 'a', 'hello', false ]
+ht1 = (1,2,false) with {0 = 'a'; 1 = 'hello'; 2 = false}
+ht1.0
+//│ ht1: (1, 2, false,) & {0: "a", 1: "hello", 2: false}
+//│    = [ 'a', 'hello', false ]
 //│ res: nothing
 //│    = 'a'
 
@@ -361,25 +361,25 @@ hg1 ((5,5,5))
 (hg1 ht1).1
 //│ hg1: {0: '0, 1: '1} -> ('0, '1,)
 //│    = [Function: hg1]
-//│ res: (1, nothing,)
-//│    = [ 1, 'a' ]
+//│ res: (nothing, nothing,)
+//│    = [ 'a', 'hello' ]
 //│ res: (5, 5,)
 //│    = [ 5, 5 ]
 //│ res: nothing
-//│    = 'a'
+//│    = 'hello'
 
 def ta1: Array[int] | (int, bool)
-def test: (string, 1) & { 1: "hello" }
-def test2: (string, 1) & { 1: "hello"; 3: int }
+def test: (string, 1) & { 0: "hello" }
+def test2: (string, 1) & { 0: "hello"; 2: int }
 //│ ta1: Array[bool | int]
 //│    = <missing implementation>
-//│ test: (string, 1,) & {1: "hello"}
+//│ test: (string, 1,) & {0: "hello"}
 //│     = <missing implementation>
-//│ test2: (string, 1,) & {1: "hello", 3: int}
+//│ test2: (string, 1,) & {0: "hello", 2: int}
 //│      = <missing implementation>
 
-test: { 1: 'a }
-//│ res: {1: nothing}
+test: { 0: 'a }
+//│ res: {0: "hello"}
 //│    = <no result>
 //│      test is not implemented
 
@@ -392,8 +392,8 @@ test: ('a, 1)
 //│      test is not implemented
 
 // TODO in principe, we could narrow the refinement to ` & { 1: 1 }` here...
-def test3: Array[1] & { 1: int }
-//│ test3: Array[1] & {1: int}
+def test3: Array[1] & { 0: int }
+//│ test3: Array[1] & {0: int}
 //│      = <missing implementation>
 
 def fta1: Array[int | bool] -> int
@@ -417,9 +417,9 @@ fta1 r1
 :NoJS
 def p1: T | Array[bool] | (int, string) | (true, 3)
 def p2: T | (string, bool) | Array[int] | (2, 4)
-def pf t = (t[1], t.1)
+def pf t = (t[1], t.0)
 pf((1,2,3))
 //│ p1: Array[bool | int | string] | T
 //│ p2: Array[bool | int | string] | T
-//│ pf: (Array['a & ~undefined] & {1: '1}) -> (undefined | 'a, '1,)
-//│ res: (1 | 2 | 3 | undefined, 2,)
+//│ pf: (Array['a & ~undefined] & {0: '0}) -> (undefined | 'a, '0,)
+//│ res: (1 | 2 | 3 | undefined, 1,)

--- a/shared/src/test/diff/mlscript/TupleArray.mls
+++ b/shared/src/test/diff/mlscript/TupleArray.mls
@@ -58,21 +58,21 @@ r = {b = "a", c = 1}
 //│    = [ 'oops', 2, 3 ]
 
 :e
-(res: (int,int,int,)).1
+(res: (int,int,int,)).0
 //│ ╔══[ERROR] Type mismatch in type ascription:
-//│ ║  l.61: 	(res: (int,int,int,)).1
+//│ ║  l.61: 	(res: (int,int,int,)).0
 //│ ║        	 ^^^
 //│ ╟── `with` extension of type `{0: "oops", 1: 2, 2: 3}` is not a 3-element tuple
 //│ ║  l.56: 	(1,2,3) with { 0 = "oops" }
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `(int, int, int,)`
-//│ ║  l.61: 	(res: (int,int,int,)).1
+//│ ║  l.61: 	(res: (int,int,int,)).0
 //│ ║        	 ^^^
 //│ ╟── Note: constraint arises from tuple type:
-//│ ║  l.61: 	(res: (int,int,int,)).1
+//│ ║  l.61: 	(res: (int,int,int,)).0
 //│ ╙──      	      ^^^^^^^^^^^^^^
 //│ res: int
-//│    = 2
+//│    = 'oops'
 
 
 def r: int \ 0

--- a/shared/src/test/diff/mlscript/TupleArray.mls
+++ b/shared/src/test/diff/mlscript/TupleArray.mls
@@ -212,7 +212,7 @@ def myval: A & { x: anything }
 
 
 def tuuu: (1 | 2, true) & {0: 2 | 3}
-//│ tuuu: (1 | 2, true,)
+//│ tuuu: (2, true,)
 //│     = <missing implementation>
 // tuuu: ((1 | 2) & (2 | 3), true,)
 // tuuu: (2, true,)
@@ -385,9 +385,9 @@ def test: (string, 1) & { 0: "hello" }
 def test2: (string, 1) & { 0: "hello"; 2: int }
 //│ ta1: Array[bool | int]
 //│    = <missing implementation>
-//│ test: (string, 1,)
+//│ test: ("hello", 1,)
 //│     = <missing implementation>
-//│ test2: (string, 1,) & {2: int}
+//│ test2: ("hello", 1,) & {2: int}
 //│      = <missing implementation>
 
 test: { 0: 'a }

--- a/shared/src/test/diff/mlscript/TupleArray.mls
+++ b/shared/src/test/diff/mlscript/TupleArray.mls
@@ -54,11 +54,23 @@ r = {b = "a", c = 1}
 //│    = [ 1, 2, 3, 'oops' ]
 
 (1,2,3) with { 0 = "oops" }
-//│ res: (1, 2, 3,)
+//│ res: {0: "oops", 1: 2, 2: 3}
 //│    = [ 'oops', 2, 3 ]
 
-// :e TODO
+:e
 (res: (int,int,int,)).1
+//│ ╔══[ERROR] Type mismatch in type ascription:
+//│ ║  l.61: 	(res: (int,int,int,)).1
+//│ ║        	 ^^^
+//│ ╟── `with` extension of type `{0: "oops", 1: 2, 2: 3}` is not a 3-element tuple
+//│ ║  l.56: 	(1,2,3) with { 0 = "oops" }
+//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── but it flows into reference with expected type `(int, int, int,)`
+//│ ║  l.61: 	(res: (int,int,int,)).1
+//│ ║        	 ^^^
+//│ ╟── Note: constraint arises from tuple type:
+//│ ║  l.61: 	(res: (int,int,int,)).1
+//│ ╙──      	      ^^^^^^^^^^^^^^
 //│ res: int
 //│    = 2
 
@@ -68,7 +80,7 @@ def r: int \ 0
 //│  = <missing implementation>
 
 def r: (1,2,3) \ 0
-//│ r: in (1, 2, 3,)\0 out (1, 2, 3,)
+//│ r: in (1, 2, 3,)\0 out {1: 2, 2: 3}
 //│  = <missing implementation>
 // (1,2,3).toRecord \ 1
 
@@ -97,14 +109,14 @@ fr : Array[int] & {b: int}
 :e
 arr.0
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.98: 	arr.0
-//│ ║        	^^^^^
+//│ ║  l.110: 	arr.0
+//│ ║         	^^^^^
 //│ ╟── type `Array[int]` does not have field '0'
-//│ ║  l.79: 	def arr: Array[int]
+//│ ║  l.91: 	def arr: Array[int]
 //│ ║        	         ^^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `{0: ?0}`
-//│ ║  l.98: 	arr.0
-//│ ╙──      	^^^
+//│ ║  l.110: 	arr.0
+//│ ╙──       	^^^
 //│ res: error
 //│    = 1
 
@@ -158,10 +170,10 @@ def test: {x: 1} & (1, 2, 3)
 :e
 f(1,2,3) : 1 | 2 | 3
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.159: 	f(1,2,3) : 1 | 2 | 3
+//│ ║  l.171: 	f(1,2,3) : 1 | 2 | 3
 //│ ║         	^^^^^^^^
 //│ ╟── argument list of type `(1, 2, 3,)` does not match type `(?a,)`
-//│ ║  l.159: 	f(1,2,3) : 1 | 2 | 3
+//│ ║  l.171: 	f(1,2,3) : 1 | 2 | 3
 //│ ╙──       	 ^^^^^^^
 //│ res: 1 | 2 | 3
 //│    = [Number: 1] { b: 2 }
@@ -169,19 +181,19 @@ f(1,2,3) : 1 | 2 | 3
 :e
 (arr[0])[1][2]
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.170: 	(arr[0])[1][2]
+//│ ║  l.182: 	(arr[0])[1][2]
 //│ ║         	^^^^^^^^^^^
 //│ ╟── type `int` does not match type `Array[?a]`
-//│ ║  l.79: 	def arr: Array[int]
+//│ ║  l.91: 	def arr: Array[int]
 //│ ║        	               ^^^
 //│ ╟── but it flows into array access with expected type `Array[?b]`
-//│ ║  l.170: 	(arr[0])[1][2]
+//│ ║  l.182: 	(arr[0])[1][2]
 //│ ╙──       	 ^^^^^^
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.170: 	(arr[0])[1][2]
+//│ ║  l.182: 	(arr[0])[1][2]
 //│ ║         	^^^^^^^^^^^^^^
 //│ ╟── possibly-undefined array access of type `undefined` does not match type `Array[?a]`
-//│ ║  l.170: 	(arr[0])[1][2]
+//│ ║  l.182: 	(arr[0])[1][2]
 //│ ╙──       	^^^^^^^^^^^
 //│ res: error | undefined
 //│ Runtime error:
@@ -281,15 +293,15 @@ k1.2
 //│    = false
 
 (1,2,3) with {1 = "hello"; _a = true; 3 = 4}
-//│ res: (nothing, 2, 3,) & {3: 4, _a: true}
+//│ res: {0: 1, 1: "hello", 2: 3, 3: 4, _a: true}
 //│    = [ 1, 'hello', 3, 4, _a: true ]
 
 (1,2,3) with {1 = true; 0 = 233}
-//│ res: (nothing, 2, 3,)
+//│ res: {0: 233, 1: true, 2: 3}
 //│    = [ 233, true, 3 ]
 
 (1, 2, true) with {0 = "hello"}
-//│ res: (1, 2, true,)
+//│ res: {0: "hello", 1: 2, 2: true}
 //│    = [ 'hello', 2, true ]
 
 ta1 = (5, 6, true, false, "hahaha")
@@ -299,7 +311,7 @@ ta2.1
 ta2.2
 //│ ta1: (5, 6, true, false, "hahaha",)
 //│    = [ 5, 6, true, false, 'hahaha' ]
-//│ ta2: (5, 6, true, false, "hahaha",) & {7: "bye", x: 123}
+//│ ta2: {0: 0, 1: 6, 2: true, 3: false, 4: "hahaha", 7: "bye", x: 123}
 //│    = [ 0, 6, true, false, 'hahaha', <2 empty items>, 'bye', x: 123 ]
 //│ res: 5
 //│    = 5
@@ -333,13 +345,13 @@ a2.x
 :e
 a2.0
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.334: 	a2.0
+//│ ║  l.346: 	a2.0
 //│ ║         	^^^^
 //│ ╟── type `Array['a]` does not match type `{0: ?0} | ~{1: true, x: "haha"}`
-//│ ║  l.311: 	def rep5: 'a -> Array['a]
+//│ ║  l.323: 	def rep5: 'a -> Array['a]
 //│ ║         	                ^^^^^^^^^
 //│ ╟── but it flows into reference with expected type `{0: ?0} | ~{1: true, x: "haha"}`
-//│ ║  l.334: 	a2.0
+//│ ║  l.346: 	a2.0
 //│ ╙──       	^^
 //│ res: error
 //│    = 2
@@ -350,9 +362,9 @@ a2.0
 
 ht1 = (1,2,false) with {0 = 'a'; 1 = 'hello'; 2 = false}
 ht1.0
-//│ ht1: (nothing, nothing, false,)
+//│ ht1: {0: "a", 1: "hello", 2: false}
 //│    = [ 'a', 'hello', false ]
-//│ res: nothing
+//│ res: "a"
 //│    = 'a'
 
 def hg1 t = (t.0, t.1)
@@ -361,11 +373,11 @@ hg1 ((5,5,5))
 (hg1 ht1).1
 //│ hg1: {0: '0, 1: '1} -> ('0, '1,)
 //│    = [Function: hg1]
-//│ res: (nothing, nothing,)
+//│ res: ("a", "hello",)
 //│    = [ 'a', 'hello' ]
 //│ res: (5, 5,)
 //│    = [ 5, 5 ]
-//│ res: nothing
+//│ res: "hello"
 //│    = 'hello'
 
 def ta1: Array[int] | (int, bool)

--- a/shared/src/test/diff/mlscript/TupleArray2.mls
+++ b/shared/src/test/diff/mlscript/TupleArray2.mls
@@ -155,14 +155,14 @@ f_2 = f_1
 
 
 def test: (string, 1) & { 0: "hello" }
-//│ test: (string, 1,)
+//│ test: ("hello", 1,)
 //│     = <missing implementation>
 
 :e
 test = ("hi", 1)
 //│ ("hi", 1,)
 //│   <:  test:
-//│ (string, 1,)
+//│ ("hello", 1,)
 //│ ╔══[ERROR] Type mismatch in def definition:
 //│ ║  l.162: 	test = ("hi", 1)
 //│ ║         	^^^^^^^^^^^^^^^^
@@ -177,7 +177,7 @@ test = ("hi", 1)
 test = ("hello", 1)
 //│ ("hello", 1,)
 //│   <:  test:
-//│ (string, 1,)
+//│ ("hello", 1,)
 //│     = [ 'hello', 1 ]
 
 (fun ((a, b)) -> a) test

--- a/shared/src/test/diff/mlscript/TupleArray2.mls
+++ b/shared/src/test/diff/mlscript/TupleArray2.mls
@@ -155,14 +155,14 @@ f_2 = f_1
 
 
 def test: (string, 1) & { 0: "hello" }
-//│ test: (string, 1,) & {0: "hello"}
+//│ test: (string, 1,)
 //│     = <missing implementation>
 
 :e
 test = ("hi", 1)
 //│ ("hi", 1,)
 //│   <:  test:
-//│ (string, 1,) & {0: "hello"}
+//│ (string, 1,)
 //│ ╔══[ERROR] Type mismatch in def definition:
 //│ ║  l.162: 	test = ("hi", 1)
 //│ ║         	^^^^^^^^^^^^^^^^
@@ -177,7 +177,7 @@ test = ("hi", 1)
 test = ("hello", 1)
 //│ ("hello", 1,)
 //│   <:  test:
-//│ (string, 1,) & {0: "hello"}
+//│ (string, 1,)
 //│     = [ 'hello', 1 ]
 
 (fun ((a, b)) -> a) test

--- a/shared/src/test/diff/mlscript/TupleArray2.mls
+++ b/shared/src/test/diff/mlscript/TupleArray2.mls
@@ -184,8 +184,8 @@ test = ("hello", 1)
 //│ res: string
 //│    = 'hello'
 
-test: { 1: 'a }
-//│ res: {1: 1}
+test: { 0: 'a }
+//│ res: {0: "hello"}
 //│    = [ 'hello', 1 ]
 
 test: ('a, 1)
@@ -200,7 +200,7 @@ class A: (1,2)
 
 
 :re
-error: Array[1] & { _1: int }
-//│ res: Array[1] & {_1: int}
+error: Array[1] & { 0: int }
+//│ res: Array[1] & {0: int}
 //│ Runtime error:
 //│   Error: an error was thrown

--- a/shared/src/test/diff/mlscript/TupleArray2.mls
+++ b/shared/src/test/diff/mlscript/TupleArray2.mls
@@ -154,15 +154,15 @@ f_2 = f_1
 
 
 
-def test: (string, 1) & { _1: "hello" }
-//│ test: ("hello", 1,)
+def test: (string, 1) & { 0: "hello" }
+//│ test: (string, 1,) & {0: "hello"}
 //│     = <missing implementation>
 
 :e
 test = ("hi", 1)
 //│ ("hi", 1,)
 //│   <:  test:
-//│ ("hello", 1,)
+//│ (string, 1,) & {0: "hello"}
 //│ ╔══[ERROR] Type mismatch in def definition:
 //│ ║  l.162: 	test = ("hi", 1)
 //│ ║         	^^^^^^^^^^^^^^^^
@@ -170,22 +170,22 @@ test = ("hi", 1)
 //│ ║  l.162: 	test = ("hi", 1)
 //│ ║         	        ^^^^
 //│ ╟── Note: constraint arises from literal type:
-//│ ║  l.157: 	def test: (string, 1) & { _1: "hello" }
-//│ ╙──       	                              ^^^^^^^
+//│ ║  l.157: 	def test: (string, 1) & { 0: "hello" }
+//│ ╙──       	                             ^^^^^^^
 //│     = [ 'hi', 1 ]
 
 test = ("hello", 1)
 //│ ("hello", 1,)
 //│   <:  test:
-//│ ("hello", 1,)
+//│ (string, 1,) & {0: "hello"}
 //│     = [ 'hello', 1 ]
 
 (fun ((a, b)) -> a) test
 //│ res: string
 //│    = 'hello'
 
-test: { _1: 'a }
-//│ res: {_1: "hello"}
+test: { 1: 'a }
+//│ res: {1: 1}
 //│    = [ 'hello', 1 ]
 
 test: ('a, 1)

--- a/shared/src/test/diff/mlscript/Yicong.mls
+++ b/shared/src/test/diff/mlscript/Yicong.mls
@@ -212,11 +212,11 @@ def h f = (f ((1,2,false)), f ((1,true)))
 //│  = [Function: h1]
 
 h (fun x -> x[0])
-h (fun x -> x.1)
+h (fun x -> x.0)
 //│ res: (1 | 2 | false | undefined, 1 | true | undefined,)
 //│    = [ 1, 1 ]
-//│ res: (2, true,)
-//│    = [ 2, true ]
+//│ res: (1, 1,)
+//│    = [ 1, 1 ]
 
 
 q1 = (1,1,1,1)
@@ -332,7 +332,7 @@ tk (two.snd)
 :e
 def a1: Array[int]
 a1 = (1,2,true,'hello')
-a1.2
+a1.1
 //│ a1: Array[int]
 //│   = <missing implementation>
 //│ (1, 2, true, "hello",)
@@ -349,16 +349,16 @@ a1.2
 //│ ╙──       	              ^^^
 //│   = [ 1, 2, true, 'hello' ]
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.335: 	a1.2
+//│ ║  l.335: 	a1.1
 //│ ║         	^^^^
-//│ ╟── type `Array[int]` does not have field '2'
+//│ ╟── type `Array[int]` does not have field '1'
 //│ ║  l.333: 	def a1: Array[int]
 //│ ║         	        ^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{2: ?2}`
-//│ ║  l.335: 	a1.2
+//│ ╟── but it flows into reference with expected type `{1: ?1}`
+//│ ║  l.335: 	a1.1
 //│ ╙──       	^^
 //│ res: error
-//│    = true
+//│    = 2
 
 def getx p = p.x
 def a123: Array[int]

--- a/shared/src/test/diff/mlscript/Yicong.mls
+++ b/shared/src/test/diff/mlscript/Yicong.mls
@@ -22,11 +22,11 @@ r = if true then T1 ((1,2,3)) else T2 ((3,4,5,4))
 //│  = [ 1, 2, 3 ]
 
 case r of { T1 -> r | _ -> 0 }
-//│ res: 0 | #T1 & ((nothing, nothing, 3,) | (nothing, nothing, nothing, 4,) & #T2)
+//│ res: 0 | #T1 & ((1, 2, 3,) | (3, 4, 5, 4,) & #T2)
 //│    = [ 1, 2, 3 ]
 
 case r of { T1 -> r | T2 -> r }
-//│ res: (nothing, nothing, 3,) & #T1 | 'a | #T2 & ((nothing, nothing, nothing, 4,) & #T1 | (nothing, nothing, nothing, 4,) & ~#T1 | (nothing, nothing, nothing, 4,) & ~#T2 | (nothing, nothing, nothing, 4,) & ~'a)
+//│ res: (1, 2, 3,) & #T1 | 'a | #T2 & ((3, 4, 5, 4,) & #T1 | (3, 4, 5, 4,) & ~#T1 | (3, 4, 5, 4,) & ~#T2 | (3, 4, 5, 4,) & ~'a)
 //│    = [ 1, 2, 3 ]
 
 
@@ -532,10 +532,10 @@ snd (T1 ((1,2,3)))
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.516: 	snd (T1 ((1,2,3)))
 //│ ║         	^^^^^^^^^^^^^^^^^^
-//│ ╟── tuple literal of type `(1, 2, 3,)` does not match type `(?a & ?b, ?b,) | ~#T1`
+//│ ╟── tuple literal of type `(1, 2, 3,)` does not match type `(?a, ?b,) | ~#T1`
 //│ ║  l.516: 	snd (T1 ((1,2,3)))
 //│ ║         	         ^^^^^^^
-//│ ╟── but it flows into application with expected type `(?a & ?b, ?b,) | ~#T1`
+//│ ╟── but it flows into application with expected type `(?a, ?b,) | ~#T1`
 //│ ║  l.516: 	snd (T1 ((1,2,3)))
 //│ ║         	     ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from tuple literal:

--- a/shared/src/test/diff/mlscript/Yicong.mls
+++ b/shared/src/test/diff/mlscript/Yicong.mls
@@ -678,32 +678,32 @@ ra: (Array['a], Array['a], Array['a]) as 'a
 //│    = <no result>
 //│      ra is not implemented
 
-def tktup t = (t.2, t.3)
+def tktup t = (t.1, t.2)
 tktup ((1,2,3,true))
-//│ tktup: {2: '2, 3: '3} -> ('2, '3,)
+//│ tktup: {1: '1, 2: '2} -> ('1, '2,)
 //│      = [Function: tktup]
-//│ res: (3, true,)
-//│    = [ 3, true ]
+//│ res: (2, 3,)
+//│    = [ 2, 3 ]
 
 :e
 tktup a123
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.689: 	tktup a123
 //│ ║         	^^^^^^^^^^
-//│ ╟── type `Array[int]` does not have field '3'
+//│ ╟── type `Array[int]` does not have field '2'
 //│ ║  l.364: 	def a123: Array[int]
 //│ ║         	          ^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{3: ?3}`
+//│ ╟── but it flows into reference with expected type `{2: ?2}`
 //│ ║  l.689: 	tktup a123
 //│ ║         	      ^^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.681: 	def tktup t = (t.2, t.3)
+//│ ║  l.681: 	def tktup t = (t.1, t.2)
 //│ ║         	                    ^^^
 //│ ╟── from reference:
-//│ ║  l.681: 	def tktup t = (t.2, t.3)
+//│ ║  l.681: 	def tktup t = (t.1, t.2)
 //│ ╙──       	                    ^
 //│ res: error | (nothing, nothing,)
-//│    = [ 3, undefined ]
+//│    = [ 2, 3 ]
 
 
 def definedOr x els = case x of {
@@ -861,12 +861,12 @@ mk1[2  ]
 //│    = undefined
 
 def s1 a = (defined a[1] + defined a[2], a[(1,2).1])
-def s2 a = (defined (defined a[1])[0]).2 + (defined a[2]).0
+def s2 a = (defined (defined a[1])[0]).1 + (defined a[2]).0
 def s3 a = defined a.0.t[0] + defined (defined a.x[1])[2]
 (defined ((1, "hello"),(2, true, false),(3,3,4))[0]).0
 //│ s1: Array[int & 'a] -> (int, undefined | 'a,)
 //│   = [Function: s1]
-//│ s2: Array[Array[{2: int} & ~undefined] & {0: int}] -> int
+//│ s2: Array[Array[{1: int} & ~undefined] & {0: int}] -> int
 //│   = [Function: s2]
 //│ s3: {0: {t: Array[int]}, x: Array[Array[int]]} -> int
 //│   = [Function: s3]
@@ -877,7 +877,7 @@ def ara: Array[(int, bool)]
 def arb: Array[Array[(int, int)]]
 (defined ara[1]).0
 (defined (defined arb[0])[1]).1
-def s4 arr = (defined (defined (defined arr.x[0]).3[6])[7])._h.hello
+def s4 arr = (defined (defined (defined arr.x[0]).2[6])[7])._h.hello
 //│ ara: Array[(int, bool,)]
 //│    = <missing implementation>
 //│ arb: Array[Array[(int, int,)]]
@@ -888,7 +888,7 @@ def s4 arr = (defined (defined (defined arr.x[0]).3[6])[7])._h.hello
 //│ res: int
 //│    = <no result>
 //│      arb is not implemented
-//│ s4: {x: Array[{3: Array[Array[{_h: {hello: 'hello}} & ~undefined]]} & ~undefined]} -> 'hello
+//│ s4: {x: Array[{2: Array[Array[{_h: {hello: 'hello}} & ~undefined]]} & ~undefined]} -> 'hello
 //│   = [Function: s4]
 
 def at1 xs = (defined xs[0]).0
@@ -903,15 +903,15 @@ dup (defined ara[1]).0 (defined (defined arb[10])[8]).1 + 1
 //│      ara is not implemented
 
 :e
-(1,2,3).1[1]
+(1,2,3).0[1]
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.906: 	(1,2,3).1[1]
+//│ ║  l.906: 	(1,2,3).0[1]
 //│ ║         	^^^^^^^^^^^^
-//│ ╟── integer literal of type `2` does not match type `Array[?a]`
-//│ ║  l.906: 	(1,2,3).1[1]
-//│ ║         	   ^
+//│ ╟── integer literal of type `1` does not match type `Array[?a]`
+//│ ║  l.906: 	(1,2,3).0[1]
+//│ ║         	 ^
 //│ ╟── but it flows into field selection with expected type `Array[?b]`
-//│ ║  l.906: 	(1,2,3).1[1]
+//│ ║  l.906: 	(1,2,3).0[1]
 //│ ╙──       	^^^^^^^^^
 //│ res: error | undefined
 //│    = undefined

--- a/shared/src/test/diff/mlscript/Yicong.mls
+++ b/shared/src/test/diff/mlscript/Yicong.mls
@@ -22,11 +22,11 @@ r = if true then T1 ((1,2,3)) else T2 ((3,4,5,4))
 //│  = [ 1, 2, 3 ]
 
 case r of { T1 -> r | _ -> 0 }
-//│ res: 0 | #T1 & ((1, 2, 3,) | (3, 4, 5, 4,) & #T2)
+//│ res: 0 | #T1 & ((1, 2, 3,) & {0: 1, 1: 2, 2: 3} | (3, 4, 5, 4,) & {0: 3, 1: 4, 2: 5, 3: 4} & #T2)
 //│    = [ 1, 2, 3 ]
 
 case r of { T1 -> r | T2 -> r }
-//│ res: (1, 2, 3,) & #T1 | 'a | #T2 & ((3, 4, 5, 4,) & #T1 | (3, 4, 5, 4,) & ~#T1 | (3, 4, 5, 4,) & ~#T2 | (3, 4, 5, 4,) & ~'a)
+//│ res: (1, 2, 3,) & {0: 1, 1: 2, 2: 3} & #T1 | 'a | #T2 & ((3, 4, 5, 4,) & {0: 3, 1: 4, 2: 5, 3: 4} & #T1 | (3, 4, 5, 4,) & {0: 3, 1: 4, 2: 5, 3: 4} & ~#T1 | (3, 4, 5, 4,) & {0: 3, 1: 4, 2: 5, 3: 4} & ~#T2 | (3, 4, 5, 4,) & {0: 3, 1: 4, 2: 5, 3: 4} & ~'a)
 //│    = [ 1, 2, 3 ]
 
 
@@ -141,18 +141,18 @@ t = if false then res else hhh
 g = if true then (6,6,6) else res
 gwx = g with {x=123}
 gwx.x with {y = gwx}
-//│ res: Array["hello" | 1 | 2 | 3 | 4 | false | true] & {_1: 1 | true, _2: 2 | 4, _3: 3 | false}
+//│ res: Array["hello" | 1 | 2 | 3 | 4 | false | true] & {0: 1 | true, 1: 2 | 4, 2: 3 | false}
 //│    = [ 1, 2, 3, 'hello' ]
-//│ hhh: Array["bye" | 345 | 3 | 45 | false | true] & {_1: 45 | false, _2: 345 | 3}
+//│ hhh: Array["bye" | 345 | 3 | 45 | false | true] & {0: 45 | false, 1: 345 | 3}
 //│    = [ false, 3 ]
-//│ t: Array["bye" | "hello" | 1 | 2 | 345 | 3 | 45 | 4 | false | true] & {_1: 1 | 45 | false | true, _2: 2 | 345 | 3 | 4}
+//│ t: Array["bye" | "hello" | 1 | 2 | 345 | 3 | 45 | 4 | false | true] & {0: 1 | 45 | false | true, 1: 2 | 345 | 3 | 4}
 //│  = [ false, 3 ]
-//│ g: Array["hello" | 1 | 2 | 3 | 4 | 6 | false | true] & {_1: 1 | 6 | true, _2: 2 | 4 | 6, _3: 3 | 6 | false}
+//│ g: Array["hello" | 1 | 2 | 3 | 4 | 6 | false | true] & {0: 1 | 6 | true, 1: 2 | 4 | 6, 2: 3 | 6 | false}
 //│  = [ 6, 6, 6 ]
-//│ gwx: Array["hello" | 1 | 2 | 3 | 4 | 6 | false | true] & {_1: 1 | 6 | true, _2: 2 | 4 | 6, _3: 3 | 6 | false, x: 123}
+//│ gwx: Array["hello" | 1 | 2 | 3 | 4 | 6 | false | true] & {0: 1 | 6 | true, 1: 2 | 4 | 6, 2: 3 | 6 | false, x: 123}
 //│    = [ 6, 6, 6, x: 123 ]
 //│ res: 123 & {
-//│   y: Array["hello" | 1 | 2 | 3 | 4 | 6 | false | true] & {_1: 1 | 6 | true, _2: 2 | 4 | 6, _3: 3 | 6 | false, x: 123}
+//│   y: Array["hello" | 1 | 2 | 3 | 4 | 6 | false | true] & {0: 1 | 6 | true, 1: 2 | 4 | 6, 2: 3 | 6 | false, x: 123}
 //│ }
 //│    = [Number: 123] { y: [ 6, 6, 6, x: 123 ] }
 
@@ -165,14 +165,14 @@ def g: (bool, string, int) -> int
 //│  = <missing implementation>
 
 p1 = if true then (1, 2, 2) else (true, false)
-//│ p1: Array[1 | 2 | false | true] & {_1: 1 | true, _2: 2 | false}
+//│ p1: Array[1 | 2 | false | true] & {0: 1 | true, 1: 2 | false}
 //│   = [ 1, 2, 2 ]
 
 def q: Array[int]
 q = if true then (1,1) else (1,1,1)
 //│ q: Array[int]
 //│  = <missing implementation>
-//│ Array[1] & {_1: 1, _2: 1}
+//│ Array[1] & {0: 1, 1: 1}
 //│   <:  q:
 //│ Array[int]
 //│  = [ 1, 1 ]
@@ -212,11 +212,11 @@ def h f = (f ((1,2,false)), f ((1,true)))
 //│  = [Function: h1]
 
 h (fun x -> x[0])
-h (fun x -> x._1)
+h (fun x -> x.1)
 //│ res: (1 | 2 | false | undefined, 1 | true | undefined,)
 //│    = [ 1, 1 ]
-//│ res: (1, 1,)
-//│    = [ undefined, undefined ]
+//│ res: (2, true,)
+//│    = [ 2, true ]
 
 
 q1 = (1,1,1,1)
@@ -332,7 +332,7 @@ tk (two.snd)
 :e
 def a1: Array[int]
 a1 = (1,2,true,'hello')
-a1._2
+a1.2
 //│ a1: Array[int]
 //│   = <missing implementation>
 //│ (1, 2, true, "hello",)
@@ -349,16 +349,16 @@ a1._2
 //│ ╙──       	              ^^^
 //│   = [ 1, 2, true, 'hello' ]
 //│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.335: 	a1._2
-//│ ║         	^^^^^
-//│ ╟── type `Array[int]` does not have field '_2'
+//│ ║  l.335: 	a1.2
+//│ ║         	^^^^
+//│ ╟── type `Array[int]` does not have field '2'
 //│ ║  l.333: 	def a1: Array[int]
 //│ ║         	        ^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{_2: ?a}`
-//│ ║  l.335: 	a1._2
+//│ ╟── but it flows into reference with expected type `{2: ?2}`
+//│ ║  l.335: 	a1.2
 //│ ╙──       	^^
 //│ res: error
-//│    = undefined
+//│    = true
 
 def getx p = p.x
 def a123: Array[int]
@@ -532,10 +532,10 @@ snd (T1 ((1,2,3)))
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.516: 	snd (T1 ((1,2,3)))
 //│ ║         	^^^^^^^^^^^^^^^^^^
-//│ ╟── tuple literal of type `(1, 2, 3,)` does not match type `(?a, ?b,) | ~#T1`
+//│ ╟── tuple literal of type `(1, 2, 3,)` does not match type `(?a, ?b,) & {0: ?a, 1: ?b} | ~#T1`
 //│ ║  l.516: 	snd (T1 ((1,2,3)))
 //│ ║         	         ^^^^^^^
-//│ ╟── but it flows into application with expected type `(?a, ?b,) | ~#T1`
+//│ ╟── but it flows into application with expected type `(?a, ?b,) & {0: ?a, 1: ?b} | ~#T1`
 //│ ║  l.516: 	snd (T1 ((1,2,3)))
 //│ ║         	     ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from tuple literal:
@@ -678,32 +678,32 @@ ra: (Array['a], Array['a], Array['a]) as 'a
 //│    = <no result>
 //│      ra is not implemented
 
-def tktup t = (t._2, t._3)
+def tktup t = (t.2, t.3)
 tktup ((1,2,3,true))
-//│ tktup: {_2: 'a, _3: 'b} -> ('a, 'b,)
+//│ tktup: {2: '2, 3: '3} -> ('2, '3,)
 //│      = [Function: tktup]
-//│ res: (2, 3,)
-//│    = [ undefined, undefined ]
+//│ res: (3, true,)
+//│    = [ 3, true ]
 
 :e
 tktup a123
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.689: 	tktup a123
 //│ ║         	^^^^^^^^^^
-//│ ╟── type `Array[int]` does not have field '_3'
+//│ ╟── type `Array[int]` does not have field '3'
 //│ ║  l.364: 	def a123: Array[int]
 //│ ║         	          ^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{_3: ?a}`
+//│ ╟── but it flows into reference with expected type `{3: ?3}`
 //│ ║  l.689: 	tktup a123
 //│ ║         	      ^^^^
 //│ ╟── Note: constraint arises from field selection:
-//│ ║  l.681: 	def tktup t = (t._2, t._3)
-//│ ║         	                     ^^^^
+//│ ║  l.681: 	def tktup t = (t.2, t.3)
+//│ ║         	                    ^^^
 //│ ╟── from reference:
-//│ ║  l.681: 	def tktup t = (t._2, t._3)
-//│ ╙──       	                     ^
+//│ ║  l.681: 	def tktup t = (t.2, t.3)
+//│ ╙──       	                    ^
 //│ res: error | (nothing, nothing,)
-//│    = [ undefined, undefined ]
+//│    = [ 3, undefined ]
 
 
 def definedOr x els = case x of {
@@ -860,24 +860,24 @@ mk1[2  ]
 //│ res: error | undefined
 //│    = undefined
 
-def s1 a = (defined a[1] + defined a[2], a[(1,2)._2])
-def s2 a = (defined (defined a[1])[0])._2 + (defined a[2])._1
-def s3 a = defined a._1.t[0] + defined (defined a.x[1])[2]
-(defined ((1, "hello"),(2, true, false),(3,3,4))[0])._1
+def s1 a = (defined a[1] + defined a[2], a[(1,2).1])
+def s2 a = (defined (defined a[1])[0]).2 + (defined a[2]).0
+def s3 a = defined a.0.t[0] + defined (defined a.x[1])[2]
+(defined ((1, "hello"),(2, true, false),(3,3,4))[0]).0
 //│ s1: Array[int & 'a] -> (int, undefined | 'a,)
 //│   = [Function: s1]
-//│ s2: Array[Array[{_2: int} & ~undefined] & {_1: int}] -> int
+//│ s2: Array[Array[{2: int} & ~undefined] & {0: int}] -> int
 //│   = [Function: s2]
-//│ s3: {_1: {t: Array[int]}, x: Array[Array[int]]} -> int
+//│ s3: {0: {t: Array[int]}, x: Array[Array[int]]} -> int
 //│   = [Function: s3]
 //│ res: 1 | 2 | 3
-//│    = undefined
+//│    = 1
 
 def ara: Array[(int, bool)]
 def arb: Array[Array[(int, int)]]
-(defined ara[1])._1
-(defined (defined arb[0])[1])._2
-def s4 arr = (defined (defined (defined arr.x[0])._3[6])[7])._h.hello
+(defined ara[1]).0
+(defined (defined arb[0])[1]).1
+def s4 arr = (defined (defined (defined arr.x[0]).3[6])[7])._h.hello
 //│ ara: Array[(int, bool,)]
 //│    = <missing implementation>
 //│ arb: Array[Array[(int, int,)]]
@@ -888,13 +888,13 @@ def s4 arr = (defined (defined (defined arr.x[0])._3[6])[7])._h.hello
 //│ res: int
 //│    = <no result>
 //│      arb is not implemented
-//│ s4: {x: Array[{_3: Array[Array[{_h: {hello: 'hello}} & ~undefined]]} & ~undefined]} -> 'hello
+//│ s4: {x: Array[{3: Array[Array[{_h: {hello: 'hello}} & ~undefined]]} & ~undefined]} -> 'hello
 //│   = [Function: s4]
 
-def at1 xs = (defined xs[0])._1
+def at1 xs = (defined xs[0]).0
 def dup a b = a * 2 + b
-dup (defined ara[1])._1 (defined (defined arb[10])[8])._2 + 1
-//│ at1: Array[{_1: 'a} & ~undefined] -> 'a
+dup (defined ara[1]).0 (defined (defined arb[10])[8]).1 + 1
+//│ at1: Array[{0: '0} & ~undefined] -> '0
 //│    = [Function: at1]
 //│ dup: int -> int -> int
 //│    = [Function: dup]
@@ -903,16 +903,15 @@ dup (defined ara[1])._1 (defined (defined arb[10])[8])._2 + 1
 //│      ara is not implemented
 
 :e
-(1,2,3)._1[1]
+(1,2,3).1[1]
 //│ ╔══[ERROR] Type mismatch in array access:
-//│ ║  l.906: 	(1,2,3)._1[1]
-//│ ║         	^^^^^^^^^^^^^
-//│ ╟── integer literal of type `1` does not match type `Array[?a]`
-//│ ║  l.906: 	(1,2,3)._1[1]
-//│ ║         	 ^
+//│ ║  l.906: 	(1,2,3).1[1]
+//│ ║         	^^^^^^^^^^^^
+//│ ╟── integer literal of type `2` does not match type `Array[?a]`
+//│ ║  l.906: 	(1,2,3).1[1]
+//│ ║         	   ^
 //│ ╟── but it flows into field selection with expected type `Array[?b]`
-//│ ║  l.906: 	(1,2,3)._1[1]
-//│ ╙──       	^^^^^^^^^^
+//│ ║  l.906: 	(1,2,3).1[1]
+//│ ╙──       	^^^^^^^^^
 //│ res: error | undefined
-//│ Runtime error:
-//│   TypeError: Cannot read properties of undefined (reading '1')
+//│    = undefined

--- a/shared/src/test/diff/mlscript/Yicong.mls
+++ b/shared/src/test/diff/mlscript/Yicong.mls
@@ -22,11 +22,11 @@ r = if true then T1 ((1,2,3)) else T2 ((3,4,5,4))
 //│  = [ 1, 2, 3 ]
 
 case r of { T1 -> r | _ -> 0 }
-//│ res: 0 | #T1 & ((1, 2, 3,) & {0: 1, 1: 2, 2: 3} | (3, 4, 5, 4,) & {0: 3, 1: 4, 2: 5, 3: 4} & #T2)
+//│ res: 0 | #T1 & ((nothing, nothing, 3,) | (nothing, nothing, nothing, 4,) & #T2)
 //│    = [ 1, 2, 3 ]
 
 case r of { T1 -> r | T2 -> r }
-//│ res: (1, 2, 3,) & {0: 1, 1: 2, 2: 3} & #T1 | 'a | #T2 & ((3, 4, 5, 4,) & {0: 3, 1: 4, 2: 5, 3: 4} & #T1 | (3, 4, 5, 4,) & {0: 3, 1: 4, 2: 5, 3: 4} & ~#T1 | (3, 4, 5, 4,) & {0: 3, 1: 4, 2: 5, 3: 4} & ~#T2 | (3, 4, 5, 4,) & {0: 3, 1: 4, 2: 5, 3: 4} & ~'a)
+//│ res: (nothing, nothing, 3,) & #T1 | 'a | #T2 & ((nothing, nothing, nothing, 4,) & #T1 | (nothing, nothing, nothing, 4,) & ~#T1 | (nothing, nothing, nothing, 4,) & ~#T2 | (nothing, nothing, nothing, 4,) & ~'a)
 //│    = [ 1, 2, 3 ]
 
 
@@ -532,10 +532,10 @@ snd (T1 ((1,2,3)))
 //│ ╔══[ERROR] Type mismatch in application:
 //│ ║  l.516: 	snd (T1 ((1,2,3)))
 //│ ║         	^^^^^^^^^^^^^^^^^^
-//│ ╟── tuple literal of type `(1, 2, 3,)` does not match type `(?a, ?b,) & {0: ?a, 1: ?b} | ~#T1`
+//│ ╟── tuple literal of type `(1, 2, 3,)` does not match type `(?a & ?b, ?b,) | ~#T1`
 //│ ║  l.516: 	snd (T1 ((1,2,3)))
 //│ ║         	         ^^^^^^^
-//│ ╟── but it flows into application with expected type `(?a, ?b,) & {0: ?a, 1: ?b} | ~#T1`
+//│ ╟── but it flows into application with expected type `(?a & ?b, ?b,) | ~#T1`
 //│ ║  l.516: 	snd (T1 ((1,2,3)))
 //│ ║         	     ^^^^^^^^^^^^
 //│ ╟── Note: constraint arises from tuple literal:

--- a/shared/src/test/diff/mlscript/Yicong.mls
+++ b/shared/src/test/diff/mlscript/Yicong.mls
@@ -354,7 +354,7 @@ a1.1
 //│ ╟── type `Array[int]` does not have field '1'
 //│ ║  l.333: 	def a1: Array[int]
 //│ ║         	        ^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{1: ?1}`
+//│ ╟── but it flows into reference with expected type `{1: ?a}`
 //│ ║  l.335: 	a1.1
 //│ ╙──       	^^
 //│ res: error
@@ -680,7 +680,7 @@ ra: (Array['a], Array['a], Array['a]) as 'a
 
 def tktup t = (t.1, t.2)
 tktup ((1,2,3,true))
-//│ tktup: {1: '1, 2: '2} -> ('1, '2,)
+//│ tktup: {1: 'a, 2: 'b} -> ('a, 'b,)
 //│      = [Function: tktup]
 //│ res: (2, 3,)
 //│    = [ 2, 3 ]
@@ -693,7 +693,7 @@ tktup a123
 //│ ╟── type `Array[int]` does not have field '2'
 //│ ║  l.364: 	def a123: Array[int]
 //│ ║         	          ^^^^^^^^^^
-//│ ╟── but it flows into reference with expected type `{2: ?2}`
+//│ ╟── but it flows into reference with expected type `{2: ?a}`
 //│ ║  l.689: 	tktup a123
 //│ ║         	      ^^^^
 //│ ╟── Note: constraint arises from field selection:
@@ -894,7 +894,7 @@ def s4 arr = (defined (defined (defined arr.x[0]).2[6])[7])._h.hello
 def at1 xs = (defined xs[0]).0
 def dup a b = a * 2 + b
 dup (defined ara[1]).0 (defined (defined arb[10])[8]).1 + 1
-//│ at1: Array[{0: '0} & ~undefined] -> '0
+//│ at1: Array[{0: 'a} & ~undefined] -> 'a
 //│    = [Function: at1]
 //│ dup: int -> int -> int
 //│    = [Function: dup]

--- a/shared/src/test/diff/nu/Ascription.mls
+++ b/shared/src/test/diff/nu/Ascription.mls
@@ -31,8 +31,21 @@ foo(123 : Int) : Int
 //│ res
 //│     = 124
 
-foo(123:Int):Int
+:e
+foo(123: Int): Int
+//│ ╔══[ERROR] Cannot use named arguments as the function type has untyped arguments
+//│ ║  l.35: 	foo(123: Int): Int
+//│ ╙──      	   ^^^^^^^^^^
 //│ Int
-//│ res
-//│     = 124
+//│ Code generation encountered an error:
+//│   unresolved symbol Int
+
+:e
+foo(123:Int):Int
+//│ ╔══[ERROR] Cannot use named arguments as the function type has untyped arguments
+//│ ║  l.44: 	foo(123:Int):Int
+//│ ╙──      	   ^^^^^^^^^
+//│ Int
+//│ Code generation encountered an error:
+//│   unresolved symbol Int
 

--- a/shared/src/test/diff/nu/BasicMixins.mls
+++ b/shared/src/test/diff/nu/BasicMixins.mls
@@ -316,20 +316,9 @@ let wd = w(1)
 //│ wd
 //│    = [ [ [ 1 ] ] ]
 
-// TODO implement _1
-wd.1.1.1 + 1
-//│ ╔══[ERROR] Type mismatch in field selection:
-//│ ║  l.320: 	wd.1.1.1 + 1
-//│ ║         	^^^^
-//│ ╟── application of type `{0: ?a}` does not have field '1'
-//│ ║  l.314: 	let wd = w(1)
-//│ ║         	         ^^^^
-//│ ╟── but it flows into reference with expected type `{1: ?1}`
-//│ ║  l.320: 	wd.1.1.1 + 1
-//│ ╙──       	^^
+wd.0.0.0 + 1
 //│ Int
 //│ res
-//│ Runtime error:
-//│   TypeError: Cannot read properties of undefined (reading '1')
+//│     = 2
 
 

--- a/shared/src/test/diff/nu/BasicMixins.mls
+++ b/shared/src/test/diff/nu/BasicMixins.mls
@@ -317,10 +317,19 @@ let wd = w(1)
 //│    = [ [ [ 1 ] ] ]
 
 // TODO implement _1
-wd._1._1._1 + 1
+wd.1.1.1 + 1
+//│ ╔══[ERROR] Type mismatch in field selection:
+//│ ║  l.320: 	wd.1.1.1 + 1
+//│ ║         	^^^^
+//│ ╟── application of type `{0: ?a}` does not have field '1'
+//│ ║  l.314: 	let wd = w(1)
+//│ ║         	         ^^^^
+//│ ╟── but it flows into reference with expected type `{1: ?1}`
+//│ ║  l.320: 	wd.1.1.1 + 1
+//│ ╙──       	^^
 //│ Int
 //│ res
 //│ Runtime error:
-//│   TypeError: Cannot read properties of undefined (reading '_1')
+//│   TypeError: Cannot read properties of undefined (reading '1')
 
 

--- a/shared/src/test/diff/nu/InterfaceGeneric.mls
+++ b/shared/src/test/diff/nu/InterfaceGeneric.mls
@@ -26,7 +26,7 @@ trait Product[A, B] extends Into[A] {
 //│   'T := A
 
 class TwoInts(val pair: [Int, Int]) extends Product[Int, Int] {
-    fun Into = pair._1 + pair._2
+    fun Into = pair.0 + pair.1
 }
 //│ class TwoInts(pair: [Int, Int]) extends Into, Product {
 //│   fun Into: Int

--- a/shared/src/test/diff/nu/Interfaces.mls
+++ b/shared/src/test/diff/nu/Interfaces.mls
@@ -964,7 +964,7 @@ class CP() extends BPar[Int] {
   fun f(x) = [x.1, x.0]
 }
 //│ class CP() extends BPar, Base {
-//│   fun f: forall '0 '1. {0: '0, 1: '1} -> ['1, '0]
+//│   fun f: forall 'a 'b. {0: 'a, 1: 'b} -> ['b, 'a]
 //│ }
 
 let cp1 = CP()

--- a/shared/src/test/diff/nu/Interfaces.mls
+++ b/shared/src/test/diff/nu/Interfaces.mls
@@ -961,10 +961,10 @@ fb(bp, false)
 //│       bp is not implemented
 
 class CP() extends BPar[Int] {
-  fun f(x) = [x._2, x._1]
+  fun f(x) = [x.1, x.0]
 }
 //│ class CP() extends BPar, Base {
-//│   fun f: forall 'a 'b. {_1: 'a, _2: 'b} -> ['b, 'a]
+//│   fun f: forall '0 '1. {0: '0, 1: '1} -> ['1, '0]
 //│ }
 
 let cp1 = CP()
@@ -975,7 +975,7 @@ let cp1 = CP()
 fb(cp1, 2)
 //│ [Int, Int]
 //│ res
-//│     = [ undefined, undefined ]
+//│     = [ 2, 1 ]
 
 trait BInfer1 extends Base
 //│ trait BInfer1 extends Base {

--- a/shared/src/test/diff/nu/Interfaces.mls
+++ b/shared/src/test/diff/nu/Interfaces.mls
@@ -843,7 +843,7 @@ class Bc12() extends Bc1(1), Bc2(true)
 //│ Code generation encountered an error:
 //│   unexpected parent symbol new class Bc2.
 
-class Bc02() extends Bc1(1:Int) {
+class Bc02() extends Bc1(1 : Int) {
   val foo = 2
 }
 //│ class Bc02() extends Bc1 {

--- a/shared/src/test/diff/nu/PolymorphicVariants_Alt.mls
+++ b/shared/src/test/diff/nu/PolymorphicVariants_Alt.mls
@@ -38,16 +38,16 @@ fun list_assoc(s, l: List<'a>) =
   l.match(
     ifNil: () => NotFound,
     ifCons: (h, t) =>
-      if eq(s, h._1) then Success(h._2)
+      if eq(s, h.0) then Success(h.1)
       else list_assoc(s, t)
   )
-//│ fun list_assoc: forall 'A. (Str, l: List[{_1: Str, _2: 'A}]) -> (NotFound | Success['A])
+//│ fun list_assoc: forall 'A. (Str, l: List[{0: Str, 1: 'A}]) -> (NotFound | Success['A])
 
-list_assoc : (Str, List<{ _1: Str, _2: 'b }>) => (NotFound | Success['b])
-//│ (Str, List[{_1: Str, _2: 'b}]) -> (NotFound | Success['b])
+list_assoc : (Str, List<{ 0: Str, 1: 'b }>) => (NotFound | Success['b])
+//│ (Str, List[{0: Str, 1: 'b}]) -> (NotFound | Success['b])
 
-fun list_assoc(s: Str, l: List<{ _1: Str, _2: 'b }>): NotFound | Success['b]
-//│ fun list_assoc: forall 'b. (s: Str, l: List[{_1: Str, _2: 'b}]) -> (NotFound | Success['b])
+fun list_assoc(s: Str, l: List<{ 0: Str, 1: 'b }>): NotFound | Success['b]
+//│ fun list_assoc: forall 'b. (s: Str, l: List[{0: Str, 1: 'b}]) -> (NotFound | Success['b])
 
 class Var(s: Str)
 //│ class Var(s: Str)
@@ -60,7 +60,7 @@ mixin EvalVar {
         Success(r) then r
 }
 //│ mixin EvalVar() {
-//│   fun eval: (List[{_1: Str, _2: 'a}], Var) -> (Var | 'a)
+//│   fun eval: (List[{0: Str, 1: 'a}], Var) -> (Var | 'a)
 //│ }
 
 class Abs<out A>(x: Str, t: A)
@@ -103,7 +103,7 @@ mixin EvalLambda {
 
 module Test1 extends EvalVar, EvalLambda
 //│ module Test1 {
-//│   fun eval: (List[{_1: Str, _2: 'a}], 'b) -> 'a
+//│   fun eval: (List[{0: Str, 1: 'a}], 'b) -> 'a
 //│ }
 //│ where
 //│   'b <: Abs['b] | App['b & (Abs['b] | Object & ~#Abs)] | Var
@@ -162,7 +162,7 @@ mixin EvalExpr {
 
 module Test2 extends EvalVar, EvalExpr
 //│ module Test2 {
-//│   fun eval: forall 'a. (List[{_1: Str, _2: Object & 'b}], 'a & (Add['c] | Mul['c] | Numb | Var)) -> (Numb | Var | 'b | 'a | 'c)
+//│   fun eval: forall 'a. (List[{0: Str, 1: Object & 'b}], 'a & (Add['c] | Mul['c] | Numb | Var)) -> (Numb | Var | 'b | 'a | 'c)
 //│ }
 //│ where
 //│   'c <: Add['c] | Mul['c] | Numb | Var
@@ -181,7 +181,7 @@ Test2.eval(Cons(["a", Abs("d", Var("d"))], Nil()), Add(Numb(1), Var("a")))
 
 module Test3 extends EvalVar, EvalExpr, EvalLambda
 //│ module Test3 {
-//│   fun eval: (List[{_1: Str, _2: 'a}], 'b) -> 'c
+//│   fun eval: (List[{0: Str, 1: 'a}], 'b) -> 'c
 //│ }
 //│ where
 //│   'a :> 'c
@@ -202,7 +202,7 @@ Test3.eval(Cons(["c", Abs("d", Var("d"))], Nil()), App(Abs("a", Var("a")), Add(N
 
 module Test3 extends EvalVar, EvalLambda, EvalExpr
 //│ module Test3 {
-//│   fun eval: (List[{_1: Str, _2: 'a}], 'a & (Add['b] | Mul['b] | Numb | Var)) -> ('a | 'b | 'c)
+//│   fun eval: (List[{0: Str, 1: 'a}], 'a & (Add['b] | Mul['b] | Numb | Var)) -> ('a | 'b | 'c)
 //│ }
 //│ where
 //│   'a :> 'b | 'c

--- a/shared/src/test/diff/nu/Tuples.mls
+++ b/shared/src/test/diff/nu/Tuples.mls
@@ -60,7 +60,7 @@ t.3
 //│     = undefined
 
 
-// Note that record field can be arbitrary integer literals.
+// Note that record fields can be integers with leading zeros.
 { 000000: "just zero" }
 { 042: "cuarenta y dos" }
 //│ {42: "cuarenta y dos"}

--- a/shared/src/test/diff/nu/Tuples.mls
+++ b/shared/src/test/diff/nu/Tuples.mls
@@ -1,5 +1,109 @@
 :NewDefs
 
+
+// Tuple literals use square brackets.
+let t = [0, 1, 2]
+//│ let t: [0, 1, 2]
+//│ t
+//│   = [ 0, 1, 2 ]
+
+
+// Tuple indices are zero-based.
+t.0
+t.1
+t.2
+//│ 2
+//│ res
+//│     = 0
+//│ res
+//│     = 1
+//│ res
+//│     = 2
+
+
+// Tuple indices cannot be negative.
+:e
+t.-1
+//│ ╔══[ERROR] identifier not found: .-
+//│ ║  l.26: 	t.-1
+//│ ╙──      	 ^^
+//│ error
+//│ Code generation encountered an error:
+//│   unresolved symbol .-
+
+
+// Non-zero tuple indices cannot start with a zero.
+:e
+t.01
+//│ ╔══[ERROR] identifier not found: .
+//│ ║  l.37: 	t.01
+//│ ╙──      	 ^
+//│ error
+//│ Code generation encountered an error:
+//│   unresolved symbol .
+
+
+// Out of bounds indices cause type errors.
+:e
+t.3
+//│ ╔══[ERROR] Type mismatch in field selection:
+//│ ║  l.48: 	t.3
+//│ ║        	^^^
+//│ ╟── tuple literal of type `{0: 0, 1: 1, 2: 2}` does not have field '3'
+//│ ║  l.5: 	let t = [0, 1, 2]
+//│ ║       	        ^^^^^^^^^
+//│ ╟── but it flows into reference with expected type `{3: ?a}`
+//│ ║  l.48: 	t.3
+//│ ╙──      	^
+//│ error
+//│ res
+//│     = undefined
+
+
+// Note that record field can be arbitrary integer literals.
+{ 000000: "just zero" }
+{ 042: "cuarenta y dos" }
+//│ {42: "cuarenta y dos"}
+//│ res
+//│     = { '0': 'just zero' }
+//│ res
+//│     = { '42': 'cuarenta y dos' }
+
+
+// Negative integer record fields are disallowed, which aligns with JavaScript.
+:pe
+:e
+{ -1: "oh no" }
+//│ ╔══[PARSE ERROR] Record field should have a name
+//│ ╙──
+//│ ╔══[ERROR] Type mismatch in type ascription:
+//│ ╟── integer literal of type `-1` does not match type `"oh no"`
+//│ ╟── Note: constraint arises from literal type:
+//│ ║  l.76: 	{ -1: "oh no" }
+//│ ╙──      	      ^^^^^^^
+//│ {<error>: "oh no"}
+//│ res
+//│     = { '<error>': -1 }
+
+
+// Note that leading zeros of integer record fields are ignored.
+// And duplicate fields lead to errors.
+:e
+{ 0: "oh", 00: "no" }
+//│ ╔══[ERROR] Multiple declarations of field name 0 in record literal
+//│ ║  l.92: 	{ 0: "oh", 00: "no" }
+//│ ║        	     ^^^^^^^^^^^^^^
+//│ ╟── Declared at
+//│ ║  l.92: 	{ 0: "oh", 00: "no" }
+//│ ║        	  ^
+//│ ╟── Declared at
+//│ ║  l.92: 	{ 0: "oh", 00: "no" }
+//│ ╙──      	           ^^
+//│ {0: "oh", 0: "no"}
+//│ res
+//│     = { '0': 'no' }
+
+
 // Fields that are integers or start with an underscore should not be used as name hints.
 fun f(x) = x._q
 fun g(x) = x._1
@@ -7,6 +111,7 @@ fun h(x) = x.1
 //│ fun f: forall 'a. {_q: 'a} -> 'a
 //│ fun g: forall 'b. {_1: 'b} -> 'b
 //│ fun h: forall 'c. {1: 'c} -> 'c
+
 
 // Other fields should be used as name hints.
 fun p(x) = x.y

--- a/shared/src/test/diff/nu/Tuples.mls
+++ b/shared/src/test/diff/nu/Tuples.mls
@@ -1,0 +1,13 @@
+:NewDefs
+
+// Fields that are integers or start with an underscore should not be used as name hints.
+fun f(x) = x._q
+fun g(x) = x._1
+fun h(x) = x.1
+//│ fun f: forall 'a. {_q: 'a} -> 'a
+//│ fun g: forall 'b. {_1: 'b} -> 'b
+//│ fun h: forall 'c. {1: 'c} -> 'c
+
+// Other fields should be used as name hints.
+fun p(x) = x.y
+//│ fun p: forall 'y. {y: 'y} -> 'y

--- a/shared/src/test/diff/nu/WeirdUnions.mls
+++ b/shared/src/test/diff/nu/WeirdUnions.mls
@@ -6,7 +6,7 @@ fun f: Str | [Str, Int]
 //│ fun f: Str | [Str, Int]
 
 fun f: [Str] | [Str, Int]
-//│ fun f: Array[Int | Str] & {_1: Str}
+//│ fun f: Array[Int | Str] & {0: Str}
 
 fun f: (Str | [Str, Int])
 //│ fun f: Str | [Str, Int]
@@ -33,7 +33,7 @@ fun f: Str | ((Str, Int))
 
 // * This type merges the input tuples, resulting in the union seen above:
 fun f: (Str => Str) & ((Str, Int) => Str)
-//│ fun f: (...Array[Int | Str] & {_1: Str}) -> Str
+//│ fun f: (...Array[Int | Str] & {0: Str}) -> Str
 
 f("abc", "abc")
 //│ Str


### PR DESCRIPTION
### Changes

#### Syntax

Tuple indices _in selection_ should matches regular expression `0|[1-9][0-9]`. Records and record types now accept non-negative integers as field names (e.g., `{ 1: "Hello" }`).

- `Parser`: Allow selecting tuple indices (e.g., `x.0`) and using non-negative integer fields in records.
- `MLParser`: Same as `Parser`. Also allow non-negative integer fields in record types (e.g., `{ 1: int }`).
- `NewLexer`: Allow `SELECT`'s `name` to be tuple indices.
- `NewParser`: Same as `Parser`.

#### Typing

- `TyperDatatypes`: Update `TupleType`'s `toRecord` methods.
- `TypeSimplifier`: Update the code that simplify tuple types.
- `Typer`: Update the code which treats `Array` as a supertype of tuple types.
- `Typer`: Fields that are integers or start with an underscore are not used as name hints.

#### JavaScript Code Generation

- Do not enclose field names in quotes if they are integers.

#### Tests

- Test cases: replace `._n` to `.(n-1)`.
- [x] I have meticulously read and reviewed the changes in DiffTests.