### PR TITLE
Adjust heap size and stack size of JVM of GitHub workflow

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -23,6 +23,6 @@ jobs:
     - name: Install TypeScript
       run: npm ci
     - name: Run tests
-      run: sbt test
+      run: sbt -J-Xmx4096M test
     - name: Check no changes
       run: git diff-files -p --exit-code

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -23,6 +23,6 @@ jobs:
     - name: Install TypeScript
       run: npm ci
     - name: Run tests
-      run: sbt -J-Xmx4096M test
+      run: sbt -J-Xmx4096M -J-Xss64M test
     - name: Check no changes
       run: git diff-files -p --exit-code

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -23,6 +23,6 @@ jobs:
     - name: Install TypeScript
       run: npm ci
     - name: Run tests
-      run: sbt -J-Xmx4096M -J-Xss64M test
+      run: sbt -J-Xmx4096M -J-Xss4M test
     - name: Check no changes
       run: git diff-files -p --exit-code


### PR DESCRIPTION
After pushing commits to PR, sometimes the CI would time out due to spending too much time on GC. The root of the cause is its insufficient memory. Considering that the built-in runner on GitHub has [7 GB of memory][1], this issue should be improvable. So, I set the [maximum memory of JVM that sbt runs on][2] to 4 GB in the GitHub workflow.

I also found that the default stack size (512 KB) is small for some test cases. Therefore, I also increase the stack size to 64 MB.

[1]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
[2]: https://www.scala-sbt.org/1.x/docs/Command-Line-Reference.html#sbt+JVM+heap%2C+permgen%2C+and+stack+sizes