### PR TITLE
Fix/virtual type arg params

### DIFF
--- a/shared/src/main/scala/mlscript/NuTypeDefs.scala
+++ b/shared/src/main/scala/mlscript/NuTypeDefs.scala
@@ -762,7 +762,6 @@ class NuTypeDefs extends ConstraintSolver { self: Typer =>
         case (p, v @ Var(parNme), lti, parTargs, parArgs) =>
           trace(s"${lvl}. Typing parent spec $p") {
             val info = lti.complete()
-            println(s"!!! $info")
             info match {
               
               case rawMxn: TypedNuMxn =>
@@ -1052,11 +1051,7 @@ class NuTypeDefs extends ConstraintSolver { self: Typer =>
       case td: NuTypeDef =>
         (td.params.getOrElse(Tup(Nil)).fields.iterator.flatMap(_._1) ++ td.body.entities.iterator.collect {
           case fd: NuFunDef => fd.nme
-        }).toSet ++ inheritedFields ++ /* (this match {
-          case tpd: TypedNuCls => virtualMembers.keysIterator
-          case _ => Nil
-        }) */
-        tparams.map {
+        }).toSet ++ inheritedFields ++ tparams.map {
           case (nme @ TypeName(name), tv, _) =>
             Var(td.nme.name+"#"+name).withLocOf(nme)
         }
@@ -1064,12 +1059,10 @@ class NuTypeDefs extends ConstraintSolver { self: Typer =>
     }
     
     lazy val typedFields: Map[Var, FieldType] = {
-      // println(("privateFields"),privateParams)
       (typedParams.getOrElse(Nil).toMap
         // -- privateFields
         -- inheritedFields /* parameters can be overridden by inherited fields/methods */
       ) ++ typedSignatures.iterator.map(fd_ty => fd_ty._1.nme -> fd_ty._2.toUpper(noProv)) ++
-        // typedParents.flatMap(_._3).map(kv => Var(kv._1) -> kv._2.toUpper(noProv))
         typedParents.flatMap(_._3).flatMap {
           case (k, p: NuParam) => Var(k) -> p.ty :: Nil
           case _ => Nil

--- a/shared/src/main/scala/mlscript/NuTypeDefs.scala
+++ b/shared/src/main/scala/mlscript/NuTypeDefs.scala
@@ -1057,11 +1057,17 @@ class NuTypeDefs extends ConstraintSolver { self: Typer =>
       case _: NuFunDef => Set.empty
     }
     
-    lazy val typedFields: Map[Var, FieldType] = {println(("privateFields"),privateParams)
+    lazy val typedFields: Map[Var, FieldType] = {
+      // println(("privateFields"),privateParams)
       (typedParams.getOrElse(Nil).toMap
         // -- privateFields
         -- inheritedFields /* parameters can be overridden by inherited fields/methods */
-      ) ++ typedSignatures.iterator.map(fd_ty => fd_ty._1.nme -> fd_ty._2.toUpper(noProv))
+      ) ++ typedSignatures.iterator.map(fd_ty => fd_ty._1.nme -> fd_ty._2.toUpper(noProv)) ++
+        // typedParents.flatMap(_._3).map(kv => Var(kv._1) -> kv._2.toUpper(noProv))
+        typedParents.flatMap(_._3).flatMap {
+          case (k, p: NuParam) => Var(k) -> p.ty :: Nil
+          case _ => Nil
+        }
     }
     lazy val mutRecTV: TV = freshVar(
       TypeProvenance(decl.toLoc, decl.describe, S(decl.name), decl.isInstanceOf[NuTypeDef]),

--- a/shared/src/test/diff/gadt/ThisMatching.mls
+++ b/shared/src/test/diff/gadt/ThisMatching.mls
@@ -67,25 +67,40 @@ class Pair(lhs: Exp, rhs: Exp) extends Exp
 
 
 class Exp: (Pair | Lit) {
+  fun test: Int
   fun test = if this is
     Lit then 0
     Pair(l, r) then 1
 }
 class Lit(n: Int) extends Exp
 class Pair(lhs: Exp, rhs: Exp) extends Exp
+//│ ╔══[ERROR] Unhandled cyclic definition
+//│ ║  l.69: 	class Exp: (Pair | Lit) {
+//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.70: 	  fun test: Int
+//│ ║        	^^^^^^^^^^^^^^^
+//│ ║  l.71: 	  fun test = if this is
+//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.72: 	    Lit then 0
+//│ ║        	^^^^^^^^^^^^^^
+//│ ║  l.73: 	    Pair(l, r) then 1
+//│ ║        	^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.74: 	}
+//│ ╙──      	^
 //│ class Exp: Lit | Pair {
 //│   constructor()
-//│   fun test: 0 | 1
+//│   fun test: Int
 //│ }
 //│ class Lit(n: Int) extends Exp {
-//│   fun test: 0 | 1
+//│   fun test: Int
 //│ }
-//│ class Pair(lhs: Exp, rhs: Exp) extends Exp {
-//│   fun test: 0 | 1
-//│ }
+//│ class Pair(lhs: Exp, rhs: Exp) extends Exp
 
 Pair(Lit(1), Lit(2)).test
-//│ 0 | 1
+//│ ╔══[ERROR] Type `Pair` does not contain member `test`
+//│ ║  l.99: 	Pair(Lit(1), Lit(2)).test
+//│ ╙──      	                    ^^^^^
+//│ error
 //│ res
 //│     = 1
 
@@ -98,9 +113,20 @@ class Exp: (Pair | Lit) {
 }
 class Lit(n: Int) extends Exp
 class Pair(lhs: Exp, rhs: Exp) extends Exp
+//│ ╔══[ERROR] Unhandled cyclic definition
+//│ ║  l.109: 	class Exp: (Pair | Lit) {
+//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.110: 	  fun test = if this is
+//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.111: 	    Lit then 0
+//│ ║         	^^^^^^^^^^^^^^
+//│ ║  l.112: 	    Pair(l, r) then l.test + r.test
+//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.113: 	}
+//│ ╙──       	^
 //│ ╔══[ERROR] Indirectly-recursive member should have type annotation
-//│ ║  l.97: 	    Pair(l, r) then l.test + r.test
-//│ ╙──      	                     ^^^^^
+//│ ║  l.112: 	    Pair(l, r) then l.test + r.test
+//│ ╙──       	                     ^^^^^
 //│ class Exp: Lit | Pair {
 //│   constructor()
 //│   fun test: Int | error
@@ -108,9 +134,7 @@ class Pair(lhs: Exp, rhs: Exp) extends Exp
 //│ class Lit(n: Int) extends Exp {
 //│   fun test: Int | error
 //│ }
-//│ class Pair(lhs: Exp, rhs: Exp) extends Exp {
-//│   fun test: Int | error
-//│ }
+//│ class Pair(lhs: Exp, rhs: Exp) extends Exp
 
 
 class Exp: (Pair | Lit) {
@@ -121,6 +145,19 @@ class Exp: (Pair | Lit) {
 }
 class Lit(n: Int) extends Exp
 class Pair(lhs: Exp, rhs: Exp) extends Exp
+//│ ╔══[ERROR] Unhandled cyclic definition
+//│ ║  l.140: 	class Exp: (Pair | Lit) {
+//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.141: 	  fun test : Int
+//│ ║         	^^^^^^^^^^^^^^^^
+//│ ║  l.142: 	  fun test = if this is
+//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.143: 	    Lit then 0
+//│ ║         	^^^^^^^^^^^^^^
+//│ ║  l.144: 	    Pair(l, r) then l.test + r.test
+//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.145: 	}
+//│ ╙──       	^
 //│ class Exp: Lit | Pair {
 //│   constructor()
 //│   fun test: Int
@@ -128,9 +165,7 @@ class Pair(lhs: Exp, rhs: Exp) extends Exp
 //│ class Lit(n: Int) extends Exp {
 //│   fun test: Int
 //│ }
-//│ class Pair(lhs: Exp, rhs: Exp) extends Exp {
-//│   fun test: Int
-//│ }
+//│ class Pair(lhs: Exp, rhs: Exp) extends Exp
 
 
 :e // TODO support – this requires implementing type member lookup without forced completion (we get constraints like Pair<Exp> <: Pair#L)
@@ -142,25 +177,25 @@ class Exp[A]: (Pair | Lit) {
 class Lit(n: Int) extends Exp[Int]
 class Pair[L, R](lhs: L, rhs: R) extends Exp[[L, R]]
 //│ ╔══[ERROR] Unhandled cyclic definition
-//│ ║  l.137: 	class Exp[A]: (Pair | Lit) {
+//│ ║  l.172: 	class Exp[A]: (Pair | Lit) {
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.138: 	  fun test = if this is
+//│ ║  l.173: 	  fun test = if this is
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.139: 	    Lit then 0
+//│ ║  l.174: 	    Lit then 0
 //│ ║         	^^^^^^^^^^^^^^
-//│ ║  l.140: 	    Pair then 1
+//│ ║  l.175: 	    Pair then 1
 //│ ║         	^^^^^^^^^^^^^^^
-//│ ║  l.141: 	}
+//│ ║  l.176: 	}
 //│ ╙──       	^
 //│ ╔══[ERROR] Type error in `case` expression
-//│ ║  l.138: 	  fun test = if this is
+//│ ║  l.173: 	  fun test = if this is
 //│ ║         	                ^^^^^^^
-//│ ║  l.139: 	    Lit then 0
+//│ ║  l.174: 	    Lit then 0
 //│ ║         	^^^^^^^^^^^^^^
-//│ ║  l.140: 	    Pair then 1
+//│ ║  l.175: 	    Pair then 1
 //│ ║         	^^^^^^^^^^^^^^^
 //│ ╟── type variable `L` leaks out of its scope
-//│ ║  l.143: 	class Pair[L, R](lhs: L, rhs: R) extends Exp[[L, R]]
+//│ ║  l.178: 	class Pair[L, R](lhs: L, rhs: R) extends Exp[[L, R]]
 //│ ╙──       	           ^
 //│ class Exp[A]: Lit | Pair[anything, anything] {
 //│   constructor()

--- a/shared/src/test/diff/gadt/ThisMatching.mls
+++ b/shared/src/test/diff/gadt/ThisMatching.mls
@@ -66,6 +66,48 @@ class Pair(lhs: Exp, rhs: Exp) extends Exp
 //│ }
 
 
+class Exp: (() | Lit) {
+  fun test = if this is
+    Lit then 0
+    () then 1
+}
+class Lit(n: Int) extends Exp
+//│ class Exp: Lit | () {
+//│   constructor()
+//│   fun test: 0 | 1
+//│ }
+//│ class Lit(n: Int) extends Exp {
+//│   fun test: 0 | 1
+//│ }
+
+// * TODO fix this by requiring a type annotation on `test` and delaying its body's type checking until all the involed classes are completed
+// * Currently we try to complete Exp ->{type checking defn body} complete test ->{type checking pattern} find Wrap's typed fields ->{get Wrap's typed parents} complete Exp
+:e
+class Exp: (() | Wrap) {
+  fun test = if this is
+    Wrap(a) then 0
+    () then 1
+}
+class Wrap(n: Exp) extends Exp
+//│ ╔══[ERROR] Unhandled cyclic definition
+//│ ║  l.86: 	class Exp: (() | Wrap) {
+//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.87: 	  fun test = if this is
+//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.88: 	    Wrap(a) then 0
+//│ ║        	^^^^^^^^^^^^^^^^^^
+//│ ║  l.89: 	    () then 1
+//│ ║        	^^^^^^^^^^^^^
+//│ ║  l.90: 	}
+//│ ╙──      	^
+//│ class Exp: Wrap | () {
+//│   constructor()
+//│   fun test: 0 | 1
+//│ }
+//│ class Wrap(n: Exp) extends Exp
+
+// * TODO (same as above)
+:e
 class Exp: (Pair | Lit) {
   fun test: Int
   fun test = if this is
@@ -75,18 +117,18 @@ class Exp: (Pair | Lit) {
 class Lit(n: Int) extends Exp
 class Pair(lhs: Exp, rhs: Exp) extends Exp
 //│ ╔══[ERROR] Unhandled cyclic definition
-//│ ║  l.69: 	class Exp: (Pair | Lit) {
-//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.70: 	  fun test: Int
-//│ ║        	^^^^^^^^^^^^^^^
-//│ ║  l.71: 	  fun test = if this is
-//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.72: 	    Lit then 0
-//│ ║        	^^^^^^^^^^^^^^
-//│ ║  l.73: 	    Pair(l, r) then 1
-//│ ║        	^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.74: 	}
-//│ ╙──      	^
+//│ ║  l.111: 	class Exp: (Pair | Lit) {
+//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.112: 	  fun test: Int
+//│ ║         	^^^^^^^^^^^^^^^
+//│ ║  l.113: 	  fun test = if this is
+//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.114: 	    Lit then 0
+//│ ║         	^^^^^^^^^^^^^^
+//│ ║  l.115: 	    Pair(l, r) then 1
+//│ ║         	^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.116: 	}
+//│ ╙──       	^
 //│ class Exp: Lit | Pair {
 //│   constructor()
 //│   fun test: Int
@@ -96,10 +138,11 @@ class Pair(lhs: Exp, rhs: Exp) extends Exp
 //│ }
 //│ class Pair(lhs: Exp, rhs: Exp) extends Exp
 
+:e // TODO
 Pair(Lit(1), Lit(2)).test
 //│ ╔══[ERROR] Type `Pair` does not contain member `test`
-//│ ║  l.99: 	Pair(Lit(1), Lit(2)).test
-//│ ╙──      	                    ^^^^^
+//│ ║  l.142: 	Pair(Lit(1), Lit(2)).test
+//│ ╙──       	                    ^^^^^
 //│ error
 //│ res
 //│     = 1
@@ -114,18 +157,18 @@ class Exp: (Pair | Lit) {
 class Lit(n: Int) extends Exp
 class Pair(lhs: Exp, rhs: Exp) extends Exp
 //│ ╔══[ERROR] Unhandled cyclic definition
-//│ ║  l.109: 	class Exp: (Pair | Lit) {
+//│ ║  l.152: 	class Exp: (Pair | Lit) {
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.110: 	  fun test = if this is
+//│ ║  l.153: 	  fun test = if this is
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.111: 	    Lit then 0
+//│ ║  l.154: 	    Lit then 0
 //│ ║         	^^^^^^^^^^^^^^
-//│ ║  l.112: 	    Pair(l, r) then l.test + r.test
+//│ ║  l.155: 	    Pair(l, r) then l.test + r.test
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.113: 	}
+//│ ║  l.156: 	}
 //│ ╙──       	^
 //│ ╔══[ERROR] Indirectly-recursive member should have type annotation
-//│ ║  l.112: 	    Pair(l, r) then l.test + r.test
+//│ ║  l.155: 	    Pair(l, r) then l.test + r.test
 //│ ╙──       	                     ^^^^^
 //│ class Exp: Lit | Pair {
 //│   constructor()
@@ -137,6 +180,7 @@ class Pair(lhs: Exp, rhs: Exp) extends Exp
 //│ class Pair(lhs: Exp, rhs: Exp) extends Exp
 
 
+:e // TODO
 class Exp: (Pair | Lit) {
   fun test : Int
   fun test = if this is
@@ -146,17 +190,17 @@ class Exp: (Pair | Lit) {
 class Lit(n: Int) extends Exp
 class Pair(lhs: Exp, rhs: Exp) extends Exp
 //│ ╔══[ERROR] Unhandled cyclic definition
-//│ ║  l.140: 	class Exp: (Pair | Lit) {
+//│ ║  l.184: 	class Exp: (Pair | Lit) {
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.141: 	  fun test : Int
+//│ ║  l.185: 	  fun test : Int
 //│ ║         	^^^^^^^^^^^^^^^^
-//│ ║  l.142: 	  fun test = if this is
+//│ ║  l.186: 	  fun test = if this is
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.143: 	    Lit then 0
+//│ ║  l.187: 	    Lit then 0
 //│ ║         	^^^^^^^^^^^^^^
-//│ ║  l.144: 	    Pair(l, r) then l.test + r.test
+//│ ║  l.188: 	    Pair(l, r) then l.test + r.test
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.145: 	}
+//│ ║  l.189: 	}
 //│ ╙──       	^
 //│ class Exp: Lit | Pair {
 //│   constructor()
@@ -177,25 +221,25 @@ class Exp[A]: (Pair | Lit) {
 class Lit(n: Int) extends Exp[Int]
 class Pair[L, R](lhs: L, rhs: R) extends Exp[[L, R]]
 //│ ╔══[ERROR] Unhandled cyclic definition
-//│ ║  l.172: 	class Exp[A]: (Pair | Lit) {
+//│ ║  l.216: 	class Exp[A]: (Pair | Lit) {
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.173: 	  fun test = if this is
+//│ ║  l.217: 	  fun test = if this is
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.174: 	    Lit then 0
+//│ ║  l.218: 	    Lit then 0
 //│ ║         	^^^^^^^^^^^^^^
-//│ ║  l.175: 	    Pair then 1
+//│ ║  l.219: 	    Pair then 1
 //│ ║         	^^^^^^^^^^^^^^^
-//│ ║  l.176: 	}
+//│ ║  l.220: 	}
 //│ ╙──       	^
 //│ ╔══[ERROR] Type error in `case` expression
-//│ ║  l.173: 	  fun test = if this is
+//│ ║  l.217: 	  fun test = if this is
 //│ ║         	                ^^^^^^^
-//│ ║  l.174: 	    Lit then 0
+//│ ║  l.218: 	    Lit then 0
 //│ ║         	^^^^^^^^^^^^^^
-//│ ║  l.175: 	    Pair then 1
+//│ ║  l.219: 	    Pair then 1
 //│ ║         	^^^^^^^^^^^^^^^
 //│ ╟── type variable `L` leaks out of its scope
-//│ ║  l.178: 	class Pair[L, R](lhs: L, rhs: R) extends Exp[[L, R]]
+//│ ║  l.222: 	class Pair[L, R](lhs: L, rhs: R) extends Exp[[L, R]]
 //│ ╙──       	           ^
 //│ class Exp[A]: Lit | Pair[anything, anything] {
 //│   constructor()

--- a/shared/src/test/diff/nu/NuScratch.mls
+++ b/shared/src/test/diff/nu/NuScratch.mls
@@ -1,3 +1,4 @@
 :NewDefs
 
 
+

--- a/shared/src/test/diff/nu/NuScratch.mls
+++ b/shared/src/test/diff/nu/NuScratch.mls
@@ -1,4 +1,3 @@
 :NewDefs
 
 
-

--- a/shared/src/test/diff/nu/OptionFilter.mls
+++ b/shared/src/test/diff/nu/OptionFilter.mls
@@ -1,170 +1,7 @@
 :NewDefs
 
 
-
-:d
-abstract class Option[out T]: (None | ()) {
-  virtual fun filter: Option[T]
-}
-module None extends Option[nothing] {
-  fun filter = None
-}
-//│ 0. Typing TypingUnit(List(NuTypeDef(Cls,TypeName(Option),List((Some(+),TypeName(T))),None,None,Some(Union(TypeName(None),Literal(UnitLit(true)))),List(),None,None,TypingUnit(List(NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T))))))))), NuTypeDef(Mod,TypeName(None),List(),None,None,None,List(TyApp(Var(Option),List(TypeName(nothing)))),None,None,TypingUnit(List(NuFunDef(None,Var(filter),None,List(),Left(Var(None))))))))
-//│ | 0. Created lazy type info for NuTypeDef(Cls,TypeName(Option),List((Some(+),TypeName(T))),None,None,Some(Union(TypeName(None),Literal(UnitLit(true)))),List(),None,None,TypingUnit(List(NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T)))))))))
-//│ | 0. Created lazy type info for NuTypeDef(Mod,TypeName(None),List(),None,None,None,List(TyApp(Var(Option),List(TypeName(nothing)))),None,None,TypingUnit(List(NuFunDef(None,Var(filter),None,List(),Left(Var(None))))))
-//│ | Completing class Option‹T›: None | () {fun filter: Option[T]}
-//│ | | Type params (TypeName(T),T29',Some(+))
-//│ | | Params 
-//│ | | Typing type PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T))))
-//│ | | | vars=Map(T -> ‘T29') newDefsInfo=Map()
-//│ | | | 2. type PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T))))
-//│ | | | | 3. type AppliedType(TypeName(Option),List(TypeName(T)))
-//│ | | | | | 3. type TypeName(T)
-//│ | | | | | => ‘T29'
-//│ | | | | => Option[‘T29']
-//│ | | | | Inferred poly constr: Option[‘T29']  —— where 
-//│ | | | => Option[‘T29']
-//│ | | => Option[‘T29'] ——— 
-//│ | | Inferred poly constr: Option[‘T29']  —— where 
-//│ | | Typing type Union(TypeName(None),Literal(UnitLit(true)))
-//│ | | | vars=Map(T -> ‘T29') newDefsInfo=Map()
-//│ | | | 2. type Union(TypeName(None),Literal(UnitLit(true)))
-//│ | | | | 2. type TypeName(None)
-//│ | | | | => None
-//│ | | | | 2. type Literal(UnitLit(true))
-//│ | | | | => #undefined<Object>
-//│ | | | => (None | #undefined<Object>)
-//│ | | => (None | #undefined<Object>) ——— 
-//│ | | CONSTRAIN (None | #undefined<Object>) <! α30'
-//│ | |   where 
-//│ | | 1. C (None | #undefined<Object>) <! α30'    (0)
-//│ | | | NEW α30' LB (0)
-//│ | | Done inheriting: Pack({},List(NuParam(TypeName(Option#T),mut ‘T29'..‘T29',true)),None,List(),List(),Map())
-//│ | | 1. Finalizing inheritance with ((({} w/ {} & #Option<Object>) & {Option#T: mut ‘T29'..‘T29'}) & ⊤..(None | #undefined<Object>)) <: option31'
-//│ | | | CONSTRAIN ((({} w/ {} & #Option<Object>) & {Option#T: mut ‘T29'..‘T29'}) & ⊤..(None | #undefined<Object>)) <! option31'
-//│ | | |   where 
-//│ | | | 1. C ((({} w/ {} & #Option<Object>) & {Option#T: mut ‘T29'..‘T29'}) & ⊤..(None | #undefined<Object>)) <! option31'    (0)
-//│ | | | | NEW option31' LB (1)
-//│ | | 1. Typing TypingUnit(List(NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T))))))))
-//│ | | | Typing unit statements
-//│ | | | : None
-//│ | | baseClsImplemMembers List()
-//│ | | Checking `this` accesses...
-//│ | | Checking base class implementations against inherited signatures...
-//│ | | Checking new implementations against inherited signatures...
-//│ | | | Checking overriding for NuParam(TypeName(Option#T),mut ‘T29'..‘T29',true) against None...
-//│ | | Checking new signatures against inherited signatures...
-//│ | | | Checking overriding for TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T)))))),Option[‘T29']) against None...
-//│ | | allMembers Map(Option#T -> NuParam(TypeName(Option#T),mut ‘T29'..‘T29',true), filter -> TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T)))))),Option[‘T29']))
-//│ | | Computing variances of Option
-//│ | | | Trav(+)(Option[‘T29'])
-//│ | | | | Trav(+)(‘T29')
-//│ | | | | | Trav(+)(T29')
-//│ | | = HashMap(T29' -> +)
-//│ | Completed TypedNuCls(0, TypeName(Option),
-//│ 	List((TypeName(T),T29',Some(+))),
-//│ 	None,
-//│ 	this: ⊤, 
-//│ 	(Option#T,NuParam(TypeName(Option#T),mut ‘T29'..‘T29',true))
-//│ 	(filter,TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T)))))),Option[‘T29'])),
-//│ 	: ⊤..(None | #undefined<Object>), Set(), Map()) where 
-//│ | Completing module None: Option‹nothing› {fun filter = None}
-//│ | | Type params 
-//│ | | Params 
-//│ | | 1. Typing parent spec Var(Option)
-//│ | | | Typing type TypeName(nothing)
-//│ | | | | vars=Map() newDefsInfo=Map()
-//│ | | | | 1. type TypeName(nothing)
-//│ | | | | => Nothing
-//│ | | | => Nothing ——— 
-//│ | | | Assigning T :: T29' := Nothing where 
-//│ | | | Set T29_33 ~> T29'
-//│ | | | Class arg members List()
-//│ | | => Inheriting from TypedNuCls(0, TypeName(Option),
-//│ 	List((TypeName(T),T29_33#,Some(+))),
-//│ 	None,
-//│ 	this: ⊤, 
-//│ 	(Option#T,NuParam(TypeName(Option#T),mut T29_33#..T29_33#,true))
-//│ 	(filter,TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T)))))),Option[T29_33#])),
-//│ 	: ⊤..(None | #undefined<Object>), Set(), Map())
-//│ | | argMembs List()
-//│ | | Done inheriting: Pack({},List(),Some(Option),List(NuParam(TypeName(Option#T),mut T29_33#..T29_33#,true), TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T)))))),Option[T29_33#])),List(),Map(Option#T -> NuParam(TypeName(T),mut T29_33#..T29_33#,true)))
-//│ | | 1. Finalizing inheritance with ({} w/ {} & #None<Object,Option>) <: none32'
-//│ | | | CONSTRAIN ({} w/ {} & #None<Object,Option>) <! none32'
-//│ | | |   where 
-//│ | | | 1. C ({} w/ {} & #None<Object,Option>) <! none32'    (0)
-//│ | | | | NEW none32' LB (0)
-//│ | | 1. Typing TypingUnit(List(NuFunDef(None,Var(filter),None,List(),Left(Var(None)))))
-//│ | | | 1. Created lazy type info for NuFunDef(None,Var(filter),None,List(),Left(Var(None)))
-//│ | | | Completing fun filter = None
-//│ | | | | Type params 
-//│ | | | | Params 
-//│ | | | | 2. Typing term Var(None)
-//│ | | | | 2. : #None<Option,Object>
-//│ | | | | CONSTRAIN #None<Option,Object> <! filter34''
-//│ | | | |   where 
-//│ | | | | 2. C #None<Option,Object> <! filter34''    (0)
-//│ | | | | | NEW filter34'' LB (0)
-//│ | | | Completed TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Left(Var(None))),#None<Option,Object>) where 
-//│ | | | Typing unit statements
-//│ | | | : None
-//│ | | baseClsImplemMembers List(NuParam(TypeName(Option#T),mut T29_33#..T29_33#,true))
-//│ | | Checking `this` accesses...
-//│ | | Checking base class implementations against inherited signatures...
-//│ | | | Checking overriding for NuParam(TypeName(Option#T),mut T29_33#..T29_33#,true) against None...
-//│ | | Checking new implementations against inherited signatures...
-//│ | | | Checking overriding for TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Left(Var(None))),#None<Option,Object>) against Some(TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T)))))),Option[T29_33#]))...
-//│ | | | CONSTRAIN #None<Option,Object> <! Option[T29_33#]
-//│ | | |   where 
-//│ 		T29_33# := Nothing
-//│ | | | 1. C #None<Option,Object> <! Option[T29_33#]    (0)
-//│ | | | | Passing T :: T29' <=< T29_33#
-//│ | | | | 1. C #None<Option,Object> <! ((#Option<Object> & ⊤..(None | #undefined<Object>)) & {Option#T: T29_33#})    (2)
-//│ | | | | | 1. C #None<Option,Object> <! (#Option<Object> & ⊤..(None | #undefined<Object>))    (4)
-//│ | | | | | | Already a subtype by <:<
-//│ | | | | | 1. C #None<Option,Object> <! {Option#T: T29_33#}    (4)
-//│ | | | | | | Looking up field Option#T in Some(None) & TreeSet() & {...}
-//│ | | | | | | | (privateFields,Set())
-//│ | | | | | | | Lookup None.Option#T : None where 
-//│ | | | | | | | Fresh[0] None.Option#T : None where None
-//│ | | | | | | |   & None  (from refinement)
-//│ ╔══[ERROR] Indirectly-recursive member should have type annotation
-//│ ║  l.6: 	abstract class Option[out T]: (None | ()) {
-//│ ╙──     	                          ^
-//│ | | | | | | 1. C #error<> <! T29_33#    (3)
-//│ | | | | | | | 1. C #error<> <! Nothing    (5)
-//│ | | Checking new signatures against inherited signatures...
-//│ | | allMembers Map(Option#T -> NuParam(TypeName(Option#T),mut T29_33#..T29_33#,true), filter -> TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Left(Var(None))),#None<Option,Object>))
-//│ | | Computing variances of None
-//│ | | | Trav(+)(#None<Option,Object>)
-//│ | | = HashMap()
-//│ | Completed TypedNuCls(0, TypeName(None),
-//│ 	List(),
-//│ 	None,
-//│ 	this: ⊤, 
-//│ 	(Option#T,NuParam(TypeName(Option#T),mut T29_33#..T29_33#,true))
-//│ 	(filter,TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Left(Var(None))),#None<Option,Object>)),
-//│ 	: ⊤, Set(TypeName(Option)), Map(Option#T -> NuParam(TypeName(T),mut T29_33#..T29_33#,true))) where 
-//│ 		T29_33# := Nothing
-//│ | Typing unit statements
-//│ | : None
-//│ ======== TYPED ========
-//│ class Option
-//│   this: ⊤ 
-//│ class None
-//│   this: ⊤ 
-//│ abstract class Option[T]: None | () {
-//│   fun filter: Option[T]
-//│ }
-//│ module None extends Option {
-//│   fun filter: None
-//│ }
-
-
-
-:exit
-====================================================================================================
-
+// * Minimization of code that used to cause a problem:
 
 abstract class Option[T]: (None | ()) {
   virtual fun filter: Option[T]
@@ -172,24 +9,6 @@ abstract class Option[T]: (None | ()) {
 module None extends Option[nothing] {
   fun filter = None
 }
-//│ ╔══[ERROR] Type `#None` does not contain member `Option#T`
-//│ ║  l.48: 	abstract class Option[T]: (None | ()) {
-//│ ╙──      	                      ^
-//│ ╔══[ERROR] Type mismatch in definition of method filter:
-//│ ║  l.52: 	  fun filter = None
-//│ ║        	      ^^^^^^^^^^^^^
-//│ ╟── reference of type `#None` does not have field 'Option#T'
-//│ ║  l.52: 	  fun filter = None
-//│ ║        	               ^^^^
-//│ ╟── but it flows into definition of method filter with expected type `{Option#T = ?T}`
-//│ ║  l.52: 	  fun filter = None
-//│ ║        	      ^^^^^^^^^^^^^
-//│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.49: 	  virtual fun filter: Option[T]
-//│ ║        	                      ^^^^^^^^^
-//│ ╟── from signature of member `filter`:
-//│ ║  l.49: 	  virtual fun filter: Option[T]
-//│ ╙──      	              ^^^^^^^^^^^^^^^^^
 //│ abstract class Option[T]: None | () {
 //│   fun filter: Option[T]
 //│ }
@@ -198,14 +17,8 @@ module None extends Option[nothing] {
 //│ }
 
 
+// * Original code:
 
-
-
-
-
-
-
-// FIXME: this looks like a bug about mutually-referential definitions
 abstract class Option[out T]: (Some[T] | None) {
   virtual fun filter: (p: T -> Bool) -> Option[T]
 }
@@ -215,12 +28,6 @@ class Some[out T](val value: T) extends Option[T] {
 module None extends Option[nothing] {
   fun filter(_) = None
 }
-//│ ╔══[ERROR] Type `#Some & {Some#T <: ?T}` does not contain member `Option#T`
-//│ ║  l.5: 	abstract class Option[out T]: (Some[T] | None) {
-//│ ╙──     	                          ^
-//│ ╔══[ERROR] Type `#None` does not contain member `Option#T`
-//│ ║  l.5: 	abstract class Option[out T]: (Some[T] | None) {
-//│ ╙──     	                          ^
 //│ abstract class Option[T]: None | Some[T] {
 //│   fun filter: (p: T -> Bool) -> Option[T]
 //│ }
@@ -230,4 +37,5 @@ module None extends Option[nothing] {
 //│ module None extends Option {
 //│   fun filter: anything -> None
 //│ }
+
 

--- a/shared/src/test/diff/nu/OptionFilter.mls
+++ b/shared/src/test/diff/nu/OptionFilter.mls
@@ -39,3 +39,34 @@ module None extends Option[nothing] {
 //│ }
 
 
+
+abstract class Boxful[T] {
+  virtual fun clone(): Boxful[T]
+}
+class MetalBox[T](value: T) extends Boxful[T] {
+  fun clone(): Boxful[T] = MetalBox(value)
+}
+//│ abstract class Boxful[T] {
+//│   fun clone: () -> Boxful[T]
+//│ }
+//│ class MetalBox[T](value: T) extends Boxful {
+//│   fun clone: () -> Boxful[T]
+//│ }
+
+
+fun makeMetalBox(value: 'A): Boxful['A] = MetalBox(value)
+abstract class Boxful[T] {
+  virtual fun clone(): Boxful[T]
+}
+class MetalBox[T](value: T) extends Boxful[T] {
+  fun clone(): Boxful[T] = makeMetalBox(value)
+}
+//│ fun makeMetalBox: forall 'T. (value: 'T) -> Boxful['T]
+//│ abstract class Boxful[T] {
+//│   fun clone: () -> Boxful[T]
+//│ }
+//│ class MetalBox[T](value: T) extends Boxful {
+//│   fun clone: () -> Boxful[T]
+//│ }
+
+

--- a/shared/src/test/diff/nu/OptionFilter.mls
+++ b/shared/src/test/diff/nu/OptionFilter.mls
@@ -1,5 +1,210 @@
 :NewDefs
 
+
+
+:d
+abstract class Option[out T]: (None | ()) {
+  virtual fun filter: Option[T]
+}
+module None extends Option[nothing] {
+  fun filter = None
+}
+//│ 0. Typing TypingUnit(List(NuTypeDef(Cls,TypeName(Option),List((Some(+),TypeName(T))),None,None,Some(Union(TypeName(None),Literal(UnitLit(true)))),List(),None,None,TypingUnit(List(NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T))))))))), NuTypeDef(Mod,TypeName(None),List(),None,None,None,List(TyApp(Var(Option),List(TypeName(nothing)))),None,None,TypingUnit(List(NuFunDef(None,Var(filter),None,List(),Left(Var(None))))))))
+//│ | 0. Created lazy type info for NuTypeDef(Cls,TypeName(Option),List((Some(+),TypeName(T))),None,None,Some(Union(TypeName(None),Literal(UnitLit(true)))),List(),None,None,TypingUnit(List(NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T)))))))))
+//│ | 0. Created lazy type info for NuTypeDef(Mod,TypeName(None),List(),None,None,None,List(TyApp(Var(Option),List(TypeName(nothing)))),None,None,TypingUnit(List(NuFunDef(None,Var(filter),None,List(),Left(Var(None))))))
+//│ | Completing class Option‹T›: None | () {fun filter: Option[T]}
+//│ | | Type params (TypeName(T),T29',Some(+))
+//│ | | Params 
+//│ | | Typing type PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T))))
+//│ | | | vars=Map(T -> ‘T29') newDefsInfo=Map()
+//│ | | | 2. type PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T))))
+//│ | | | | 3. type AppliedType(TypeName(Option),List(TypeName(T)))
+//│ | | | | | 3. type TypeName(T)
+//│ | | | | | => ‘T29'
+//│ | | | | => Option[‘T29']
+//│ | | | | Inferred poly constr: Option[‘T29']  —— where 
+//│ | | | => Option[‘T29']
+//│ | | => Option[‘T29'] ——— 
+//│ | | Inferred poly constr: Option[‘T29']  —— where 
+//│ | | Typing type Union(TypeName(None),Literal(UnitLit(true)))
+//│ | | | vars=Map(T -> ‘T29') newDefsInfo=Map()
+//│ | | | 2. type Union(TypeName(None),Literal(UnitLit(true)))
+//│ | | | | 2. type TypeName(None)
+//│ | | | | => None
+//│ | | | | 2. type Literal(UnitLit(true))
+//│ | | | | => #undefined<Object>
+//│ | | | => (None | #undefined<Object>)
+//│ | | => (None | #undefined<Object>) ——— 
+//│ | | CONSTRAIN (None | #undefined<Object>) <! α30'
+//│ | |   where 
+//│ | | 1. C (None | #undefined<Object>) <! α30'    (0)
+//│ | | | NEW α30' LB (0)
+//│ | | Done inheriting: Pack({},List(NuParam(TypeName(Option#T),mut ‘T29'..‘T29',true)),None,List(),List(),Map())
+//│ | | 1. Finalizing inheritance with ((({} w/ {} & #Option<Object>) & {Option#T: mut ‘T29'..‘T29'}) & ⊤..(None | #undefined<Object>)) <: option31'
+//│ | | | CONSTRAIN ((({} w/ {} & #Option<Object>) & {Option#T: mut ‘T29'..‘T29'}) & ⊤..(None | #undefined<Object>)) <! option31'
+//│ | | |   where 
+//│ | | | 1. C ((({} w/ {} & #Option<Object>) & {Option#T: mut ‘T29'..‘T29'}) & ⊤..(None | #undefined<Object>)) <! option31'    (0)
+//│ | | | | NEW option31' LB (1)
+//│ | | 1. Typing TypingUnit(List(NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T))))))))
+//│ | | | Typing unit statements
+//│ | | | : None
+//│ | | baseClsImplemMembers List()
+//│ | | Checking `this` accesses...
+//│ | | Checking base class implementations against inherited signatures...
+//│ | | Checking new implementations against inherited signatures...
+//│ | | | Checking overriding for NuParam(TypeName(Option#T),mut ‘T29'..‘T29',true) against None...
+//│ | | Checking new signatures against inherited signatures...
+//│ | | | Checking overriding for TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T)))))),Option[‘T29']) against None...
+//│ | | allMembers Map(Option#T -> NuParam(TypeName(Option#T),mut ‘T29'..‘T29',true), filter -> TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T)))))),Option[‘T29']))
+//│ | | Computing variances of Option
+//│ | | | Trav(+)(Option[‘T29'])
+//│ | | | | Trav(+)(‘T29')
+//│ | | | | | Trav(+)(T29')
+//│ | | = HashMap(T29' -> +)
+//│ | Completed TypedNuCls(0, TypeName(Option),
+//│ 	List((TypeName(T),T29',Some(+))),
+//│ 	None,
+//│ 	this: ⊤, 
+//│ 	(Option#T,NuParam(TypeName(Option#T),mut ‘T29'..‘T29',true))
+//│ 	(filter,TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T)))))),Option[‘T29'])),
+//│ 	: ⊤..(None | #undefined<Object>), Set(), Map()) where 
+//│ | Completing module None: Option‹nothing› {fun filter = None}
+//│ | | Type params 
+//│ | | Params 
+//│ | | 1. Typing parent spec Var(Option)
+//│ | | | Typing type TypeName(nothing)
+//│ | | | | vars=Map() newDefsInfo=Map()
+//│ | | | | 1. type TypeName(nothing)
+//│ | | | | => Nothing
+//│ | | | => Nothing ——— 
+//│ | | | Assigning T :: T29' := Nothing where 
+//│ | | | Set T29_33 ~> T29'
+//│ | | | Class arg members List()
+//│ | | => Inheriting from TypedNuCls(0, TypeName(Option),
+//│ 	List((TypeName(T),T29_33#,Some(+))),
+//│ 	None,
+//│ 	this: ⊤, 
+//│ 	(Option#T,NuParam(TypeName(Option#T),mut T29_33#..T29_33#,true))
+//│ 	(filter,TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T)))))),Option[T29_33#])),
+//│ 	: ⊤..(None | #undefined<Object>), Set(), Map())
+//│ | | argMembs List()
+//│ | | Done inheriting: Pack({},List(),Some(Option),List(NuParam(TypeName(Option#T),mut T29_33#..T29_33#,true), TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T)))))),Option[T29_33#])),List(),Map(Option#T -> NuParam(TypeName(T),mut T29_33#..T29_33#,true)))
+//│ | | 1. Finalizing inheritance with ({} w/ {} & #None<Object,Option>) <: none32'
+//│ | | | CONSTRAIN ({} w/ {} & #None<Object,Option>) <! none32'
+//│ | | |   where 
+//│ | | | 1. C ({} w/ {} & #None<Object,Option>) <! none32'    (0)
+//│ | | | | NEW none32' LB (0)
+//│ | | 1. Typing TypingUnit(List(NuFunDef(None,Var(filter),None,List(),Left(Var(None)))))
+//│ | | | 1. Created lazy type info for NuFunDef(None,Var(filter),None,List(),Left(Var(None)))
+//│ | | | Completing fun filter = None
+//│ | | | | Type params 
+//│ | | | | Params 
+//│ | | | | 2. Typing term Var(None)
+//│ | | | | 2. : #None<Option,Object>
+//│ | | | | CONSTRAIN #None<Option,Object> <! filter34''
+//│ | | | |   where 
+//│ | | | | 2. C #None<Option,Object> <! filter34''    (0)
+//│ | | | | | NEW filter34'' LB (0)
+//│ | | | Completed TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Left(Var(None))),#None<Option,Object>) where 
+//│ | | | Typing unit statements
+//│ | | | : None
+//│ | | baseClsImplemMembers List(NuParam(TypeName(Option#T),mut T29_33#..T29_33#,true))
+//│ | | Checking `this` accesses...
+//│ | | Checking base class implementations against inherited signatures...
+//│ | | | Checking overriding for NuParam(TypeName(Option#T),mut T29_33#..T29_33#,true) against None...
+//│ | | Checking new implementations against inherited signatures...
+//│ | | | Checking overriding for TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Left(Var(None))),#None<Option,Object>) against Some(TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Right(PolyType(List(),AppliedType(TypeName(Option),List(TypeName(T)))))),Option[T29_33#]))...
+//│ | | | CONSTRAIN #None<Option,Object> <! Option[T29_33#]
+//│ | | |   where 
+//│ 		T29_33# := Nothing
+//│ | | | 1. C #None<Option,Object> <! Option[T29_33#]    (0)
+//│ | | | | Passing T :: T29' <=< T29_33#
+//│ | | | | 1. C #None<Option,Object> <! ((#Option<Object> & ⊤..(None | #undefined<Object>)) & {Option#T: T29_33#})    (2)
+//│ | | | | | 1. C #None<Option,Object> <! (#Option<Object> & ⊤..(None | #undefined<Object>))    (4)
+//│ | | | | | | Already a subtype by <:<
+//│ | | | | | 1. C #None<Option,Object> <! {Option#T: T29_33#}    (4)
+//│ | | | | | | Looking up field Option#T in Some(None) & TreeSet() & {...}
+//│ | | | | | | | (privateFields,Set())
+//│ | | | | | | | Lookup None.Option#T : None where 
+//│ | | | | | | | Fresh[0] None.Option#T : None where None
+//│ | | | | | | |   & None  (from refinement)
+//│ ╔══[ERROR] Indirectly-recursive member should have type annotation
+//│ ║  l.6: 	abstract class Option[out T]: (None | ()) {
+//│ ╙──     	                          ^
+//│ | | | | | | 1. C #error<> <! T29_33#    (3)
+//│ | | | | | | | 1. C #error<> <! Nothing    (5)
+//│ | | Checking new signatures against inherited signatures...
+//│ | | allMembers Map(Option#T -> NuParam(TypeName(Option#T),mut T29_33#..T29_33#,true), filter -> TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Left(Var(None))),#None<Option,Object>))
+//│ | | Computing variances of None
+//│ | | | Trav(+)(#None<Option,Object>)
+//│ | | = HashMap()
+//│ | Completed TypedNuCls(0, TypeName(None),
+//│ 	List(),
+//│ 	None,
+//│ 	this: ⊤, 
+//│ 	(Option#T,NuParam(TypeName(Option#T),mut T29_33#..T29_33#,true))
+//│ 	(filter,TypedNuFun(1,NuFunDef(None,Var(filter),None,List(),Left(Var(None))),#None<Option,Object>)),
+//│ 	: ⊤, Set(TypeName(Option)), Map(Option#T -> NuParam(TypeName(T),mut T29_33#..T29_33#,true))) where 
+//│ 		T29_33# := Nothing
+//│ | Typing unit statements
+//│ | : None
+//│ ======== TYPED ========
+//│ class Option
+//│   this: ⊤ 
+//│ class None
+//│   this: ⊤ 
+//│ abstract class Option[T]: None | () {
+//│   fun filter: Option[T]
+//│ }
+//│ module None extends Option {
+//│   fun filter: None
+//│ }
+
+
+
+:exit
+====================================================================================================
+
+
+abstract class Option[T]: (None | ()) {
+  virtual fun filter: Option[T]
+}
+module None extends Option[nothing] {
+  fun filter = None
+}
+//│ ╔══[ERROR] Type `#None` does not contain member `Option#T`
+//│ ║  l.48: 	abstract class Option[T]: (None | ()) {
+//│ ╙──      	                      ^
+//│ ╔══[ERROR] Type mismatch in definition of method filter:
+//│ ║  l.52: 	  fun filter = None
+//│ ║        	      ^^^^^^^^^^^^^
+//│ ╟── reference of type `#None` does not have field 'Option#T'
+//│ ║  l.52: 	  fun filter = None
+//│ ║        	               ^^^^
+//│ ╟── but it flows into definition of method filter with expected type `{Option#T = ?T}`
+//│ ║  l.52: 	  fun filter = None
+//│ ║        	      ^^^^^^^^^^^^^
+//│ ╟── Note: constraint arises from applied type reference:
+//│ ║  l.49: 	  virtual fun filter: Option[T]
+//│ ║        	                      ^^^^^^^^^
+//│ ╟── from signature of member `filter`:
+//│ ║  l.49: 	  virtual fun filter: Option[T]
+//│ ╙──      	              ^^^^^^^^^^^^^^^^^
+//│ abstract class Option[T]: None | () {
+//│   fun filter: Option[T]
+//│ }
+//│ module None extends Option {
+//│   fun filter: None
+//│ }
+
+
+
+
+
+
+
+
+
 // FIXME: this looks like a bug about mutually-referential definitions
 abstract class Option[out T]: (Some[T] | None) {
   virtual fun filter: (p: T -> Bool) -> Option[T]
@@ -11,10 +216,10 @@ module None extends Option[nothing] {
   fun filter(_) = None
 }
 //│ ╔══[ERROR] Type `#Some & {Some#T <: ?T}` does not contain member `Option#T`
-//│ ║  l.4: 	abstract class Option[out T]: (Some[T] | None) {
+//│ ║  l.5: 	abstract class Option[out T]: (Some[T] | None) {
 //│ ╙──     	                          ^
 //│ ╔══[ERROR] Type `#None` does not contain member `Option#T`
-//│ ║  l.4: 	abstract class Option[out T]: (Some[T] | None) {
+//│ ║  l.5: 	abstract class Option[out T]: (Some[T] | None) {
 //│ ╙──     	                          ^
 //│ abstract class Option[T]: None | Some[T] {
 //│   fun filter: (p: T -> Bool) -> Option[T]
@@ -25,3 +230,4 @@ module None extends Option[nothing] {
 //│ module None extends Option {
 //│   fun filter: anything -> None
 //│ }
+

--- a/shared/src/test/diff/nu/SelfRec.mls
+++ b/shared/src/test/diff/nu/SelfRec.mls
@@ -229,7 +229,14 @@ class Foo8[A](x: A) {
 :e // * FIXME this is caused by the self-annotation...
 abstract class List(val length: Int): Cons
 class Cons(tail: List) extends List(tail.length + 1)
-//│ /!!!\ Uncaught error: java.lang.StackOverflowError
+//│ ╔══[ERROR] Unhandled cyclic parent specification
+//│ ║  l.231: 	class Cons(tail: List) extends List(tail.length + 1)
+//│ ╙──       	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╔══[ERROR] Indirectly-recursive member should have type annotation
+//│ ║  l.231: 	class Cons(tail: List) extends List(tail.length + 1)
+//│ ╙──       	                                        ^^^^^^^
+//│ abstract class List(length: Int): Cons
+//│ class Cons(tail: List) extends List
 
 // * Note: full (non-minimized) definitions:
 
@@ -237,6 +244,14 @@ class Cons(tail: List) extends List(tail.length + 1)
 abstract class List[out A](val length: Int): Cons[A] | Nil
 class Cons[out A](val head: A, val tail: List[A]) extends List[A](tail.length + 1)
 module Nil extends List[nothing](0)
-//│ /!!!\ Uncaught error: java.lang.StackOverflowError
+//│ ╔══[ERROR] Unhandled cyclic parent specification
+//│ ║  l.245: 	class Cons[out A](val head: A, val tail: List[A]) extends List[A](tail.length + 1)
+//│ ╙──       	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╔══[ERROR] Indirectly-recursive member should have type annotation
+//│ ║  l.245: 	class Cons[out A](val head: A, val tail: List[A]) extends List[A](tail.length + 1)
+//│ ╙──       	                                                                      ^^^^^^^
+//│ abstract class List[A](length: Int): Cons[A] | Nil
+//│ class Cons[A](head: A, tail: List[A]) extends List
+//│ module Nil extends List
 
 

--- a/shared/src/test/diff/nu/SelfRec.mls
+++ b/shared/src/test/diff/nu/SelfRec.mls
@@ -229,11 +229,7 @@ class Foo8[A](x: A) {
 :e // * FIXME this is caused by the self-annotation...
 abstract class List(val length: Int): Cons
 class Cons(tail: List) extends List(tail.length + 1)
-//│ ╔══[ERROR] Indirectly-recursive member should have type annotation
-//│ ║  l.231: 	class Cons(tail: List) extends List(tail.length + 1)
-//│ ╙──       	                                        ^^^^^^^
-//│ abstract class List(length: Int): Cons
-//│ class Cons(tail: List) extends List
+//│ /!!!\ Uncaught error: java.lang.StackOverflowError
 
 // * Note: full (non-minimized) definitions:
 
@@ -241,11 +237,6 @@ class Cons(tail: List) extends List(tail.length + 1)
 abstract class List[out A](val length: Int): Cons[A] | Nil
 class Cons[out A](val head: A, val tail: List[A]) extends List[A](tail.length + 1)
 module Nil extends List[nothing](0)
-//│ ╔══[ERROR] Indirectly-recursive member should have type annotation
-//│ ║  l.242: 	class Cons[out A](val head: A, val tail: List[A]) extends List[A](tail.length + 1)
-//│ ╙──       	                                                                      ^^^^^^^
-//│ abstract class List[A](length: Int): Cons[A] | Nil
-//│ class Cons[A](head: A, tail: List[A]) extends List
-//│ module Nil extends List
+//│ /!!!\ Uncaught error: java.lang.StackOverflowError
 
 


### PR DESCRIPTION
This change exposed some more limitations when typing cyclic definitions. In the future we should create a proper framework for correctly dealing with typing dependencies, allowing to type more things, to still infer refined types in the absence of cycles, and to give more specific error messages.