### PR TITLE
Fix `let` annotation handling

### DIFF
--- a/shared/src/main/scala/mlscript/NewParser.scala
+++ b/shared/src/main/scala/mlscript/NewParser.scala
@@ -522,7 +522,7 @@ abstract class NewParser(origin: Origin, tokens: Ls[Stroken -> Loc], newDefs: Bo
                       consume
                       if (tparams.nonEmpty) err(msg"Unsupported type parameters on 'let' binding" -> S(l1) :: Nil)
                       val rest = expr(0)
-                      R(Let(isLetRec.getOrElse(die), v, body, rest).withLoc(S(l0 ++ annotatedBody.toLoc)))
+                      R(Let(isLetRec.getOrElse(die), v, annotatedBody, rest).withLoc(S(l0 ++ annotatedBody.toLoc)))
                     case _ =>
                       R(NuFunDef(
                           isLetRec, v, opStr, tparams, L(ps.foldRight(annotatedBody)((i, acc) => Lam(i, acc)))

--- a/shared/src/test/diff/nu/Ascription.mls
+++ b/shared/src/test/diff/nu/Ascription.mls
@@ -49,3 +49,10 @@ foo(123:Int):Int
 //│ Code generation encountered an error:
 //│   unresolved symbol Int
 
+fun foo(f) =
+  let g = (x => f(x)): forall 'a : 'a -> 'a in g(123)
+//│ fun foo: (??a -> ??a0) -> 123
+
+fun foo(f) =
+  let g: forall 'a : 'a -> 'a = x => f(x) in g(123)
+//│ fun foo: (??a -> ??a0) -> 123


### PR DESCRIPTION
The annotation for let-binding was not handled correctly:
```ts
// the annotation `forall 'a : 'a -> 'a` is ignored
fun foo(f) =
  let g: forall 'a : 'a -> 'a = x => f(x) in g(123)
//│ fun foo: forall 'a. (123 -> 'a) -> 'a

fun foo(f) =
  let g = (x => f(x)): forall 'a : 'a -> 'a in g(123)
//│ fun foo: (??a -> ??a0) -> 123
```

This simple PR fixed this problem so that two given functions above have the same type:
```ts
fun foo(f) =
  let g = (x => f(x)): forall 'a : 'a -> 'a in g(123)
//│ fun foo: (??a -> ??a0) -> 123

fun foo(f) =
  let g: forall 'a : 'a -> 'a = x => f(x) in g(123)
//│ fun foo: (??a -> ??a0) -> 123
```