### PR TITLE
Type Classes

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
@@ -7,6 +7,7 @@ import utils.*
 
 import hkmc2.semantics.MemberSymbol
 import hkmc2.semantics.Elaborator
+import semantics.Elaborator.Ctx
 import hkmc2.syntax.Keyword.`override`
 import semantics.Elaborator.State
 
@@ -69,16 +70,16 @@ class MLsCompiler(preludeFile: os.Path, mkOutput: ((Str => Unit) => Unit) => Uni
     val preludeParse = ParserSetup(preludeFile, dbgParsing)
     val mainParse = ParserSetup(file, dbgParsing)
     
-    val elab = Elaborator(etl, wd)
+    val elab = Elaborator(etl, wd, Ctx.empty)
     
     val initState = State.init.nest(N)
     
     val (pblk, newCtx) = elab.importFrom(preludeParse.resultBlk)(using initState)
     
     newCtx.nest(N).givenIn:
-      
+      val elab = Elaborator(etl, wd, newCtx)
       val parsed = mainParse.resultBlk
-      val (blk0, newCtx) = elab.importFrom(parsed)
+      val (blk0, _) = elab.importFrom(parsed)
       val blk = blk0.copy(stats = semantics.Import(State.runtimeSymbol, runtimeFile.toString) :: blk0.stats)
       val low = ltl.givenIn:
         codegen.Lowering(lowerHandlers = false, stackLimit = None) // TODO: properly hook up stack limit

--- a/hkmc2/shared/src/main/scala/hkmc2/bbml/bbML.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/bbml/bbML.scala
@@ -441,15 +441,15 @@ class BBTyper(using elState: Elaborator.State, tl: TL):
             effBuff += eff
             ctx += sym -> rhsTy
             goStats(stats)
-          case TermDefinition(_, Fun, sym, ps :: Nil, sig, S(body), _, _, _) :: stats =>
+          case TermDefinition(_, Fun, sym, ps :: Nil, _, sig, S(body), _, _, _) :: stats =>
             typeFunDef(sym, Term.Lam(ps, body), sig, ctx)
             goStats(stats)
-          case TermDefinition(_, Fun, sym, Nil, sig, S(body), _, _, _) :: stats =>
+          case TermDefinition(_, Fun, sym, Nil, _, sig, S(body), _, _, _) :: stats =>
             typeFunDef(sym, body, sig, ctx)  // * may be a case expressions
             goStats(stats)
-          case TermDefinition(_, Fun, sym1, _, S(sig), None, _, _, _) :: (td @ TermDefinition(_, Fun, sym2, _, _, S(body), _, _, _)) :: stats
+          case TermDefinition(_, Fun, sym1, _, _, S(sig), None, _, _, _) :: (td @ TermDefinition(_, Fun, sym2, _, _, _, S(body), _, _, _)) :: stats
             if sym1 === sym2 => goStats(td :: stats) // * avoid type check signatures twice
-          case TermDefinition(_, Fun, sym, _, S(sig), None, _, _, _) :: stats =>
+          case TermDefinition(_, Fun, sym, _, _, S(sig), None, _, _, _) :: stats =>
             ctx += sym -> typeType(sig)
             goStats(stats)
           case (clsDef: ClassDef) :: stats =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
@@ -198,7 +198,7 @@ class BlockTransformer(subst: SymbolSubst):
     val resSym2 = td.resSym.subst
     if (owner2 is td.owner) && (sym2 is td.sym) &&
         (params2 is td.params) && (resSym2 is td.resSym)
-      then td else TermDefinition(owner2, td.k, sym2, params2, td.sign, td.body, resSym2, td.flags, td.annotations)
+      then td else TermDefinition(owner2, td.k, sym2, params2, td.tparams, td.sign, td.body, resSym2, td.flags, td.annotations)
 
 class BlockTransformerShallow(subst: SymbolSubst) extends BlockTransformer(subst):
   override def applyLam(lam: Value.Lam) = lam

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ImplicitResolver.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ImplicitResolver.scala
@@ -1,0 +1,7 @@
+package hkmc2.semantics
+
+import mlscript.utils.*, shorthands.*
+
+class CtxArgImpl(val param: Param) extends CtxArg:
+  override def term: Opt[Term] = N
+

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ImplicitResolver.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ImplicitResolver.scala
@@ -144,15 +144,13 @@ class ImplicitResolver(tl: TraceLogger)
         val paramss = tdf.params
         (paramss zip argss).foreach: 
           case (ps, Term.Tup(args)) =>
-            // * TODO: Check the arity.
-            // if ps.paramCountUB
-            // then if ps.paramCountLB != args.length then
-            //   raise(ErrorReport(msg"Expected ${ps.paramCountLB.toString()} arguments, " +
-            //     msg"got ${args.length.toString()}" -> base.toLoc :: Nil))
-            // else if ps.paramCountLB > args.length then
-            //   raise(ErrorReport(msg"Expected at least ${ps.paramCountLB.toString()} arguments, " +
-            //     msg"got ${args.length.toString()}" -> base.toLoc :: Nil))
-            assert(ps.params.sizeCompare(args) === 0)
+            if ps.paramCountUB
+            then if ps.paramCountLB != args.length then
+              raise(ErrorReport(msg"Expected ${ps.paramCountLB.toString()} arguments, " +
+                msg"got ${args.length.toString()}" -> base.toLoc :: Nil))
+            else if ps.paramCountLB > args.length then
+              raise(ErrorReport(msg"Expected at least ${ps.paramCountLB.toString()} arguments, " +
+                msg"got ${args.length.toString()}" -> base.toLoc :: Nil))
             (ps.params zip args).foreach((p, arg) => resolveArg(p, arg)(base))
           case _ =>
             lastWords("Other argument forms.")

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ImplicitResolver.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ImplicitResolver.scala
@@ -1,7 +1,342 @@
-package hkmc2.semantics
+package hkmc2
+package semantics
 
 import mlscript.utils.*, shorthands.*
+import utils.TraceLogger
 
-class CtxArgImpl(val param: Param) extends CtxArg:
-  override def term: Opt[Term] = N
+import syntax.Tree
+import syntax.{Fun, Ins, Mod}
+import semantics.Term
+import semantics.Elaborator.State
+import ImplicitResolver.ICtx.Type
+import ImplicitResolver.TyParamSymbol
 
+import Message.MessageContext
+
+class CtxArgImpl extends CtxArg:
+  
+  var arg: Opt[Term] = N
+  override def term: Opt[Term] = arg
+  
+  def populate(term: Term): Unit = 
+    arg = S(term)
+    
+  def showDbg: Str = s"CtxArg ${term.fold("‹unpopulated›")(_.showDbg)}"
+
+object ImplicitResolver:
+  
+  type TyParamSymbol = LocalSymbol & NamedSymbol
+  
+  /*
+   * An "implicit" or "instance" context, as opposed to the one in Elaborator.
+   */
+  case class ICtx(
+    parent: Opt[ICtx], 
+    iEnv: Map[Type.Sym, Ls[(Type, ICtx.Instance)]],
+    tEnv: Map[TyParamSymbol, Type]
+  ):
+    
+    def +(typ: Type.Concrete, sym: Symbol): ICtx =
+      val newLs = (typ -> ICtx.Instance(sym)) :: iEnv.getOrElse(typ.toSym, Nil)
+      val newEnv = iEnv + (typ.toSym -> newLs)
+      copy(iEnv = newEnv)
+    
+    def withTypeArg(param: TyParamSymbol, arg: Type): ICtx =
+      copy(tEnv = tEnv + (param -> arg))
+    
+    def get(query: Type.Concrete): Opt[ICtx.Instance] =
+      iEnv.getOrElse(query.toSym, Nil)
+        .find: (typ, _) => 
+          compare(query, typ)
+        .map: (_, instance) => 
+          instance
+    
+    private def compare(a: Type, b: Type): Boolean = (a, b) match
+      case (Type.Unspecified, _) => true
+      case (_, Type.Unspecified) => true
+      case (a: Type.Sym, b: Type.Sym) if a == b => true
+      case (a @ Type.Sym(aSym: VarSymbol), b) if tEnv contains aSym => 
+        compare(tEnv(aSym), b)
+      case (a, b @ Type.Sym(bSym: VarSymbol)) if tEnv contains bSym => 
+        compare(a, tEnv(bSym))
+      case (Type.App(qSym, qArgs), Type.App(tSym, tArgs)) =>
+        compare(qSym, tSym) && 
+        (qArgs.length == tArgs.length) && 
+        (qArgs zip tArgs).forall((a, b) => compare(a, b))
+      case _ => false
+  
+  object ICtx:
+    
+    enum Type:
+      /** 
+       * A symbol type, can be either concrete (a type symbol) or 
+       * abstract (a var symbol representing a type param).
+       */
+      case Sym(sym: BaseTypeSymbol | VarSymbol)
+      /**
+       * An application of a symbol type to a list of type arguments.
+       */
+      case App(t: Sym, typeArgs: Ls[Type])
+      /**
+       * A type that is not specified. 
+       * This is for when the type is not known because no type inference is done.
+       */
+      case Unspecified
+      
+      def show: Str = this match
+        case Sym(sym) => sym.id.name
+        case App(t, args) => s"${t.show}[${args.map(_.show).mkString(", ")}]"
+        case Unspecified => "‹unspecified›"
+    
+    object Type:
+      type Concrete = Sym | App
+      extension (t: Concrete)
+        def toSym: Sym = t match
+          case sym: Sym => sym
+          case App(sym, _) => sym
+    
+    final case class Instance(sym: Symbol)
+    
+    val empty = ICtx(N, Map.empty, Map.empty)
+    
+  def ictx(using ICtx) = summon[ICtx]
+
+class ImplicitResolver(tl: TraceLogger)
+(using raise: Raise, state: State):
+  import tl.*
+  import ImplicitResolver.ICtx
+  import ImplicitResolver.ictx
+  
+  def resolve(t: Term)(using ictx: ICtx): Unit = t match
+    case blk: Term.Blk => 
+      resolveBlk(blk)
+    case Apps(Term.TyApp(base, targs), argss) if argss.nonEmpty =>
+      resolveApp(base, S(targs), argss)
+      t.subTerms.foreach(resolve(_))
+    case Apps(base, argss) if argss.nonEmpty =>
+      resolveApp(base, N, argss)
+      t.subTerms.foreach(resolve(_))
+    case _ => 
+      t.subTerms.foreach(resolve(_))
+  
+  def resolveApp(base: Term, targs: Opt[List[Term]], argss: List[Term])(using ICtx) =
+  trace[Unit](s"Resolving App: $base; $targs; $argss", _ => s"~> $base; $targs; $argss"):
+    base match
+      case ModuleChecker.MethodDef(tdf) =>
+        given withTypeArgs: ICtx = tdf.tparams match
+          case S(tparams) => targs match
+            case S(targs) =>
+              if tparams.length != targs.length then
+                raise(ErrorReport(msg"Expected ${tparams.length.toString()} type arguments, " +
+                  msg"got ${targs.length.toString()}" -> base.toLoc :: Nil))
+              (tparams zip targs).foldLeft(ictx):
+                case (ictx, (tparam, targ)) => (tparam.sym, resolveType(targ)) match
+                  case (sym: TyParamSymbol, S(typ)) =>
+                    log(s"Resolving App with type arg ${sym} = $typ")
+                    ictx.withTypeArg(sym, typ)
+                  case _ => ictx
+            case N => tparams.foldLeft(ictx): 
+              case (ictx, tparam) => 
+                log(s"Resolving App with type arg ${tparam.sym} = ${Type.Unspecified}")
+                ictx.withTypeArg(tparam.sym, Type.Unspecified)
+          // No type parameters for the definition.
+          case N => ictx
+        val paramss = tdf.params
+        (paramss zip argss).foreach: 
+          case (ps, Term.Tup(args)) =>
+            // * TODO: Check the arity.
+            // if ps.paramCountUB
+            // then if ps.paramCountLB != args.length then
+            //   raise(ErrorReport(msg"Expected ${ps.paramCountLB.toString()} arguments, " +
+            //     msg"got ${args.length.toString()}" -> base.toLoc :: Nil))
+            // else if ps.paramCountLB > args.length then
+            //   raise(ErrorReport(msg"Expected at least ${ps.paramCountLB.toString()} arguments, " +
+            //     msg"got ${args.length.toString()}" -> base.toLoc :: Nil))
+            assert(ps.params.sizeCompare(args) === 0)
+            (ps.params zip args).foreach((p, arg) => resolveArg(p, arg)(base))
+          case _ =>
+            lastWords("Other argument forms.")
+      case _ => // Not module method app, do nothing.
+  
+  def resolveArg(p: Param, a: Elem)(t: Term)(using ictx: ICtx): Unit = a match
+    case arg: CtxArgImpl =>
+      log(s"Resolving contextual argument, expecting a ${p.sign}")
+      p.sign match
+        case S(sign) => resolveType(sign) match
+          case S(tpe: Type.Concrete) =>
+            ictx.get(tpe) match
+              case S(i) =>
+                log(s"Populate contextual parameter ${p} with instance ${i}")
+                arg.populate(i.sym.ref())
+              case N =>
+                raise(ErrorReport(
+                  msg"Missing instance for contextual parameter ${tpe.show}" -> p.toLoc ::
+                  msg"Required by module method application at: " -> t.toLoc ::
+                  msg"Expected: ${tpe.show}; Available: ${ictx.iEnv.toString()}" -> N :: Nil))
+          case N =>
+        case N =>
+          // By the syntax of contextual parameter, the type signature should be present.
+          lastWords(s"No type signature for contextual parameter ${p.showDbg} at ${p.toLoc}")
+    case _ =>
+      a.subTerms.foreach(resolve(_))
+  
+  def resolveBlk(blk: Term.Blk)(using ictx: ICtx): ICtx =
+  trace[ICtx](s"Resolving block: $blk", _ => s"~> $blk"):
+    def go(rest: Ls[Statement])(using ictx: ICtx): ICtx = rest match
+      case Nil => ictx
+      case stmt :: rest => 
+        log(s"Resolving statement: $stmt")
+        given newICtx: ICtx = stmt match
+          // Case: instance definition. 
+          // Add the instance to the context.
+          case t @ TermDefinition(_, Ins, sym, _, _, sign, _, _, _, _) => 
+            log(s"Resolving instance definition ${t.showDbg}")
+            sign match
+              case N =>
+                // By the syntax of instance defintiion, the type signature should be present.
+                lastWords(s"No type signature for instance definition ${t.showDbg} at ${t.toLoc}")
+              case S(sign) => resolveType(sign) match
+                case N => ictx
+                case S(typ) => ictx + (typ, sym)
+          
+          // Case: function definition. 
+          // Add the contextual parameters to the context and use the context to resolve the body.
+          // Resolve other subterms with the original context.
+          case t @ TermDefinition(_, Fun, _, pss, _, _, _, _, _, _) =>
+            log(s"Resolving function definition $t")
+            val withCtxArgs = pss
+              .filter(_.flags.ctx)
+              .foldLeft(ictx): (ictx, ps) => 
+                ps.params.foldLeft(ictx): (ictx, p) => 
+                  log(s"Resolving function parameter ${p.showDbg}")
+                  p.sign match
+                    case N =>
+                      // By the syntax of contextual parameter, the type signature should be present.
+                      lastWords(s"No type signature for contextual parameter ${t.showDbg} at ${t.toLoc}")
+                    case S(sign) => resolveType(sign) match
+                      case N => ictx
+                      case S(tpe) => ictx + (tpe, p.sym)
+            t.subTerms.foreach: st => 
+              if t.body.exists(st == _)
+              then resolve(st)(using withCtxArgs)
+              else resolve(st)
+            ictx
+          
+          // Default Case. Simply resovle all subterms.
+          case _ =>
+            stmt.subTerms.foreach(resolve(_))
+            ictx
+        
+        go(rest)
+    
+    val newICtx = go(blk.stats)(using ictx)
+    resolve(blk.res)(using newICtx)
+    newICtx
+  
+  /** Resolve the type signature of a term. */
+  def resolveType(t: Term): Opt[ICtx.Type.Concrete] = t match
+      // If the term is a type application, e.g., T[A, ...],
+      // resolve the type constructor and arguments respectively.
+      case Term.TyApp(con, args) => 
+        (resolveType(con), args.map(resolveType(_)).sequence) match
+          case (S(sym: ICtx.Type.Sym), S(typeArgs)) =>
+            S(ICtx.Type.App(sym, typeArgs))
+          case _ =>
+            // Either the type constructor or the arguments is not resolved.
+            // The error should have been reported.
+            N
+      // Otherwise, resolve the term directly.
+      case _ => t.symbol match
+        // A VarSymbol is probably a type parameter.
+        case S(sym: VarSymbol) if ModuleChecker.isTypeParam(sym) =>
+          S(ICtx.Type.Sym(sym))
+        case S(sym) => sym.asTpe match
+          // A BaseTypeSymbol is some concrete type.
+          case S(tpe: BaseTypeSymbol) =>
+            S(ICtx.Type.Sym(tpe))
+          // A TypeAliasSymbol is a type alias that require further resolution.
+          case S(tpe: TypeAliasSymbol) =>
+            tpe.defn match
+              case S(tpe) => 
+                tpe.rhs.flatMap(resolveType(_))
+              case N => 
+                // No definition for the type alias. 
+                // There must be an error reported on elaborating the type alias.
+                N
+          case N =>
+            raise(ErrorReport(msg"Expected a type, got ${t.describe}" -> t.toLoc :: Nil))
+            N
+        case N =>
+          raise(ErrorReport(msg"Expected a type symbol, got ${t.describe}" -> t.toLoc :: Nil))
+          N
+
+end ImplicitResolver
+
+object ModuleChecker:
+  
+  /** Checks if a term is a reference to a type parameter. */
+  def isTypeParam(t: Term): Bool = t.symbol
+    .filter(_.isInstanceOf[VarSymbol])
+    .flatMap(_.asInstanceOf[VarSymbol].decl)
+    .exists(_.isInstanceOf[TyParam])
+    
+  def isTypeParam(sym: VarSymbol): Bool = sym.decl
+    .exists(_.isInstanceOf[TyParam])
+  
+  /** Checks if a term evaluates to a module value. */
+  def evalsToModule(t: Term): Bool = 
+    def isModule(t: Tree): Bool = t match
+      case Tree.TypeDef(Mod, _, _, _) => true
+      case _ => false
+    def returnsModule(t: Tree.TermDef): Bool = t.annotatedResultType match
+      case S(Tree.TypeDef(Mod, _, N, N)) => true
+      case _ => false
+    t match
+      case Term.Blk(_, res) => evalsToModule(res)
+      case Term.App(lhs, rhs) => lhs.symbol match
+        case S(sym: BlockMemberSymbol) => sym.trmTree.exists(returnsModule)
+        case _ => false
+      case t => t.symbol match
+        case S(sym: BlockMemberSymbol) => sym.modTree.exists(isModule)
+        case _ => false
+  
+  /**
+   * An extractor that extracts the (tree) definition of a module method.
+   */
+  object MethodTreeDef:
+    def unapply(t: Term): Opt[Tree.TermDef] = t match
+      case t @ Term.Sel(pre, _) if evalsToModule(pre) => 
+        t.symbol match
+        case S(sym: BlockMemberSymbol) => sym.trmTree match
+          case S(tree @ Tree.TermDef(k = Fun)) => S(tree)
+          case _ => N
+        case _ => N
+      case t @ Term.SynthSel(pre, _) if evalsToModule(pre) => t.symbol match
+        case S(sym: BlockMemberSymbol) => sym.trmTree match
+          case S(tree @ Tree.TermDef(k = Fun)) => S(tree)
+          case _ => N
+        case _ => N
+      case _ => N
+  
+  object MethodDef:
+    def unapply(t: Term): Opt[TermDefinition] = t match
+      case t @ Term.Sel(pre, _) if evalsToModule(pre) => t.symbol match
+        case S(sym: BlockMemberSymbol) => sym.defn match
+          case S(defn @ TermDefinition(k = Fun)) => S(defn)
+          case _ => N
+        case _ => N
+      case t @ Term.SynthSel(pre, _) if evalsToModule(pre) => t.symbol match
+        case S(sym: BlockMemberSymbol) => sym.defn match
+          case S(defn @ TermDefinition(k = Fun)) => S(defn)
+          case _ => N
+        case _ => N
+      case _ => N
+  
+
+extension [T](xs: Ls[Opt[T]])
+  def sequence: Opt[Ls[T]] =
+    xs.foldRight(S(Nil): Opt[Ls[T]]): (x, acc) => 
+      for 
+        x <- x
+        acc <- acc
+      yield x :: acc

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Importer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Importer.scala
@@ -60,15 +60,9 @@ class Importer:
           val res = p.parseAll(p.block(allowNewlines = true))
           val resBlk = new syntax.Tree.Block(res)
           
-          // * Note: we don't even need to elaborate the block!
-          // * Though doing so may be needed later for type checking,
-          // * so we should probably do it lazily in the future.
-          /* 
-          given Elaborator.State = new Elaborator.State
-          given Elaborator.Ctx = Elaborator.Ctx.init.nest(N)
-          val elab = Elaborator(tl, file / os.up)
-          val (blk, newCtx) = elab.importFrom(resBlk)
-          */
+          given Elaborator.Ctx = prelude.copy(mode = Mode.Light).nest(N)
+          val elab = Elaborator(tl, file / os.up, prelude)
+          elab.importFrom(resBlk)
           
           resBlk.definedSymbols.find(_._1 === nme) match
           case Some(nme -> sym) => sym

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
@@ -199,7 +199,10 @@ case class TupSymbol(arity: Opt[Int])(using State) extends CtorSymbol:
   override def toString: Str = s"tup:$arity"
 
 
-type TypeSymbol = ClassSymbol | TypeAliasSymbol
+/** A TypeSymbol that is not an alias. */
+type BaseTypeSymbol = ClassSymbol
+
+type TypeSymbol = BaseTypeSymbol | TypeAliasSymbol
 
 type FieldSymbol = MemberSymbol[?]
 

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
@@ -59,6 +59,10 @@ abstract class Symbol(using State) extends Located:
     (asCls: Opt[ClassSymbol | ModuleSymbol | PatternSymbol]) orElse asModOrObj orElse asPat
   def asTpe: Opt[TypeSymbol] = asCls orElse asAls
   
+  def asBlkMember: Opt[BlockMemberSymbol] = this match
+    case mem: BlockMemberSymbol => S(mem)
+    case _ => N
+  
   override def equals(x: Any): Bool = x match
     case that: Symbol => uid === that.uid
     case _ => false

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
@@ -31,6 +31,7 @@ enum Annot extends AutoLocated:
 enum Term extends Statement:
   case Error
   case UnitVal()
+  case Missing // Placeholder terms that were not elaborated due to the "lightweight" elaboration mode `Mode.Light`
   case Lit(lit: Literal)
   case Builtin(id: Tree.Ident, nme: Str)
   case Ref(sym: Symbol)(val tree: Tree.Ident, val refNum: Int)
@@ -213,6 +214,7 @@ sealed trait Statement extends AutoLocated with ProductWithExtraInfo:
     case WildcardTy(in, out) => s"in ${in.map(_.toString).getOrElse("⊥")} out ${out.map(_.toString).getOrElse("⊤")}"
     case Sel(pre, nme) => s"${pre.showDbg}.${nme.name}"
     case SynthSel(pre, nme) => s"(${pre.showDbg}.)${nme.name}"
+    case DynSel(pre, fld, _) => s"${pre.showDbg}[${fld.showDbg}]"
     case IfLike(kw, body) => s"${kw.name} { ${body.showDbg} }"
     case Lam(params, body) => s"λ${params.showDbg}. ${body.showDbg}"
     case Blk(stats, res) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
@@ -462,6 +462,15 @@ object PlainFld:
 final case class Spd(eager: Bool, term: Term) extends Elem:
   def showDbg: Str = (if eager then "..." else "..") + term.showDbg
 
+/** 
+ * Context arguments. 
+ * 
+ * Placeholders represents a nonexistent term that is *expected*
+ * to be populated (resolved) by the implicit resolver later to represent some concrete term.
+ */
+abstract class CtxArg extends Elem:
+  def term: Opt[Term]
+  def showDbg: Str = s"‹using› ${term.fold("‹unpopulated›")(_.showDbg)}"
 
 final case class TyParam(flags: FldFlags, vce: Opt[Bool], sym: VarSymbol) extends Declaration:
   

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Translator.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Translator.scala
@@ -204,7 +204,7 @@ class Translator(val elaborator: Elaborator)
     val ps = PlainParamList(Param(FldFlags.empty, scrut, N) :: Nil)
     val body = Term.IfLike(Keyword.`if`, topmost)(normalize(topmost))
     val res = FlowSymbol(s"result of $name")
-    TermDefinition(N, Fun, sym, ps :: Nil, N, S(body), res, TermDefFlags.empty, Nil)
+    TermDefinition(N, Fun, sym, ps :: Nil, N, N, S(body), res, TermDefFlags.empty, Nil)
   
   /** Translate a list of extractor/matching functions for the given pattern.
    *  There are currently two functions: `unapply` and `unapplyStringPrefix`.

--- a/hkmc2/shared/src/main/scala/hkmc2/syntax/Keyword.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/syntax/Keyword.scala
@@ -97,6 +97,7 @@ object Keyword:
   val `new` = Keyword("new", N, curPrec) // TODO: check the prec
   // val `namespace` = Keyword("namespace", N, N)
   val `use` = Keyword("use", N, curPrec)
+  val `using` = Keyword("using", N, N)
   val `module` = Keyword("module", N, curPrec)
   val `object` = Keyword("object", N, curPrec)
   val `open` = Keyword("open", N, curPrec)

--- a/hkmc2/shared/src/main/scala/hkmc2/syntax/Keyword.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/syntax/Keyword.scala
@@ -96,6 +96,7 @@ object Keyword:
   val `super` = Keyword("super", N, N)
   val `new` = Keyword("new", N, curPrec) // TODO: check the prec
   // val `namespace` = Keyword("namespace", N, N)
+  val `use` = Keyword("use", N, curPrec)
   val `module` = Keyword("module", N, curPrec)
   val `object` = Keyword("object", N, curPrec)
   val `open` = Keyword("open", N, curPrec)

--- a/hkmc2/shared/src/main/scala/hkmc2/syntax/ParseRule.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/syntax/ParseRule.scala
@@ -321,6 +321,7 @@ class ParseRules(using State):
     modified(`throw`),
     modified(`import`), // TODO improve – only allow strings
     // modified(`type`),
+    modified(`using`),
     singleKw(`true`)(BoolLit(true)),
     singleKw(`false`)(BoolLit(false)),
     singleKw(`undefined`)(UnitLit(false)),

--- a/hkmc2/shared/src/main/scala/hkmc2/syntax/ParseRule.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/syntax/ParseRule.scala
@@ -293,6 +293,7 @@ class ParseRules(using State):
       ),
     Kw(`fun`)(termDefBody(Fun)),
     Kw(`val`)(termDefBody(ImmutVal)),
+    Kw(`use`)(termDefBody(Ins)),
     typeAliasLike(`type`, Als),
     typeAliasLike(`pattern`, Pat),
     Kw(`class`)(typeDeclBody(Cls)),

--- a/hkmc2/shared/src/main/scala/hkmc2/syntax/Tree.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/syntax/Tree.scala
@@ -202,6 +202,11 @@ enum Tree extends AutoLocated:
     case Spread(Keyword.`...`, _, S(und: Under)) => S(S(true), new Ident("_").withLocOf(und), N)
     case InfixApp(lhs: Ident, Keyword.`:`, rhs) => S(N, lhs, S(rhs))
     case TermDef(ImmutVal, inner, _) => inner.asParam
+    case Modified(Keyword.`using`, _, inner) => inner match
+      // Param of form (using ..., name: Type). Parse it as usual.
+      case inner: InfixApp => inner.asParam
+      // Param of form (using ..., Type). Synthesize an identifier for it.
+      case _ => S(N, Ident(""), S(inner))
   
   def isModuleModifier: Bool = this match
     case Tree.TypeDef(Mod, _, N, N) => true
@@ -313,8 +318,7 @@ trait TypeOrTermDef:
       
       // use Foo = ...
       case typ if k == Ins =>
-        // TODO: Synthesize a better name.
-        val name = typ.showDbg
+        val name = typ.toString()
         val id: Ident = Ident(s"instance$$$name")
         (S(R(id)), R(id), Nil, N, S(typ))
       

--- a/hkmc2/shared/src/main/scala/hkmc2/utils/utils.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/utils/utils.scala
@@ -24,6 +24,7 @@ import hkmc2.semantics.TermDefFlags
 import hkmc2.semantics.FldFlags
 import scala.collection.mutable.Buffer
 import mlscript.utils.StringOps
+import hkmc2.semantics.CtxArg
 
 trait ProductWithTail extends Product
 
@@ -57,6 +58,12 @@ extension (t: Product)
         val (sl, _, sc) = origin.fph.getLineColAt(start)
         val (el, _, ec) = origin.fph.getLineColAt(end)
         s"Loc at :$sl:$sc-$el:$ec"
+      case arg: CtxArg => arg.term match
+        case N =>
+          s"CtxArg"
+        case Some(t) => 
+          t.showAsTree
+      
       case t: Product => t.showAsTree(inTailPos)
       case v => v.toString
     val postfix = post(t)

--- a/hkmc2/shared/src/test/mlscript-compile/Stack.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/Stack.mls
@@ -6,7 +6,7 @@ open Predef
 // TODO
 // type Stack[A] = Stack.Cons[A] | Stack.Nil
 
-module Stack with ...
+module Stack[T] with ...
 
 class (::) Cons[A](head: A, tail: Stack[A])
 object Nil

--- a/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
+++ b/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
@@ -89,6 +89,9 @@ set g.0 = g.0 + 1
 :todo // TODO instrument Predef
 :re
 id(1, 2)
+//│ ╔══[ERROR] Expected 1 arguments, got 2
+//│ ║  l.91: 	id(1, 2)
+//│ ╙──      	^^
 //│ = 1
 
 // ——— ——— ———
@@ -149,7 +152,7 @@ f of
       2
   of 3
 //│ ╔══[PARSE ERROR] Expected end of input; found indented block instead
-//│ ║  l.150: 	  of 3
+//│ ║  l.153: 	  of 3
 //│ ╙──       	^^
 //│ = [function]
 
@@ -180,7 +183,7 @@ object Oops with
 :e
 Oops.fakeField
 //│ ╔══[ERROR] Object 'Oops' does not contain member 'fakeField'
-//│ ║  l.181: 	Oops.fakeField
+//│ ║  l.184: 	Oops.fakeField
 //│ ╙──       	    ^^^^^^^^^^
 //│ = 1
 
@@ -246,7 +249,7 @@ object Cls(x) with
 :e
 Cls.x
 //│ ╔══[ERROR] Object 'Cls' does not contain member 'x'
-//│ ║  l.247: 	Cls.x
+//│ ║  l.250: 	Cls.x
 //│ ╙──       	   ^^
 //│ ═══[RUNTIME ERROR] Error: Access to required field 'x' yielded 'undefined'
 
@@ -274,15 +277,15 @@ module Example with
 // whoops
   val a = this
 //│ ╔══[PARSE ERROR] Expected block after type declaration body; found newline instead
-//│ ║  l.273: 	module Example with
+//│ ║  l.276: 	module Example with
 //│ ║         	                   ^
-//│ ║  l.274: 	// whoops
+//│ ║  l.277: 	// whoops
 //│ ╙──       	
 //│ ╔══[PARSE ERROR] Expected an expression; found block instead
-//│ ║  l.275: 	  val a = this
+//│ ║  l.278: 	  val a = this
 //│ ╙──       	  ^
 //│ ╔══[PARSE ERROR] Expected end of input; found indented block instead
-//│ ║  l.275: 	  val a = this
+//│ ║  l.278: 	  val a = this
 //│ ╙──       	^^
 
 // ——— ——— ———
@@ -290,7 +293,7 @@ module Example with
 :fixme // ("Not in scope" error)
 let xs = new Oopsie
 //│ ╔══[ERROR] Name not found: Oopsie
-//│ ║  l.291: 	let xs = new Oopsie
+//│ ║  l.294: 	let xs = new Oopsie
 //│ ╙──       	             ^^^^^^
 //│ /!!!\ Uncaught error: hkmc2.InternalError: Not in scope: xs (class hkmc2.semantics.VarSymbol)
 

--- a/hkmc2/shared/src/test/mlscript/basics/BadTypeClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/BadTypeClasses.mls
@@ -1,0 +1,59 @@
+
+:e
+module M with
+  fun f(foo: Int, using bar: Int)
+//│ ╔══[ERROR] Keyword `using` must occur before all parameters.
+//│ ║  l.4: 	  fun f(foo: Int, using bar: Int)
+//│ ╙──     	                        ^^^^^^^^
+
+module M with
+  fun f(using Int)
+
+:e
+M.f
+//│ ╔══[ERROR] Missing instance for contextual parameter Int
+//│ ║  l.10: 	  fun f(using Int)
+//│ ║        	              ^^^
+//│ ╟── Required by module method application at: 
+//│ ║  l.13: 	M.f
+//│ ║        	^^^
+//│ ╙── Expected: Int; Available: Map()
+
+:e
+use 42 = 42
+//│ ╔══[ERROR] Expected a type symbol, got integer literal
+//│ ║  l.23: 	use 42 = 42
+//│ ╙──      	    ^^
+
+val someInt = 42
+
+:e
+use someInt = 42
+//│ ╔══[ERROR] Expected a type, got reference
+//│ ║  l.31: 	use someInt = 42
+//│ ╙──      	    ^^^^^^^
+
+module M with
+  fun bar[A, B](a: A, b: B) = a + b
+
+:e
+M.bar[](1, 2)
+//│ ╔══[ERROR] Expected 2 type arguments, got 0
+//│ ║  l.40: 	M.bar[](1, 2)
+//│ ╙──      	^^^^^
+
+:e
+M.bar[Int](1, 2)
+//│ ╔══[ERROR] Expected 2 type arguments, got 1
+//│ ║  l.46: 	M.bar[Int](1, 2)
+//│ ╙──      	^^^^^
+
+use Int = 42
+
+module M with
+  fun foo()(using a: Int)
+
+// This should fail because M.foo() returns a function that requires special handling
+:todo
+:e
+M.foo()

--- a/hkmc2/shared/src/test/mlscript/basics/StrTest.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/StrTest.mls
@@ -17,24 +17,32 @@ concat of
 
 // TODO (~) should be sanitized
 
+:e
 (~)("a", "b", "c")
+//│ ╔══[ERROR] Expected 2 arguments, got 3
+//│ ║  l.21: 	(~)("a", "b", "c")
+//│ ╙──      	 ^
 //│ = "ab"
 
 
+:e
 (~)("a")
+//│ ╔══[ERROR] Expected 2 arguments, got 1
+//│ ║  l.29: 	(~)("a")
+//│ ╙──      	 ^
 //│ = "aundefined"
 
 :ge
 ~"a"
 //│ ╔══[COMPILATION ERROR] Unexpected type annotations ~"a"
-//│ ║  l.28: 	~"a"
+//│ ║  l.36: 	~"a"
 //│ ╙──      	 ^^^
 
 
 :ge
 ~("a", "b")
 //│ ╔══[COMPILATION ERROR] Unexpected type annotations ~{ "a"; "b" }
-//│ ║  l.35: 	~("a", "b")
+//│ ║  l.43: 	~("a", "b")
 //│ ╙──      	       ^^^
 
 
@@ -42,10 +50,10 @@ concat of
 :ge
 ~ of "a", "b"
 //│ ╔══[PARSE ERROR] Expected start of statement in this position; found 'of' keyword instead
-//│ ║  l.43: 	~ of "a", "b"
+//│ ║  l.51: 	~ of "a", "b"
 //│ ╙──      	  ^^
 //│ ╔══[PARSE ERROR] Expected end of input; found literal instead
-//│ ║  l.43: 	~ of "a", "b"
+//│ ║  l.51: 	~ of "a", "b"
 //│ ╙──      	     ^^^
 //│ ═══[COMPILATION ERROR] Unexpected type annotations ~<error>
 

--- a/hkmc2/shared/src/test/mlscript/basics/TypeClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/TypeClasses.mls
@@ -1,83 +1,149 @@
+:js
 
-:p
-:el
+// Syntaxes
+
 use Int = 42
-//│ |use| |Int| |=| |42|
-//│ Parsed:
-//│ 	TermDef(Ins,Ident(Int),Some(IntLit(42)))
-//│ Elab: { ‹› use member:instance$Ident(Int): member:Int#666 = 42; }
 
-:p
-:el
 use Int as someInt = 42
-//│ |use| |Int| |as| |someInt| |=| |42|
-//│ Parsed:
-//│ 	TermDef(Ins,InfixApp(Ident(Int),keyword 'as',Ident(someInt)),Some(IntLit(42)))
-//│ Elab: { ‹› use member:someInt: member:Int#666 = 42; }
 
-:p
-:el
 module M with
   fun f(using Int) = 42
-//│ |module| |M| |with|→|fun| |f|(|using| |Int|)| |=| |42|←|
-//│ Parsed:
-//│ 	TypeDef(Mod,Ident(M),None,Some(Block(List(TermDef(Fun,App(Ident(f),Tup(List(Modified(keyword 'using',None,Ident(Int))))),Some(IntLit(42)))))))
-//│ Elab: { Mod M { ‹module› fun member:fctx (Param(‹›,,Some(Ref(member:Int))), ) = 42; }; }
 
-:p
-:el
 module M with
   fun f(using foo: Int) = 42
-//│ |module| |M| |with|→|fun| |f|(|using| |foo|:| |Int|)| |=| |42|←|
-//│ Parsed:
-//│ 	TypeDef(Mod,Ident(M),None,Some(Block(List(TermDef(Fun,App(Ident(f),Tup(List(Modified(keyword 'using',None,InfixApp(Ident(foo),keyword ':',Ident(Int)))))),Some(IntLit(42)))))))
-//│ Elab: { Mod M { ‹module› fun member:fctx (Param(‹›,foo,Some(Ref(member:Int))), ) = 42; }; }
 
-:p
-:el
 module M with
   fun f(using foo: Int, bar: Int) = 42
-//│ |module| |M| |with|→|fun| |f|(|using| |foo|:| |Int|,| |bar|:| |Int|)| |=| |42|←|
-//│ Parsed:
-//│ 	TypeDef(Mod,Ident(M),None,Some(Block(List(TermDef(Fun,App(Ident(f),Tup(List(Modified(keyword 'using',None,InfixApp(Ident(foo),keyword ':',Ident(Int))), InfixApp(Ident(bar),keyword ':',Ident(Int))))),Some(IntLit(42)))))))
-//│ Elab: { Mod M { ‹module› fun member:fctx (Param(‹›,foo,Some(Ref(member:Int))), Param(‹›,bar,Some(Ref(member:Int))), ) = 42; }; }
 
-:p
-:el
 module M with
   fun f(using foo: Int)(bar: Int) = 42
-//│ |module| |M| |with|→|fun| |f|(|using| |foo|:| |Int|)|(|bar|:| |Int|)| |=| |42|←|
-//│ Parsed:
-//│ 	TypeDef(Mod,Ident(M),None,Some(Block(List(TermDef(Fun,App(App(Ident(f),Tup(List(Modified(keyword 'using',None,InfixApp(Ident(foo),keyword ':',Ident(Int)))))),Tup(List(InfixApp(Ident(bar),keyword ':',Ident(Int))))),Some(IntLit(42)))))))
-//│ Elab: { Mod M { ‹module› fun member:fctx (Param(‹›,foo,Some(Ref(member:Int))), )(Param(‹›,bar,Some(Ref(member:Int))), ) = 42; }; }
 
-:p
-:el
 module M with
   fun f(foo: Int)(using bar: Int) = 42
-//│ |module| |M| |with|→|fun| |f|(|foo|:| |Int|)|(|using| |bar|:| |Int|)| |=| |42|←|
-//│ Parsed:
-//│ 	TypeDef(Mod,Ident(M),None,Some(Block(List(TermDef(Fun,App(App(Ident(f),Tup(List(InfixApp(Ident(foo),keyword ':',Ident(Int))))),Tup(List(Modified(keyword 'using',None,InfixApp(Ident(bar),keyword ':',Ident(Int)))))),Some(IntLit(42)))))))
-//│ Elab: { Mod M { ‹module› fun member:f(Param(‹›,foo,Some(Ref(member:Int))), )ctx (Param(‹›,bar,Some(Ref(member:Int))), ) = 42; }; }
 
-:p
-:el
 module M with
   fun f(using foo: Int)(using bar: Int) = 42
-//│ |module| |M| |with|→|fun| |f|(|using| |foo|:| |Int|)|(|using| |bar|:| |Int|)| |=| |42|←|
-//│ Parsed:
-//│ 	TypeDef(Mod,Ident(M),None,Some(Block(List(TermDef(Fun,App(App(Ident(f),Tup(List(Modified(keyword 'using',None,InfixApp(Ident(foo),keyword ':',Ident(Int)))))),Tup(List(Modified(keyword 'using',None,InfixApp(Ident(bar),keyword ':',Ident(Int)))))),Some(IntLit(42)))))))
-//│ Elab: { Mod M { ‹module› fun member:fctx (Param(‹›,foo,Some(Ref(member:Int))), )ctx (Param(‹›,bar,Some(Ref(member:Int))), ) = 42; }; }
 
-:e
-:p
-:el
+
+// Basic Resolution
+
+abstract class Foo[T] with
+  fun foo(): T
+class IntFoo extends Foo[Int] with
+  fun foo(): Int = 42
+class StrFoo extends Foo[Str] with
+  fun foo(): Str = "42"
 module M with
-  fun f(foo: Int, using bar: Int)
-//│ |module| |M| |with|→|fun| |f|(|foo|:| |Int|,| |using| |bar|:| |Int|)|←|
-//│ Parsed:
-//│ 	TypeDef(Mod,Ident(M),None,Some(Block(List(TermDef(Fun,App(Ident(f),Tup(List(InfixApp(Ident(foo),keyword ':',Ident(Int)), Modified(keyword 'using',None,InfixApp(Ident(bar),keyword ':',Ident(Int)))))),None)))))
-//│ ╔══[ERROR] Keyword `using` must occur before all parameters.
-//│ ║  l.76: 	  fun f(foo: Int, using bar: Int)
-//│ ╙──      	                        ^^^^^^^^
-//│ Elab: { Mod M { ‹module› fun member:fctx (Param(‹›,foo,Some(Ref(member:Int))), Param(‹›,bar,Some(Ref(member:Int))), ); }; }
+  fun foo(using someInt: Int): Int = someInt
+  fun strFoo(using someFoo: Foo[Str]): Str = someFoo.foo()
+  fun intFoo(using someFoo: Foo[Int]): Int = someFoo.foo()
+  fun tFoo[T](using someFoo: Foo[T]): T = someFoo.foo()
+
+use Int as i = 24
+
+use Foo[Int] = new IntFoo()
+
+use Foo[Str] = new StrFoo()
+
+// should resolve to foo(i)
+M.foo
+//│ = 24
+
+// should resolve to intFoo(new IntFoo())
+M.intFoo
+//│ = 42
+
+// should resolve to strFoo(new StrFoo())
+M.strFoo
+//│ = "42"
+
+// should resolve to 100 + intFoo(new IntFoo())
+100 + M.intFoo
+//│ = 142
+
+// should be able to resolve in function body from outer scope
+fun f: Int = M.intFoo
+f
+//│ = 42
+
+// should be able to resolve in function body from parameters
+module N with
+  fun f(using someNum: Num): Num = someNum
+  fun g(using Num): Num = N.f
+use Num = 3.14
+N.g
+//│ = 3.14
+
+
+// Parameterized Type Resolution
+
+// should resolve to tFoo(new StrFoo())
+M.tFoo
+//│ = "42"
+
+// should resolve to tFoo(new IntFoo())
+M.tFoo[Int]
+//│ = 42
+
+abstract class Bar[A, B] with
+  fun bar(): Str
+class IntStrBar extends Bar[Int, Str] with
+  fun bar(): Str = "IntStr"
+class StrIntBar extends Bar[Str, Int] with
+  fun bar(): Str = "StrInt"
+module M with
+  fun tBar1[T](using someFoo: Bar[Int, T]): Str = someFoo.bar()
+  fun tBar2[T](using someFoo: Bar[Str, T]): Str = someFoo.bar()
+  fun tBar3[A, B](using someFoo: Bar[A, B]): Str = someFoo.bar()
+
+use Bar[Int, Str] = new IntStrBar()
+use Bar[Str, Int] = new StrIntBar()
+
+// should resolve to tFoo1(new IntStrBar())
+M.tBar1
+//│ = "IntStr"
+
+// should resolve to tFoo2(new StrIntBar())
+M.tBar2
+//│ = "StrInt"
+
+// should resolve to tFoo3(new StrIntBar())
+M.tBar3
+//│ = "StrInt"
+
+// should resolve to tFoo3(new IntStrBar())
+M.tBar3[Int, Str]
+//│ = "IntStr"
+
+
+// Monoid Example
+
+abstract class Monoid[T] with
+  fun combine(a: T, b: T): T
+  fun empty: T
+
+object IntAddMonoid extends Monoid[Int] with
+  fun combine(a: Int, b: Int): Int = a + b
+  fun empty: Int = 0
+
+object IntMulMonoid extends Monoid[Int] with
+  fun combine(a: Int, b: Int): Int = a * b
+  fun empty: Int = 1
+
+module M with
+  fun foldInt(x1: Int, x2: Int, x3: Int)(using m: Monoid[Int]): Int =
+    m.combine(x1, m.combine(x2, m.combine(x3, m.empty)))
+  fun fold[T](x1: T, x2: T, x3: T)(using m: Monoid[T]): T =
+    m.combine(x1, m.combine(x2, m.combine(x3, m.empty)))
+    
+use Monoid[Int] = IntAddMonoid
+M.foldInt(2, 3, 4)
+//│ = 9
+
+use Monoid[Int] = IntMulMonoid
+M.foldInt(2, 3, 4)
+//│ = 24
+
+use Monoid[Int] = IntAddMonoid
+M.fold(1, 2, 3)
+//│ = 6

--- a/hkmc2/shared/src/test/mlscript/basics/TypeClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/TypeClasses.mls
@@ -5,7 +5,7 @@ use Int = 42
 //│ |use| |Int| |=| |42|
 //│ Parsed:
 //│ 	TermDef(Ins,Ident(Int),Some(IntLit(42)))
-//│ Elab: { ‹› use member:instance$Ident(Int): globalThis:import#Prelude#666(.)Int‹member:Int› = 42; }
+//│ Elab: { ‹› use member:instance$Ident(Int): member:Int#666 = 42; }
 
 :p
 :el
@@ -13,4 +13,71 @@ use Int as someInt = 42
 //│ |use| |Int| |as| |someInt| |=| |42|
 //│ Parsed:
 //│ 	TermDef(Ins,InfixApp(Ident(Int),keyword 'as',Ident(someInt)),Some(IntLit(42)))
-//│ Elab: { ‹› use member:someInt: globalThis:import#Prelude#666(.)Int‹member:Int› = 42; }
+//│ Elab: { ‹› use member:someInt: member:Int#666 = 42; }
+
+:p
+:el
+module M with
+  fun f(using Int) = 42
+//│ |module| |M| |with|→|fun| |f|(|using| |Int|)| |=| |42|←|
+//│ Parsed:
+//│ 	TypeDef(Mod,Ident(M),None,Some(Block(List(TermDef(Fun,App(Ident(f),Tup(List(Modified(keyword 'using',None,Ident(Int))))),Some(IntLit(42)))))))
+//│ Elab: { Mod M { ‹module› fun member:fctx (Param(‹›,,Some(Ref(member:Int))), ) = 42; }; }
+
+:p
+:el
+module M with
+  fun f(using foo: Int) = 42
+//│ |module| |M| |with|→|fun| |f|(|using| |foo|:| |Int|)| |=| |42|←|
+//│ Parsed:
+//│ 	TypeDef(Mod,Ident(M),None,Some(Block(List(TermDef(Fun,App(Ident(f),Tup(List(Modified(keyword 'using',None,InfixApp(Ident(foo),keyword ':',Ident(Int)))))),Some(IntLit(42)))))))
+//│ Elab: { Mod M { ‹module› fun member:fctx (Param(‹›,foo,Some(Ref(member:Int))), ) = 42; }; }
+
+:p
+:el
+module M with
+  fun f(using foo: Int, bar: Int) = 42
+//│ |module| |M| |with|→|fun| |f|(|using| |foo|:| |Int|,| |bar|:| |Int|)| |=| |42|←|
+//│ Parsed:
+//│ 	TypeDef(Mod,Ident(M),None,Some(Block(List(TermDef(Fun,App(Ident(f),Tup(List(Modified(keyword 'using',None,InfixApp(Ident(foo),keyword ':',Ident(Int))), InfixApp(Ident(bar),keyword ':',Ident(Int))))),Some(IntLit(42)))))))
+//│ Elab: { Mod M { ‹module› fun member:fctx (Param(‹›,foo,Some(Ref(member:Int))), Param(‹›,bar,Some(Ref(member:Int))), ) = 42; }; }
+
+:p
+:el
+module M with
+  fun f(using foo: Int)(bar: Int) = 42
+//│ |module| |M| |with|→|fun| |f|(|using| |foo|:| |Int|)|(|bar|:| |Int|)| |=| |42|←|
+//│ Parsed:
+//│ 	TypeDef(Mod,Ident(M),None,Some(Block(List(TermDef(Fun,App(App(Ident(f),Tup(List(Modified(keyword 'using',None,InfixApp(Ident(foo),keyword ':',Ident(Int)))))),Tup(List(InfixApp(Ident(bar),keyword ':',Ident(Int))))),Some(IntLit(42)))))))
+//│ Elab: { Mod M { ‹module› fun member:fctx (Param(‹›,foo,Some(Ref(member:Int))), )(Param(‹›,bar,Some(Ref(member:Int))), ) = 42; }; }
+
+:p
+:el
+module M with
+  fun f(foo: Int)(using bar: Int) = 42
+//│ |module| |M| |with|→|fun| |f|(|foo|:| |Int|)|(|using| |bar|:| |Int|)| |=| |42|←|
+//│ Parsed:
+//│ 	TypeDef(Mod,Ident(M),None,Some(Block(List(TermDef(Fun,App(App(Ident(f),Tup(List(InfixApp(Ident(foo),keyword ':',Ident(Int))))),Tup(List(Modified(keyword 'using',None,InfixApp(Ident(bar),keyword ':',Ident(Int)))))),Some(IntLit(42)))))))
+//│ Elab: { Mod M { ‹module› fun member:f(Param(‹›,foo,Some(Ref(member:Int))), )ctx (Param(‹›,bar,Some(Ref(member:Int))), ) = 42; }; }
+
+:p
+:el
+module M with
+  fun f(using foo: Int)(using bar: Int) = 42
+//│ |module| |M| |with|→|fun| |f|(|using| |foo|:| |Int|)|(|using| |bar|:| |Int|)| |=| |42|←|
+//│ Parsed:
+//│ 	TypeDef(Mod,Ident(M),None,Some(Block(List(TermDef(Fun,App(App(Ident(f),Tup(List(Modified(keyword 'using',None,InfixApp(Ident(foo),keyword ':',Ident(Int)))))),Tup(List(Modified(keyword 'using',None,InfixApp(Ident(bar),keyword ':',Ident(Int)))))),Some(IntLit(42)))))))
+//│ Elab: { Mod M { ‹module› fun member:fctx (Param(‹›,foo,Some(Ref(member:Int))), )ctx (Param(‹›,bar,Some(Ref(member:Int))), ) = 42; }; }
+
+:e
+:p
+:el
+module M with
+  fun f(foo: Int, using bar: Int)
+//│ |module| |M| |with|→|fun| |f|(|foo|:| |Int|,| |using| |bar|:| |Int|)|←|
+//│ Parsed:
+//│ 	TypeDef(Mod,Ident(M),None,Some(Block(List(TermDef(Fun,App(Ident(f),Tup(List(InfixApp(Ident(foo),keyword ':',Ident(Int)), Modified(keyword 'using',None,InfixApp(Ident(bar),keyword ':',Ident(Int)))))),None)))))
+//│ ╔══[ERROR] Keyword `using` must occur before all parameters.
+//│ ║  l.76: 	  fun f(foo: Int, using bar: Int)
+//│ ╙──      	                        ^^^^^^^^
+//│ Elab: { Mod M { ‹module› fun member:fctx (Param(‹›,foo,Some(Ref(member:Int))), Param(‹›,bar,Some(Ref(member:Int))), ); }; }

--- a/hkmc2/shared/src/test/mlscript/basics/TypeClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/TypeClasses.mls
@@ -1,0 +1,16 @@
+
+:p
+:el
+use Int = 42
+//│ |use| |Int| |=| |42|
+//│ Parsed:
+//│ 	TermDef(Ins,Ident(Int),Some(IntLit(42)))
+//│ Elab: { ‹› use member:instance$Ident(Int): globalThis:import#Prelude#666(.)Int‹member:Int› = 42; }
+
+:p
+:el
+use Int as someInt = 42
+//│ |use| |Int| |as| |someInt| |=| |42|
+//│ Parsed:
+//│ 	TermDef(Ins,InfixApp(Ident(Int),keyword 'as',Ident(someInt)),Some(IntLit(42)))
+//│ Elab: { ‹› use member:someInt: globalThis:import#Prelude#666(.)Int‹member:Int› = 42; }

--- a/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing.mls
@@ -9,7 +9,7 @@ class Reg[Rg, Br]
 fun letreg: [E, Res] -> ([Rg] -> Reg[Rg, E] ->{E | Rg} Res) ->{E} Res
 //│ Type: ⊤
 
-fun use: [Rg, Br] -> Reg[Rg, Br] ->{Rg} Int
+fun use_: [Rg, Br] -> Reg[Rg, Br] ->{Rg} Int
 //│ Type: ⊤
 
 
@@ -138,10 +138,10 @@ letreg of r =>
 
 
 letreg of r =>
-  use(r)
+  use_(r)
   integers(r) of it =>
     next(it)
-  use(r)
+  use_(r)
   r
 //│ Type: Reg[?, 'E]
 //│ Where:
@@ -149,25 +149,25 @@ letreg of r =>
 
 :e
 letreg of r =>
-  use(r)
+  use_(r)
   integers(r) of it =>
-    use(r)
+    use_(r)
     next(it)
-  use(r)
+  use_(r)
   r
 //│ ╔══[ERROR] Type error in block
 //│ ║  l.151: 	letreg of r =>
 //│ ║         	^^^^^^^^^^^^^^
-//│ ║  l.152: 	  use(r)
-//│ ║         	^^^^^^^^
+//│ ║  l.152: 	  use_(r)
+//│ ║         	^^^^^^^^^
 //│ ║  l.153: 	  integers(r) of it =>
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.154: 	    use(r)
-//│ ║         	^^^^^^^^^^
+//│ ║  l.154: 	    use_(r)
+//│ ║         	^^^^^^^^^^^
 //│ ║  l.155: 	    next(it)
 //│ ║         	^^^^^^^^^^^^
-//│ ║  l.156: 	  use(r)
-//│ ║         	^^^^^^^^
+//│ ║  l.156: 	  use_(r)
+//│ ║         	^^^^^^^^^
 //│ ║  l.157: 	  r
 //│ ║         	^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
@@ -183,9 +183,9 @@ letreg of r =>
 letreg of r0 =>
   letreg of r1 =>
     integers(r1) of it =>
-      use(r0)
+      use_(r0)
       next(it)
-    use(r1)
+    use_(r1)
     r1
 //│ Type: Reg[?, in 'E]
 //│ Where:

--- a/hkmc2/shared/src/test/mlscript/nofib/ansi.mls
+++ b/hkmc2/shared/src/test/mlscript/nofib/ansi.mls
@@ -14,13 +14,13 @@ fun highlight(s) = nofibStringToList("ESC[7m") +: s +: nofibStringToList("ESC[0m
 
 fun end(xs) = nofibStringToList("")
 
-fun readChar(eof, use, cs) = if cs is
+fun readChar(eof, consume, cs) = if cs is
   Nil then eof(Nil)
-  c :: cs then use(c, cs)
+  c :: cs then consume(c, cs)
 
-fun peekChar(eof, use, cs) = if cs is
+fun peekChar(eof, consume, cs) = if cs is
   Nil then eof(Nil)
-  c :: cs then use(c, c :: cs)
+  c :: cs then consume(c, c :: cs)
 
 fun pressAnyKey(prog, x) = readChar(prog, (c, x) => prog(x), x)
 
@@ -40,27 +40,27 @@ fun writeAt(x_y, s, a) = if x_y is [x, y] then p => writeString(goto(x, y) +: s,
 
 fun moveTo(x_y, a) = if x_y is [x, y] then p => writeString(goto(x, y), a, p)
 
-fun returnn(s, use) = use(reverse(s))
+fun returnn(s, consume) = consume(reverse(s))
 
 :...
 //│ ————————————————————————————————————————————————————————————————————————————————
-fun deletee(n, s, l, use) = if n > 0 then writeString(nofibStringToList("BS_BS"), loop(n - 1, tail(s), l, use)) else ringBell(loop(0, nofibStringToList(""), l, use))
+fun deletee(n, s, l, consume) = if n > 0 then writeString(nofibStringToList("BS_BS"), loop(n - 1, tail(s), l, consume)) else ringBell(loop(0, nofibStringToList(""), l, consume))
 
-fun loop(n, s, l, use) = x => readChar of
-  returnn(s, use)
+fun loop(n, s, l, consume) = x => readChar of
+  returnn(s, consume)
   (c, d) => if
-            c == "B" then deletee(n, s, l, use) 
-            c == "D" then deletee(n, s, l, use)
-            c == "`" then returnn(s, use)
-            n < l then writeChar(c, loop(n + 1, c :: s, l, use), d)
-            else ringBell(loop(n, s, l, use), d)
+            c == "B" then deletee(n, s, l, consume) 
+            c == "D" then deletee(n, s, l, consume)
+            c == "`" then returnn(s, consume)
+            n < l then writeChar(c, loop(n + 1, c :: s, l, consume), d)
+            else ringBell(loop(n, s, l, consume), d)
   x
 //│ ————————————————————————————————————————————————————————————————————————————————
 
-fun readAt(x_y, l, use) = writeAt(x_y, replicate(l, "_"), moveTo(x_y, loop(0, "", l, use)))
+fun readAt(x_y, l, consume) = writeAt(x_y, replicate(l, "_"), moveTo(x_y, loop(0, "", l, consume)))
 
-fun promptReadAt(x_y, l, prompt, use) = if x_y is [x, y] then
-  writeAt([x, y], prompt, readAt([x + listLen(prompt), y], l, use))
+fun promptReadAt(x_y, l, prompt, consume) = if x_y is [x, y] then
+  writeAt([x, y], prompt, readAt([x + listLen(prompt), y], l, consume))
   
 fun program(input) = writes(
   cls ::

--- a/hkmc2/shared/src/test/mlscript/parser/Handler.mls
+++ b/hkmc2/shared/src/test/mlscript/parser/Handler.mls
@@ -50,7 +50,7 @@ handle h = Eff with
   fun f()(r) = r(0)
 in
   foo(h)
-//│ Elab: { { handle h = Ref(member:Eff)() List(HandlerTermDefinition(r,TermDefinition(Some(class:Handler$h$),Fun,member:f,List(ParamList(‹›,List(),None)),None,Some(App(Ref(r),Tup(List(Fld(‹›,Lit(IntLit(0)),None))))),‹result of member:f›,‹›,List()))); member:foo#666(h#666) } }
+//│ Elab: { { handle h = Ref(member:Eff)() List(HandlerTermDefinition(r,TermDefinition(Some(class:Handler$h$),Fun,member:f,List(ParamList(‹›,List(),None)),None,None,Some(App(Ref(r),Tup(List(Fld(‹›,Lit(IntLit(0)),None))))),‹result of member:f›,‹›,List()))); member:foo#666(h#666) } }
 
 :e
 (
@@ -74,7 +74,7 @@ handle h = Mod.Eff(3) with
   fun f()(r) = r(0)
   fun g(a)()()(r) = r(1)
 foo(h)
-//│ Elab: { { handle h = SynthSel(Sel(Ref(member:Mod),Ident(Eff)),Ident(class))(Lit(IntLit(3))) List(HandlerTermDefinition(r,TermDefinition(Some(class:Handler$h$),Fun,member:f,List(ParamList(‹›,List(),None)),None,Some(App(Ref(r),Tup(List(Fld(‹›,Lit(IntLit(0)),None))))),‹result of member:f›,‹›,List())), HandlerTermDefinition(r,TermDefinition(Some(class:Handler$h$),Fun,member:g,List(ParamList(‹›,List(Param(‹›,a,None)),None), ParamList(‹›,List(),None), ParamList(‹›,List(),None)),None,Some(App(Ref(r),Tup(List(Fld(‹›,Lit(IntLit(1)),None))))),‹result of member:g›,‹›,List()))); member:foo#666(h#666) } }
+//│ Elab: { { handle h = SynthSel(Sel(Ref(member:Mod),Ident(Eff)),Ident(class))(Lit(IntLit(3))) List(HandlerTermDefinition(r,TermDefinition(Some(class:Handler$h$),Fun,member:f,List(ParamList(‹›,List(),None)),None,None,Some(App(Ref(r),Tup(List(Fld(‹›,Lit(IntLit(0)),None))))),‹result of member:f›,‹›,List())), HandlerTermDefinition(r,TermDefinition(Some(class:Handler$h$),Fun,member:g,List(ParamList(‹›,List(Param(‹›,a,None)),None), ParamList(‹›,List(),None), ParamList(‹›,List(),None)),None,None,Some(App(Ref(r),Tup(List(Fld(‹›,Lit(IntLit(1)),None))))),‹result of member:g›,‹›,List()))); member:foo#666(h#666) } }
 
 :e
 handle h = Eff with
@@ -128,4 +128,4 @@ foo(h)
 //│ ╔══[WARNING] Terms in handler block do nothing
 //│ ║  l.126: 	  12345
 //│ ╙──       	  ^^^^^
-//│ Elab: { { handle h = Ref(member:Eff)() List(HandlerTermDefinition(r,TermDefinition(Some(class:Handler$h$),Fun,member:f,List(ParamList(‹›,List(),None)),None,Some(App(Ref(r),Tup(List(Fld(‹›,Lit(IntLit(0)),None))))),‹result of member:f›,‹›,List())), HandlerTermDefinition(r,TermDefinition(Some(class:Handler$h$),Fun,member:g,List(ParamList(‹›,List(Param(‹›,a,None)),None)),None,Some(App(Ref(r),Tup(List(Fld(‹›,Lit(IntLit(1)),None))))),‹result of member:g›,‹›,List()))); member:foo#666(h#666) } }
+//│ Elab: { { handle h = Ref(member:Eff)() List(HandlerTermDefinition(r,TermDefinition(Some(class:Handler$h$),Fun,member:f,List(ParamList(‹›,List(),None)),None,None,Some(App(Ref(r),Tup(List(Fld(‹›,Lit(IntLit(0)),None))))),‹result of member:f›,‹›,List())), HandlerTermDefinition(r,TermDefinition(Some(class:Handler$h$),Fun,member:g,List(ParamList(‹›,List(Param(‹›,a,None)),None)),None,None,Some(App(Ref(r),Tup(List(Fld(‹›,Lit(IntLit(1)),None))))),‹result of member:g›,‹›,List()))); member:foo#666(h#666) } }

--- a/hkmc2/shared/src/test/mlscript/ucs/examples/EitherOrBoth.mls
+++ b/hkmc2/shared/src/test/mlscript/ucs/examples/EitherOrBoth.mls
@@ -11,23 +11,38 @@ class Both[out A, out B](left: A, right: B) extends EitherOrBoth[A, B]
 
 type Either[A, B] = Left[A, B] | Right[A, B]
 
+// TODO: fix type parameters of Option. See mlscript-compile/Option.mls
+:todo
 fun getLeft[A, B](eob: EitherOrBoth[A, B]): Option[A] =
   if eob is
     Left(left) then Some(left)
     Right(_) then None
     Both(left, _) then Some(left)
+//│ ╔══[ERROR] Wrong number of type arguments
+//│ ║  l.16: 	fun getLeft[A, B](eob: EitherOrBoth[A, B]): Option[A] =
+//│ ╙──      	                                            ^^^^^^^^
 
+// TODO: fix type parameters of Option. See mlscript-compile/Option.mls
+:todo
 fun getRight[A, B](eob: EitherOrBoth[A, B]): Option[B] =
   if eob is
     Left(_) then None
     Right(right) then Some(right)
     Both(_, right) then Some(right)
+//│ ╔══[ERROR] Wrong number of type arguments
+//│ ║  l.27: 	fun getRight[A, B](eob: EitherOrBoth[A, B]): Option[B] =
+//│ ╙──      	                                             ^^^^^^^^
 
+// TODO: fix type parameters of Option. See mlscript-compile/Option.mls
+:todo
 fun getBoth[A, B](eob: EitherOrBoth[A, B]): Option[[A, B]] =
   if eob is
     Left(_) then None
     Right(_) then None
     Both(left, right) then Some([left, right])
+//│ ╔══[ERROR] Wrong number of type arguments
+//│ ║  l.38: 	fun getBoth[A, B](eob: EitherOrBoth[A, B]): Option[[A, B]] =
+//│ ╙──      	                                            ^^^^^^^^^^^^^
 
 fun mapLeft[A, B, C](eob: EitherOrBoth[A, B], f: A -> C): EitherOrBoth[C, B] =
   if eob is

--- a/hkmc2/shared/src/test/mlscript/ucs/papers/OperatorSplit.mls
+++ b/hkmc2/shared/src/test/mlscript/ucs/papers/OperatorSplit.mls
@@ -82,6 +82,7 @@ fun example(args) =
 //│               sym = args
 //│               sign = N
 //│           restParam = N
+//│       tparams = N
 //│       sign = N
 //│       body = S of IfLike:
 //│         kw = keyword 'if'

--- a/hkmc2/shared/src/test/mlscript/ucs/syntax/NestedOpSplits.mls
+++ b/hkmc2/shared/src/test/mlscript/ucs/syntax/NestedOpSplits.mls
@@ -23,6 +23,7 @@ fun f(x) =
 //│               sym = x
 //│               sign = N
 //│           restParam = N
+//│       tparams = N
 //│       sign = N
 //│       body = S of IfLike:
 //│         kw = keyword 'if'


### PR DESCRIPTION
This (draft) PR introduces type classes by a minimal implementation of contextual parameters, including:

### Parser rules for parsing `use` and `using` keywords.

```fs
abstract class Foo with
  fun foo(): Int

class FooImpl extends Foo with
  fun foo(): Int = 40

use Int as i = 2

use Foo = new FooImpl()
```

```fs
module M with
  fun f(using someInt: Int, someFoo: Foo): Int = someInt + someFoo.foo()
```

### Elaborator rules for elaborating `use` and `using` keywords.

A `use` definition is elaborated into a `TermDefinition` of kind instance (`Ins`). If there is no explicitly specified identifier with the instance, a synthesized identifier is used. 

If any parameter in the parameter list is modified by the `using` keyword, the whole parameter list becomes an "implicit parameter list". 

### Further elaboration on module methods

Module method applications (or implicit applications) are further elaborated with the type information. 

In particular, if there is any missing contextual argument lists, the elaborator will *unify* the argument lists with the parameter lists, with some placeholder `Elem`. These `Elem`s are populated later in the new implicit resolution pass.

```fs
module M with
  fun foo(using someInt: Int, someFoo: Foo): Int = someInt + someFoo.foo()
  fun bar()(using someInt: Int) = someInt

M.foo
// => M.foo(using Int ‹unpopulated›, using Foo ‹unpopulated›)

M.bar
// => elaboration error: mismatch

M.bar()
// => M.foo()(using Int ‹unpopulated›)
```

### New pass: Implicit Resolution

A new pass called `ImplicitResolution` is introduced to resolve implicit arguments after elaboration. 

It traverses the elaboration tree, find:

- Instance definitions: add them into the *context* with their type signature as the key.
- Contextual argument placeholder: resolve the contextual argument with the corresponding instance definition in the context.

**TODO**: Move rules of module methods to this pass.