### PR TITLE
Revert workspace setting modified in hkust-taco#174

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,5 @@
             "other": "off",
             "strings": "off"
         }
-    },
-    "files.autoSave": "off"
+    }
 }


### PR DESCRIPTION
https://github.com/hkust-taco/mlscript/pull/174/files#r1290512647
Turns out `files.autoSave` is indeed enabled by others.