### PR TITLE
Better Flatten

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -135,22 +135,47 @@ sealed abstract class Block extends Product with AutoLocated:
     
     (transformer.applyBlock(this), defns)
     
+  private lazy val fAndRest: (Block => Block, BlockTail) = this match
+    case Match(scrut, arms, dflt, rest) =>
+      val (f, r) = rest.fAndRest
+      ((k: Block) => Match(scrut, arms, dflt, f(k))) -> r
+    case Label(label, body, rest) =>
+      val (f, r) = rest.fAndRest
+      ((k: Block) => Label(label, body, f(k))) -> r
+    case Begin(sub, rest) =>
+      val (f, r) = sub.fAndRest
+      r match
+        case End(_) =>
+          val (f1, r1) = rest.fAndRest
+          ((k: Block) => f(f1(k))) -> r1
+        case _ => f -> r
+    case TryBlock(sub, finallyDo, rest) =>
+      val (f, r) = rest.fAndRest
+      ((k: Block) => TryBlock(sub, finallyDo, f(k))) -> r
+    case Assign(lhs, rhs, rest) =>
+      val (f, r) = rest.fAndRest
+      ((k: Block) => Assign(lhs, rhs, f(k))) -> r
+    case a@AssignField(lhs, nme, rhs, rest) =>
+      val (f, r) = rest.fAndRest
+      ((k: Block) => AssignField(lhs, nme, rhs, f(k))(a.symbol)) -> r
+    case AssignDynField(lhs, fld, arrayIdx, rhs, rest) =>
+      val (f, r) = rest.fAndRest
+      ((k: Block) => AssignDynField(lhs, fld, arrayIdx, rhs, f(k))) -> r
+    case Define(defn, rest) =>
+      val (f, r) = rest.fAndRest
+      ((k: Block) => Define(defn, f(k))) -> r
+    case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) =>
+      val (f, r) = rest.fAndRest
+      ((k: Block) => HandleBlock(lhs, res, par, args, cls, handlers, body, f(k))) -> r
+    case t: BlockTail => (identity: Block => Block) -> t
+  
+  lazy val flattenTopLevel = fAndRest._1(fAndRest._2)
+  
+  object FlattenAllNested extends BlockTransformer(new SymbolSubst()):
+    override def applyBlock(b: Block): Block = super.applyBlock(b.flattenTopLevel)
+  
   lazy val flatten: Block =
-    
-    def flattenConcat(a: Block, b: => Block): Block = a match
-      case Match(scrut, arms, dflt, rest) => Match(scrut, arms, dflt, flattenConcat(rest, b))
-      case Label(label, body, rest) => Label(label, body, flattenConcat(rest, b))
-      case Begin(sub, rest) => flattenConcat(sub, flattenConcat(rest, b))
-      case TryBlock(sub, finallyDo, rest) => TryBlock(sub, finallyDo, flattenConcat(rest, b))
-      case Assign(lhs, rhs, rest) => Assign(lhs, rhs, flattenConcat(rest, b))
-      case a@AssignField(lhs, nme, rhs, rest) => AssignField(lhs, nme, rhs, flattenConcat(rest, b))(a.symbol)
-      case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => AssignDynField(lhs, fld, arrayIdx, rhs, flattenConcat(rest, b))
-      case Define(defn, rest) => Define(defn, flattenConcat(rest, b))
-      case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) => HandleBlock(lhs, res, par, args, cls, handlers, body, flattenConcat(rest, b))
-      case End(_) => b
-      case _: BlockTail => a
-    
-    flattenConcat(this, End(""))
+    FlattenAllNested.applyBlock(this)
   
 end Block
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -134,61 +134,84 @@ sealed abstract class Block extends Product with AutoLocated:
         case _ => super.applyBlock(b)
     
     (transformer.applyBlock(this), defns)
-      
-  private lazy val flattenContAndTailAndRes: (Block => Block) -> BlockTail -> Block = this match
-    case Match(scrut, arms, dflt, rest) =>
-      val f -> t -> r = rest.flattenContAndTailAndRes
-      ((k: Block) => Match(scrut, arms, dflt, f(k))) ->
-      t ->
-      (if r is rest then this else Match(scrut, arms, dflt, r))
-    case Label(label, body, rest) =>
-      val f -> t -> r = rest.flattenContAndTailAndRes
-      ((k: Block) => Label(label, body, f(k)))->
-      t ->
-      (if r is rest then this else Label(label, body, r))
-    case Begin(sub, rest) =>
-      val f -> t -> r = sub.flattenContAndTailAndRes
-      t match
-        case End(_) =>
-          val f1 -> t1 -> r1 = rest.flattenContAndTailAndRes
-          ((k: Block) => f(f1(k))) ->
-          t1 ->
-          f(r1)
-        case _ => f -> t -> r
-    case TryBlock(sub, finallyDo, rest) =>
-      val f -> t -> r = rest.flattenContAndTailAndRes
-      ((k: Block) => TryBlock(sub, finallyDo, f(k))) ->
-      t ->
-      (if r is rest then this else TryBlock(sub, finallyDo, r))
-    case Assign(lhs, rhs, rest) =>
-      val f -> t -> r = rest.flattenContAndTailAndRes
-      ((k: Block) => Assign(lhs, rhs, f(k))) ->
-      t ->
-      (if r is rest then this else Assign(lhs, rhs, r))
-    case a@AssignField(lhs, nme, rhs, rest) =>
-      val f -> t -> r = rest.flattenContAndTailAndRes
-      ((k: Block) => AssignField(lhs, nme, rhs, f(k))(a.symbol)) ->
-      t ->
-      (if r is rest then this else AssignField(lhs, nme, rhs, r)(a.symbol))
-    case AssignDynField(lhs, fld, arrayIdx, rhs, rest) =>
-      val f -> t -> r = rest.flattenContAndTailAndRes
-      ((k: Block) => AssignDynField(lhs, fld, arrayIdx, rhs, f(k))) ->
-      t ->
-      (if r is rest then this else AssignDynField(lhs, fld, arrayIdx, rhs, r))
-    case Define(defn, rest) =>
-      val f -> t -> r = rest.flattenContAndTailAndRes
-      ((k: Block) => Define(defn, f(k))) ->
-      t ->
-      (if r is rest then this else Define(defn, r))
-    case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) =>
-      val f -> t -> r = rest.flattenContAndTailAndRes
-      ((k: Block) => HandleBlock(lhs, res, par, args, cls, handlers, body, f(k))) ->
-      t ->
-      (if r is rest then this else HandleBlock(lhs, res, par, args, cls, handlers, body, r))
-    case t: BlockTail => 
-      (identity: Block => Block) -> t -> t
+  
+  // the flatten function that preserves the information in `End`
+  def flattenConcat(b: End => Block): Block = this match
+    case Match(scrut, arms, dflt, rest) => Match(scrut, arms, dflt, rest.flattenConcat(b))
+    case Label(label, body, rest) => Label(label, body, rest.flattenConcat(b))
+    case Begin(sub, rest) => sub.flattenConcat(_ => rest.flattenConcat(b))
+    case TryBlock(sub, finallyDo, rest) => TryBlock(sub, finallyDo, rest.flattenConcat(b))
+    case Assign(lhs, rhs, rest) => Assign(lhs, rhs, rest.flattenConcat(b))
+    case a@AssignField(lhs, nme, rhs, rest) => AssignField(lhs, nme, rhs, rest.flattenConcat(b))(a.symbol)
+    case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => AssignDynField(lhs, fld, arrayIdx, rhs, rest.flattenConcat(b))
+    case Define(defn, rest) => Define(defn, rest.flattenConcat(b))
+    case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) => HandleBlock(lhs, res, par, args, cls, handlers, body, rest.flattenConcat(b))
+    case e: End => b(e)
+    case _: BlockTail => this
+  
+  lazy val flattenTopLevel = this.flattenConcat(identity)
+  
+  // the block transformer that go through nested blocks and flatten them
+  object DeepBlockFlattenTransformer extends BlockTransformer(new SymbolSubst()):
+    override def applyBlock(b: Block): Block = super.applyBlock(b.flattenTopLevel)
+  
+  lazy val flatten = DeepBlockFlattenTransformer.applyBlock(this)
+  
+  
+  // private lazy val flattenContAndTailAndRes: (Block => Block) -> BlockTail -> Block = this match
+  //   case Match(scrut, arms, dflt, rest) =>
+  //     val f -> t -> r = rest.flattenContAndTailAndRes
+  //     ((k: Block) => Match(scrut, arms, dflt, f(k))) ->
+  //     t ->
+  //     (if r is rest then this else Match(scrut, arms, dflt, r))
+  //   case Label(label, body, rest) =>
+  //     val f -> t -> r = rest.flattenContAndTailAndRes
+  //     ((k: Block) => Label(label, body, f(k)))->
+  //     t ->
+  //     (if r is rest then this else Label(label, body, r))
+  //   case Begin(sub, rest) =>
+  //     val f -> t -> r = sub.flattenContAndTailAndRes
+  //     t match
+  //       case End(_) =>
+  //         val f1 -> t1 -> r1 = rest.flattenContAndTailAndRes
+  //         ((k: Block) => f(f1(k))) ->
+  //         t1 ->
+  //         f(r1)
+  //       case _ => f -> t -> r
+  //   case TryBlock(sub, finallyDo, rest) =>
+  //     val f -> t -> r = rest.flattenContAndTailAndRes
+  //     ((k: Block) => TryBlock(sub, finallyDo, f(k))) ->
+  //     t ->
+  //     (if r is rest then this else TryBlock(sub, finallyDo, r))
+  //   case Assign(lhs, rhs, rest) =>
+  //     val f -> t -> r = rest.flattenContAndTailAndRes
+  //     ((k: Block) => Assign(lhs, rhs, f(k))) ->
+  //     t ->
+  //     (if r is rest then this else Assign(lhs, rhs, r))
+  //   case a@AssignField(lhs, nme, rhs, rest) =>
+  //     val f -> t -> r = rest.flattenContAndTailAndRes
+  //     ((k: Block) => AssignField(lhs, nme, rhs, f(k))(a.symbol)) ->
+  //     t ->
+  //     (if r is rest then this else AssignField(lhs, nme, rhs, r)(a.symbol))
+  //   case AssignDynField(lhs, fld, arrayIdx, rhs, rest) =>
+  //     val f -> t -> r = rest.flattenContAndTailAndRes
+  //     ((k: Block) => AssignDynField(lhs, fld, arrayIdx, rhs, f(k))) ->
+  //     t ->
+  //     (if r is rest then this else AssignDynField(lhs, fld, arrayIdx, rhs, r))
+  //   case Define(defn, rest) =>
+  //     val f -> t -> r = rest.flattenContAndTailAndRes
+  //     ((k: Block) => Define(defn, f(k))) ->
+  //     t ->
+  //     (if r is rest then this else Define(defn, r))
+  //   case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) =>
+  //     val f -> t -> r = rest.flattenContAndTailAndRes
+  //     ((k: Block) => HandleBlock(lhs, res, par, args, cls, handlers, body, f(k))) ->
+  //     t ->
+  //     (if r is rest then this else HandleBlock(lhs, res, par, args, cls, handlers, body, r))
+  //   case t: BlockTail => 
+  //     (identity: Block => Block) -> t -> t
     
-  lazy val flatten: Block = this.flattenContAndTailAndRes._2
+  // lazy val flatten: Block = this.flattenContAndTailAndRes._2
   
 end Block
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -134,48 +134,61 @@ sealed abstract class Block extends Product with AutoLocated:
         case _ => super.applyBlock(b)
     
     (transformer.applyBlock(this), defns)
-    
-  private lazy val fAndRest: (Block => Block, BlockTail) = this match
+      
+  private lazy val flattenContAndTailAndRes: (Block => Block) -> BlockTail -> Block = this match
     case Match(scrut, arms, dflt, rest) =>
-      val (f, r) = rest.fAndRest
-      ((k: Block) => Match(scrut, arms, dflt, f(k))) -> r
+      val f -> t -> r = rest.flattenContAndTailAndRes
+      ((k: Block) => Match(scrut, arms, dflt, f(k))) ->
+      t ->
+      (if r is rest then this else Match(scrut, arms, dflt, r))
     case Label(label, body, rest) =>
-      val (f, r) = rest.fAndRest
-      ((k: Block) => Label(label, body, f(k))) -> r
+      val f -> t -> r = rest.flattenContAndTailAndRes
+      ((k: Block) => Label(label, body, f(k)))->
+      t ->
+      (if r is rest then this else Label(label, body, r))
     case Begin(sub, rest) =>
-      val (f, r) = sub.fAndRest
-      r match
+      val f -> t -> r = sub.flattenContAndTailAndRes
+      t match
         case End(_) =>
-          val (f1, r1) = rest.fAndRest
-          ((k: Block) => f(f1(k))) -> r1
-        case _ => f -> r
+          val f1 -> t1 -> r1 = rest.flattenContAndTailAndRes
+          ((k: Block) => f(f1(k))) ->
+          t1 ->
+          f(r1)
+        case _ => f -> t -> r
     case TryBlock(sub, finallyDo, rest) =>
-      val (f, r) = rest.fAndRest
-      ((k: Block) => TryBlock(sub, finallyDo, f(k))) -> r
+      val f -> t -> r = rest.flattenContAndTailAndRes
+      ((k: Block) => TryBlock(sub, finallyDo, f(k))) ->
+      t ->
+      (if r is rest then this else TryBlock(sub, finallyDo, r))
     case Assign(lhs, rhs, rest) =>
-      val (f, r) = rest.fAndRest
-      ((k: Block) => Assign(lhs, rhs, f(k))) -> r
+      val f -> t -> r = rest.flattenContAndTailAndRes
+      ((k: Block) => Assign(lhs, rhs, f(k))) ->
+      t ->
+      (if r is rest then this else Assign(lhs, rhs, r))
     case a@AssignField(lhs, nme, rhs, rest) =>
-      val (f, r) = rest.fAndRest
-      ((k: Block) => AssignField(lhs, nme, rhs, f(k))(a.symbol)) -> r
+      val f -> t -> r = rest.flattenContAndTailAndRes
+      ((k: Block) => AssignField(lhs, nme, rhs, f(k))(a.symbol)) ->
+      t ->
+      (if r is rest then this else AssignField(lhs, nme, rhs, r)(a.symbol))
     case AssignDynField(lhs, fld, arrayIdx, rhs, rest) =>
-      val (f, r) = rest.fAndRest
-      ((k: Block) => AssignDynField(lhs, fld, arrayIdx, rhs, f(k))) -> r
+      val f -> t -> r = rest.flattenContAndTailAndRes
+      ((k: Block) => AssignDynField(lhs, fld, arrayIdx, rhs, f(k))) ->
+      t ->
+      (if r is rest then this else AssignDynField(lhs, fld, arrayIdx, rhs, r))
     case Define(defn, rest) =>
-      val (f, r) = rest.fAndRest
-      ((k: Block) => Define(defn, f(k))) -> r
+      val f -> t -> r = rest.flattenContAndTailAndRes
+      ((k: Block) => Define(defn, f(k))) ->
+      t ->
+      (if r is rest then this else Define(defn, r))
     case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) =>
-      val (f, r) = rest.fAndRest
-      ((k: Block) => HandleBlock(lhs, res, par, args, cls, handlers, body, f(k))) -> r
-    case t: BlockTail => (identity: Block => Block) -> t
-  
-  lazy val flattenTopLevel = fAndRest._1(fAndRest._2)
-  
-  object FlattenAllNested extends BlockTransformer(new SymbolSubst()):
-    override def applyBlock(b: Block): Block = super.applyBlock(b.flattenTopLevel)
-  
-  lazy val flatten: Block =
-    FlattenAllNested.applyBlock(this)
+      val f -> t -> r = rest.flattenContAndTailAndRes
+      ((k: Block) => HandleBlock(lhs, res, par, args, cls, handlers, body, f(k))) ->
+      t ->
+      (if r is rest then this else HandleBlock(lhs, res, par, args, cls, handlers, body, r))
+    case t: BlockTail => 
+      (identity: Block => Block) -> t -> t
+    
+  lazy val flatten: Block = this.flattenContAndTailAndRes._2
   
 end Block
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -200,7 +200,7 @@ sealed abstract class Block extends Product with AutoLocated:
           else c.copy(preCtor = newPreCtor, ctor = newCtor)
       
       val newRest = rest.flatten(k)
-      if newRest is rest
+      if (newDefn is defn) && (newRest is rest)
       then this
       else Define(newDefn, newRest)
     

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -134,84 +134,88 @@ sealed abstract class Block extends Product with AutoLocated:
         case _ => super.applyBlock(b)
     
     (transformer.applyBlock(this), defns)
-  
-  // the flatten function that preserves the information in `End` by turning `b` into a `End => Block`
-  def flattenConcat(b: End => Block): Block = this match
-    case Match(scrut, arms, dflt, rest) => Match(scrut, arms, dflt, rest.flattenConcat(b))
-    case Label(label, body, rest) => Label(label, body, rest.flattenConcat(b))
-    case Begin(sub, rest) => sub.flattenConcat(_ => rest.flattenConcat(b)) // discard the `End` in the first block `sub`
-    case TryBlock(sub, finallyDo, rest) => TryBlock(sub, finallyDo, rest.flattenConcat(b))
-    case Assign(lhs, rhs, rest) => Assign(lhs, rhs, rest.flattenConcat(b))
-    case a@AssignField(lhs, nme, rhs, rest) => AssignField(lhs, nme, rhs, rest.flattenConcat(b))(a.symbol)
-    case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => AssignDynField(lhs, fld, arrayIdx, rhs, rest.flattenConcat(b))
-    case Define(defn, rest) => Define(defn, rest.flattenConcat(b))
-    case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) => HandleBlock(lhs, res, par, args, cls, handlers, body, rest.flattenConcat(b))
-    case e: End => b(e)
-    case _: BlockTail => this
-  
-  lazy val flattenTopLevel = this.flattenConcat(identity)
-  
-  // the block transformer that goes through nested blocks and flatten them
-  object DeepFlattenTransformer extends BlockTransformer(new SymbolSubst()):
-    override def applyBlock(b: Block): Block = super.applyBlock(b.flattenTopLevel)
-  
-  lazy val flatten = DeepFlattenTransformer.applyBlock(this)
-  
-  
-  // private lazy val flattenContAndTailAndRes: (Block => Block) -> BlockTail -> Block = this match
-  //   case Match(scrut, arms, dflt, rest) =>
-  //     val f -> t -> r = rest.flattenContAndTailAndRes
-  //     ((k: Block) => Match(scrut, arms, dflt, f(k))) ->
-  //     t ->
-  //     (if r is rest then this else Match(scrut, arms, dflt, r))
-  //   case Label(label, body, rest) =>
-  //     val f -> t -> r = rest.flattenContAndTailAndRes
-  //     ((k: Block) => Label(label, body, f(k)))->
-  //     t ->
-  //     (if r is rest then this else Label(label, body, r))
-  //   case Begin(sub, rest) =>
-  //     val f -> t -> r = sub.flattenContAndTailAndRes
-  //     t match
-  //       case End(_) =>
-  //         val f1 -> t1 -> r1 = rest.flattenContAndTailAndRes
-  //         ((k: Block) => f(f1(k))) ->
-  //         t1 ->
-  //         f(r1)
-  //       case _ => f -> t -> r
-  //   case TryBlock(sub, finallyDo, rest) =>
-  //     val f -> t -> r = rest.flattenContAndTailAndRes
-  //     ((k: Block) => TryBlock(sub, finallyDo, f(k))) ->
-  //     t ->
-  //     (if r is rest then this else TryBlock(sub, finallyDo, r))
-  //   case Assign(lhs, rhs, rest) =>
-  //     val f -> t -> r = rest.flattenContAndTailAndRes
-  //     ((k: Block) => Assign(lhs, rhs, f(k))) ->
-  //     t ->
-  //     (if r is rest then this else Assign(lhs, rhs, r))
-  //   case a@AssignField(lhs, nme, rhs, rest) =>
-  //     val f -> t -> r = rest.flattenContAndTailAndRes
-  //     ((k: Block) => AssignField(lhs, nme, rhs, f(k))(a.symbol)) ->
-  //     t ->
-  //     (if r is rest then this else AssignField(lhs, nme, rhs, r)(a.symbol))
-  //   case AssignDynField(lhs, fld, arrayIdx, rhs, rest) =>
-  //     val f -> t -> r = rest.flattenContAndTailAndRes
-  //     ((k: Block) => AssignDynField(lhs, fld, arrayIdx, rhs, f(k))) ->
-  //     t ->
-  //     (if r is rest then this else AssignDynField(lhs, fld, arrayIdx, rhs, r))
-  //   case Define(defn, rest) =>
-  //     val f -> t -> r = rest.flattenContAndTailAndRes
-  //     ((k: Block) => Define(defn, f(k))) ->
-  //     t ->
-  //     (if r is rest then this else Define(defn, r))
-  //   case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) =>
-  //     val f -> t -> r = rest.flattenContAndTailAndRes
-  //     ((k: Block) => HandleBlock(lhs, res, par, args, cls, handlers, body, f(k))) ->
-  //     t ->
-  //     (if r is rest then this else HandleBlock(lhs, res, par, args, cls, handlers, body, r))
-  //   case t: BlockTail => 
-  //     (identity: Block => Block) -> t -> t
     
-  // lazy val flatten: Block = this.flattenContAndTailAndRes._2
+  lazy val flattened: Block = this.flatten(identity)
+  
+  private def flatten(k: End => Block): Block = this match
+    case Match(scrut, arms, dflt, rest) =>
+      val newRest = rest.flatten(k)
+      val newArms = arms.mapConserve: arm =>
+        val newBody = arm._2.flattened
+        if newBody is arm._2 then arm else (arm._1, newBody)
+      val newDflt = dflt.map(_.flattened)
+      if (newRest is rest) && (newArms is arms) && (dflt is newDflt)
+      then this
+      else Match(scrut, newArms, newDflt, newRest)
+
+    case Label(label, body, rest) =>
+      val newBody = body.flattened
+      val newRest = rest.flatten(k)
+      if (newBody is body) && (newRest is rest)
+      then this
+      else Label(label, newBody, newRest)
+      
+    case Begin(sub, rest) =>
+      sub.flatten(_ => rest.flatten(k))
+    
+    case TryBlock(sub, finallyDo, rest) =>
+      val newSub = sub.flattened
+      val newFinallyDo = finallyDo.flattened
+      val newRest = rest.flatten(k)
+      if (newSub is sub) && (newFinallyDo is finallyDo) && (newRest is rest)
+      then this
+      else TryBlock(newSub, newFinallyDo, newRest)
+      
+    case Assign(lhs, rhs, rest) =>
+      val newRest = rest.flatten(k)
+      if newRest is rest
+      then this
+      else Assign(lhs, rhs, newRest)
+      
+    case a@AssignField(lhs, nme, rhs, rest) =>
+      val newRest = rest.flatten(k)
+      if newRest is rest
+      then this
+      else AssignField(lhs, nme, rhs, newRest)(a.symbol)
+      
+    case AssignDynField(lhs, fld, arrayIdx, rhs, rest) =>
+      val newRest = rest.flatten(k)
+      if newRest is rest
+      then this
+      else AssignDynField(lhs, fld, arrayIdx, rhs, newRest)
+    
+    case Define(defn, rest) =>
+      val newDefn = defn match
+        case d: FunDefn =>
+          val newBody = d.body.flattened
+          if newBody is d.body
+          then d
+          else d.copy(body = newBody)
+        case v: ValDefn => v
+        case c: ClsLikeDefn =>
+          val newPreCtor = c.preCtor.flattened
+          val newCtor = c.ctor.flattened
+          if (newPreCtor is c.preCtor) && (newCtor is c.ctor)
+          then c
+          else c.copy(preCtor = newPreCtor, ctor = newCtor)
+      
+      val newRest = rest.flatten(k)
+      if newRest is rest
+      then this
+      else Define(newDefn, newRest)
+    
+    case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) =>
+      val newHandlers = handlers.mapConserve: h =>
+        val newBody = h.body.flattened
+        if newBody is h.body then h else h.copy(body = newBody)
+      val newBody = body.flattened
+      val newRest = rest.flatten(k)
+      if (newHandlers is handlers) && (newBody is body) && (newRest is rest)
+      then this
+      else HandleBlock(lhs, res, par, args, cls, newHandlers, newBody, newRest)
+
+    case e: End => k(e)
+    case t: BlockTail => this
   
 end Block
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -134,44 +134,22 @@ sealed abstract class Block extends Product with AutoLocated:
     
     (transformer.applyBlock(this), defns)
     
-  lazy val flatten: Block = 
-    // traverses a Block like a list, flatten `Begin`s using an accumulator
-    // returns the flattend but reversed Block (with the dummy tail `End("for flatten only")`) and the actual tail of the Block
-    def getReversedFlattenAndTrueTail(b: Block, acc: Block): (Block, BlockTail) = b match
-      case Match(scrut, arms, dflt, rest) => getReversedFlattenAndTrueTail(rest, Match(scrut, arms, dflt, acc))
-      case Label(label, body, rest) => getReversedFlattenAndTrueTail(rest, Label(label, body, acc))
-      case Begin(sub, rest) =>
-        val (firstBlockRev, firstTail) = getReversedFlattenAndTrueTail(sub, acc)
-        firstTail match
-          case _: End => getReversedFlattenAndTrueTail(rest, firstBlockRev)
-          // if the tail of `sub` is not `End`, ignore the `rest` of this `Begin`
-          case _ => firstBlockRev -> firstTail
-      case TryBlock(sub, finallyDo, rest) => getReversedFlattenAndTrueTail(rest, TryBlock(sub, finallyDo, acc))
-      case Assign(lhs, rhs, rest) => getReversedFlattenAndTrueTail(rest, Assign(lhs, rhs, acc))
-      case a@AssignField(lhs, nme, rhs, rest) => getReversedFlattenAndTrueTail(rest, AssignField(lhs, nme, rhs, acc)(a.symbol))
-      case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => getReversedFlattenAndTrueTail(rest, AssignDynField(lhs, fld, arrayIdx, rhs, acc))
-      case Define(defn, rest) => getReversedFlattenAndTrueTail(rest, Define(defn, acc))
-      case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) => getReversedFlattenAndTrueTail(rest, HandleBlock(lhs, res, par, args, cls, handlers, body, acc))
-      case t: BlockTail => acc -> t
+  lazy val flatten: Block =
     
-    // reverse the Block returnned from the previous function,
-    // which does not contain `Begin` (except for the nested ones),
-    // and whose tail must be the dummy `End("for flatten only")`
-    def rev(b: Block, t: Block): Block = b match
-      case Match(scrut, arms, dflt, rest) => rev(rest, Match(scrut, arms, dflt, t))
-      case Label(label, body, rest) => rev(rest, Label(label, body, t))
-      case TryBlock(sub, finallyDo, rest) => rev(rest, TryBlock(sub, finallyDo, t))
-      case Assign(lhs, rhs, rest) => rev(rest, Assign(lhs, rhs, t))
-      case a@AssignField(lhs, nme, rhs, rest) => rev(rest, AssignField(lhs, nme, rhs, t)(a.symbol))
-      case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => rev(rest, AssignDynField(lhs, fld, arrayIdx, rhs, t))
-      case Define(defn, rest) => rev(rest, Define(defn, t))
-      case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) => rev(rest, HandleBlock(lhs, res, par, args, cls, handlers, body, t))
-      case End(msg) => t
-      case _: BlockTail => ??? // unreachable
-      case Begin(sub, rest) => ??? // unreachable
+    def flattenConcat(a: Block, b: => Block): Block = a match
+      case Match(scrut, arms, dflt, rest) => Match(scrut, arms, dflt, flattenConcat(rest, b))
+      case Label(label, body, rest) => Label(label, body, flattenConcat(rest, b))
+      case Begin(sub, rest) => flattenConcat(sub, flattenConcat(rest, b))
+      case TryBlock(sub, finallyDo, rest) => TryBlock(sub, finallyDo, flattenConcat(rest, b))
+      case Assign(lhs, rhs, rest) => Assign(lhs, rhs, flattenConcat(rest, b))
+      case a@AssignField(lhs, nme, rhs, rest) => AssignField(lhs, nme, rhs, flattenConcat(rest, b))(a.symbol)
+      case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => AssignDynField(lhs, fld, arrayIdx, rhs, flattenConcat(rest, b))
+      case Define(defn, rest) => Define(defn, flattenConcat(rest, b))
+      case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) => HandleBlock(lhs, res, par, args, cls, handlers, body, flattenConcat(rest, b))
+      case End(_) => b
+      case _: BlockTail => a
     
-    val (flattenRev, actualTail) = getReversedFlattenAndTrueTail(this, End("for flatten only"))
-    rev(flattenRev, actualTail)
+    flattenConcat(this, End(""))
   
 end Block
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -135,11 +135,11 @@ sealed abstract class Block extends Product with AutoLocated:
     
     (transformer.applyBlock(this), defns)
   
-  // the flatten function that preserves the information in `End`
+  // the flatten function that preserves the information in `End` by turning `b` into a `End => Block`
   def flattenConcat(b: End => Block): Block = this match
     case Match(scrut, arms, dflt, rest) => Match(scrut, arms, dflt, rest.flattenConcat(b))
     case Label(label, body, rest) => Label(label, body, rest.flattenConcat(b))
-    case Begin(sub, rest) => sub.flattenConcat(_ => rest.flattenConcat(b))
+    case Begin(sub, rest) => sub.flattenConcat(_ => rest.flattenConcat(b)) // discard the `End` in the first block `sub`
     case TryBlock(sub, finallyDo, rest) => TryBlock(sub, finallyDo, rest.flattenConcat(b))
     case Assign(lhs, rhs, rest) => Assign(lhs, rhs, rest.flattenConcat(b))
     case a@AssignField(lhs, nme, rhs, rest) => AssignField(lhs, nme, rhs, rest.flattenConcat(b))(a.symbol)
@@ -151,11 +151,11 @@ sealed abstract class Block extends Product with AutoLocated:
   
   lazy val flattenTopLevel = this.flattenConcat(identity)
   
-  // the block transformer that go through nested blocks and flatten them
-  object DeepBlockFlattenTransformer extends BlockTransformer(new SymbolSubst()):
+  // the block transformer that goes through nested blocks and flatten them
+  object DeepFlattenTransformer extends BlockTransformer(new SymbolSubst()):
     override def applyBlock(b: Block): Block = super.applyBlock(b.flattenTopLevel)
   
-  lazy val flatten = DeepBlockFlattenTransformer.applyBlock(this)
+  lazy val flatten = DeepFlattenTransformer.applyBlock(this)
   
   
   // private lazy val flattenContAndTailAndRes: (Block => Block) -> BlockTail -> Block = this match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -588,11 +588,12 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
     val stackSafe = config.stackSafety match
       case N => res
       case S(sts) => StackSafeTransform(sts.stackLimit).transformTopLevel(res)
-    
-    MergeMatchArmTransformer.applyBlock(
-      if lowerHandlers then HandlerLowering().translateTopLevel(stackSafe)
+    val withHandlers = if lowerHandlers
+      then HandlerLowering().translateTopLevel(stackSafe)
       else stackSafe
-    )
+    val flattened = withHandlers.flattened
+    
+    MergeMatchArmTransformer.applyBlock(flattened)
   
   def program(main: st): Program =
     def go(acc: Ls[Local -> Str], trm: st): Program =
@@ -762,7 +763,7 @@ object TrivialStatementsAndMatch:
 object MergeMatchArmTransformer extends BlockTransformer(new SymbolSubst()):
   override def applyBlock(b: Block): Block = super.applyBlock(b) match
     case m@Match(scrut, arms, Some(dflt), rest) =>
-      dflt.flattened match
+      dflt match
         case TrivialStatementsAndMatch(k, Match(scrutRewritten, armsRewritten, dfltRewritten, restRewritten))
           if (scrutRewritten === scrut) && (restRewritten.size * armsRewritten.length) < 10 =>
             val newArms = restRewritten match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -762,7 +762,7 @@ object TrivialStatementsAndMatch:
 object MergeMatchArmTransformer extends BlockTransformer(new SymbolSubst()):
   override def applyBlock(b: Block): Block = super.applyBlock(b) match
     case m@Match(scrut, arms, Some(dflt), rest) =>
-      dflt.flatten match
+      dflt.flattened match
         case TrivialStatementsAndMatch(k, Match(scrutRewritten, armsRewritten, dfltRewritten, restRewritten))
           if (scrutRewritten === scrut) && (restRewritten.size * armsRewritten.length) < 10 =>
             val newArms = restRewritten match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
@@ -31,7 +31,7 @@ object Printer:
         .map{ case (c, b) => doc"${case_doc(c)} => #{  # ${mkDocument(b)} #} " }
         .mkDocument(sep = doc" # ")
       val docDefault = dflt.map(mkDocument).getOrElse(doc"")
-      doc"match ${mkDocument(scrut)} #{  # ${docCases} # else #{  # ${docDefault} #}  #} "
+      doc"match ${mkDocument(scrut)} #{  # ${docCases} # else #{  # ${docDefault} #}  #}  # in # ${mkDocument(rest)} "
     case Return(res, implct) => doc"return ${mkDocument(res)}"
     case Throw(exc) => doc"throw ${mkDocument(exc)}"
     case Label(label, body, rest) =>

--- a/hkmc2/shared/src/test/mlscript/codegen/BlockPrinter.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/BlockPrinter.mls
@@ -21,18 +21,18 @@ let x = x + 1
 //│ Pretty Lowered:
 //│  
 //│ set x2 = 1 in
-//│ begin
-//│   set scrut = ==(x2, 0) in
-//│   match scrut
-//│     true =>
-//│       set tmp = 1 in
-//│       end
-//│     else
-//│       set tmp = 0 in
-//│       end;
-//│   set x3 = tmp in
-//│   set tmp1 = +(x3, 1) in
-//│   set x4 = tmp1 in
-//│   set block$res3 = undefined in
-//│   end
+//│ set scrut = ==(x2, 0) in
+//│ match scrut
+//│   true =>
+//│     set tmp = 1 in
+//│     end
+//│   else
+//│     set tmp = 0 in
+//│     end
+//│ in
+//│ set x3 = tmp in
+//│ set tmp1 = +(x3, 1) in
+//│ set x4 = tmp1 in
+//│ set block$res3 = undefined in
+//│ end 
 //│ x = 1


### PR DESCRIPTION
This PR improves the flattening of Blocks to remove `Begin`s. Now the I believe the internal function `flattenConcat` traverses everything once to build the flattened Block. The second parameter is by-name [so that in the case of `Begin`, `rest` is not traversed if `sub` ends with something other than `End`](https://github.com/CrescentonC/mlscript/commit/87fffa970c75e61591aaa2d6a9cf5ad7bb6e39b7#diff-72bbb753659dd44a5e47f3cd0b3954e4ee95fda127ca491a2c267461779c60fbR142).