### PR TITLE
Support explicitly specifying contextual arguments

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -226,6 +226,8 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
       term(lhs, inStmtPos = inStmtPos)(k)
     case st.Tup(fs) =>
       args(fs)(args => k(Value.Arr(args)))
+    case st.CtxTup(fs) =>
+      args(fs)(args => k(Value.Arr(args)))
     case ref @ st.Ref(sym) =>
       sym match
       case ctx.builtins.source.bms | ctx.builtins.js.bms | ctx.builtins.debug.bms | ctx.builtins.annotations.bms =>

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
@@ -577,6 +577,8 @@ extends Importer:
           Tree.App(nme, Tree.Tup(Nil)) // FIXME
           , N, rs)
       )
+    case tree @ Tup(TermDef(Ins, f, N) :: fs) =>
+      Term.CtxTup((f :: fs).map(fld(_)))(tree)
     case tree @ Tup(fields) =>
       Term.Tup(fields.map(fld(_)))(tree)
     // case New(c, rfto) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Resolver.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Resolver.scala
@@ -467,18 +467,28 @@ class Resolver(tl: TraceLogger)
     *    the semantic of the term, so it has to done before the symbol
     *    resolution.
     *
+    * @param inCtxPrefix if true, the currently resolving term is the
+    * prefix of an App where the implicit arguments are explicitly
+    * specified, e.g., `f(using 42)`. The implicit arguments should be
+    * resolved on the the App `f(using 42)`, but not on the base of the
+    * App `f`.
     * @param inTyPrefix if true, the currently resolving term is the
-    * prefix of an TyApp which the implicit arguments shouldn't be
-    * resolved on it, but on the TyApp instead.
+    * prefix of an TyApp, e.g., `f[Int]`. The implicit arguments should
+    * be resolved on the the TyApp `f[Int]`, but not on the base of the
+    * TyApp `f`.
     */
-  def resolve(t: Resolvable, inTyPrefix: Bool = false)(using ICtx): (Opt[CallableDefinition], ICtx) =
+  def resolve(t: Resolvable, inCtxPrefix: Bool = false, inTyPrefix: Bool = false)(using ICtx): (Opt[CallableDefinition], ICtx) =
   trace[(Opt[CallableDefinition], ICtx)](s"Resolving resolvable term: ${t}, (inPrefix = ${inTyPrefix})", _ => s"~> ${t}"):
     // Resolve the sub-resolvable-terms of the term. 
     val (defn, newICtx1) = t match
       // Note: the arguments of the App are traversed later because the
       // definition is required.
-      case Term.App(lhs: Resolvable, _) =>
-        val result = resolve(lhs)
+      case Term.App(lhs: Resolvable, args) =>
+        val result = args match
+          case t @ Term.CtxTup(_) => 
+            resolve(lhs, inCtxPrefix = true, inTyPrefix = inTyPrefix)
+          case _ => 
+            resolve(lhs, inCtxPrefix = inCtxPrefix, inTyPrefix = inTyPrefix)
         resolveSymbol(t)
         result
       case Term.App(lhs, _) =>
@@ -547,7 +557,7 @@ class Resolver(tl: TraceLogger)
       //
       // For example: In `fun f(a)(b) = 42`, f's definition should
       // indicate that it accepts two argument lists; f(42)'s definition
-      // should indicate that it accepts one argument list; f(42, 43)'s
+      // should indicate that it accepts one argument list; f(42)(43)'s
       // definition should indicate that it accepts zero argument lists.
       //
       // Currently, only parameters are processed for these new term
@@ -559,18 +569,22 @@ class Resolver(tl: TraceLogger)
         case S(defn @ CallableDefinition(params = ps :: pss)) =>
           val (argCountUB, argCountLB) = as match
           // Tup: regular arguments
-          case tup: Term.Tup => (
-            !tup.fields.exists(_.isInstanceOf[Spd]),
-            tup.fields.map:
-              case Fld(asc = S(_)) => 0
-              case _: Fld => 1
-              case _: Spd => 0
-            .sum +
-            tup.fields.exists:
-              case Fld(asc = S(_)) => true
-              case _ => false
-            .into(if _ then 1 else 0)
-          )
+          case tup: (Term.Tup | Term.CtxTup) => 
+            val fields = tup match
+              case Term.Tup(fs) => fs
+              case Term.CtxTup(fs) => fs
+            (
+              !fields.exists(_.isInstanceOf[Spd]),
+              fields.map:
+                case Fld(asc = S(_)) => 0
+                case _: Fld => 1
+                case _: Spd => 0
+              .sum +
+              fields.exists:
+                case Fld(asc = S(_)) => true
+                case _ => false
+              .into(if _ then 1 else 0)
+            )
           // Other: spread arguments
           case _ => (false, 0)
           
@@ -633,6 +647,7 @@ class Resolver(tl: TraceLogger)
           
           val args = as match
             case Term.Tup(args) => args
+            case Term.CtxTup(args) => args
             case spd => Spd(true, spd) :: Nil
           
           // The lhs of the App is already traversed by the recursive
@@ -648,7 +663,7 @@ class Resolver(tl: TraceLogger)
       
       // Resolve the implicit arguments.
       newDefn match
-      case S(defn) if !inTyPrefix =>
+      case S(defn) if !inCtxPrefix && !inTyPrefix =>
         def resolveParamList(pss: Ls[ParamList], ass: Ls[Term.Tup]): (Ls[ParamList], Ls[Term.Tup]) = pss match
           case ParamList(flags = ParamListFlags(ctx = true), params = ps) :: pss =>
             val as = ps.map(resolveArg(_)(t))
@@ -663,6 +678,9 @@ class Resolver(tl: TraceLogger)
           resolveSymbol(t)
           
         (S(defn.copy(params = pss)), ictx)
+      case S(defn) =>
+        t.withIArgs(Nil)
+        (S(defn), ictx)
       case _ =>
         t.withIArgs(Nil)
         (N, ictx)

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Resolver.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Resolver.scala
@@ -581,10 +581,9 @@ class Resolver(tl: TraceLogger)
                     case _: Fld => true
                     case _: Spd => false
                 ) + (
-                  fields.exists:
-                    case Fld(asc = S(_)) => true
-                    case _ => false
-                  .into(if _ then 1 else 0)
+                  fields.collectFirst:
+                    case Fld(asc = S(_)) => 1
+                  .getOrElse(0)
                 )
               )
             // Other: spread arguments
@@ -647,6 +646,7 @@ class Resolver(tl: TraceLogger)
                 recordArgs.reverse
             end zip
             
+            // Application arguments that are not tuples represent spreads, as in `f(...arg)`
             val args = as match
               case Term.Tup(args) => args
               case Term.CtxTup(args) => args

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Resolver.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Resolver.scala
@@ -349,7 +349,7 @@ class Resolver(tl: TraceLogger)
           rft.foreach((sym, bdy) => traverseBlock(bdy.blk))
         
         case t: Resolvable =>
-          resolve(t)
+          resolve(t, inTyPrefix = false, inCtxPrefix = false)
         
         case _ => 
           t.subTerms.foreach(traverse(_, expect = NonModule(N)))
@@ -477,7 +477,7 @@ class Resolver(tl: TraceLogger)
     * be resolved on the the TyApp `f[Int]`, but not on the base of the
     * TyApp `f`.
     */
-  def resolve(t: Resolvable, inCtxPrefix: Bool = false, inTyPrefix: Bool = false)(using ICtx): (Opt[CallableDefinition], ICtx) =
+  def resolve(t: Resolvable, inCtxPrefix: Bool, inTyPrefix: Bool)(using ICtx): (Opt[CallableDefinition], ICtx) =
   trace[(Opt[CallableDefinition], ICtx)](s"Resolving resolvable term: ${t}, (inPrefix = ${inTyPrefix})", _ => s"~> ${t}"):
     // Resolve the sub-resolvable-terms of the term. 
     val (defn, newICtx1) = t match
@@ -496,7 +496,7 @@ class Resolver(tl: TraceLogger)
         (t.callableDefn, ictx)
       
       case Term.TyApp(lhs: Resolvable, targs) =>
-        resolve(lhs, inTyPrefix = true)
+        resolve(lhs, inCtxPrefix= false, inTyPrefix = true)
         targs.foreach(traverse(_, expect = Any))
         resolveSymbol(t)
         (t.callableDefn, ictx)
@@ -506,7 +506,7 @@ class Resolver(tl: TraceLogger)
         (t.callableDefn, ictx)
       
       case AnySel(pre: Resolvable, id) =>
-        resolve(pre)
+        resolve(pre, inCtxPrefix = false, inTyPrefix = false)
         resolveSymbol(t)
         (t.callableDefn, ictx)
       case AnySel(pre, id) =>
@@ -565,101 +565,103 @@ class Resolver(tl: TraceLogger)
       // as-is. In the future we may take them into consideration as
       // well.
       val newDefn: Opt[CallableDefinition] = t match
-      case Term.App(lhs, as) => defn match
-        case S(defn @ CallableDefinition(params = ps :: pss)) =>
-          val (argCountUB, argCountLB) = as match
-          // Tup: regular arguments
-          case tup: (Term.Tup | Term.CtxTup) => 
-            val fields = tup match
-              case Term.Tup(fs) => fs
-              case Term.CtxTup(fs) => fs
-            (
-              !fields.exists(_.isInstanceOf[Spd]),
-              fields.map:
-                case Fld(asc = S(_)) => 0
-                case _: Fld => 1
-                case _: Spd => 0
-              .sum +
-              fields.exists:
-                case Fld(asc = S(_)) => true
-                case _ => false
-              .into(if _ then 1 else 0)
-            )
-          // Other: spread arguments
-          case _ => (false, 0)
-          
-          (ps.paramCountUB, argCountUB) match
-            case (true, true) => if ps.paramCountLB != argCountLB then
-              raise(ErrorReport(msg"Expected ${ps.paramCountLB.toString()} arguments, " +
-                msg"got ${argCountLB.toString()}" -> as.toLoc :: Nil))
-            case (true, false) => if ps.paramCountLB < argCountLB then
-              raise(ErrorReport(msg"Expected ${ps.paramCountLB.toString()} arguments, " +
-                msg"got at least ${argCountLB.toString()}" -> as.toLoc :: Nil))
-            case (false, true) => if ps.paramCountLB > argCountLB then
-              raise(ErrorReport(msg"Expected at least ${ps.paramCountLB.toString()} arguments, " +
-                msg"got ${argCountLB.toString()}" -> as.toLoc :: Nil))
-            case (false, false) => ()
-          
-          /**
-           * Zip (pair) a list of parameter and a list of arguments.
-           *
-           * If there are some spread parameters, we are not able to
-           * pair all the parameters and arguments statically. We will
-           * try to pair as many as possible.
-           */
-          @tailrec
-          def zip(ps: Ls[Param], as: Ls[Elem], recordArgs: Ls[Fld], beforeSpread: Bool): Ls[Fld] = (ps, as) match
-            // The spread argument takes all the remaining arguments.
-            case (ps, (a: Spd) :: as) =>
-              traverse(a.term, expect = NonModule(N))
-              zip(ps, as, recordArgs, false)
-            case (ps, a :: as) if !beforeSpread =>
-              a.subTerms.foreach(traverse(_, expect = NonModule(N)))
-              zip(ps, as, recordArgs, false)
-            
-            // Pair the parameter and the argument.
-            case (p :: ps, (a @ Fld(asc = N)) :: as) =>
-              traverse(a.term, 
-                // note: we accept regular arguments for module parameters
-                expect = if p.modulefulness.isModuleful
-                  then Any
-                  else NonModule(S(msg"Module argument passed to a non-module parameter."))
+        case Term.App(lhs, as) => defn match
+          case S(defn @ CallableDefinition(params = ps :: pss)) =>
+            val (argCountUB, argCountLB) = as match
+            // Tup: regular arguments
+            case tup: (Term.Tup | Term.CtxTup) => 
+              val fields = tup match
+                case Term.Tup(fs) => fs
+                case Term.CtxTup(fs) => fs
+              (
+                !fields.exists(_.isInstanceOf[Spd]),
+                (
+                  fields.count:
+                    case Fld(asc = S(_)) => false
+                    case _: Fld => true
+                    case _: Spd => false
+                ) + (
+                  fields.exists:
+                    case Fld(asc = S(_)) => true
+                    case _ => false
+                  .into(if _ then 1 else 0)
+                )
               )
-              zip(ps, as, recordArgs, true)
+            // Other: spread arguments
+            case _ => (false, 0)
             
-            // Record Arguments. They are pushed to the last parameter.
-            case (_, (a @ Fld(asc = S(_))) :: as) =>
-              zip(ps, as, a :: recordArgs, true)
+            (ps.paramCountUB, argCountUB) match
+              case (true, true) => if ps.paramCountLB != argCountLB then
+                raise(ErrorReport(msg"Expected ${ps.paramCountLB.toString()} arguments, " +
+                  msg"got ${argCountLB.toString()}" -> as.toLoc :: Nil))
+              case (true, false) => if ps.paramCountLB < argCountLB then
+                raise(ErrorReport(msg"Expected ${ps.paramCountLB.toString()} arguments, " +
+                  msg"got at least ${argCountLB.toString()}" -> as.toLoc :: Nil))
+              case (false, true) => if ps.paramCountLB > argCountLB then
+                raise(ErrorReport(msg"Expected at least ${ps.paramCountLB.toString()} arguments, " +
+                  msg"got ${argCountLB.toString()}" -> as.toLoc :: Nil))
+              case (false, false) => ()
             
-            // If there are more parameters, there must be a spread
-            // argument, or some record arguments before.
-            case (p :: ps, Nil) =>
-              recordArgs.reverse
+            /**
+             * Zip (pair) a list of parameter and a list of arguments.
+             *
+             * If there are some spread parameters, we are not able to
+             * pair all the parameters and arguments statically. We will
+             * try to pair as many as possible.
+             */
+            @tailrec
+            def zip(ps: Ls[Param], as: Ls[Elem], recordArgs: Ls[Fld], beforeSpread: Bool): Ls[Fld] = (ps, as) match
+              // The spread argument takes all the remaining arguments.
+              case (ps, (a: Spd) :: as) =>
+                traverse(a.term, expect = NonModule(N))
+                zip(ps, as, recordArgs, false)
+              case (ps, a :: as) if !beforeSpread =>
+                a.subTerms.foreach(traverse(_, expect = NonModule(N)))
+                zip(ps, as, recordArgs, false)
               
-            // If there are more arguments, all of them go to `restParam`.
-            case (Nil, a :: as) =>
-              a.subTerms.foreach(traverse(_, expect = NonModule(N)))
-              zip(Nil, as, recordArgs, beforeSpread)
+              // Pair the parameter and the argument.
+              case (p :: ps, (a @ Fld(asc = N)) :: as) =>
+                traverse(a.term, 
+                  // note: we accept regular arguments for module parameters
+                  expect = if p.modulefulness.isModuleful
+                    then Any
+                    else NonModule(S(msg"Module argument passed to a non-module parameter."))
+                )
+                zip(ps, as, recordArgs, true)
+              
+              // Record Arguments. They are pushed to the last parameter.
+              case (_, (a @ Fld(asc = S(_))) :: as) =>
+                zip(ps, as, a :: recordArgs, true)
+              
+              // If there are more parameters, there must be a spread
+              // argument, or some record arguments before.
+              case (p :: ps, Nil) =>
+                recordArgs.reverse
+                
+              // If there are more arguments, all of them go to `restParam`.
+              case (Nil, a :: as) =>
+                a.subTerms.foreach(traverse(_, expect = NonModule(N)))
+                zip(Nil, as, recordArgs, beforeSpread)
+              
+              case (Nil, Nil) => 
+                recordArgs.reverse
+            end zip
             
-            case (Nil, Nil) => 
-              recordArgs.reverse
-          end zip
-          
-          val args = as match
-            case Term.Tup(args) => args
-            case Term.CtxTup(args) => args
-            case spd => Spd(true, spd) :: Nil
-          
-          // The lhs of the App is already traversed by the recursive
-          // `traverse` or `resolve` at the beginning.
-          val recordArgs = zip(ps.params, args, Nil, true)
-          recordArgs.foreach:
-            _.subTerms.foreach(traverse(_, expect = NonModule(N)))
-          S(defn.copy(params = pss))
-        case _ =>
-          traverse(as, expect = NonModule(N))
-          N
-      case _ => defn
+            val args = as match
+              case Term.Tup(args) => args
+              case Term.CtxTup(args) => args
+              case spd => Spd(true, spd) :: Nil
+            
+            // The lhs of the App is already traversed by the recursive
+            // `traverse` or `resolve` at the beginning.
+            val recordArgs = zip(ps.params, args, Nil, true)
+            recordArgs.foreach:
+              _.subTerms.foreach(traverse(_, expect = NonModule(N)))
+            S(defn.copy(params = pss))
+          case _ =>
+            traverse(as, expect = NonModule(N))
+            N
+        case _ => defn
       
       // Resolve the implicit arguments.
       newDefn match

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Resolver.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Resolver.scala
@@ -496,7 +496,7 @@ class Resolver(tl: TraceLogger)
         (t.callableDefn, ictx)
       
       case Term.TyApp(lhs: Resolvable, targs) =>
-        resolve(lhs, inCtxPrefix= false, inTyPrefix = true)
+        resolve(lhs, inCtxPrefix = false, inTyPrefix = true)
         targs.foreach(traverse(_, expect = Any))
         resolveSymbol(t)
         (t.callableDefn, ictx)

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
@@ -89,6 +89,7 @@ enum Term extends Statement:
   case SynthSel(prefix: Term, nme: Tree.Ident)(var sym: Opt[FieldSymbol]) extends Term with ResolvableImpl
   case DynSel(prefix: Term, fld: Term, arrayIdx: Bool)
   case Tup(fields: Ls[Elem])(val tree: Tree.Tup)
+  case CtxTup(fields: Ls[Elem])(val tree: Tree.Tup)
   case IfLike(kw: Keyword.`if`.type | Keyword.`while`.type, desugared: Split)
   case Lam(params: ParamList, body: Term)
   case FunTy(lhs: Term, rhs: Term, eff: Opt[Term])
@@ -161,6 +162,7 @@ enum Term extends Statement:
     case Sel(pre, nme) => "selection"
     case SynthSel(pre, nme) => "selection"
     case Tup(fields) => "tuple literal"
+    case CtxTup(fields) => "contextual tuple literal"
     case IfLike(Keyword.`if`, body) => "`if` expression"
     case IfLike(Keyword.`while`, body) => "`while` expression"
     case Lam(params, body) => "function literal"
@@ -215,6 +217,7 @@ sealed trait Statement extends AutoLocated with ProductWithExtraInfo:
     case SynthSel(pre, _) => pre :: Nil
     case DynSel(o, f, _) => o :: f :: Nil
     case Tup(fields) => fields.flatMap(_.subTerms)
+    case CtxTup(fields) => fields.flatMap(_.subTerms)
     case IfLike(_, body) => body.subTerms
     case Lam(params, body) => body :: Nil
     case Blk(stats, res) => stats.flatMap(_.subTerms) ::: res :: Nil
@@ -326,6 +329,7 @@ sealed trait Statement extends AutoLocated with ProductWithExtraInfo:
     case CompType(lhs, rhs, pol) => s"${lhs.showDbg} ${if pol then "|" else "&"} ${rhs.showDbg}"
     case Error => "<error>"
     case Tup(fields) => fields.map(_.showDbg).mkString("[", ", ", "]")
+    case CtxTup(fields) => fields.map(_.showDbg).mkString("‹using›[", ", ", "]")
     case TermDefinition(_, k, sym, pss, tps, sign, body, res, flags, _, _) => s"${flags} ${k.str} ${sym}${
       tps.map(_.map(_.showDbg)).mkStringOr(", ", "[", "]")
     }${

--- a/hkmc2/shared/src/test/mlscript/ctx/ExplicitlySpecifying.mls
+++ b/hkmc2/shared/src/test/mlscript/ctx/ExplicitlySpecifying.mls
@@ -1,0 +1,87 @@
+:js
+
+fun f(using i: Int): Int = i
+
+:expect 42
+f(using 42)
+//│ = 42
+
+
+fun f(using i: Int, j: Num): Num = i + j
+
+:e
+:re
+f(using 42)
+//│ ╔══[ERROR] Expected 2 arguments, got 1
+//│ ║  l.14: 	f(using 42)
+//│ ╙──      	        ^^
+//│ ═══[RUNTIME ERROR] Error: Function 'f' expected 2 arguments but got 1
+
+:expect 45.14
+f(using 42, 3.14)
+//│ = 45.14
+
+
+fun f(using i: Int)(using j: Int)(using k: Int): Int = i + j + k
+
+:e
+:re
+f(using 32)
+//│ ╔══[ERROR] Cannot query instance of type Int for call: 
+//│ ║  l.29: 	f(using 32)
+//│ ║        	^^^^^^^^^^^
+//│ ╟── Required by contextual parameter declaration: 
+//│ ║  l.25: 	fun f(using i: Int)(using j: Int)(using k: Int): Int = i + j + k
+//│ ║        	                          ^^^^^^
+//│ ╙── Missing instance: Expected: Int; Available: ‹none available›
+//│ ╔══[ERROR] Cannot query instance of type Int for call: 
+//│ ║  l.29: 	f(using 32)
+//│ ║        	^^^^^^^^^^^
+//│ ╟── Required by contextual parameter declaration: 
+//│ ║  l.25: 	fun f(using i: Int)(using j: Int)(using k: Int): Int = i + j + k
+//│ ║        	                                        ^^^^^^
+//│ ╙── Missing instance: Expected: Int; Available: ‹none available›
+//│ ═══[RUNTIME ERROR] Error: Function expected 1 argument but got 0
+
+:e
+:re
+f(using 32)(using 8)
+//│ ╔══[ERROR] Cannot query instance of type Int for call: 
+//│ ║  l.48: 	f(using 32)(using 8)
+//│ ║        	^^^^^^^^^^^^^^^^^^^^
+//│ ╟── Required by contextual parameter declaration: 
+//│ ║  l.25: 	fun f(using i: Int)(using j: Int)(using k: Int): Int = i + j + k
+//│ ║        	                                        ^^^^^^
+//│ ╙── Missing instance: Expected: Int; Available: ‹none available›
+//│ ═══[RUNTIME ERROR] Error: Function expected 1 argument but got 0
+
+:expect 42
+f(using 32)(using 8)(using 2)
+//│ = 42
+
+
+fun f(using i: Int)(j: Int)(using k: Int)(l: Num): Int = i + j + k + l
+
+:expect [function]
+f(using 32)
+//│ = [function]
+
+:e
+:re
+f(using 32)(8)
+//│ ╔══[ERROR] Cannot query instance of type Int for call: 
+//│ ║  l.71: 	f(using 32)(8)
+//│ ║        	^^^^^^^^^^^^^^
+//│ ╟── Required by contextual parameter declaration: 
+//│ ║  l.63: 	fun f(using i: Int)(j: Int)(using k: Int)(l: Num): Int = i + j + k + l
+//│ ║        	                                  ^^^^^^
+//│ ╙── Missing instance: Expected: Int; Available: ‹none available›
+//│ ═══[RUNTIME ERROR] Error: Function expected 1 argument but got 0
+
+:expect [function]
+f(using 32)(8)(using 2)
+//│ = [function]
+
+:expect 45.14
+f(using 32)(8)(using 2)(3.14)
+//│ = 45.14


### PR DESCRIPTION
I created a new term form `CtxTup`, which represents an argument tuple prefixed by `using`, e.g., 

```cs
foo(using 42)
   ^^^^^^^^^^
```

If the resolver sees a `App(base, iargs: CtxTup)`, it skips the implicit argument resolution of `base`. It checks the arity of the implicit arguments against the parameter declarations, *but it doesn't check if the types of the arguments match the declarations*.

After resolution, the compiler just compiles `CtxTup` to regular `Tup`, which essentially provides the implicit arguments to the function.

I tried to add a flag to `Tup` to indicate if the tuple is prefixed by `using` rather than using `CtxTup`, but it appears that there are a huge number of places that I have to update. So I gave up and just created `CtxTup`.


