### PR TITLE
Fix constraint cache and unexpected generalizations in BbML

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/bbml/ConstraintSolver.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/bbml/ConstraintSolver.scala
@@ -87,13 +87,13 @@ class ConstraintSolver(infVarState: InfVarUid.State, elState: Elaborator.State, 
         else
           val bd = if v.lvl >= rest.lvl then rest else extrude(rest)(using v.lvl, true, mutable.HashMap.empty)
           if pol then
-            val nc = Type.mkNegType(bd).toDnf
+            val nc = Type.mkNegType(bd).toDnf // always cache the normal form to avoid unexpected cache misses
             log(s"New bound: ${v.showDbg} <: ${nc.showDbg}")
             cctx.nest(v -> nc) givenIn:
               v.state.upperBounds ::= nc
               v.state.lowerBounds.foreach(lb => constrainImpl(lb, nc))
           else
-            val c = bd.toDnf
+            val c = bd.toDnf // always cache the normal form to avoid unexpected cache misses
             log(s"New bound: ${v.showDbg} :> ${c.showDbg}")
             cctx.nest(c -> v) givenIn:
               v.state.lowerBounds ::= c

--- a/hkmc2/shared/src/main/scala/hkmc2/bbml/ConstraintSolver.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/bbml/ConstraintSolver.scala
@@ -21,7 +21,7 @@ case class CCtx(cache: Cache, parents: Ls[(Type, Type)], origin: Term, exp: Opt[
           case N => msg""
         }" -> origin.toLoc
       :: parents.reverse.map(p =>
-        msg"because: cannot constrain  ${p._1.show}  <:  ${p._2.show}" -> N
+        msg"because: cannot constrain  ${p._1.simp.show}  <:  ${p._2.simp.show}" -> N
       )
     ))
   def nest(sub: (Type, Type)): CCtx =
@@ -87,16 +87,17 @@ class ConstraintSolver(infVarState: InfVarUid.State, elState: Elaborator.State, 
         else
           val bd = if v.lvl >= rest.lvl then rest else extrude(rest)(using v.lvl, true, mutable.HashMap.empty)
           if pol then
-            val nc = Type.mkNegType(bd)
+            val nc = Type.mkNegType(bd).toBasic
             log(s"New bound: ${v.showDbg} <: ${nc.showDbg}")
             cctx.nest(v -> nc) givenIn:
               v.state.upperBounds ::= nc
               v.state.lowerBounds.foreach(lb => constrainImpl(lb, nc))
           else
-            log(s"New bound: ${v.showDbg} :> ${bd.showDbg}")
-            cctx.nest(bd -> v) givenIn:
-              v.state.lowerBounds ::= bd
-              v.state.upperBounds.foreach(ub => constrainImpl(bd, ub))
+            val c = bd.toBasic
+            log(s"New bound: ${v.showDbg} :> ${c.showDbg}")
+            cctx.nest(c -> v) givenIn:
+              v.state.lowerBounds ::= c
+              v.state.upperBounds.foreach(ub => constrainImpl(c, ub))
       case Conj(i, u, Nil) => (conj.i, conj.u) match
         case (_, Union(N, Nil)) =>
           // raise(ErrorReport(msg"Cannot solve ${conj.i.toString()} ∧ ¬⊥" -> N :: Nil))

--- a/hkmc2/shared/src/main/scala/hkmc2/bbml/ConstraintSolver.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/bbml/ConstraintSolver.scala
@@ -21,7 +21,7 @@ case class CCtx(cache: Cache, parents: Ls[(Type, Type)], origin: Term, exp: Opt[
           case N => msg""
         }" -> origin.toLoc
       :: parents.reverse.map(p =>
-        msg"because: cannot constrain  ${p._1.simp.show}  <:  ${p._2.simp.show}" -> N
+        msg"because: cannot constrain  ${p._1.show}  <:  ${p._2.show}" -> N
       )
     ))
   def nest(sub: (Type, Type)): CCtx =
@@ -87,13 +87,13 @@ class ConstraintSolver(infVarState: InfVarUid.State, elState: Elaborator.State, 
         else
           val bd = if v.lvl >= rest.lvl then rest else extrude(rest)(using v.lvl, true, mutable.HashMap.empty)
           if pol then
-            val nc = Type.mkNegType(bd).toBasic
+            val nc = Type.mkNegType(bd).toDnf
             log(s"New bound: ${v.showDbg} <: ${nc.showDbg}")
             cctx.nest(v -> nc) givenIn:
               v.state.upperBounds ::= nc
               v.state.lowerBounds.foreach(lb => constrainImpl(lb, nc))
           else
-            val c = bd.toBasic
+            val c = bd.toDnf
             log(s"New bound: ${v.showDbg} :> ${c.showDbg}")
             cctx.nest(c -> v) givenIn:
               v.state.lowerBounds ::= c
@@ -138,7 +138,7 @@ class ConstraintSolver(infVarState: InfVarUid.State, elState: Elaborator.State, 
     case _: ClassLikeType | _: FunType | _: InfVar | Top | Bot => ty
 
   private def constrainImpl(lhs: Type, rhs: Type)(using BbCtx, CCtx, TL): Unit =
-    val p = lhs.toBasic -> rhs.toBasic
+    val p = lhs.toDnf -> rhs.toDnf
     if cctx.cache(p) then log(s"Cached!")
     else trace(s"CONSTRAINT ${lhs.showDbg} <: ${rhs.showDbg}"):
       cctx.nest(p) givenIn:

--- a/hkmc2/shared/src/main/scala/hkmc2/bbml/ConstraintSolver.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/bbml/ConstraintSolver.scala
@@ -137,9 +137,10 @@ class ConstraintSolver(infVarState: InfVarUid.State, elState: Elaborator.State, 
     case _: ClassLikeType | _: FunType | _: InfVar | Top | Bot => ty
 
   private def constrainImpl(lhs: Type, rhs: Type)(using BbCtx, CCtx, TL): Unit =
-    if cctx.cache((lhs, rhs)) then log(s"Cached!")
+    val p = lhs.toBasic -> rhs.toBasic
+    if cctx.cache(p) then log(s"Cached!")
     else trace(s"CONSTRAINT ${lhs.showDbg} <: ${rhs.showDbg}"):
-      cctx.nest(lhs -> rhs) givenIn:
+      cctx.nest(p) givenIn:
         val ty = dnf(inlineSkolemBounds(lhs & rhs.!, true)(using Set.empty)) 
         constrainDNF(ty)
   def constrain(lhs: Type, rhs: Type)(using BbCtx, CCtx, TL): Unit =

--- a/hkmc2/shared/src/main/scala/hkmc2/bbml/NormalForm.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/bbml/NormalForm.scala
@@ -54,20 +54,22 @@ extends NormalForm with CachedBasicType:
     })
   def toDnf(using TL): Disj = Disj(this :: Nil)
   override def show(using Scope): Str =
-    ((i :: Nil).filterNot(_.isTop).map(_.show) :::
+    val s = ((i :: Nil).filterNot(_.isTop).map(_.show) :::
       (u :: Nil).filterNot(_.isBot).map("¬{"+_.show+"}") :::
       vars.map:
         case (tv, true) => tv.show
         case (tv, false) => "¬" + tv.show
     ).mkString(" ∧ ")
+    if s.isEmpty then "⊤" else s
 
   override def showDbg: Str =
-    ((i :: Nil).filterNot(_.isTop).map(_.showDbg) :::
+    val s = ((i :: Nil).filterNot(_.isTop).map(_.showDbg) :::
       (u :: Nil).filterNot(_.isBot).map("~{"+_.showDbg+"}") :::
       vars.map:
         case (tv, true) => tv.showDbg
         case (tv, false) => "~" + tv.showDbg
     ).mkString(" && ")
+    if s.isEmpty then "⊤" else s
 object Conj:
   // * Conj objects cannot be created with `new` except in this file.
   // * This is because we want to sort the vars in the apply function.

--- a/hkmc2/shared/src/main/scala/hkmc2/bbml/bbML.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/bbml/bbML.scala
@@ -46,7 +46,6 @@ final case class BbCtx(
   def getRegEnv: Type = outVar match
     case S(v) => v | outRegAcc
     case N => outRegAcc
-  def isTopLevel = parent.isEmpty
   
 
 given (using ctx: BbCtx): Raise = ctx.raise
@@ -268,24 +267,23 @@ class BBTyper(using elState: Elaborator.State, tl: TL):
     case _ =>
       (error(msg"Cannot quote ${code.toString}" -> code.toLoc :: Nil), Bot, Bot)
 
-  private def typeFunDef(sym: Symbol, lam: Term, sig: Opt[Term], pctx: BbCtx)(using ctx: BbCtx, cctx: CCtx, scope: Scope) = lam match
+  private def typeFunDef(sym: Symbol, lam: Term, sig: Opt[Term])(using ctx: BbCtx, cctx: CCtx, scope: Scope) = lam match
     case Term.Lam(params, body) => sig match
       case S(sig) =>
         val sigTy = typeType(sig)(using ctx)
-        pctx += sym -> sigTy
+        ctx += sym -> sigTy
         ascribe(lam, sigTy)
         ()
       case N =>
         val outer = freshOuter(new TempSymbol(S(lam), "outer"))(using ctx)
         given BbCtx = ctx.nestWithOuter(outer)
         val funTyV = freshVar(sym)
-        pctx += sym -> funTyV // for recursive functions
+        ctx += sym -> funTyV // for recursive functions
         val (res, _) = typeCheck(lam)
         val funTy = tryMkMono(res, lam)
         given CCtx = CCtx.init(lam, N)
         constrain(funTy, funTyV)(using ctx)
-        if pctx.isTopLevel then // only generalize top-level definitions
-          pctx += sym -> PolyType.generalize(funTy, S(outer), 1)
+        ctx += sym -> PolyType.generalize(funTy, S(outer), ctx.lvl + 1)
     case _ => error(msg"Function definition shape not yet supported for ${sym.nme}" -> lam.toLoc :: Nil)
 
   private def typeSplit
@@ -445,10 +443,10 @@ class BBTyper(using elState: Elaborator.State, tl: TL):
             ctx += sym -> rhsTy
             goStats(stats)
           case (td @ TermDefinition(k = Fun, params = ps :: Nil, sign = sig, body = S(body))) :: stats =>
-            typeFunDef(td.sym, Term.Lam(ps, body), sig, ctx)
+            typeFunDef(td.sym, Term.Lam(ps, body), sig)
             goStats(stats)
           case (td @ TermDefinition(k = Fun, params = Nil, sign = sig, body = S(body))) :: stats =>
-            typeFunDef(td.sym, body, sig, ctx)  // * may be a case expressions
+            typeFunDef(td.sym, body, sig)  // * may be a case expressions
             goStats(stats)
           case (td1 @ TermDefinition(k = Fun, sign = S(sig), body = None)) :: (td2 @ TermDefinition(k = Fun, body = S(body))) :: stats
             if td1.sym === td2.sym => goStats(td2 :: stats) // * avoid type check signatures twice
@@ -570,7 +568,7 @@ class BBTyper(using elState: Elaborator.State, tl: TL):
         constrain(tryMkMono(refTy, ref), BbCtx.refTy(ctnt, sk))
         (ctnt, sk | refEff)
       case Term.Quoted(body) =>
-        val nestCtx = ctx.nextLevel
+        val nestCtx = ctx.nest
         given BbCtx = nestCtx
         val (ty, ctxTy, eff) = typeCode(body)
         (BbCtx.codeTy(ty, ctxTy), eff)

--- a/hkmc2/shared/src/main/scala/hkmc2/bbml/bbML.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/bbml/bbML.scala
@@ -46,6 +46,7 @@ final case class BbCtx(
   def getRegEnv: Type = outVar match
     case S(v) => v | outRegAcc
     case N => outRegAcc
+  def isTopLevel = parent.isEmpty
   
 
 given (using ctx: BbCtx): Raise = ctx.raise
@@ -283,7 +284,8 @@ class BBTyper(using elState: Elaborator.State, tl: TL):
         val funTy = tryMkMono(res, lam)
         given CCtx = CCtx.init(lam, N)
         constrain(funTy, funTyV)(using ctx)
-        pctx += sym -> PolyType.generalize(funTy, S(outer), 1)
+        if pctx.isTopLevel then // only generalize top-level definitions
+          pctx += sym -> PolyType.generalize(funTy, S(outer), 1)
     case _ => error(msg"Function definition shape not yet supported for ${sym.nme}" -> lam.toLoc :: Nil)
 
   private def typeSplit

--- a/hkmc2/shared/src/main/scala/hkmc2/bbml/types.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/bbml/types.scala
@@ -354,7 +354,7 @@ object PolyType:
     visited.toSet
 
   def generalize(ty: GeneralType, outer: Opt[InfVar], lvl: Int): PolyType =
-    PolyType(collectTVs(ty).filter(v => outer.map(_.uid != v.uid).getOrElse(true)).toList.sorted, outer, ty)
+    PolyType(collectTVs(ty).filter(v => v.lvl == lvl && outer.map(_.uid != v.uid).getOrElse(true)).toList.sorted, outer, ty)
 
 // * Functions that accept/return a polymorphic type.
 // * Note that effects are always monomorphic

--- a/hkmc2/shared/src/main/scala/hkmc2/bbml/types.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/bbml/types.scala
@@ -80,8 +80,6 @@ trait CachedBasicType extends Type:
 abstract class TypeExt extends Type:
   override def hashCode: Int =
     toBasic.hashCode
-  override def equals(that: Any): Bool =
-    toBasic === that
   
 sealed abstract class Type extends GeneralType with TypeArg:
   

--- a/hkmc2/shared/src/test/mlscript/bbml/bbBasics.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbBasics.mls
@@ -164,9 +164,9 @@ let ip = new Printer(foofoo) in ip.Printer#f("42")
 //│ ║         	                                             ^^^^
 //│ ╟── because: cannot constrain  Str  <:  'T
 //│ ╟── because: cannot constrain  Str  <:  'T
-//│ ╟── because: cannot constrain  Str  <:  ¬(¬'T)
 //│ ╟── because: cannot constrain  Str  <:  'T
-//│ ╙── because: cannot constrain  Str  <:  ¬(¬{Int})
+//│ ╟── because: cannot constrain  Str  <:  'T
+//│ ╙── because: cannot constrain  Str  <:  Int
 //│ Type: Str
 
 data class TFun[T](f: T -> T)
@@ -191,9 +191,9 @@ let tf = new TFun(inc) in tf.TFun#f("1")
 //│ ║         	                                    ^^^
 //│ ╟── because: cannot constrain  Str  <:  'T
 //│ ╟── because: cannot constrain  Str  <:  'T
-//│ ╟── because: cannot constrain  Str  <:  ¬(¬'T)
 //│ ╟── because: cannot constrain  Str  <:  'T
-//│ ╙── because: cannot constrain  Str  <:  ¬(¬{Int})
+//│ ╟── because: cannot constrain  Str  <:  'T
+//│ ╙── because: cannot constrain  Str  <:  Int
 //│ Type: Str ∨ Int
 
 data class Pair[A, B](fst: A, snd: B)

--- a/hkmc2/shared/src/test/mlscript/bbml/bbBasics.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbBasics.mls
@@ -164,9 +164,9 @@ let ip = new Printer(foofoo) in ip.Printer#f("42")
 //│ ║         	                                             ^^^^
 //│ ╟── because: cannot constrain  Str  <:  'T
 //│ ╟── because: cannot constrain  Str  <:  'T
-//│ ╟── because: cannot constrain  Str ∧ ¬⊥  <:  ¬(¬'T)
+//│ ╟── because: cannot constrain  Str  <:  ¬(¬'T)
 //│ ╟── because: cannot constrain  Str  <:  'T
-//│ ╙── because: cannot constrain  Str ∧ ¬⊥  <:  ¬(¬{Int})
+//│ ╙── because: cannot constrain  Str  <:  ¬(¬{Int})
 //│ Type: Str
 
 data class TFun[T](f: T -> T)
@@ -191,9 +191,9 @@ let tf = new TFun(inc) in tf.TFun#f("1")
 //│ ║         	                                    ^^^
 //│ ╟── because: cannot constrain  Str  <:  'T
 //│ ╟── because: cannot constrain  Str  <:  'T
-//│ ╟── because: cannot constrain  Str ∧ ¬⊥  <:  ¬(¬'T)
+//│ ╟── because: cannot constrain  Str  <:  ¬(¬'T)
 //│ ╟── because: cannot constrain  Str  <:  'T
-//│ ╙── because: cannot constrain  Str ∧ ¬⊥  <:  ¬(¬{Int})
+//│ ╙── because: cannot constrain  Str  <:  ¬(¬{Int})
 //│ Type: Str ∨ Int
 
 data class Pair[A, B](fst: A, snd: B)

--- a/hkmc2/shared/src/test/mlscript/bbml/bbBasics.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbBasics.mls
@@ -164,9 +164,9 @@ let ip = new Printer(foofoo) in ip.Printer#f("42")
 //│ ║         	                                             ^^^^
 //│ ╟── because: cannot constrain  Str  <:  'T
 //│ ╟── because: cannot constrain  Str  <:  'T
-//│ ╟── because: cannot constrain  Str  <:  ¬(¬'T)
+//│ ╟── because: cannot constrain  Str ∧ ¬⊥  <:  ¬(¬'T)
 //│ ╟── because: cannot constrain  Str  <:  'T
-//│ ╙── because: cannot constrain  Str  <:  ¬(¬{Int})
+//│ ╙── because: cannot constrain  Str ∧ ¬⊥  <:  ¬(¬{Int})
 //│ Type: Str
 
 data class TFun[T](f: T -> T)
@@ -191,9 +191,9 @@ let tf = new TFun(inc) in tf.TFun#f("1")
 //│ ║         	                                    ^^^
 //│ ╟── because: cannot constrain  Str  <:  'T
 //│ ╟── because: cannot constrain  Str  <:  'T
-//│ ╟── because: cannot constrain  Str  <:  ¬(¬'T)
+//│ ╟── because: cannot constrain  Str ∧ ¬⊥  <:  ¬(¬'T)
 //│ ╟── because: cannot constrain  Str  <:  'T
-//│ ╙── because: cannot constrain  Str  <:  ¬(¬{Int})
+//│ ╙── because: cannot constrain  Str ∧ ¬⊥  <:  ¬(¬{Int})
 //│ Type: Str ∨ Int
 
 data class Pair[A, B](fst: A, snd: B)

--- a/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing.mls
@@ -91,10 +91,10 @@ letreg of r =>
 //│ ║  l.75: 	  k()
 //│ ║        	^^^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
-//│ ╟── because: cannot constrain  'E  <:  ¬()
-//│ ╟── because: cannot constrain  ¬'Rg  <:  ¬()
+//│ ╟── because: cannot constrain  'E  <:  ⊥
+//│ ╟── because: cannot constrain  ¬'Rg  <:  ⊥
 //│ ╟── because: cannot constrain  ⊤  <:  'Rg
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ Type: ⊥
 
 :e
@@ -127,10 +127,10 @@ letreg of r =>
 //│ ║  l.109: 	  r
 //│ ║         	^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
-//│ ╟── because: cannot constrain  'E  <:  ¬()
-//│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  'E  <:  ⊥
+//│ ╟── because: cannot constrain  'Rg  <:  ⊥
+//│ ╟── because: cannot constrain  'Rg  <:  ⊥
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ Type: Reg[?, 'E]
 //│ Where:
 //│   ⊤ <: 'E
@@ -171,10 +171,10 @@ letreg of r =>
 //│ ║  l.157: 	  r
 //│ ║         	^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
-//│ ╟── because: cannot constrain  'E  <:  ¬()
-//│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  'E  <:  ⊥
+//│ ╟── because: cannot constrain  'Rg  <:  ⊥
+//│ ╟── because: cannot constrain  'Rg  <:  ⊥
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ Type: Reg[?, 'E]
 //│ Where:
 //│   ⊤ <: 'E

--- a/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing.mls
@@ -94,7 +94,7 @@ letreg of r =>
 //│ ╟── because: cannot constrain  'E  <:  ¬()
 //│ ╟── because: cannot constrain  ¬⊥ ∧ ¬'Rg  <:  ¬()
 //│ ╟── because: cannot constrain    <:  'Rg
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ Type: ⊥
 
 :e
@@ -130,7 +130,7 @@ letreg of r =>
 //│ ╟── because: cannot constrain  'E  <:  ¬()
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'Rg  <:  ¬()
 //│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ Type: Reg[?, 'E]
 //│ Where:
 //│   ⊤ <: 'E
@@ -174,7 +174,7 @@ letreg of r =>
 //│ ╟── because: cannot constrain  'E  <:  ¬()
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'Rg  <:  ¬()
 //│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ Type: Reg[?, 'E]
 //│ Where:
 //│   ⊤ <: 'E

--- a/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing.mls
@@ -92,9 +92,9 @@ letreg of r =>
 //│ ║        	^^^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
 //│ ╟── because: cannot constrain  'E  <:  ¬()
-//│ ╟── because: cannot constrain  ¬⊥ ∧ ¬'Rg  <:  ¬()
-//│ ╟── because: cannot constrain    <:  'Rg
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  ¬'Rg  <:  ¬()
+//│ ╟── because: cannot constrain  ⊤  <:  'Rg
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ Type: ⊥
 
 :e
@@ -128,9 +128,9 @@ letreg of r =>
 //│ ║         	^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
 //│ ╟── because: cannot constrain  'E  <:  ¬()
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'Rg  <:  ¬()
 //│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  'Rg  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ Type: Reg[?, 'E]
 //│ Where:
 //│   ⊤ <: 'E
@@ -172,9 +172,9 @@ letreg of r =>
 //│ ║         	^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
 //│ ╟── because: cannot constrain  'E  <:  ¬()
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'Rg  <:  ¬()
 //│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  'Rg  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ Type: Reg[?, 'E]
 //│ Where:
 //│   ⊤ <: 'E

--- a/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing2.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing2.mls
@@ -51,7 +51,7 @@ letreg of r =>
 //│ ╟── because: cannot constrain  'E  <:  ¬()
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'Rg  <:  ¬()
 //│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ Type: Int
 
 
@@ -90,7 +90,7 @@ letreg of r =>
 //│ ╟── because: cannot constrain  'E  <:  ¬()
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'Rg  <:  ¬()
 //│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ Type: Int
 
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing2.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing2.mls
@@ -48,10 +48,10 @@ letreg of r =>
 //│ ║  l.36: 	  write(r)
 //│ ║        	^^^^^^^^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
-//│ ╟── because: cannot constrain  'E  <:  ¬()
-//│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  'E  <:  ⊥
+//│ ╟── because: cannot constrain  'Rg  <:  ⊥
+//│ ╟── because: cannot constrain  'Rg  <:  ⊥
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ Type: Int
 
 
@@ -87,10 +87,10 @@ letreg of r =>
 //│ ║  l.75: 	  write(r)
 //│ ║        	^^^^^^^^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
-//│ ╟── because: cannot constrain  'E  <:  ¬()
-//│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  'E  <:  ⊥
+//│ ╟── because: cannot constrain  'Rg  <:  ⊥
+//│ ╟── because: cannot constrain  'Rg  <:  ⊥
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ Type: Int
 
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing2.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing2.mls
@@ -49,9 +49,9 @@ letreg of r =>
 //│ ║        	^^^^^^^^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
 //│ ╟── because: cannot constrain  'E  <:  ¬()
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'Rg  <:  ¬()
 //│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  'Rg  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ Type: Int
 
 
@@ -88,9 +88,9 @@ letreg of r =>
 //│ ║        	^^^^^^^^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
 //│ ╟── because: cannot constrain  'E  <:  ¬()
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'Rg  <:  ¬()
 //│ ╟── because: cannot constrain  'Rg  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  'Rg  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ Type: Int
 
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbBounds.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbBounds.mls
@@ -35,7 +35,7 @@ iid("42")
 //│ ║        	    ^^^^
 //│ ╟── because: cannot constrain  Str  <:  'A
 //│ ╟── because: cannot constrain  Str  <:  'A
-//│ ╙── because: cannot constrain  Str  <:  Int
+//│ ╙── because: cannot constrain  Str ∧ ¬⊥  <:  Int
 //│ Type: Str
 
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbBounds.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbBounds.mls
@@ -35,7 +35,7 @@ iid("42")
 //│ ║        	    ^^^^
 //│ ╟── because: cannot constrain  Str  <:  'A
 //│ ╟── because: cannot constrain  Str  <:  'A
-//│ ╙── because: cannot constrain  Str ∧ ¬⊥  <:  Int
+//│ ╙── because: cannot constrain  Str  <:  Int
 //│ Type: Str
 
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbCheck.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbCheck.mls
@@ -180,8 +180,8 @@ foo(42, 1)
 //│ ║  l.178: 	foo(42, 1)
 //│ ║         	        ^
 //│ ╟── because: cannot constrain  Int  <:  ¬'A
-//│ ╟── because: cannot constrain  'A  <:  ¬(Int)
-//│ ╙── because: cannot constrain  Int  <:  ¬(Int)
+//│ ╟── because: cannot constrain  'A  <:  ¬{Int}
+//│ ╙── because: cannot constrain  Int  <:  ¬{Int}
 //│ Type: Int
 
 foo(42, false)

--- a/hkmc2/shared/src/test/mlscript/bbml/bbCheck.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbCheck.mls
@@ -181,7 +181,7 @@ foo(42, 1)
 //│ ║         	        ^
 //│ ╟── because: cannot constrain  Int  <:  ¬'A
 //│ ╟── because: cannot constrain  'A  <:  ¬(Int)
-//│ ╙── because: cannot constrain  Int  <:  ¬(Int)
+//│ ╙── because: cannot constrain  Int ∧ ¬⊥  <:  ¬(Int)
 //│ Type: Int
 
 foo(42, false)

--- a/hkmc2/shared/src/test/mlscript/bbml/bbCheck.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbCheck.mls
@@ -181,7 +181,7 @@ foo(42, 1)
 //│ ║         	        ^
 //│ ╟── because: cannot constrain  Int  <:  ¬'A
 //│ ╟── because: cannot constrain  'A  <:  ¬(Int)
-//│ ╙── because: cannot constrain  Int ∧ ¬⊥  <:  ¬(Int)
+//│ ╙── because: cannot constrain  Int  <:  ¬(Int)
 //│ Type: Int
 
 foo(42, false)

--- a/hkmc2/shared/src/test/mlscript/bbml/bbCodeGen.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbCodeGen.mls
@@ -268,3 +268,40 @@ region x in let y = x.ref 42 in y := 0
 //│ let x5, y1, tmp5; x5 = new this.Region(); tmp5 = new this.Ref(x5, 42); y1 = tmp5; y1.value = 0; 0
 //│ = 0
 //│ Type: Int
+
+
+
+data class LsAlg[A, E](nil:() -> E, cons: (A, E) -> E)
+//│ Type: ⊤
+
+fun nil(x) = x.LsAlg#nil()
+fun cons(x, y, z) = x.LsAlg#cons(y, z)
+//│ Type: ⊤
+
+data class Nil()
+data class Cons[A, B](val x: A,val y: B)
+//│ Type: ⊤
+
+fun mk() = new LsAlg(() => new Nil, (x, y) => new Cons(x, y))
+//│ Type: ⊤
+
+// fun xs: [E] -> LsAlg[in Int, E] -> E
+fun xs(x) = x cons(1, x nil())
+//│ Type: ⊤
+
+fun ys: [E] -> LsAlg[in Nothing, E] -> E
+fun ys(x) = x nil()
+//│ Type: ⊤
+
+fun zs: [E] -> LsAlg[in Int | E, E] -> E
+fun zs(x) = x cons(xs(x), x cons(ys(x),x nil()))
+//│ Type: ⊤
+
+mk() zs()
+//│ = Cons(Cons(1, Nil()), Cons(Nil(), Nil()))
+//│ Type: Nil ∨ Cons['A, 'B]
+//│ Where:
+//│   ('E ∨ Cons['A, 'B]) ∨ Nil <: 'B
+//│   Nil <: 'E
+//│   Cons['A, 'B] <: 'E
+//│   'E ∨ Int <: 'A

--- a/hkmc2/shared/src/test/mlscript/bbml/bbCyclicExtrude.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbCyclicExtrude.mls
@@ -23,10 +23,10 @@ f => (let g = x => f(x(x)) in g) as [A] -> A -> A
 //│ ╔══[ERROR] Type error in block with expected type (A) ->{⊥} A
 //│ ║  l.22: 	f => (let g = x => f(x(x)) in g) as [A] -> A -> A
 //│ ║        	              ^^^^^^^^^^^^^^^^^
-//│ ╟── because: cannot constrain  'x ->{'eff ∨ 'eff1} 'app  <:  A -> A
+//│ ╟── because: cannot constrain  ('x) ->{'eff ∨ 'eff1} ('app)  <:  (A) ->{⊥} (A)
 //│ ╟── because: cannot constrain  A  <:  'x
 //│ ╟── because: cannot constrain  A  <:  'x
-//│ ╙── because: cannot constrain  A  <:  ¬(¬{'x ->{'eff1} 'app1})
+//│ ╙── because: cannot constrain  A  <:  ('x) ->{'eff1} ('app1)
 //│ Type: (⊥ -> ⊥) ->{⊥} ['A] -> ('A) ->{⊥} 'A
 
 f => (x => f(x(x)) as [A] -> A -> A)

--- a/hkmc2/shared/src/test/mlscript/bbml/bbCyclicExtrude.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbCyclicExtrude.mls
@@ -24,9 +24,9 @@ f => (let g = x => f(x(x)) in g) as [A] -> A -> A
 //│ ║  l.22: 	f => (let g = x => f(x(x)) in g) as [A] -> A -> A
 //│ ║        	              ^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'x ->{'eff ∨ 'eff1} 'app  <:  A -> A
+//│ ╟── because: cannot constrain  A  <:  ⊤ ∧ (¬⊥ ∧ 'x)
 //│ ╟── because: cannot constrain  A  <:  'x
-//│ ╟── because: cannot constrain  A  <:  'x
-//│ ╙── because: cannot constrain  A  <:  ¬(¬{'x ->{'eff1} 'app1})
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ A)  <:  ¬(¬{'x ->{'eff1} 'app1})
 //│ Type: (⊥ -> ⊥) ->{⊥} ['A] -> ('A) ->{⊥} 'A
 
 f => (x => f(x(x)) as [A] -> A -> A)

--- a/hkmc2/shared/src/test/mlscript/bbml/bbCyclicExtrude.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbCyclicExtrude.mls
@@ -24,9 +24,9 @@ f => (let g = x => f(x(x)) in g) as [A] -> A -> A
 //│ ║  l.22: 	f => (let g = x => f(x(x)) in g) as [A] -> A -> A
 //│ ║        	              ^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'x ->{'eff ∨ 'eff1} 'app  <:  A -> A
-//│ ╟── because: cannot constrain  A  <:  ⊤ ∧ (¬⊥ ∧ 'x)
 //│ ╟── because: cannot constrain  A  <:  'x
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ A)  <:  ¬(¬{'x ->{'eff1} 'app1})
+//│ ╟── because: cannot constrain  A  <:  'x
+//│ ╙── because: cannot constrain  A  <:  ¬(¬{'x ->{'eff1} 'app1})
 //│ Type: (⊥ -> ⊥) ->{⊥} ['A] -> ('A) ->{⊥} 'A
 
 f => (x => f(x(x)) as [A] -> A -> A)

--- a/hkmc2/shared/src/test/mlscript/bbml/bbDisjoint.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbDisjoint.mls
@@ -30,12 +30,12 @@ region x in
 //│ ║  l.28: 	  fork((_ => x.ref 1), (_ => x.ref 2))
 //│ ║        	                             ^^^^^^^
 //│ ╟── because: cannot constrain  'reg  <:  'B
-//│ ╟── because: cannot constrain  'reg  <:  ¬(¬'B)
-//│ ╟── because: cannot constrain  x  <:  ¬(¬'B)
+//│ ╟── because: cannot constrain  'reg  <:  'B
+//│ ╟── because: cannot constrain  x  <:  'B
 //│ ╟── because: cannot constrain  x  <:  'B
 //│ ╟── because: cannot constrain  x  <:  ¬'A
-//│ ╟── because: cannot constrain  'A  <:  ¬(x)
-//│ ╙── because: cannot constrain  x  <:  ¬(x)
+//│ ╟── because: cannot constrain  'A  <:  ¬x
+//│ ╙── because: cannot constrain  x  <:  ¬x
 //│ Type: Pair[out Ref[Int, ?], out Ref[Int, ?]]
 
 
@@ -63,37 +63,38 @@ region x in
 //│ ║  l.61: 	  naive_helper(x)
 //│ ║        	               ^
 //│ ╟── because: cannot constrain  Region[x]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2]  <:  Region[in 'reg out 'reg1]
+//│ ╟── because: cannot constrain  Region[in 'x1 out 'x2]  <:  'r1
+//│ ╟── because: cannot constrain  Region[in 'x1 out 'x2]  <:  Region[in 'reg out 'reg1]
 //│ ╟── because: cannot constrain  'x2  <:  'reg1
-//│ ╟── because: cannot constrain  'x2  <:  ¬(¬'reg1)
-//│ ╟── because: cannot constrain  ⊤  <:  ¬(¬'reg1)
+//│ ╟── because: cannot constrain  'x2  <:  'reg1
+//│ ╟── because: cannot constrain  ⊤  <:  'reg1
 //│ ╟── because: cannot constrain  ⊤  <:  'reg1
 //│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ ╔══[ERROR] Type error in reference with expected type 'r1
 //│ ║  l.61: 	  naive_helper(x)
 //│ ║        	               ^
 //│ ╟── because: cannot constrain  Region[x]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2]  <:  Region[in 'reg out 'reg1]
+//│ ╟── because: cannot constrain  Region[in 'x1 out 'x2]  <:  'r1
+//│ ╟── because: cannot constrain  Region[in 'x1 out 'x2]  <:  Region[in 'reg out 'reg1]
 //│ ╟── because: cannot constrain  'x2  <:  'reg1
-//│ ╟── because: cannot constrain  'x2  <:  ¬(¬'reg1)
-//│ ╟── because: cannot constrain  ⊤  <:  ¬(¬'reg1)
+//│ ╟── because: cannot constrain  'x2  <:  'reg1
+//│ ╟── because: cannot constrain  ⊤  <:  'reg1
 //│ ╟── because: cannot constrain  ⊤  <:  'reg1
 //│ ╟── because: cannot constrain  ⊤  <:  'reg
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  ⊤  <:  'reg
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ ╔══[ERROR] Type error in block
 //│ ║  l.61: 	  naive_helper(x)
 //│ ║        	  ^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'eff  <:  ⊥
-//│ ╟── because: cannot constrain  'eff  <:  ¬()
-//│ ╟── because: cannot constrain  'eff1 ∧ ¬'x3  <:  ¬()
+//│ ╟── because: cannot constrain  'eff  <:  ⊥
+//│ ╟── because: cannot constrain  ¬'x3 ∧ 'eff1  <:  ⊥
 //│ ╟── because: cannot constrain  'eff1  <:  'x3
-//│ ╟── because: cannot constrain  'eff1  <:  ¬()
-//│ ╟── because: cannot constrain  'eff1  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  'eff1  <:  ⊥
+//│ ╟── because: cannot constrain  'eff1  <:  ⊥
+//│ ╟── because: cannot constrain  'reg1  <:  ⊥
+//│ ╟── because: cannot constrain  'reg1  <:  ⊥
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ Type: Pair[out Ref[Int, ?], out Ref[Int, ?]]
 
 
@@ -127,22 +128,24 @@ region x in
 region x in
   (region y in let t = helper(x) in 42) as [A] -> Int
 //│ ╔══[ERROR] Type error in reference with expected type 'r1
-//│ ║  l.128: 	  (region y in let t = helper(x) in 42) as [A] -> Int
+//│ ║  l.129: 	  (region y in let t = helper(x) in 42) as [A] -> Int
 //│ ║         	                              ^
 //│ ╟── because: cannot constrain  Region[x]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in x out x]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in x out x]  <:  Region[in 'reg out 'reg1]
+//│ ╟── because: cannot constrain  Region[x]  <:  'r1
+//│ ╟── because: cannot constrain  Region[x]  <:  Region[in 'reg out 'reg1]
 //│ ╟── because: cannot constrain  x  <:  'reg1
+//│ ╟── because: cannot constrain  x  <:  'reg1
+//│ ╟── because: cannot constrain  x  <:  'env
 //│ ╟── because: cannot constrain  x  <:  'env
 //│ ╙── because: cannot constrain  x  <:  outer ∨ y
 //│ ╔══[ERROR] Type error in region expression with expected type [outer, 'A] -> Int
-//│ ║  l.128: 	  (region y in let t = helper(x) in 42) as [A] -> Int
+//│ ║  l.129: 	  (region y in let t = helper(x) in 42) as [A] -> Int
 //│ ║         	                       ^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'eff  <:  ⊥
-//│ ╟── because: cannot constrain  'eff  <:  ¬()
-//│ ╟── because: cannot constrain  ¬'y1 ∧ x  <:  ¬()
+//│ ╟── because: cannot constrain  'eff  <:  ⊥
+//│ ╟── because: cannot constrain  ¬'y1 ∧ x  <:  ⊥
 //│ ╟── because: cannot constrain  x  <:  'y1
-//│ ╙── because: cannot constrain  x  <:  ¬()
+//│ ╙── because: cannot constrain  x  <:  ⊥
 //│ Type: Int
 
 
@@ -163,10 +166,10 @@ fun badanno: outer
 :e
 fun badanno2: [outer A, outer B] -> Int ->{A | B} Int
 //│ ╔══[ERROR] Only one outer variable can be bound.
-//│ ║  l.164: 	fun badanno2: [outer A, outer B] -> Int ->{A | B} Int
+//│ ║  l.167: 	fun badanno2: [outer A, outer B] -> Int ->{A | B} Int
 //│ ╙──       	              ^^^^^^^^^^^^^^^^^^
 //│ ╔══[ERROR] Illegal forall annotation.
-//│ ║  l.164: 	fun badanno2: [outer A, outer B] -> Int ->{A | B} Int
+//│ ║  l.167: 	fun badanno2: [outer A, outer B] -> Int ->{A | B} Int
 //│ ╙──       	              ^^^^^^^^^^^^^^^^^^
 //│ ═══[ERROR] Invalid type
 //│ Type: ⊤
@@ -210,48 +213,49 @@ fun foo(r1) =
     fork((_ => r1.ref 1), (_ => r2.ref 2))
     foo(r2)
 //│ ╔══[ERROR] Type error in function literal
-//│ ║  l.208: 	fun foo(r1) =
+//│ ║  l.211: 	fun foo(r1) =
 //│ ║         	        ^^^^^
-//│ ║  l.209: 	  region r2 in
+//│ ║  l.212: 	  region r2 in
 //│ ║         	^^^^^^^^^^^^^^
-//│ ║  l.210: 	    fork((_ => r1.ref 1), (_ => r2.ref 2))
+//│ ║  l.213: 	    fork((_ => r1.ref 1), (_ => r2.ref 2))
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.211: 	    foo(r2)
+//│ ║  l.214: 	    foo(r2)
 //│ ║         	^^^^^^^^^^^
-//│ ╟── because: cannot constrain  'r1 ->{'eff} 'app  <:  'foo
 //│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  'foo
-//│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  Region[in 'r2 out 'r21] ->{'eff1} 'app1
+//│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  'foo
+//│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  (Region[in 'r2 out 'r21]) ->{'eff1} ('app1)
 //│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  'r1
 //│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  'r1
 //│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  Region[in 'reg out 'reg1]
 //│ ╟── because: cannot constrain  'r21  <:  'reg1
-//│ ╟── because: cannot constrain  'r21  <:  ¬(¬'reg1)
-//│ ╟── because: cannot constrain  ¬outer  <:  ¬(¬'reg1)
+//│ ╟── because: cannot constrain  'r21  <:  'reg1
+//│ ╟── because: cannot constrain  ¬outer  <:  'reg1
 //│ ╟── because: cannot constrain  ¬outer  <:  'reg1
 //│ ╟── because: cannot constrain  ¬outer  <:  ¬'r22 ∨ outer
-//│ ╟── because: cannot constrain  'r22  <:  ¬(¬outer)
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬outer)
+//│ ╟── because: cannot constrain  'r22  <:  outer
+//│ ╙── because: cannot constrain  ¬outer  <:  outer
 //│ ╔══[ERROR] Type error in function literal
-//│ ║  l.208: 	fun foo(r1) =
+//│ ║  l.211: 	fun foo(r1) =
 //│ ║         	        ^^^^^
-//│ ║  l.209: 	  region r2 in
+//│ ║  l.212: 	  region r2 in
 //│ ║         	^^^^^^^^^^^^^^
-//│ ║  l.210: 	    fork((_ => r1.ref 1), (_ => r2.ref 2))
+//│ ║  l.213: 	    fork((_ => r1.ref 1), (_ => r2.ref 2))
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.211: 	    foo(r2)
+//│ ║  l.214: 	    foo(r2)
 //│ ║         	^^^^^^^^^^^
-//│ ╟── because: cannot constrain  'r1 ->{'eff} 'app  <:  'foo
 //│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  'foo
-//│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  Region[in 'r2 out 'r21] ->{'eff1} 'app1
+//│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  'foo
+//│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  (Region[in 'r2 out 'r21]) ->{'eff1} ('app1)
 //│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  'r1
 //│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  'r1
 //│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  Region[in 'reg out 'reg1]
 //│ ╟── because: cannot constrain  'r21  <:  'reg1
-//│ ╟── because: cannot constrain  'r21  <:  ¬(¬'reg1)
-//│ ╟── because: cannot constrain  ¬outer  <:  ¬(¬'reg1)
+//│ ╟── because: cannot constrain  'r21  <:  'reg1
+//│ ╟── because: cannot constrain  ¬outer  <:  'reg1
 //│ ╟── because: cannot constrain  ¬outer  <:  'reg1
 //│ ╟── because: cannot constrain  ¬outer  <:  'reg
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬()
+//│ ╟── because: cannot constrain  ¬outer  <:  'reg
+//│ ╙── because: cannot constrain  ¬outer  <:  ⊥
 //│ Type: ⊤
 
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbDisjoint.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbDisjoint.mls
@@ -31,11 +31,11 @@ region x in
 //│ ║        	                             ^^^^^^^
 //│ ╟── because: cannot constrain  'reg  <:  'B
 //│ ╟── because: cannot constrain  'reg  <:  ¬(¬'B)
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  ¬(¬'B)
+//│ ╟── because: cannot constrain  x  <:  ¬(¬'B)
 //│ ╟── because: cannot constrain  x  <:  'B
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  ¬'A
+//│ ╟── because: cannot constrain  x  <:  ¬'A
 //│ ╟── because: cannot constrain  'A  <:  ¬(x)
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  ¬(x)
+//│ ╙── because: cannot constrain  x  <:  ¬(x)
 //│ Type: Pair[out Ref[Int, ?], out Ref[Int, ?]]
 
 
@@ -63,37 +63,37 @@ region x in
 //│ ║  l.61: 	  naive_helper(x)
 //│ ║        	               ^
 //│ ╟── because: cannot constrain  Region[x]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2] ∧ ¬⊥  <:  'r1
-//│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2] ∧ ¬⊥  <:  Region[in 'reg out 'reg1]
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'x2)  <:  'reg1
+//│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2]  <:  'r1
+//│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2]  <:  Region[in 'reg out 'reg1]
+//│ ╟── because: cannot constrain  'x2  <:  'reg1
 //│ ╟── because: cannot constrain  'x2  <:  ¬(¬'reg1)
-//│ ╟── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬(¬'reg1)
-//│ ╟── because: cannot constrain    <:  'reg1
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ⊥
+//│ ╟── because: cannot constrain  ⊤  <:  ¬(¬'reg1)
+//│ ╟── because: cannot constrain  ⊤  <:  'reg1
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ ╔══[ERROR] Type error in reference with expected type 'r1
 //│ ║  l.61: 	  naive_helper(x)
 //│ ║        	               ^
 //│ ╟── because: cannot constrain  Region[x]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2] ∧ ¬⊥  <:  'r1
-//│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2] ∧ ¬⊥  <:  Region[in 'reg out 'reg1]
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'x2)  <:  'reg1
+//│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2]  <:  'r1
+//│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2]  <:  Region[in 'reg out 'reg1]
+//│ ╟── because: cannot constrain  'x2  <:  'reg1
 //│ ╟── because: cannot constrain  'x2  <:  ¬(¬'reg1)
-//│ ╟── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬(¬'reg1)
-//│ ╟── because: cannot constrain    <:  'reg1
-//│ ╟── because: cannot constrain  ⊤ ∧ ¬⊥  <:  'reg
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  ⊤  <:  ¬(¬'reg1)
+//│ ╟── because: cannot constrain  ⊤  <:  'reg1
+//│ ╟── because: cannot constrain  ⊤  <:  'reg
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ ╔══[ERROR] Type error in block
 //│ ║  l.61: 	  naive_helper(x)
 //│ ║        	  ^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'eff  <:  ⊥
 //│ ╟── because: cannot constrain  'eff  <:  ¬()
-//│ ╟── because: cannot constrain  (¬⊥ ∧ 'eff1) ∧ ¬'x3  <:  ¬()
+//│ ╟── because: cannot constrain  'eff1 ∧ ¬'x3  <:  ¬()
 //│ ╟── because: cannot constrain  'eff1  <:  'x3
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'eff1)  <:  ¬()
+//│ ╟── because: cannot constrain  'eff1  <:  ¬()
 //│ ╟── because: cannot constrain  'eff1  <:  ¬()
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ Type: Pair[out Ref[Int, ?], out Ref[Int, ?]]
 
 
@@ -131,18 +131,18 @@ region x in
 //│ ║         	                              ^
 //│ ╟── because: cannot constrain  Region[x]  <:  'r1
 //│ ╟── because: cannot constrain  Region[in x out x]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in x out x] ∧ ¬⊥  <:  Region[in 'reg out 'reg1]
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  'reg1
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  'env
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  outer ∨ y
+//│ ╟── because: cannot constrain  Region[in x out x]  <:  Region[in 'reg out 'reg1]
+//│ ╟── because: cannot constrain  x  <:  'reg1
+//│ ╟── because: cannot constrain  x  <:  'env
+//│ ╙── because: cannot constrain  x  <:  outer ∨ y
 //│ ╔══[ERROR] Type error in region expression with expected type [outer, 'A] -> Int
 //│ ║  l.128: 	  (region y in let t = helper(x) in 42) as [A] -> Int
 //│ ║         	                       ^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'eff  <:  ⊥
 //│ ╟── because: cannot constrain  'eff  <:  ¬()
-//│ ╟── because: cannot constrain  (¬⊥ ∧ ¬'y1) ∧ x  <:  ¬()
+//│ ╟── because: cannot constrain  ¬'y1 ∧ x  <:  ¬()
 //│ ╟── because: cannot constrain  x  <:  'y1
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  ¬()
+//│ ╙── because: cannot constrain  x  <:  ¬()
 //│ Type: Int
 
 
@@ -220,17 +220,17 @@ fun foo(r1) =
 //│ ║         	^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'r1 ->{'eff} 'app  <:  'foo
 //│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  'foo
-//│ ╟── because: cannot constrain  (('r1) ->{'eff} ('app)) ∧ ¬⊥  <:  Region[in 'r2 out 'r21] ->{'eff1} 'app1
-//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  ⊤ ∧ (¬⊥ ∧ 'r1)
+//│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  Region[in 'r2 out 'r21] ->{'eff1} 'app1
 //│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21] ∧ ¬⊥  <:  Region[in 'reg out 'reg1]
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'r21)  <:  'reg1
+//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  'r1
+//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  Region[in 'reg out 'reg1]
+//│ ╟── because: cannot constrain  'r21  <:  'reg1
 //│ ╟── because: cannot constrain  'r21  <:  ¬(¬'reg1)
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬'reg1)
+//│ ╟── because: cannot constrain  ¬outer  <:  ¬(¬'reg1)
 //│ ╟── because: cannot constrain  ¬outer  <:  'reg1
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬'r22 ∨ outer
+//│ ╟── because: cannot constrain  ¬outer  <:  ¬'r22 ∨ outer
 //│ ╟── because: cannot constrain  'r22  <:  ¬(¬outer)
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬outer)
+//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬outer)
 //│ ╔══[ERROR] Type error in function literal
 //│ ║  l.208: 	fun foo(r1) =
 //│ ║         	        ^^^^^
@@ -242,16 +242,16 @@ fun foo(r1) =
 //│ ║         	^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'r1 ->{'eff} 'app  <:  'foo
 //│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  'foo
-//│ ╟── because: cannot constrain  (('r1) ->{'eff} ('app)) ∧ ¬⊥  <:  Region[in 'r2 out 'r21] ->{'eff1} 'app1
-//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  ⊤ ∧ (¬⊥ ∧ 'r1)
+//│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  Region[in 'r2 out 'r21] ->{'eff1} 'app1
 //│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21] ∧ ¬⊥  <:  Region[in 'reg out 'reg1]
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'r21)  <:  'reg1
+//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  'r1
+//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  Region[in 'reg out 'reg1]
+//│ ╟── because: cannot constrain  'r21  <:  'reg1
 //│ ╟── because: cannot constrain  'r21  <:  ¬(¬'reg1)
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬'reg1)
+//│ ╟── because: cannot constrain  ¬outer  <:  ¬(¬'reg1)
 //│ ╟── because: cannot constrain  ¬outer  <:  'reg1
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  'reg
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬()
+//│ ╟── because: cannot constrain  ¬outer  <:  'reg
+//│ ╙── because: cannot constrain  ¬outer  <:  ¬()
 //│ Type: ⊤
 
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbDisjoint.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbDisjoint.mls
@@ -31,11 +31,11 @@ region x in
 //│ ║        	                             ^^^^^^^
 //│ ╟── because: cannot constrain  'reg  <:  'B
 //│ ╟── because: cannot constrain  'reg  <:  ¬(¬'B)
-//│ ╟── because: cannot constrain  x  <:  ¬(¬'B)
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  ¬(¬'B)
 //│ ╟── because: cannot constrain  x  <:  'B
-//│ ╟── because: cannot constrain  x  <:  ¬'A
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  ¬'A
 //│ ╟── because: cannot constrain  'A  <:  ¬(x)
-//│ ╙── because: cannot constrain  x  <:  ¬(x)
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  ¬(x)
 //│ Type: Pair[out Ref[Int, ?], out Ref[Int, ?]]
 
 
@@ -65,24 +65,23 @@ region x in
 //│ ╟── because: cannot constrain  Region[x]  <:  'r1
 //│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2] ∧ ¬⊥  <:  'r1
 //│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2] ∧ ¬⊥  <:  Region[in 'reg out 'reg1]
-//│ ╟── because: cannot constrain  'x2  <:  'reg1
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'x2)  <:  'reg1
 //│ ╟── because: cannot constrain  'x2  <:  ¬(¬'reg1)
-//│ ╟── because: cannot constrain    <:  ¬(¬'reg1)
+//│ ╟── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬(¬'reg1)
 //│ ╟── because: cannot constrain    <:  'reg1
-//│ ╙── because: cannot constrain    <:  ⊥
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ⊥
 //│ ╔══[ERROR] Type error in reference with expected type 'r1
 //│ ║  l.61: 	  naive_helper(x)
 //│ ║        	               ^
 //│ ╟── because: cannot constrain  Region[x]  <:  'r1
 //│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2] ∧ ¬⊥  <:  'r1
 //│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'x1 out ¬⊥ ∧ 'x2] ∧ ¬⊥  <:  Region[in 'reg out 'reg1]
-//│ ╟── because: cannot constrain  'x2  <:  'reg1
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'x2)  <:  'reg1
 //│ ╟── because: cannot constrain  'x2  <:  ¬(¬'reg1)
-//│ ╟── because: cannot constrain    <:  ¬(¬'reg1)
+//│ ╟── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬(¬'reg1)
 //│ ╟── because: cannot constrain    <:  'reg1
-//│ ╟── because: cannot constrain    <:  'reg
-//│ ╟── because: cannot constrain    <:  'reg
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╟── because: cannot constrain  ⊤ ∧ ¬⊥  <:  'reg
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ ╔══[ERROR] Type error in block
 //│ ║  l.61: 	  naive_helper(x)
 //│ ║        	  ^^^^^^^^^^^^^^^
@@ -90,11 +89,11 @@ region x in
 //│ ╟── because: cannot constrain  'eff  <:  ¬()
 //│ ╟── because: cannot constrain  (¬⊥ ∧ 'eff1) ∧ ¬'x3  <:  ¬()
 //│ ╟── because: cannot constrain  'eff1  <:  'x3
-//│ ╟── because: cannot constrain  'eff1  <:  ¬()
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'eff1)  <:  ¬()
 //│ ╟── because: cannot constrain  'eff1  <:  ¬()
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ Type: Pair[out Ref[Int, ?], out Ref[Int, ?]]
 
 
@@ -128,24 +127,22 @@ region x in
 region x in
   (region y in let t = helper(x) in 42) as [A] -> Int
 //│ ╔══[ERROR] Type error in reference with expected type 'r1
-//│ ║  l.129: 	  (region y in let t = helper(x) in 42) as [A] -> Int
+//│ ║  l.128: 	  (region y in let t = helper(x) in 42) as [A] -> Int
 //│ ║         	                              ^
 //│ ╟── because: cannot constrain  Region[x]  <:  'r1
 //│ ╟── because: cannot constrain  Region[in x out x]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in x out x]  <:  Region[in 'reg out 'reg1]
-//│ ╟── because: cannot constrain  x  <:  'reg1
-//│ ╟── because: cannot constrain  x  <:  'reg1
-//│ ╟── because: cannot constrain  x  <:  'env
-//│ ╟── because: cannot constrain  x  <:  'env
-//│ ╙── because: cannot constrain  x  <:  outer ∨ y
+//│ ╟── because: cannot constrain  Region[in x out x] ∧ ¬⊥  <:  Region[in 'reg out 'reg1]
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  'reg1
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  'env
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  outer ∨ y
 //│ ╔══[ERROR] Type error in region expression with expected type [outer, 'A] -> Int
-//│ ║  l.129: 	  (region y in let t = helper(x) in 42) as [A] -> Int
+//│ ║  l.128: 	  (region y in let t = helper(x) in 42) as [A] -> Int
 //│ ║         	                       ^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'eff  <:  ⊥
 //│ ╟── because: cannot constrain  'eff  <:  ¬()
 //│ ╟── because: cannot constrain  (¬⊥ ∧ ¬'y1) ∧ x  <:  ¬()
 //│ ╟── because: cannot constrain  x  <:  'y1
-//│ ╙── because: cannot constrain  x  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  ¬()
 //│ Type: Int
 
 
@@ -166,10 +163,10 @@ fun badanno: outer
 :e
 fun badanno2: [outer A, outer B] -> Int ->{A | B} Int
 //│ ╔══[ERROR] Only one outer variable can be bound.
-//│ ║  l.167: 	fun badanno2: [outer A, outer B] -> Int ->{A | B} Int
+//│ ║  l.164: 	fun badanno2: [outer A, outer B] -> Int ->{A | B} Int
 //│ ╙──       	              ^^^^^^^^^^^^^^^^^^
 //│ ╔══[ERROR] Illegal forall annotation.
-//│ ║  l.167: 	fun badanno2: [outer A, outer B] -> Int ->{A | B} Int
+//│ ║  l.164: 	fun badanno2: [outer A, outer B] -> Int ->{A | B} Int
 //│ ╙──       	              ^^^^^^^^^^^^^^^^^^
 //│ ═══[ERROR] Invalid type
 //│ Type: ⊤
@@ -213,49 +210,48 @@ fun foo(r1) =
     fork((_ => r1.ref 1), (_ => r2.ref 2))
     foo(r2)
 //│ ╔══[ERROR] Type error in function literal
-//│ ║  l.211: 	fun foo(r1) =
+//│ ║  l.208: 	fun foo(r1) =
 //│ ║         	        ^^^^^
-//│ ║  l.212: 	  region r2 in
+//│ ║  l.209: 	  region r2 in
 //│ ║         	^^^^^^^^^^^^^^
-//│ ║  l.213: 	    fork((_ => r1.ref 1), (_ => r2.ref 2))
+//│ ║  l.210: 	    fork((_ => r1.ref 1), (_ => r2.ref 2))
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.214: 	    foo(r2)
+//│ ║  l.211: 	    foo(r2)
 //│ ║         	^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'r1 ->{'eff} 'app  <:  'foo
 //│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  'foo
-//│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  Region[in 'r2 out 'r21] ->{'eff1} 'app1
+//│ ╟── because: cannot constrain  (('r1) ->{'eff} ('app)) ∧ ¬⊥  <:  Region[in 'r2 out 'r21] ->{'eff1} 'app1
+//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  ⊤ ∧ (¬⊥ ∧ 'r1)
 //│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  Region[in 'reg out 'reg1]
-//│ ╟── because: cannot constrain  'r21  <:  'reg1
+//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21] ∧ ¬⊥  <:  Region[in 'reg out 'reg1]
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'r21)  <:  'reg1
 //│ ╟── because: cannot constrain  'r21  <:  ¬(¬'reg1)
-//│ ╟── because: cannot constrain  ¬outer  <:  ¬(¬'reg1)
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬'reg1)
 //│ ╟── because: cannot constrain  ¬outer  <:  'reg1
-//│ ╟── because: cannot constrain  ¬outer  <:  ¬'r22 ∨ outer
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬'r22 ∨ outer
 //│ ╟── because: cannot constrain  'r22  <:  ¬(¬outer)
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬outer)
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬outer)
 //│ ╔══[ERROR] Type error in function literal
-//│ ║  l.211: 	fun foo(r1) =
+//│ ║  l.208: 	fun foo(r1) =
 //│ ║         	        ^^^^^
-//│ ║  l.212: 	  region r2 in
+//│ ║  l.209: 	  region r2 in
 //│ ║         	^^^^^^^^^^^^^^
-//│ ║  l.213: 	    fork((_ => r1.ref 1), (_ => r2.ref 2))
+//│ ║  l.210: 	    fork((_ => r1.ref 1), (_ => r2.ref 2))
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.214: 	    foo(r2)
+//│ ║  l.211: 	    foo(r2)
 //│ ║         	^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'r1 ->{'eff} 'app  <:  'foo
 //│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  'foo
-//│ ╟── because: cannot constrain  ('r1) ->{'eff} ('app)  <:  Region[in 'r2 out 'r21] ->{'eff1} 'app1
+//│ ╟── because: cannot constrain  (('r1) ->{'eff} ('app)) ∧ ¬⊥  <:  Region[in 'r2 out 'r21] ->{'eff1} 'app1
+//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  ⊤ ∧ (¬⊥ ∧ 'r1)
 //│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  'r1
-//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21]  <:  Region[in 'reg out 'reg1]
-//│ ╟── because: cannot constrain  'r21  <:  'reg1
+//│ ╟── because: cannot constrain  Region[in 'r2 out 'r21] ∧ ¬⊥  <:  Region[in 'reg out 'reg1]
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'r21)  <:  'reg1
 //│ ╟── because: cannot constrain  'r21  <:  ¬(¬'reg1)
-//│ ╟── because: cannot constrain  ¬outer  <:  ¬(¬'reg1)
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬'reg1)
 //│ ╟── because: cannot constrain  ¬outer  <:  'reg1
-//│ ╟── because: cannot constrain  ¬outer  <:  'reg
-//│ ╟── because: cannot constrain  ¬outer  <:  'reg
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬()
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  'reg
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬()
 //│ Type: ⊤
 
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbErrors.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbErrors.mls
@@ -8,7 +8,7 @@
 //│ ╔══[ERROR] Type error in application
 //│ ║  l.7: 	2(2)
 //│ ║       	^^^^
-//│ ╙── because: cannot constrain  Int  <:  Int ->{'eff} 'app
+//│ ╙── because: cannot constrain  Int  <:  (Int) ->{'eff} ('app)
 //│ Type: ⊥
 
 (x => x(0))(1)
@@ -17,7 +17,7 @@
 //│ ║        	            ^
 //│ ╟── because: cannot constrain  Int  <:  'x
 //│ ╟── because: cannot constrain  Int  <:  'x
-//│ ╙── because: cannot constrain  Int  <:  ¬(¬{Int ->{'eff} 'app})
+//│ ╙── because: cannot constrain  Int  <:  (Int) ->{'eff} ('app)
 //│ Type: ⊥
 
 (1).Foo#a()
@@ -68,7 +68,7 @@ inc as Int
 //│ ╔══[ERROR] Type error in reference with expected type Int
 //│ ║  l.67: 	inc as Int
 //│ ║        	^^^
-//│ ╙── because: cannot constrain  'x -> Int  <:  Int
+//│ ╙── because: cannot constrain  ('x) ->{⊥} (Int)  <:  Int
 //│ Type: Int
 
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbErrors.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbErrors.mls
@@ -17,7 +17,7 @@
 //│ ║        	            ^
 //│ ╟── because: cannot constrain  Int  <:  'x
 //│ ╟── because: cannot constrain  Int  <:  'x
-//│ ╙── because: cannot constrain  Int  <:  ¬(¬{Int ->{'eff} 'app})
+//│ ╙── because: cannot constrain  Int ∧ ¬⊥  <:  ¬(¬{Int ->{'eff} 'app})
 //│ Type: ⊥
 
 (1).Foo#a()
@@ -60,7 +60,7 @@ inc("oops")
 //│ ║        	    ^^^^^^
 //│ ╟── because: cannot constrain  Str  <:  'x
 //│ ╟── because: cannot constrain  Str  <:  'x
-//│ ╙── because: cannot constrain  Str  <:  ¬¬Int
+//│ ╙── because: cannot constrain  Str ∧ ¬⊥  <:  ¬¬Int
 //│ Type: Int
 
 fun inc(x) = x + 1

--- a/hkmc2/shared/src/test/mlscript/bbml/bbErrors.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbErrors.mls
@@ -17,7 +17,7 @@
 //│ ║        	            ^
 //│ ╟── because: cannot constrain  Int  <:  'x
 //│ ╟── because: cannot constrain  Int  <:  'x
-//│ ╙── because: cannot constrain  Int ∧ ¬⊥  <:  ¬(¬{Int ->{'eff} 'app})
+//│ ╙── because: cannot constrain  Int  <:  ¬(¬{Int ->{'eff} 'app})
 //│ Type: ⊥
 
 (1).Foo#a()
@@ -60,7 +60,7 @@ inc("oops")
 //│ ║        	    ^^^^^^
 //│ ╟── because: cannot constrain  Str  <:  'x
 //│ ╟── because: cannot constrain  Str  <:  'x
-//│ ╙── because: cannot constrain  Str ∧ ¬⊥  <:  ¬¬Int
+//│ ╙── because: cannot constrain  Str  <:  Int
 //│ Type: Int
 
 fun inc(x) = x + 1

--- a/hkmc2/shared/src/test/mlscript/bbml/bbExtrude.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbExtrude.mls
@@ -38,12 +38,12 @@ y `=> (let t = run(x `=> x `+ y) in y)
 //│ ╔══[ERROR] Type error in quoted term with expected type CodeBase[out 'T, ⊥, ?]
 //│ ║  l.37: 	y `=> (let t = run(x `=> x `+ y) in y)
 //│ ║        	                   ^^^^^^^^^^^^
-//│ ╟── because: cannot constrain  CodeBase[out 'x -> 'cde, out 'ctx, ?]  <:  CodeBase[out 'T, ⊥, ?]
+//│ ╟── because: cannot constrain  CodeBase[in ⊥ out ('x) ->{⊥} ('cde), in ⊥ out 'ctx, in ⊥ out ⊤]  <:  CodeBase[in ⊥ out 'T, ⊥, in ⊥ out ⊤]
 //│ ╟── because: cannot constrain  'ctx  <:  ⊥
-//│ ╟── because: cannot constrain  'ctx  <:  ¬()
-//│ ╟── because: cannot constrain  ¬'x1 ∧ y  <:  ¬()
+//│ ╟── because: cannot constrain  'ctx  <:  ⊥
+//│ ╟── because: cannot constrain  ¬'x1 ∧ y  <:  ⊥
 //│ ╟── because: cannot constrain  y  <:  'x1
-//│ ╙── because: cannot constrain  y  <:  ¬()
+//│ ╙── because: cannot constrain  y  <:  ⊥
 //│ Type: CodeBase[out 'y -> 'y, ⊥, ?]
 //│ Where:
 //│   'y <: Int
@@ -81,12 +81,13 @@ f(g)(bar)
 //│ ║  l.79: 	f(g)(bar)
 //│ ║        	     ^^^
 //│ ╟── because: cannot constrain  C[Int]  <:  'A
-//│ ╟── because: cannot constrain  C[in Int out Int]  <:  'A
-//│ ╟── because: cannot constrain  C[in Int out Int]  <:  ¬C[in ⊥ out ¬⊥ ∧ 'B] ∨ C[in Int out ¬⊥ ∧ 'D]
-//│ ╟── because: cannot constrain  (Int) ∧ ('B)  <:  'D
+//│ ╟── because: cannot constrain  C[Int]  <:  'A
+//│ ╟── because: cannot constrain  C[Int]  <:  ¬{C[in ⊥ out ¬⊥ ∧ 'B]} ∨ C[in Int out 'D]
+//│ ╟── because: cannot constrain  Int ∧ 'B  <:  'D
 //│ ╟── because: cannot constrain  Int ∧ 'B  <:  'D
 //│ ╟── because: cannot constrain  Int ∧ 'B  <:  'B1
-//│ ╟── because: cannot constrain  Int ∧ 'B  <:  ¬()
-//│ ╟── because: cannot constrain  'B  <:  ¬(Int)
-//│ ╙── because: cannot constrain  ⊤  <:  ¬(Int)
+//│ ╟── because: cannot constrain  Int ∧ 'B  <:  'B1
+//│ ╟── because: cannot constrain  Int ∧ 'B  <:  ⊥
+//│ ╟── because: cannot constrain  'B  <:  ¬{Int}
+//│ ╙── because: cannot constrain  ⊤  <:  ¬{Int}
 //│ Type: Int

--- a/hkmc2/shared/src/test/mlscript/bbml/bbExtrude.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbExtrude.mls
@@ -111,3 +111,41 @@ k(_ => "")
 
 k(_ => 42)
 //│ Type: Int
+
+
+fun k(x) =
+  fun f: [S, T] -> S -> T
+  fun f(y) = x(y)
+  f(0) + 0
+k
+//│ Type: (⊤ -> ⊥) -> Int
+
+
+:e
+k(_ => "")
+//│ ╔══[ERROR] Type error in function literal with expected type 'x
+//│ ║  l.125: 	k(_ => "")
+//│ ║         	       ^^
+//│ ╟── because: cannot constrain  ('_) ->{⊥} (Str)  <:  'x
+//│ ╟── because: cannot constrain  ('_) ->{⊥} (Str)  <:  'x
+//│ ╟── because: cannot constrain  ('_) ->{⊥} (Str)  <:  (⊤) ->{⊥} ⊥
+//│ ╙── because: cannot constrain  Str  <:  ⊥
+//│ Type: Int
+
+:e
+k(_ => 42)
+//│ ╔══[ERROR] Type error in function literal with expected type 'x
+//│ ║  l.136: 	k(_ => 42)
+//│ ║         	       ^^
+//│ ╟── because: cannot constrain  ('_) ->{⊥} (Int)  <:  'x
+//│ ╟── because: cannot constrain  ('_) ->{⊥} (Int)  <:  'x
+//│ ╟── because: cannot constrain  ('_) ->{⊥} (Int)  <:  (⊤) ->{⊥} ⊥
+//│ ╙── because: cannot constrain  Int  <:  ⊥
+//│ Type: Int
+
+
+fun k(x) =
+  let f = y => x(y)
+  f(0) + 0
+k
+//│ Type: ['eff] -> (Int ->{'eff} Int) ->{'eff} Int

--- a/hkmc2/shared/src/test/mlscript/bbml/bbExtrude.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbExtrude.mls
@@ -39,11 +39,11 @@ y `=> (let t = run(x `=> x `+ y) in y)
 //│ ║  l.37: 	y `=> (let t = run(x `=> x `+ y) in y)
 //│ ║        	                   ^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  CodeBase[out 'x -> 'cde, out 'ctx, ?]  <:  CodeBase[out 'T, ⊥, ?]
-//│ ╟── because: cannot constrain  'ctx  <:  ⊥
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'ctx)  <:  ⊥
 //│ ╟── because: cannot constrain  'ctx  <:  ¬()
 //│ ╟── because: cannot constrain  (¬⊥ ∧ ¬'x1) ∧ y  <:  ¬()
 //│ ╟── because: cannot constrain  y  <:  'x1
-//│ ╙── because: cannot constrain  y  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ y)  <:  ¬()
 //│ Type: CodeBase[out 'y -> 'y, ⊥, ?]
 //│ Where:
 //│   'y <: Int
@@ -82,12 +82,11 @@ f(g)(bar)
 //│ ║        	     ^^^
 //│ ╟── because: cannot constrain  C[Int]  <:  'A
 //│ ╟── because: cannot constrain  C[in Int out Int]  <:  'A
-//│ ╟── because: cannot constrain  C[in Int out Int]  <:  ¬C[in ⊥ out ¬⊥ ∧ 'B] ∨ C[in Int out ¬⊥ ∧ 'D]
+//│ ╟── because: cannot constrain  C[in Int out Int] ∧ ¬⊥  <:  ¬C[in ⊥ out ¬⊥ ∧ 'B] ∨ C[in Int out ¬⊥ ∧ 'D]
 //│ ╟── because: cannot constrain  (Int) ∧ ('B)  <:  ¬⊥ ∧ 'D
 //│ ╟── because: cannot constrain  Int ∧ 'B  <:  'D
-//│ ╟── because: cannot constrain  Int ∧ 'B  <:  'B1
-//│ ╟── because: cannot constrain  Int ∧ 'B  <:  'B1
-//│ ╟── because: cannot constrain  Int ∧ 'B  <:  ¬()
+//│ ╟── because: cannot constrain  Int ∧ (¬⊥ ∧ 'B)  <:  'B1
+//│ ╟── because: cannot constrain  Int ∧ (¬⊥ ∧ 'B)  <:  ¬()
 //│ ╟── because: cannot constrain  'B  <:  ¬(Int)
-//│ ╙── because: cannot constrain    <:  ¬(Int)
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬(Int)
 //│ Type: Int

--- a/hkmc2/shared/src/test/mlscript/bbml/bbExtrude.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbExtrude.mls
@@ -91,3 +91,23 @@ f(g)(bar)
 //│ ╟── because: cannot constrain  'B  <:  ¬{Int}
 //│ ╙── because: cannot constrain  ⊤  <:  ¬{Int}
 //│ Type: Int
+
+fun k(x) =
+  fun f(y) = x(y)
+  f(0) + 0
+k
+//│ Type: ['eff] -> (Int ->{'eff} Int) ->{'eff} Int
+
+:e
+k(_ => "")
+//│ ╔══[ERROR] Type error in function literal with expected type 'x
+//│ ║  l.102: 	k(_ => "")
+//│ ║         	       ^^
+//│ ╟── because: cannot constrain  ('_) ->{⊥} (Str)  <:  'x
+//│ ╟── because: cannot constrain  ('_) ->{⊥} (Str)  <:  'x
+//│ ╟── because: cannot constrain  ('_) ->{⊥} (Str)  <:  (Int) ->{'eff} (Int)
+//│ ╙── because: cannot constrain  Str  <:  Int
+//│ Type: Int
+
+k(_ => 42)
+//│ Type: Int

--- a/hkmc2/shared/src/test/mlscript/bbml/bbExtrude.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbExtrude.mls
@@ -39,11 +39,11 @@ y `=> (let t = run(x `=> x `+ y) in y)
 //│ ║  l.37: 	y `=> (let t = run(x `=> x `+ y) in y)
 //│ ║        	                   ^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  CodeBase[out 'x -> 'cde, out 'ctx, ?]  <:  CodeBase[out 'T, ⊥, ?]
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'ctx)  <:  ⊥
+//│ ╟── because: cannot constrain  'ctx  <:  ⊥
 //│ ╟── because: cannot constrain  'ctx  <:  ¬()
-//│ ╟── because: cannot constrain  (¬⊥ ∧ ¬'x1) ∧ y  <:  ¬()
+//│ ╟── because: cannot constrain  ¬'x1 ∧ y  <:  ¬()
 //│ ╟── because: cannot constrain  y  <:  'x1
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ y)  <:  ¬()
+//│ ╙── because: cannot constrain  y  <:  ¬()
 //│ Type: CodeBase[out 'y -> 'y, ⊥, ?]
 //│ Where:
 //│   'y <: Int
@@ -82,11 +82,11 @@ f(g)(bar)
 //│ ║        	     ^^^
 //│ ╟── because: cannot constrain  C[Int]  <:  'A
 //│ ╟── because: cannot constrain  C[in Int out Int]  <:  'A
-//│ ╟── because: cannot constrain  C[in Int out Int] ∧ ¬⊥  <:  ¬C[in ⊥ out ¬⊥ ∧ 'B] ∨ C[in Int out ¬⊥ ∧ 'D]
-//│ ╟── because: cannot constrain  (Int) ∧ ('B)  <:  ¬⊥ ∧ 'D
+//│ ╟── because: cannot constrain  C[in Int out Int]  <:  ¬C[in ⊥ out ¬⊥ ∧ 'B] ∨ C[in Int out ¬⊥ ∧ 'D]
+//│ ╟── because: cannot constrain  (Int) ∧ ('B)  <:  'D
 //│ ╟── because: cannot constrain  Int ∧ 'B  <:  'D
-//│ ╟── because: cannot constrain  Int ∧ (¬⊥ ∧ 'B)  <:  'B1
-//│ ╟── because: cannot constrain  Int ∧ (¬⊥ ∧ 'B)  <:  ¬()
+//│ ╟── because: cannot constrain  Int ∧ 'B  <:  'B1
+//│ ╟── because: cannot constrain  Int ∧ 'B  <:  ¬()
 //│ ╟── because: cannot constrain  'B  <:  ¬(Int)
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬(Int)
+//│ ╙── because: cannot constrain  ⊤  <:  ¬(Int)
 //│ Type: Int

--- a/hkmc2/shared/src/test/mlscript/bbml/bbFuns.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbFuns.mls
@@ -25,3 +25,35 @@ id(id) as [A] -> A -> A
 //│ Type: ['A] -> ('A) ->{⊥} 'A
 
 
+
+data class Nil()
+data class Cons[A, B](val car: A, val cdr: B)
+data class Ls[A](prim: [R] -> (() -> R, (A, Ls[A]) -> R) -> R)
+//│ Type: ⊤
+
+fun nil() = new Ls((n, _) => n())
+fun cons(p, q) = new Ls((n, r) => r(p, q))
+fun from(x) = x.Ls#prim(() => new Nil, (x, y) => new Cons(x, from(y)))
+fun to(x) = if x is
+  Nil then nil()
+  Cons then cons(x.Cons#car, to(x.Cons#cdr))
+//│ Type: ⊤
+
+let foo = nil() from()
+foo
+//│ Type: Cons['A, 'B] ∨ Nil
+//│ Where:
+//│   ⊥ <: 'A
+//│   Cons['A, 'B] <: 'R
+//│   Nil <: 'R
+//│   'R <: 'B
+
+
+foo to()
+//│ Type: Ls['A] ∨ Ls['A1]
+//│ Where:
+//│   ⊥ <: 'A
+//│   'A <: 'A1
+//│   ⊥ <: 'A1
+//│   'A1 <: 'A
+

--- a/hkmc2/shared/src/test/mlscript/bbml/bbGPCE.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbGPCE.mls
@@ -67,12 +67,12 @@ fun body(x, y) = case
 //│ ╔══[ERROR] Type error in application with expected type CodeBase[out Int, out G, ?]
 //│ ║  l.66: 	  n then bind of x `+ y, (z => body(y, z)(n - 1)): [C] -> CodeBase[out Int, out C, out Any] -> CodeBase[out C, out Any]
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── because: cannot constrain  CodeBase[out 'cde, out 'ctx ∨ 'ctx1, ?]  <:  CodeBase[out Int, out G, ?]
+//│ ╟── because: cannot constrain  CodeBase[in ⊥ out 'cde, in ⊥ out 'ctx ∨ 'ctx1, in ⊥ out ⊤]  <:  CodeBase[in ⊥ out Int, in ⊥ out G, in ⊥ out ⊤]
 //│ ╟── because: cannot constrain  'ctx ∨ 'ctx1  <:  G
-//│ ╟── because: cannot constrain  'ctx1  <:  ¬(¬G)
-//│ ╟── because: cannot constrain  'ctx2  <:  ¬(¬G)
-//│ ╟── because: cannot constrain  'ctx2  <:  ¬(¬G)
-//│ ╙── because: cannot constrain  ⊤  <:  ¬(¬G)
+//│ ╟── because: cannot constrain  'ctx1  <:  G
+//│ ╟── because: cannot constrain  'ctx2  <:  G
+//│ ╟── because: cannot constrain  'ctx2  <:  G
+//│ ╙── because: cannot constrain  ⊤  <:  G
 //│ Type: ⊤
 
 fun bind: [G] -> (CodeBase[out Int, out G, out Any], [C] -> CodeBase[out Int, out C, out Any] -> CodeBase[out Int, out C | G, out Any]) -> CodeBase[out Int, out G, out Any]

--- a/hkmc2/shared/src/test/mlscript/bbml/bbGPCE.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbGPCE.mls
@@ -68,11 +68,11 @@ fun body(x, y) = case
 //│ ║  l.66: 	  n then bind of x `+ y, (z => body(y, z)(n - 1)): [C] -> CodeBase[out Int, out C, out Any] -> CodeBase[out C, out Any]
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  CodeBase[out 'cde, out 'ctx ∨ 'ctx1, ?]  <:  CodeBase[out Int, out G, ?]
-//│ ╟── because: cannot constrain  'ctx ∨ 'ctx1  <:  G
+//│ ╟── because: cannot constrain  (⊤ ∧ (¬⊥ ∧ 'ctx)) ∨ (⊤ ∧ (¬⊥ ∧ 'ctx1))  <:  G
 //│ ╟── because: cannot constrain  'ctx1  <:  ¬(¬G)
 //│ ╟── because: cannot constrain  'ctx2  <:  ¬(¬G)
 //│ ╟── because: cannot constrain  'ctx2  <:  ¬(¬G)
-//│ ╙── because: cannot constrain    <:  ¬(¬G)
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬(¬G)
 //│ Type: ⊤
 
 fun bind: [G] -> (CodeBase[out Int, out G, out Any], [C] -> CodeBase[out Int, out C, out Any] -> CodeBase[out Int, out C | G, out Any]) -> CodeBase[out Int, out G, out Any]

--- a/hkmc2/shared/src/test/mlscript/bbml/bbGPCE.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbGPCE.mls
@@ -65,8 +65,8 @@ fun body(x, y) = case
   1 then y
   n then bind of x `+ y, (z => body(y, z)(n - 1))
 //│ ╔══[ERROR] Type error in application with expected type CodeBase[out Int, out G, ?]
-//│ ║  l.707: 	  n then bind of x `+ y, (z => body(y, z)(n - 1))
-//│ ║         	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.66: 	  n then bind of x `+ y, (z => body(y, z)(n - 1))
+//│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  CodeBase[in ⊥ out 'cde, in ⊥ out 'ctx ∨ 'ctx1, in ⊥ out ⊤]  <:  CodeBase[in ⊥ out Int, in ⊥ out G, in ⊥ out ⊤]
 //│ ╟── because: cannot constrain  'ctx ∨ 'ctx1  <:  G
 //│ ╟── because: cannot constrain  'ctx1  <:  G

--- a/hkmc2/shared/src/test/mlscript/bbml/bbGPCE.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbGPCE.mls
@@ -56,17 +56,17 @@ let gn5 = run(gib_naive(5))
 
 fun bind(rhs, k) = `let x = rhs `in k(x)
 bind
-//│ Type: ['cde, 'ctx, 'cde1, 'eff, 'cde2, 'ctx1] -> (CodeBase[out 'cde, out 'ctx, ?], CodeBase[in 'cde1 out 'cde1 ∨ 'cde, ?, ⊥] ->{'eff} CodeBase[out 'cde2, out 'ctx1, ?]) ->{'eff} CodeBase[out 'cde2, out 'ctx ∨ 'ctx1, ?]
+//│ Type: ['cde, 'ctx, 'eff, 'cde1, 'ctx1] -> (CodeBase[out 'cde, out 'ctx, ?], CodeBase['cde, ?, ⊥] ->{'eff} CodeBase[out 'cde1, out 'ctx1, ?]) ->{'eff} CodeBase[out 'cde1, out 'ctx ∨ 'ctx1, ?]
 
 :e
 fun body: [G] -> (CodeBase[out Int, out G, out Any], CodeBase[out Int, out G, out Any]) -> Int -> CodeBase[out Int, out G, out Any]
 fun body(x, y) = case
   0 then x
   1 then y
-  n then bind of x `+ y, (z => body(y, z)(n - 1)): [C] -> CodeBase[out Int, out C, out Any] -> CodeBase[out C, out Any]
+  n then bind of x `+ y, (z => body(y, z)(n - 1))
 //│ ╔══[ERROR] Type error in application with expected type CodeBase[out Int, out G, ?]
-//│ ║  l.66: 	  n then bind of x `+ y, (z => body(y, z)(n - 1)): [C] -> CodeBase[out Int, out C, out Any] -> CodeBase[out C, out Any]
-//│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.707: 	  n then bind of x `+ y, (z => body(y, z)(n - 1))
+//│ ║         	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  CodeBase[in ⊥ out 'cde, in ⊥ out 'ctx ∨ 'ctx1, in ⊥ out ⊤]  <:  CodeBase[in ⊥ out Int, in ⊥ out G, in ⊥ out ⊤]
 //│ ╟── because: cannot constrain  'ctx ∨ 'ctx1  <:  G
 //│ ╟── because: cannot constrain  'ctx1  <:  G
@@ -85,7 +85,7 @@ fun body: [G] -> (CodeBase[out Int, out G, out Any], CodeBase[out Int, out G, ou
 fun body(x, y) = case
   0 then x
   1 then y
-  n then bind of x `+ y, (z => body(y, z)(n - 1)): [C] -> CodeBase[out Int, out C, out Any] -> CodeBase[out Int, out C, out Any]
+  n then bind of x `+ y, (z => body(y, z)(n - 1))
 body
 //│ Type: ['G] -> (CodeBase[out Int, out 'G, ?], CodeBase[out Int, out 'G, ?]) ->{⊥} (Int) ->{⊥} CodeBase[out Int, out 'G, ?]
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbGPCE.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbGPCE.mls
@@ -68,11 +68,11 @@ fun body(x, y) = case
 //│ ║  l.66: 	  n then bind of x `+ y, (z => body(y, z)(n - 1)): [C] -> CodeBase[out Int, out C, out Any] -> CodeBase[out C, out Any]
 //│ ║        	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  CodeBase[out 'cde, out 'ctx ∨ 'ctx1, ?]  <:  CodeBase[out Int, out G, ?]
-//│ ╟── because: cannot constrain  (⊤ ∧ (¬⊥ ∧ 'ctx)) ∨ (⊤ ∧ (¬⊥ ∧ 'ctx1))  <:  G
+//│ ╟── because: cannot constrain  'ctx ∨ 'ctx1  <:  G
 //│ ╟── because: cannot constrain  'ctx1  <:  ¬(¬G)
 //│ ╟── because: cannot constrain  'ctx2  <:  ¬(¬G)
 //│ ╟── because: cannot constrain  'ctx2  <:  ¬(¬G)
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬(¬G)
+//│ ╙── because: cannot constrain  ⊤  <:  ¬(¬G)
 //│ Type: ⊤
 
 fun bind: [G] -> (CodeBase[out Int, out G, out Any], [C] -> CodeBase[out Int, out C, out Any] -> CodeBase[out Int, out C | G, out Any]) -> CodeBase[out Int, out G, out Any]

--- a/hkmc2/shared/src/test/mlscript/bbml/bbGetters.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbGetters.mls
@@ -31,20 +31,14 @@ test1()
 //│ Type: ⊥
 
 
-:todo // it feels like this should work
 fun test2() =
   fun funny = case
     0 then 0
     n then funny(n - 1) + 1
   funny
-//│ ╔══[ERROR] Expected a monomorphic type or an instantiable type here, but () ->{⊥} [outer, 'caseScrut, 'eff] -> 'caseScrut ->{'eff} Int found
-//│ ║  l.37: 	    0 then 0
-//│ ║        	           ^
-//│ ║  l.38: 	    n then funny(n - 1) + 1
-//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.39: 	  funny
-//│ ╙──      	^^^^^^^
-//│ Type: ⊤
+test2
+//│ = [function test2]
+//│ Type: () -> (Int -> Int)
 
 fun test2() =
   fun funny = case
@@ -82,7 +76,7 @@ fun test2() =
     case n then funny(n - 1) + 1
   funny
 //│ ╔══[WARNING] Pure expression in statement position
-//│ ║  l.81: 	    case 0 then 0
+//│ ║  l.75: 	    case 0 then 0
 //│ ╙──      	                ^
 //│ JS (unsanitized):
 //│ let test22;
@@ -104,15 +98,15 @@ fun test2() =
 //│   return tmp1
 //│ };
 //│ ╔══[WARNING] Pure expression in statement position
-//│ ║  l.81: 	    case 0 then 0
+//│ ║  l.75: 	    case 0 then 0
 //│ ╙──      	                ^
 //│ ╔══[ERROR] Function definition shape not yet supported for funny
-//│ ║  l.81: 	    case 0 then 0
+//│ ║  l.75: 	    case 0 then 0
 //│ ║        	                ^
-//│ ║  l.82: 	    case n then funny(n - 1) + 1
+//│ ║  l.76: 	    case n then funny(n - 1) + 1
 //│ ╙──      	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╔══[ERROR] Variable not found: funny
-//│ ║  l.83: 	  funny
+//│ ║  l.77: 	  funny
 //│ ╙──      	  ^^^^^
 //│ Type: ⊤
 
@@ -121,7 +115,7 @@ fun test2() =
 fun test3 =
   print("Hi")
 //│ ╔══[ERROR] Function definition shape not yet supported for test3
-//│ ║  l.122: 	  print("Hi")
+//│ ║  l.116: 	  print("Hi")
 //│ ╙──       	  ^^^^^^^^^^^
 //│ Type: ⊤
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbGetters.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbGetters.mls
@@ -31,14 +31,20 @@ test1()
 //│ Type: ⊥
 
 
+:todo // it feels like this should work
 fun test2() =
   fun funny = case
     0 then 0
     n then funny(n - 1) + 1
   funny
-test2
-//│ = [function test2]
-//│ Type: () -> (Int -> Int)
+//│ ╔══[ERROR] Expected a monomorphic type or an instantiable type here, but () ->{⊥} [outer, 'caseScrut, 'eff] -> 'caseScrut ->{'eff} Int found
+//│ ║  l.37: 	    0 then 0
+//│ ║        	           ^
+//│ ║  l.38: 	    n then funny(n - 1) + 1
+//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.39: 	  funny
+//│ ╙──      	^^^^^^^
+//│ Type: ⊤
 
 fun test2() =
   fun funny = case
@@ -76,7 +82,7 @@ fun test2() =
     case n then funny(n - 1) + 1
   funny
 //│ ╔══[WARNING] Pure expression in statement position
-//│ ║  l.75: 	    case 0 then 0
+//│ ║  l.81: 	    case 0 then 0
 //│ ╙──      	                ^
 //│ JS (unsanitized):
 //│ let test22;
@@ -98,15 +104,15 @@ fun test2() =
 //│   return tmp1
 //│ };
 //│ ╔══[WARNING] Pure expression in statement position
-//│ ║  l.75: 	    case 0 then 0
+//│ ║  l.81: 	    case 0 then 0
 //│ ╙──      	                ^
 //│ ╔══[ERROR] Function definition shape not yet supported for funny
-//│ ║  l.75: 	    case 0 then 0
+//│ ║  l.81: 	    case 0 then 0
 //│ ║        	                ^
-//│ ║  l.76: 	    case n then funny(n - 1) + 1
+//│ ║  l.82: 	    case n then funny(n - 1) + 1
 //│ ╙──      	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╔══[ERROR] Variable not found: funny
-//│ ║  l.77: 	  funny
+//│ ║  l.83: 	  funny
 //│ ╙──      	  ^^^^^
 //│ Type: ⊤
 
@@ -115,7 +121,7 @@ fun test2() =
 fun test3 =
   print("Hi")
 //│ ╔══[ERROR] Function definition shape not yet supported for test3
-//│ ║  l.116: 	  print("Hi")
+//│ ║  l.122: 	  print("Hi")
 //│ ╙──       	  ^^^^^^^^^^^
 //│ Type: ⊤
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbLetRegEncoding.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbLetRegEncoding.mls
@@ -21,21 +21,20 @@ letreg(r => r).ref 1
 //│ ╟── because: cannot constrain  'Res  <:  Region['reg]
 //│ ╟── because: cannot constrain  'Res  <:  ¬(¬{Region['reg]})
 //│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'R out ¬⊥ ∧ 'R1] ∧ ¬⊥  <:  ¬(¬{Region['reg]})
-//│ ╟── because: cannot constrain  'R1  <:  'reg
-//│ ╟── because: cannot constrain  'R1  <:  'reg
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'R1)  <:  'reg
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'R1)  <:  ¬(¬'R)
 //│ ╟── because: cannot constrain  'R1  <:  ¬(¬'R)
-//│ ╟── because: cannot constrain  'R1  <:  ¬(¬'R)
-//│ ╟── because: cannot constrain    <:  ¬(¬'R)
+//│ ╟── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬(¬'R)
 //│ ╟── because: cannot constrain    <:  'R
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ ╔══[ERROR] Type error in block
 //│ ║  l.17: 	letreg(r => r).ref 1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'E  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'R1)  <:  ¬()
 //│ ╟── because: cannot constrain  'R1  <:  ¬()
-//│ ╟── because: cannot constrain  'R1  <:  ¬()
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ Type: Ref[Int, ?]
 
 letreg(r => r.ref 1)
@@ -47,15 +46,15 @@ letreg(r => !(r.ref 1))
 :e
 !letreg(r => r.ref 1)
 //│ ╔══[ERROR] Type error in block
-//│ ║  l.48: 	!letreg(r => r.ref 1)
+//│ ║  l.47: 	!letreg(r => r.ref 1)
 //│ ║        	 ^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'E  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'reg1)  <:  ¬()
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'R  <:  ¬()
 //│ ╟── because: cannot constrain  'R  <:  ¬()
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ Type: Int
 
 letreg of r =>
@@ -73,15 +72,15 @@ f
 :e
 letreg(r => arg => r.ref arg)(0)
 //│ ╔══[ERROR] Type error in block
-//│ ║  l.74: 	letreg(r => arg => r.ref arg)(0)
+//│ ║  l.73: 	letreg(r => arg => r.ref arg)(0)
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'eff ∨ 'E  <:  ⊥
 //│ ╟── because: cannot constrain  'eff  <:  ¬()
-//│ ╟── because: cannot constrain  'reg  <:  ¬()
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'reg)  <:  ¬()
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'R  <:  ¬()
 //│ ╟── because: cannot constrain  'R  <:  ¬()
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ Type: Ref['arg, ?]
 //│ Where:
 //│   Int <: 'arg
@@ -96,29 +95,29 @@ fun letreg: [E,Res] -> ([R] -> Region[R] -> Res) ->{E} Res
 :e
 letreg(r => r.ref 1)
 //│ ╔══[ERROR] Type error in function literal with expected type (Region[R]) ->{⊥} 'Res
-//│ ║  l.97: 	letreg(r => r.ref 1)
+//│ ║  l.96: 	letreg(r => r.ref 1)
 //│ ║        	       ^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╙── because: cannot constrain  R  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ R)  <:  ¬()
 //│ Type: Ref[Int, ?]
 
 :e
 letreg(r => !(r.ref 1))
 //│ ╔══[ERROR] Type error in function literal with expected type (Region[R]) ->{⊥} 'Res
-//│ ║  l.107: 	letreg(r => !(r.ref 1))
+//│ ║  l.106: 	letreg(r => !(r.ref 1))
 //│ ║         	       ^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'reg1  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'reg1)  <:  ¬()
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╙── because: cannot constrain  R  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ R)  <:  ¬()
 //│ ╔══[ERROR] Type error in function literal with expected type (Region[R]) ->{⊥} 'Res
-//│ ║  l.107: 	letreg(r => !(r.ref 1))
+//│ ║  l.106: 	letreg(r => !(r.ref 1))
 //│ ║         	       ^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'reg1  <:  ⊥
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╙── because: cannot constrain  R  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ R)  <:  ¬()
 //│ Type: Int
 
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbLetRegEncoding.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbLetRegEncoding.mls
@@ -20,21 +20,21 @@ letreg(r => r).ref 1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'Res  <:  Region['reg]
 //│ ╟── because: cannot constrain  'Res  <:  ¬(¬{Region['reg]})
-//│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'R out ¬⊥ ∧ 'R1] ∧ ¬⊥  <:  ¬(¬{Region['reg]})
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'R1)  <:  'reg
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'R1)  <:  ¬(¬'R)
+//│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'R out ¬⊥ ∧ 'R1]  <:  ¬(¬{Region['reg]})
+//│ ╟── because: cannot constrain  'R1  <:  'reg
 //│ ╟── because: cannot constrain  'R1  <:  ¬(¬'R)
-//│ ╟── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬(¬'R)
-//│ ╟── because: cannot constrain    <:  'R
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  'R1  <:  ¬(¬'R)
+//│ ╟── because: cannot constrain  ⊤  <:  ¬(¬'R)
+//│ ╟── because: cannot constrain  ⊤  <:  'R
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ ╔══[ERROR] Type error in block
 //│ ║  l.17: 	letreg(r => r).ref 1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'E  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'R1)  <:  ¬()
 //│ ╟── because: cannot constrain  'R1  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  'R1  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ Type: Ref[Int, ?]
 
 letreg(r => r.ref 1)
@@ -50,11 +50,11 @@ letreg(r => !(r.ref 1))
 //│ ║        	 ^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'E  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'reg1)  <:  ¬()
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'R  <:  ¬()
+//│ ╟── because: cannot constrain  'reg1  <:  ¬()
 //│ ╟── because: cannot constrain  'R  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  'R  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ Type: Int
 
 letreg of r =>
@@ -76,11 +76,11 @@ letreg(r => arg => r.ref arg)(0)
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'eff ∨ 'E  <:  ⊥
 //│ ╟── because: cannot constrain  'eff  <:  ¬()
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'reg)  <:  ¬()
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'R  <:  ¬()
+//│ ╟── because: cannot constrain  'reg  <:  ¬()
 //│ ╟── because: cannot constrain  'R  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  'R  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ Type: Ref['arg, ?]
 //│ Where:
 //│   Int <: 'arg
@@ -99,7 +99,7 @@ letreg(r => r.ref 1)
 //│ ║        	       ^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ R)  <:  ¬()
+//│ ╙── because: cannot constrain  R  <:  ¬()
 //│ Type: Ref[Int, ?]
 
 :e
@@ -109,15 +109,15 @@ letreg(r => !(r.ref 1))
 //│ ║         	       ^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'reg1  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'reg1)  <:  ¬()
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ R)  <:  ¬()
+//│ ╟── because: cannot constrain  'reg1  <:  ¬()
+//│ ╙── because: cannot constrain  R  <:  ¬()
 //│ ╔══[ERROR] Type error in function literal with expected type (Region[R]) ->{⊥} 'Res
 //│ ║  l.106: 	letreg(r => !(r.ref 1))
 //│ ║         	       ^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'reg1  <:  ⊥
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ R)  <:  ¬()
+//│ ╙── because: cannot constrain  R  <:  ¬()
 //│ Type: Int
 
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbLetRegEncoding.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbLetRegEncoding.mls
@@ -19,22 +19,23 @@ letreg(r => r).ref 1
 //│ ║  l.17: 	letreg(r => r).ref 1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'Res  <:  Region['reg]
-//│ ╟── because: cannot constrain  'Res  <:  ¬(¬{Region['reg]})
-//│ ╟── because: cannot constrain  Region[in ¬⊥ ∧ 'R out ¬⊥ ∧ 'R1]  <:  ¬(¬{Region['reg]})
+//│ ╟── because: cannot constrain  'Res  <:  Region['reg]
+//│ ╟── because: cannot constrain  Region[in 'R out 'R1]  <:  Region['reg]
 //│ ╟── because: cannot constrain  'R1  <:  'reg
-//│ ╟── because: cannot constrain  'R1  <:  ¬(¬'R)
-//│ ╟── because: cannot constrain  'R1  <:  ¬(¬'R)
-//│ ╟── because: cannot constrain  ⊤  <:  ¬(¬'R)
+//│ ╟── because: cannot constrain  'R1  <:  'reg
+//│ ╟── because: cannot constrain  'R1  <:  'R
+//│ ╟── because: cannot constrain  'R1  <:  'R
 //│ ╟── because: cannot constrain  ⊤  <:  'R
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  ⊤  <:  'R
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ ╔══[ERROR] Type error in block
 //│ ║  l.17: 	letreg(r => r).ref 1
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'E  <:  ⊥
-//│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  'R1  <:  ¬()
-//│ ╟── because: cannot constrain  'R1  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  'reg  <:  ⊥
+//│ ╟── because: cannot constrain  'R1  <:  ⊥
+//│ ╟── because: cannot constrain  'R1  <:  ⊥
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ Type: Ref[Int, ?]
 
 letreg(r => r.ref 1)
@@ -46,15 +47,15 @@ letreg(r => !(r.ref 1))
 :e
 !letreg(r => r.ref 1)
 //│ ╔══[ERROR] Type error in block
-//│ ║  l.47: 	!letreg(r => r.ref 1)
+//│ ║  l.48: 	!letreg(r => r.ref 1)
 //│ ║        	 ^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'E  <:  ⊥
-//│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╟── because: cannot constrain  'R  <:  ¬()
-//│ ╟── because: cannot constrain  'R  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  'reg  <:  ⊥
+//│ ╟── because: cannot constrain  'reg1  <:  ⊥
+//│ ╟── because: cannot constrain  'reg1  <:  ⊥
+//│ ╟── because: cannot constrain  'R  <:  ⊥
+//│ ╟── because: cannot constrain  'R  <:  ⊥
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ Type: Int
 
 letreg of r =>
@@ -72,15 +73,15 @@ f
 :e
 letreg(r => arg => r.ref arg)(0)
 //│ ╔══[ERROR] Type error in block
-//│ ║  l.73: 	letreg(r => arg => r.ref arg)(0)
+//│ ║  l.74: 	letreg(r => arg => r.ref arg)(0)
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'eff ∨ 'E  <:  ⊥
-//│ ╟── because: cannot constrain  'eff  <:  ¬()
-//│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  'R  <:  ¬()
-//│ ╟── because: cannot constrain  'R  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  'eff  <:  ⊥
+//│ ╟── because: cannot constrain  'reg  <:  ⊥
+//│ ╟── because: cannot constrain  'reg  <:  ⊥
+//│ ╟── because: cannot constrain  'R  <:  ⊥
+//│ ╟── because: cannot constrain  'R  <:  ⊥
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ Type: Ref['arg, ?]
 //│ Where:
 //│   Int <: 'arg
@@ -95,29 +96,29 @@ fun letreg: [E,Res] -> ([R] -> Region[R] -> Res) ->{E} Res
 :e
 letreg(r => r.ref 1)
 //│ ╔══[ERROR] Type error in function literal with expected type (Region[R]) ->{⊥} 'Res
-//│ ║  l.96: 	letreg(r => r.ref 1)
+//│ ║  l.97: 	letreg(r => r.ref 1)
 //│ ║        	       ^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg  <:  ⊥
-//│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╙── because: cannot constrain  R  <:  ¬()
+//│ ╟── because: cannot constrain  'reg  <:  ⊥
+//│ ╙── because: cannot constrain  R  <:  ⊥
 //│ Type: Ref[Int, ?]
 
 :e
 letreg(r => !(r.ref 1))
 //│ ╔══[ERROR] Type error in function literal with expected type (Region[R]) ->{⊥} 'Res
-//│ ║  l.106: 	letreg(r => !(r.ref 1))
+//│ ║  l.107: 	letreg(r => !(r.ref 1))
 //│ ║         	       ^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'reg1  <:  ⊥
-//│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╙── because: cannot constrain  R  <:  ¬()
+//│ ╟── because: cannot constrain  'reg  <:  ⊥
+//│ ╟── because: cannot constrain  'reg1  <:  ⊥
+//│ ╟── because: cannot constrain  'reg1  <:  ⊥
+//│ ╙── because: cannot constrain  R  <:  ⊥
 //│ ╔══[ERROR] Type error in function literal with expected type (Region[R]) ->{⊥} 'Res
-//│ ║  l.106: 	letreg(r => !(r.ref 1))
+//│ ║  l.107: 	letreg(r => !(r.ref 1))
 //│ ║         	       ^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'reg1  <:  ⊥
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╙── because: cannot constrain  R  <:  ¬()
+//│ ╟── because: cannot constrain  'reg1  <:  ⊥
+//│ ╙── because: cannot constrain  R  <:  ⊥
 //│ Type: Int
 
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbList.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbList.mls
@@ -61,13 +61,13 @@ fun mapi = s =>
 //│ ║  l.53: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'f ->{'E1} List[out 'B]  <:  ((Int, A) ->{E} A) ->{E} List[out A]
-//│ ╟── because: cannot constrain  'E1  <:  E
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'E1)  <:  E
 //│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  (¬⊥ ∧ 'r) ∧ ¬outer  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬E ∧ ¬outer)
 //│ ╔══[ERROR] Type error in region expression with expected type ((Int, A) ->{E} A) ->{E} List[out A]
 //│ ║  l.50: 	    let i = r.ref 0
 //│ ║        	            ^^^^^^^
@@ -78,13 +78,13 @@ fun mapi = s =>
 //│ ║  l.53: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'f ->{'E1} List[out 'B]  <:  ((Int, A) ->{E} A) ->{E} List[out A]
-//│ ╟── because: cannot constrain  'E1  <:  E
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'E1)  <:  E
 //│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  (¬⊥ ∧ 'r) ∧ ¬outer  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬E ∧ ¬outer)
 //│ ╔══[ERROR] Type error in region expression with expected type ((Int, A) ->{E} A) ->{E} List[out A]
 //│ ║  l.50: 	    let i = r.ref 0
 //│ ║        	            ^^^^^^^
@@ -95,13 +95,13 @@ fun mapi = s =>
 //│ ║  l.53: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'f ->{'E1} List[out 'B]  <:  ((Int, A) ->{E} A) ->{E} List[out A]
-//│ ╟── because: cannot constrain  'E1  <:  E
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'E1)  <:  E
 //│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  (¬⊥ ∧ 'r) ∧ ¬outer  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬E ∧ ¬outer)
 //│ Type: ⊤
 
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbList.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbList.mls
@@ -60,14 +60,14 @@ fun mapi = s =>
 //│ ║        	^^^^^^^^^^^^^^^^^
 //│ ║  l.53: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
-//│ ╟── because: cannot constrain  'f ->{'E1} List[out 'B]  <:  ((Int, A) ->{E} A) ->{E} List[out A]
+//│ ╟── because: cannot constrain  ('f) ->{'E1} (List[in ⊥ out 'B])  <:  ((Int, A) ->{E} (A)) ->{E} (List[in ⊥ out A])
 //│ ╟── because: cannot constrain  'E1  <:  E
-//│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
+//│ ╟── because: cannot constrain  'E1  <:  E
+//│ ╟── because: cannot constrain  'reg  <:  E
+//│ ╟── because: cannot constrain  'reg  <:  E
+//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  E
+//│ ╟── because: cannot constrain  'r  <:  E ∨ outer
+//│ ╙── because: cannot constrain  ¬outer  <:  E ∨ outer
 //│ ╔══[ERROR] Type error in region expression with expected type ((Int, A) ->{E} A) ->{E} List[out A]
 //│ ║  l.50: 	    let i = r.ref 0
 //│ ║        	            ^^^^^^^
@@ -77,14 +77,14 @@ fun mapi = s =>
 //│ ║        	^^^^^^^^^^^^^^^^^
 //│ ║  l.53: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
-//│ ╟── because: cannot constrain  'f ->{'E1} List[out 'B]  <:  ((Int, A) ->{E} A) ->{E} List[out A]
+//│ ╟── because: cannot constrain  ('f) ->{'E1} (List[in ⊥ out 'B])  <:  ((Int, A) ->{E} (A)) ->{E} (List[in ⊥ out A])
 //│ ╟── because: cannot constrain  'E1  <:  E
-//│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
+//│ ╟── because: cannot constrain  'E1  <:  E
+//│ ╟── because: cannot constrain  'reg  <:  E
+//│ ╟── because: cannot constrain  'reg  <:  E
+//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  E
+//│ ╟── because: cannot constrain  'r  <:  E ∨ outer
+//│ ╙── because: cannot constrain  ¬outer  <:  E ∨ outer
 //│ ╔══[ERROR] Type error in region expression with expected type ((Int, A) ->{E} A) ->{E} List[out A]
 //│ ║  l.50: 	    let i = r.ref 0
 //│ ║        	            ^^^^^^^
@@ -94,14 +94,14 @@ fun mapi = s =>
 //│ ║        	^^^^^^^^^^^^^^^^^
 //│ ║  l.53: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
-//│ ╟── because: cannot constrain  'f ->{'E1} List[out 'B]  <:  ((Int, A) ->{E} A) ->{E} List[out A]
+//│ ╟── because: cannot constrain  ('f) ->{'E1} (List[in ⊥ out 'B])  <:  ((Int, A) ->{E} (A)) ->{E} (List[in ⊥ out A])
 //│ ╟── because: cannot constrain  'E1  <:  E
-//│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
+//│ ╟── because: cannot constrain  'E1  <:  E
+//│ ╟── because: cannot constrain  'reg  <:  E
+//│ ╟── because: cannot constrain  'reg  <:  E
+//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  E
+//│ ╟── because: cannot constrain  'r  <:  E ∨ outer
+//│ ╙── because: cannot constrain  ¬outer  <:  E ∨ outer
 //│ Type: ⊤
 
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbList.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbList.mls
@@ -61,13 +61,13 @@ fun mapi = s =>
 //│ ║  l.53: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'f ->{'E1} List[out 'B]  <:  ((Int, A) ->{E} A) ->{E} List[out A]
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'E1)  <:  E
+//│ ╟── because: cannot constrain  'E1  <:  E
 //│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  (¬⊥ ∧ 'r) ∧ ¬outer  <:  ¬(¬E)
+//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
+//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬E ∧ ¬outer)
+//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
 //│ ╔══[ERROR] Type error in region expression with expected type ((Int, A) ->{E} A) ->{E} List[out A]
 //│ ║  l.50: 	    let i = r.ref 0
 //│ ║        	            ^^^^^^^
@@ -78,13 +78,13 @@ fun mapi = s =>
 //│ ║  l.53: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'f ->{'E1} List[out 'B]  <:  ((Int, A) ->{E} A) ->{E} List[out A]
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'E1)  <:  E
+//│ ╟── because: cannot constrain  'E1  <:  E
 //│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  (¬⊥ ∧ 'r) ∧ ¬outer  <:  ¬(¬E)
+//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
+//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬E ∧ ¬outer)
+//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
 //│ ╔══[ERROR] Type error in region expression with expected type ((Int, A) ->{E} A) ->{E} List[out A]
 //│ ║  l.50: 	    let i = r.ref 0
 //│ ║        	            ^^^^^^^
@@ -95,13 +95,13 @@ fun mapi = s =>
 //│ ║  l.53: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'f ->{'E1} List[out 'B]  <:  ((Int, A) ->{E} A) ->{E} List[out A]
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'E1)  <:  E
+//│ ╟── because: cannot constrain  'E1  <:  E
 //│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  (¬⊥ ∧ 'r) ∧ ¬outer  <:  ¬(¬E)
+//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
+//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬E ∧ ¬outer)
+//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
 //│ Type: ⊤
 
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbQQ.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbQQ.mls
@@ -31,7 +31,7 @@ x `=> 42
 //│ ╔══[ERROR] Type error in unquoted term
 //│ ║  l.30: 	x `=> 42
 //│ ║        	      ^^
-//│ ╙── because: cannot constrain  Int  <:  CodeBase[out 'cde, out 'ctx, ?]
+//│ ╙── because: cannot constrain  Int  <:  CodeBase[in ⊥ out 'cde, in ⊥ out 'ctx, in ⊥ out ⊤]
 //│ Type: CodeBase[out ⊤ -> ⊥, ⊥, ?]
 
 
@@ -63,7 +63,7 @@ f `=> x `=> y `=> f`(x, y)
 //│ ╔══[ERROR] Type error in unquoted term
 //│ ║  l.62: 	`let x = 42 `in x
 //│ ║        	         ^^
-//│ ╙── because: cannot constrain  Int  <:  CodeBase[out 'cde, out 'ctx, ?]
+//│ ╙── because: cannot constrain  Int  <:  CodeBase[in ⊥ out 'cde, in ⊥ out 'ctx, in ⊥ out ⊤]
 //│ Type: CodeBase[⊥, ⊥, ?]
 
 :e
@@ -71,7 +71,7 @@ f `=> x `=> y `=> f`(x, y)
 //│ ╔══[ERROR] Type error in unquoted term
 //│ ║  l.70: 	`let x = `0 `in 1
 //│ ║        	                ^
-//│ ╙── because: cannot constrain  Int  <:  CodeBase[out 'cde, out 'ctx, ?]
+//│ ╙── because: cannot constrain  Int  <:  CodeBase[in ⊥ out 'cde, in ⊥ out 'ctx, in ⊥ out ⊤]
 //│ Type: CodeBase[⊥, ⊥, ?]
 
 
@@ -93,7 +93,7 @@ run(1)
 //│ ╔══[ERROR] Type error in integer literal with expected type CodeBase[out 'T, ⊥, ?]
 //│ ║  l.92: 	run(1)
 //│ ║        	    ^
-//│ ╙── because: cannot constrain  Int  <:  CodeBase[out 'T, ⊥, ?]
+//│ ╙── because: cannot constrain  Int  <:  CodeBase[in ⊥ out 'T, ⊥, in ⊥ out ⊤]
 //│ Type: ⊥
 
 :e
@@ -101,7 +101,7 @@ x `=> run(x)
 //│ ╔══[ERROR] Type error in reference with expected type CodeBase[out 'T, ⊥, ?]
 //│ ║  l.100: 	x `=> run(x)
 //│ ║         	          ^
-//│ ╟── because: cannot constrain  CodeBase['x, x, ⊥]  <:  CodeBase[out 'T, ⊥, ?]
+//│ ╟── because: cannot constrain  CodeBase['x, x, ⊥]  <:  CodeBase[in ⊥ out 'T, ⊥, in ⊥ out ⊤]
 //│ ╙── because: cannot constrain  x  <:  ⊥
 //│ Type: CodeBase[out CodeBase[out 'cde, ?, ?] -> 'cde, out 'ctx, ?]
 
@@ -110,14 +110,14 @@ x `=> run(x)
 //│ ╔══[ERROR] Type error in reference with expected type CodeBase[out 'T, ⊥, ?]
 //│ ║  l.109: 	`let x = `42 `in run(x)
 //│ ║         	                     ^
-//│ ╟── because: cannot constrain  CodeBase['cde, x, ⊥]  <:  CodeBase[out 'T, ⊥, ?]
+//│ ╟── because: cannot constrain  CodeBase['cde, x, ⊥]  <:  CodeBase[in ⊥ out 'T, ⊥, in ⊥ out ⊤]
 //│ ╙── because: cannot constrain  x  <:  ⊥
 //│ ╔══[ERROR] Type error in unquoted term
 //│ ║  l.109: 	`let x = `42 `in run(x)
 //│ ║         	                 ^^^^^^
-//│ ╟── because: cannot constrain  'T  <:  CodeBase[out 'cde1, out 'ctx, ?]
-//│ ╟── because: cannot constrain  'T  <:  ¬(¬{CodeBase[out 'cde1, out 'ctx, ?]})
-//│ ╟── because: cannot constrain  'cde  <:  ¬(¬{CodeBase[out 'cde1, out 'ctx, ?]})
-//│ ╟── because: cannot constrain  'cde  <:  CodeBase[out 'cde2, out 'ctx1, ?]
-//│ ╙── because: cannot constrain  Int  <:  CodeBase[out 'cde2, out 'ctx1, ?]
+//│ ╟── because: cannot constrain  'T  <:  CodeBase[in ⊥ out 'cde1, in ⊥ out 'ctx, in ⊥ out ⊤]
+//│ ╟── because: cannot constrain  'T  <:  CodeBase[in ⊥ out 'cde1, in ⊥ out 'ctx, in ⊥ out ⊤]
+//│ ╟── because: cannot constrain  'cde  <:  CodeBase[in ⊥ out 'cde1, in ⊥ out 'ctx, in ⊥ out ⊤]
+//│ ╟── because: cannot constrain  'cde  <:  CodeBase[in ⊥ out 'cde2, in ⊥ out 'ctx1, in ⊥ out ⊤]
+//│ ╙── because: cannot constrain  Int  <:  CodeBase[in ⊥ out 'cde2, in ⊥ out 'ctx1, in ⊥ out ⊤]
 //│ Type: CodeBase[⊥, ⊥, ?]

--- a/hkmc2/shared/src/test/mlscript/bbml/bbQQ.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbQQ.mls
@@ -102,7 +102,7 @@ x `=> run(x)
 //│ ║  l.100: 	x `=> run(x)
 //│ ║         	          ^
 //│ ╟── because: cannot constrain  CodeBase['x, x, ⊥]  <:  CodeBase[out 'T, ⊥, ?]
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  ⊥
+//│ ╙── because: cannot constrain  x  <:  ⊥
 //│ Type: CodeBase[out CodeBase[out 'cde, ?, ?] -> 'cde, out 'ctx, ?]
 
 :e
@@ -111,13 +111,13 @@ x `=> run(x)
 //│ ║  l.109: 	`let x = `42 `in run(x)
 //│ ║         	                     ^
 //│ ╟── because: cannot constrain  CodeBase['cde, x, ⊥]  <:  CodeBase[out 'T, ⊥, ?]
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  ⊥
+//│ ╙── because: cannot constrain  x  <:  ⊥
 //│ ╔══[ERROR] Type error in unquoted term
 //│ ║  l.109: 	`let x = `42 `in run(x)
 //│ ║         	                 ^^^^^^
 //│ ╟── because: cannot constrain  'T  <:  CodeBase[out 'cde1, out 'ctx, ?]
 //│ ╟── because: cannot constrain  'T  <:  ¬(¬{CodeBase[out 'cde1, out 'ctx, ?]})
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'cde)  <:  ¬(¬{CodeBase[out 'cde1, out 'ctx, ?]})
+//│ ╟── because: cannot constrain  'cde  <:  ¬(¬{CodeBase[out 'cde1, out 'ctx, ?]})
 //│ ╟── because: cannot constrain  'cde  <:  CodeBase[out 'cde2, out 'ctx1, ?]
-//│ ╙── because: cannot constrain  Int ∧ ¬⊥  <:  CodeBase[out 'cde2, out 'ctx1, ?]
+//│ ╙── because: cannot constrain  Int  <:  CodeBase[out 'cde2, out 'ctx1, ?]
 //│ Type: CodeBase[⊥, ⊥, ?]

--- a/hkmc2/shared/src/test/mlscript/bbml/bbQQ.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbQQ.mls
@@ -102,7 +102,7 @@ x `=> run(x)
 //│ ║  l.100: 	x `=> run(x)
 //│ ║         	          ^
 //│ ╟── because: cannot constrain  CodeBase['x, x, ⊥]  <:  CodeBase[out 'T, ⊥, ?]
-//│ ╙── because: cannot constrain  x  <:  ⊥
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  ⊥
 //│ Type: CodeBase[out CodeBase[out 'cde, ?, ?] -> 'cde, out 'ctx, ?]
 
 :e
@@ -111,13 +111,13 @@ x `=> run(x)
 //│ ║  l.109: 	`let x = `42 `in run(x)
 //│ ║         	                     ^
 //│ ╟── because: cannot constrain  CodeBase['cde, x, ⊥]  <:  CodeBase[out 'T, ⊥, ?]
-//│ ╙── because: cannot constrain  x  <:  ⊥
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  ⊥
 //│ ╔══[ERROR] Type error in unquoted term
 //│ ║  l.109: 	`let x = `42 `in run(x)
 //│ ║         	                 ^^^^^^
 //│ ╟── because: cannot constrain  'T  <:  CodeBase[out 'cde1, out 'ctx, ?]
 //│ ╟── because: cannot constrain  'T  <:  ¬(¬{CodeBase[out 'cde1, out 'ctx, ?]})
-//│ ╟── because: cannot constrain  'cde  <:  ¬(¬{CodeBase[out 'cde1, out 'ctx, ?]})
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'cde)  <:  ¬(¬{CodeBase[out 'cde1, out 'ctx, ?]})
 //│ ╟── because: cannot constrain  'cde  <:  CodeBase[out 'cde2, out 'ctx1, ?]
-//│ ╙── because: cannot constrain  Int  <:  CodeBase[out 'cde2, out 'ctx1, ?]
+//│ ╙── because: cannot constrain  Int ∧ ¬⊥  <:  CodeBase[out 'cde2, out 'ctx1, ?]
 //│ Type: CodeBase[⊥, ⊥, ?]

--- a/hkmc2/shared/src/test/mlscript/bbml/bbRef.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbRef.mls
@@ -26,12 +26,12 @@ let r = region x in x.ref 42
 //│ ║  l.22: 	!r
 //│ ║        	^^
 //│ ╟── because: cannot constrain  'reg ∨ 'eff  <:  ⊥
-//│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  'reg  <:  ⊥
+//│ ╟── because: cannot constrain  'reg1  <:  ⊥
+//│ ╟── because: cannot constrain  'reg1  <:  ⊥
+//│ ╟── because: cannot constrain  'x  <:  ⊥
+//│ ╟── because: cannot constrain  'x  <:  ⊥
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ Type: Int
 
 fun mkRef() = region x in x.ref 42
@@ -45,19 +45,20 @@ let t = region x in x in t.ref 42
 //│ ║        	                         ^^^^^^^^
 //│ ╟── because: cannot constrain  Region[in 'x out 'x1]  <:  Region['reg]
 //│ ╟── because: cannot constrain  'x1  <:  'reg
-//│ ╟── because: cannot constrain  'x1  <:  ¬(¬'x)
-//│ ╟── because: cannot constrain  'x1  <:  ¬(¬'x)
-//│ ╟── because: cannot constrain  ⊤  <:  ¬(¬'x)
+//│ ╟── because: cannot constrain  'x1  <:  'reg
+//│ ╟── because: cannot constrain  'x1  <:  'x
+//│ ╟── because: cannot constrain  'x1  <:  'x
 //│ ╟── because: cannot constrain  ⊤  <:  'x
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  ⊤  <:  'x
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ ╔══[ERROR] Type error in block
 //│ ║  l.42: 	let t = region x in x in t.ref 42
 //│ ║        	                    ^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'eff  <:  ⊥
-//│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  'x1  <:  ¬()
-//│ ╟── because: cannot constrain  'x1  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  'reg  <:  ⊥
+//│ ╟── because: cannot constrain  'x1  <:  ⊥
+//│ ╟── because: cannot constrain  'x1  <:  ⊥
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ Type: Ref[Int, ?]
 
 
@@ -70,17 +71,17 @@ let t = region x in
   x.ref 42
 in t := 0
 //│ ╔══[ERROR] Type error in block
-//│ ║  l.70: 	  x.ref 42
+//│ ║  l.71: 	  x.ref 42
 //│ ║        	  ^^^^^^^^
-//│ ║  l.71: 	in t := 0
+//│ ║  l.72: 	in t := 0
 //│ ║        	^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'eff  <:  ⊥
-//│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  'reg  <:  ⊥
+//│ ╟── because: cannot constrain  'reg1  <:  ⊥
+//│ ╟── because: cannot constrain  'reg1  <:  ⊥
+//│ ╟── because: cannot constrain  'x  <:  ⊥
+//│ ╟── because: cannot constrain  'x  <:  ⊥
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ Type: Int
 
 
@@ -93,17 +94,17 @@ let t = region x in
   x.ref 42
 in !t
 //│ ╔══[ERROR] Type error in block
-//│ ║  l.93: 	  x.ref 42
+//│ ║  l.94: 	  x.ref 42
 //│ ║        	  ^^^^^^^^
-//│ ║  l.94: 	in !t
+//│ ║  l.95: 	in !t
 //│ ║        	^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'eff  <:  ⊥
-//│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  'reg  <:  ⊥
+//│ ╟── because: cannot constrain  'reg1  <:  ⊥
+//│ ╟── because: cannot constrain  'reg1  <:  ⊥
+//│ ╟── because: cannot constrain  'x  <:  ⊥
+//│ ╟── because: cannot constrain  'x  <:  ⊥
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ Type: Int
 
 region x in
@@ -125,11 +126,11 @@ fun rid(x) =
 region x in
   (let dz = x.ref 42 in 42) as [A] -> Int
 //│ ╔══[ERROR] Type error in block with expected type [outer, 'A] -> Int
-//│ ║  l.126: 	  (let dz = x.ref 42 in 42) as [A] -> Int
+//│ ║  l.127: 	  (let dz = x.ref 42 in 42) as [A] -> Int
 //│ ║         	            ^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg  <:  ⊥
-//│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╙── because: cannot constrain  x  <:  ¬()
+//│ ╟── because: cannot constrain  'reg  <:  ⊥
+//│ ╙── because: cannot constrain  x  <:  ⊥
 //│ Type: Int
 
 
@@ -139,15 +140,15 @@ let t =
     y => x.ref y
 in t(42)
 //│ ╔══[ERROR] Type error in block
-//│ ║  l.139: 	    y => x.ref y
+//│ ║  l.140: 	    y => x.ref y
 //│ ║         	    ^^^^^^^^^^^^
-//│ ║  l.140: 	in t(42)
+//│ ║  l.141: 	in t(42)
 //│ ║         	^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'eff  <:  ⊥
-//│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤  <:  ¬()
+//│ ╟── because: cannot constrain  'reg  <:  ⊥
+//│ ╟── because: cannot constrain  'x  <:  ⊥
+//│ ╟── because: cannot constrain  'x  <:  ⊥
+//│ ╙── because: cannot constrain  ⊤  <:  ⊥
 //│ Type: Ref[in 'y out 'y ∨ Int, ?]
 
 fun foo: [A] -> Int ->{A} Int
@@ -183,6 +184,6 @@ bar
 :e
 region x in x.ref bar
 //│ ╔══[ERROR] Expected a monomorphic type or an instantiable type here, but ([outer, 'A] -> ('A) ->{⊥} 'A) ->{⊥} Int found
-//│ ║  l.184: 	region x in x.ref bar
+//│ ║  l.185: 	region x in x.ref bar
 //│ ╙──       	                  ^^^
 //│ Type: Ref[⊥, ?]

--- a/hkmc2/shared/src/test/mlscript/bbml/bbRef.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbRef.mls
@@ -27,11 +27,11 @@ let r = region x in x.ref 42
 //│ ║        	^^
 //│ ╟── because: cannot constrain  'reg ∨ 'eff  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'reg1)  <:  ¬()
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'x  <:  ¬()
+//│ ╟── because: cannot constrain  'reg1  <:  ¬()
 //│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  'x  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ Type: Int
 
 fun mkRef() = region x in x.ref 42
@@ -44,20 +44,20 @@ let t = region x in x in t.ref 42
 //│ ║  l.42: 	let t = region x in x in t.ref 42
 //│ ║        	                         ^^^^^^^^
 //│ ╟── because: cannot constrain  Region[in 'x out 'x1]  <:  Region['reg]
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'x1)  <:  'reg
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'x1)  <:  ¬(¬'x)
+//│ ╟── because: cannot constrain  'x1  <:  'reg
 //│ ╟── because: cannot constrain  'x1  <:  ¬(¬'x)
-//│ ╟── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬(¬'x)
-//│ ╟── because: cannot constrain    <:  'x
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  'x1  <:  ¬(¬'x)
+//│ ╟── because: cannot constrain  ⊤  <:  ¬(¬'x)
+//│ ╟── because: cannot constrain  ⊤  <:  'x
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ ╔══[ERROR] Type error in block
 //│ ║  l.42: 	let t = region x in x in t.ref 42
 //│ ║        	                    ^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'eff  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'x1)  <:  ¬()
 //│ ╟── because: cannot constrain  'x1  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  'x1  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ Type: Ref[Int, ?]
 
 
@@ -76,11 +76,11 @@ in t := 0
 //│ ║        	^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'eff  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'reg1)  <:  ¬()
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'x  <:  ¬()
+//│ ╟── because: cannot constrain  'reg1  <:  ¬()
 //│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  'x  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ Type: Int
 
 
@@ -99,11 +99,11 @@ in !t
 //│ ║        	^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'eff  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'reg1)  <:  ¬()
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'x  <:  ¬()
+//│ ╟── because: cannot constrain  'reg1  <:  ¬()
 //│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  'x  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ Type: Int
 
 region x in
@@ -129,7 +129,7 @@ region x in
 //│ ║         	            ^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  ¬()
+//│ ╙── because: cannot constrain  x  <:  ¬()
 //│ Type: Int
 
 
@@ -145,9 +145,9 @@ in t(42)
 //│ ║         	^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'eff  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'x  <:  ¬()
 //│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
+//│ ╟── because: cannot constrain  'x  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤  <:  ¬()
 //│ Type: Ref[in 'y out 'y ∨ Int, ?]
 
 fun foo: [A] -> Int ->{A} Int

--- a/hkmc2/shared/src/test/mlscript/bbml/bbRef.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbRef.mls
@@ -27,11 +27,11 @@ let r = region x in x.ref 42
 //│ ║        	^^
 //│ ╟── because: cannot constrain  'reg ∨ 'eff  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'reg1)  <:  ¬()
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'x  <:  ¬()
 //│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ Type: Int
 
 fun mkRef() = region x in x.ref 42
@@ -44,21 +44,20 @@ let t = region x in x in t.ref 42
 //│ ║  l.42: 	let t = region x in x in t.ref 42
 //│ ║        	                         ^^^^^^^^
 //│ ╟── because: cannot constrain  Region[in 'x out 'x1]  <:  Region['reg]
-//│ ╟── because: cannot constrain  'x1  <:  'reg
-//│ ╟── because: cannot constrain  'x1  <:  'reg
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'x1)  <:  'reg
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'x1)  <:  ¬(¬'x)
 //│ ╟── because: cannot constrain  'x1  <:  ¬(¬'x)
-//│ ╟── because: cannot constrain  'x1  <:  ¬(¬'x)
-//│ ╟── because: cannot constrain    <:  ¬(¬'x)
+//│ ╟── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬(¬'x)
 //│ ╟── because: cannot constrain    <:  'x
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ ╔══[ERROR] Type error in block
 //│ ║  l.42: 	let t = region x in x in t.ref 42
 //│ ║        	                    ^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'eff  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'x1)  <:  ¬()
 //│ ╟── because: cannot constrain  'x1  <:  ¬()
-//│ ╟── because: cannot constrain  'x1  <:  ¬()
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ Type: Ref[Int, ?]
 
 
@@ -71,17 +70,17 @@ let t = region x in
   x.ref 42
 in t := 0
 //│ ╔══[ERROR] Type error in block
-//│ ║  l.71: 	  x.ref 42
+//│ ║  l.70: 	  x.ref 42
 //│ ║        	  ^^^^^^^^
-//│ ║  l.72: 	in t := 0
+//│ ║  l.71: 	in t := 0
 //│ ║        	^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'eff  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'reg1)  <:  ¬()
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'x  <:  ¬()
 //│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ Type: Int
 
 
@@ -94,17 +93,17 @@ let t = region x in
   x.ref 42
 in !t
 //│ ╔══[ERROR] Type error in block
-//│ ║  l.94: 	  x.ref 42
+//│ ║  l.93: 	  x.ref 42
 //│ ║        	  ^^^^^^^^
-//│ ║  l.95: 	in !t
+//│ ║  l.94: 	in !t
 //│ ║        	^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'eff  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╟── because: cannot constrain  'reg1  <:  ¬()
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'reg1)  <:  ¬()
 //│ ╟── because: cannot constrain  'reg1  <:  ¬()
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'x  <:  ¬()
 //│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ Type: Int
 
 region x in
@@ -126,11 +125,11 @@ fun rid(x) =
 region x in
   (let dz = x.ref 42 in 42) as [A] -> Int
 //│ ╔══[ERROR] Type error in block with expected type [outer, 'A] -> Int
-//│ ║  l.127: 	  (let dz = x.ref 42 in 42) as [A] -> Int
+//│ ║  l.126: 	  (let dz = x.ref 42 in 42) as [A] -> Int
 //│ ║         	            ^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'reg  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
-//│ ╙── because: cannot constrain  x  <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ x)  <:  ¬()
 //│ Type: Int
 
 
@@ -140,15 +139,15 @@ let t =
     y => x.ref y
 in t(42)
 //│ ╔══[ERROR] Type error in block
-//│ ║  l.140: 	    y => x.ref y
+//│ ║  l.139: 	    y => x.ref y
 //│ ║         	    ^^^^^^^^^^^^
-//│ ║  l.141: 	in t(42)
+//│ ║  l.140: 	in t(42)
 //│ ║         	^^^^^^^^
 //│ ╟── because: cannot constrain  'reg ∨ 'eff  <:  ⊥
 //│ ╟── because: cannot constrain  'reg  <:  ¬()
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'x  <:  ¬()
 //│ ╟── because: cannot constrain  'x  <:  ¬()
-//│ ╙── because: cannot constrain    <:  ¬()
+//│ ╙── because: cannot constrain  ⊤ ∧ ¬⊥  <:  ¬()
 //│ Type: Ref[in 'y out 'y ∨ Int, ?]
 
 fun foo: [A] -> Int ->{A} Int
@@ -184,6 +183,6 @@ bar
 :e
 region x in x.ref bar
 //│ ╔══[ERROR] Expected a monomorphic type or an instantiable type here, but ([outer, 'A] -> ('A) ->{⊥} 'A) ->{⊥} Int found
-//│ ║  l.185: 	region x in x.ref bar
+//│ ║  l.184: 	region x in x.ref bar
 //│ ╙──       	                  ^^^
 //│ Type: Ref[⊥, ?]

--- a/hkmc2/shared/src/test/mlscript/bbml/bbSeq.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbSeq.mls
@@ -45,13 +45,13 @@ fun mapi = s => f =>
 //│ ║  l.37: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  Seq[out 'B, out 'E1]  <:  Seq[out A, out E]
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'E1)  <:  E
+//│ ╟── because: cannot constrain  'E1  <:  E
 //│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  (¬⊥ ∧ 'r) ∧ ¬outer  <:  ¬(¬E)
+//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
+//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬E ∧ ¬outer)
+//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
 //│ ╔══[ERROR] Type error in region expression with expected type Seq[out A, out E]
 //│ ║  l.34: 	    let i = r.ref 0
 //│ ║        	            ^^^^^^^
@@ -62,13 +62,13 @@ fun mapi = s => f =>
 //│ ║  l.37: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  Seq[out 'B, out 'E1]  <:  Seq[out A, out E]
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'E1)  <:  E
+//│ ╟── because: cannot constrain  'E1  <:  E
 //│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  (¬⊥ ∧ 'r) ∧ ¬outer  <:  ¬(¬E)
+//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
+//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬E ∧ ¬outer)
+//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
 //│ ╔══[ERROR] Type error in region expression with expected type Seq[out A, out E]
 //│ ║  l.34: 	    let i = r.ref 0
 //│ ║        	            ^^^^^^^
@@ -79,13 +79,13 @@ fun mapi = s => f =>
 //│ ║  l.37: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  Seq[out 'B, out 'E1]  <:  Seq[out A, out E]
-//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'E1)  <:  E
+//│ ╟── because: cannot constrain  'E1  <:  E
 //│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  ¬⊥ ∧ 'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  (¬⊥ ∧ 'r) ∧ ¬outer  <:  ¬(¬E)
+//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
+//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬E ∧ ¬outer)
+//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
 //│ Type: ⊤
 
 // * Notice the inferred type, which produces an unusable Sequence (of effect `?` ie `Any`)

--- a/hkmc2/shared/src/test/mlscript/bbml/bbSeq.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbSeq.mls
@@ -44,14 +44,14 @@ fun mapi = s => f =>
 //│ ║        	^^^^^^^^^^^^^^^^^
 //│ ║  l.37: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
-//│ ╟── because: cannot constrain  Seq[out 'B, out 'E1]  <:  Seq[out A, out E]
+//│ ╟── because: cannot constrain  Seq[in ⊥ out 'B, in ⊥ out 'E1]  <:  Seq[in ⊥ out A, in ⊥ out E]
 //│ ╟── because: cannot constrain  'E1  <:  E
-//│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
+//│ ╟── because: cannot constrain  'E1  <:  E
+//│ ╟── because: cannot constrain  'reg  <:  E
+//│ ╟── because: cannot constrain  'reg  <:  E
+//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  E
+//│ ╟── because: cannot constrain  'r  <:  E ∨ outer
+//│ ╙── because: cannot constrain  ¬outer  <:  E ∨ outer
 //│ ╔══[ERROR] Type error in region expression with expected type Seq[out A, out E]
 //│ ║  l.34: 	    let i = r.ref 0
 //│ ║        	            ^^^^^^^
@@ -61,14 +61,14 @@ fun mapi = s => f =>
 //│ ║        	^^^^^^^^^^^^^^^^^
 //│ ║  l.37: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
-//│ ╟── because: cannot constrain  Seq[out 'B, out 'E1]  <:  Seq[out A, out E]
+//│ ╟── because: cannot constrain  Seq[in ⊥ out 'B, in ⊥ out 'E1]  <:  Seq[in ⊥ out A, in ⊥ out E]
 //│ ╟── because: cannot constrain  'E1  <:  E
-//│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
+//│ ╟── because: cannot constrain  'E1  <:  E
+//│ ╟── because: cannot constrain  'reg  <:  E
+//│ ╟── because: cannot constrain  'reg  <:  E
+//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  E
+//│ ╟── because: cannot constrain  'r  <:  E ∨ outer
+//│ ╙── because: cannot constrain  ¬outer  <:  E ∨ outer
 //│ ╔══[ERROR] Type error in region expression with expected type Seq[out A, out E]
 //│ ║  l.34: 	    let i = r.ref 0
 //│ ║        	            ^^^^^^^
@@ -78,14 +78,14 @@ fun mapi = s => f =>
 //│ ║        	^^^^^^^^^^^^^^^^^
 //│ ║  l.37: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
-//│ ╟── because: cannot constrain  Seq[out 'B, out 'E1]  <:  Seq[out A, out E]
+//│ ╟── because: cannot constrain  Seq[in ⊥ out 'B, in ⊥ out 'E1]  <:  Seq[in ⊥ out A, in ⊥ out E]
 //│ ╟── because: cannot constrain  'E1  <:  E
-//│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  ¬(¬E)
-//│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
+//│ ╟── because: cannot constrain  'E1  <:  E
+//│ ╟── because: cannot constrain  'reg  <:  E
+//│ ╟── because: cannot constrain  'reg  <:  E
+//│ ╟── because: cannot constrain  'r ∧ ¬outer  <:  E
+//│ ╟── because: cannot constrain  'r  <:  E ∨ outer
+//│ ╙── because: cannot constrain  ¬outer  <:  E ∨ outer
 //│ Type: ⊤
 
 // * Notice the inferred type, which produces an unusable Sequence (of effect `?` ie `Any`)

--- a/hkmc2/shared/src/test/mlscript/bbml/bbSeq.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbSeq.mls
@@ -45,13 +45,13 @@ fun mapi = s => f =>
 //│ ║  l.37: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  Seq[out 'B, out 'E1]  <:  Seq[out A, out E]
-//│ ╟── because: cannot constrain  'E1  <:  E
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'E1)  <:  E
 //│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  (¬⊥ ∧ 'r) ∧ ¬outer  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬E ∧ ¬outer)
 //│ ╔══[ERROR] Type error in region expression with expected type Seq[out A, out E]
 //│ ║  l.34: 	    let i = r.ref 0
 //│ ║        	            ^^^^^^^
@@ -62,13 +62,13 @@ fun mapi = s => f =>
 //│ ║  l.37: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  Seq[out 'B, out 'E1]  <:  Seq[out A, out E]
-//│ ╟── because: cannot constrain  'E1  <:  E
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'E1)  <:  E
 //│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  (¬⊥ ∧ 'r) ∧ ¬outer  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬E ∧ ¬outer)
 //│ ╔══[ERROR] Type error in region expression with expected type Seq[out A, out E]
 //│ ║  l.34: 	    let i = r.ref 0
 //│ ║        	            ^^^^^^^
@@ -79,13 +79,13 @@ fun mapi = s => f =>
 //│ ║  l.37: 	      f(!i, x)
 //│ ║        	^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  Seq[out 'B, out 'E1]  <:  Seq[out A, out E]
-//│ ╟── because: cannot constrain  'E1  <:  E
+//│ ╟── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ 'E1)  <:  E
 //│ ╟── because: cannot constrain  'E1  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  ¬⊥ ∧ 'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'reg  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  (¬⊥ ∧ 'r) ∧ ¬outer  <:  ¬(¬E)
 //│ ╟── because: cannot constrain  'r  <:  ¬(¬E ∧ ¬outer)
-//│ ╙── because: cannot constrain  ¬outer  <:  ¬(¬E ∧ ¬outer)
+//│ ╙── because: cannot constrain  ⊤ ∧ (¬⊥ ∧ ¬outer)  <:  ¬(¬E ∧ ¬outer)
 //│ Type: ⊤
 
 // * Notice the inferred type, which produces an unusable Sequence (of effect `?` ie `Any`)


### PR DESCRIPTION
Bugs found by @auht.
- [x] Some constraints cannot be correctly cached without `.toBasic`. Also improved type printing in error messages.
- [x] Fix unexpected generalizations.