### PR TITLE
Fix syntax of `(using ..., Type)`

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/syntax/Tree.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/syntax/Tree.scala
@@ -198,6 +198,7 @@ enum Tree extends AutoLocated:
    */
   def asParam(inUsing: Bool): Opt[(Opt[Bool], Ident, Opt[Tree])] = this match
     case und: Under => S(N, new Ident("_").withLocOf(und), N)
+    // * In `using` clauses, identifiers are understood as type names for unnamed contextual parameters:
     case id: Ident if inUsing => S(N, Ident(""), S(id))
     case id: Ident => S(N, id, N)
     case Spread(Keyword.`..`, _, S(id: Ident)) => S(S(false), id, N)

--- a/hkmc2/shared/src/main/scala/hkmc2/syntax/Tree.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/syntax/Tree.scala
@@ -193,8 +193,8 @@ enum Tree extends AutoLocated:
     case _ => this
   
   /** 
-   * S(true) means eager spread, S(false) means lazy spread, N means no spread.
-   * ctx means the the param list is modified by `using`.
+   * Parameter `inUsing` means the param list is modified by `using`.
+   * In the first result, `S(true)` means eager spread, `S(false)` means lazy spread, and `N` means no spread.
    */
   def asParam(inUsing: Bool): Opt[(Opt[Bool], Ident, Opt[Tree])] = this match
     case und: Under => S(N, new Ident("_").withLocOf(und), N)

--- a/hkmc2/shared/src/main/scala/hkmc2/syntax/Tree.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/syntax/Tree.scala
@@ -192,20 +192,24 @@ enum Tree extends AutoLocated:
       LetLike(letLike, id, S(App(Ident(nme.init), Tup(id :: r :: Nil))), bodo).withLocOf(this).desugared
     case _ => this
   
-  /** S(true) means eager spread, S(false) means lazy spread, N means no spread. */
-  def asParam: Opt[(Opt[Bool], Ident, Opt[Tree])] = this match
+  /** 
+   * S(true) means eager spread, S(false) means lazy spread, N means no spread.
+   * ctx means the the param list is modified by `using`.
+   */
+  def asParam(inUsing: Bool): Opt[(Opt[Bool], Ident, Opt[Tree])] = this match
     case und: Under => S(N, new Ident("_").withLocOf(und), N)
+    case id: Ident if inUsing => S(N, Ident(""), S(id))
     case id: Ident => S(N, id, N)
     case Spread(Keyword.`..`, _, S(id: Ident)) => S(S(false), id, N)
     case Spread(Keyword.`...`, _, S(id: Ident)) => S(S(true), id, N)
     case Spread(Keyword.`..`, _, S(und: Under)) => S(S(false), new Ident("_").withLocOf(und), N)
     case Spread(Keyword.`...`, _, S(und: Under)) => S(S(true), new Ident("_").withLocOf(und), N)
     case InfixApp(lhs: Ident, Keyword.`:`, rhs) => S(N, lhs, S(rhs))
-    case TermDef(ImmutVal, inner, _) => inner.asParam
+    case TermDef(ImmutVal, inner, _) => inner.asParam(inUsing)
     case Modified(Keyword.`using`, _, inner) => inner match
-      // Param of form (using ..., name: Type). Parse it as usual.
-      case inner: InfixApp => inner.asParam
-      // Param of form (using ..., Type). Synthesize an identifier for it.
+      // Param of form (using name: Type). Parse it as usual.
+      case inner: InfixApp => inner.asParam(inUsing)
+      // Param of form (using Type). Synthesize an identifier for it.
       case _ => S(N, Ident(""), S(inner))
   
   def isModuleModifier: Bool = this match
@@ -400,7 +404,7 @@ trait TypeDefImpl(using State) extends TypeOrTermDef:
   
   lazy val clsParams: Ls[semantics.TermSymbol] =
     this.paramLists.headOption.fold(Nil): tup =>
-      tup.fields.iterator.flatMap(_.asParam).map:
+      tup.fields.iterator.flatMap(_.asParam(false)).map:
         case (S(spd), id, _) => ??? // spreads are not allowed in class parameters
         case (N, id, _) => semantics.TermSymbol(ParamBind, symbol.asClsLike, id)
       .toList

--- a/hkmc2/shared/src/test/mlscript/basics/TypeClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/TypeClasses.mls
@@ -30,6 +30,12 @@ module M with
 module M with
   fun f(using Int, Int) = 42
 
+module M with
+  fun foo(using Int, arg: Str) = 42
+
+module M with
+  fun foo(using arg: Str, Int) = 42
+
 
 // Basic Resolution
 

--- a/hkmc2/shared/src/test/mlscript/basics/TypeClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/TypeClasses.mls
@@ -24,6 +24,12 @@ module M with
 module M with
   fun f(using foo: Int)(using bar: Int) = 42
 
+module M with
+  fun f(using foo: Int, bar: Int) = 42
+
+module M with
+  fun f(using Int, Int) = 42
+
 
 // Basic Resolution
 


### PR DESCRIPTION
Fix #274.

This PR fixes

```fs
module M with
  fun f(using Int, Int) = 42
```

which used to parse the `using Int` part only but failed to parse the (second) `Int` part.
