### PR TITLE
Enforce that only Arrays (and array-like constant time indexables) are used with LazyArrays

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -383,6 +383,7 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
           case Elaborator.ctx.builtins.Num => doc"typeof $sd === 'number'"
           case Elaborator.ctx.builtins.Bool => doc"typeof $sd === 'boolean'"
           case Elaborator.ctx.builtins.Int => doc"globalThis.Number.isInteger($sd)"
+          case Elaborator.ctx.builtins.TypedArray => doc"globalThis.ArrayBuffer.isView($sd) && !($sd instanceof globalThis.DataView)"
           case _ => doc"$sd instanceof ${result(pth)}"
         case Case.Tup(len, inf) => doc"$runtimeVar.Tuple.isArrayLike($sd) && $sd.length ${if inf then ">=" else "==="} ${len}"
         case Case.Field(n, safe = false) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
@@ -137,6 +137,7 @@ object Elaborator:
       val Function = assumeBuiltinCls("Function")
       val Bool = assumeBuiltinCls("Bool")
       val Object = assumeBuiltinCls("Object")
+      val TypedArray = assumeBuiltinCls("TypedArray")
       val untyped = assumeBuiltinTpe("untyped")
       // println(s"Builtins: $Int, $Num, $Str, $untyped")
       class VirtualModule(val module: ModuleSymbol):
@@ -161,7 +162,7 @@ object Elaborator:
       def getBuiltinOp(op: Str): Opt[Str] =
         if getBuiltin(op).isDefined then builtinBinOps.get(op) else N
       /** Classes that do not use `instanceof` in pattern matching. */
-      val virtualClasses = Set(Int, Num, Str, Bool)
+      val virtualClasses = Set(Int, Num, Str, Bool, TypedArray)
   
   object Ctx:
     abstract class Elem:

--- a/hkmc2/shared/src/test/mlscript-compile/LazyArray.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/LazyArray.mls
@@ -9,6 +9,10 @@ fun normIdx(i, len) =
   if i < 0 then len + i
   else i
 
+fun enforceArray = case
+  Array | LazyArr as a then a
+  ow then throw Error("Expected an Array, got: " + ow.toString())
+
 fun concatHelper(a, l, ...args) =
   let idx = 0
   let init_len = a.length
@@ -17,7 +21,7 @@ fun concatHelper(a, l, ...args) =
     let x = args.[idx]
 
     set a.[init_len + idx * 2] = SpliceMarker
-    set a.[init_len + idx * 2 + 1] = x
+    set a.[init_len + idx * 2 + 1] = enforceArray(x)
     set l += x.length
     set idx += 1
   Splice of a, l
@@ -44,7 +48,7 @@ fun sliceHelper(beg, fin, arr) =
   if arr is
     View(itr, start, end) then View of itr, start + beg, end + (len - fin)
     Splice(bits, l) as s then View of s.materialize().slice(beg, fin), 0, 0
-    _ as itr then View of itr, beg, (arr.length - fin)
+    _ as itr then View of enforceArray(itr), beg, (arr.length - fin)
 
 // Marker base class for View and Splice
 class LazyArr extends IterableBase with
@@ -172,7 +176,7 @@ fun __concat(...args) =
   let idx = 0
   while (idx < args.length) do
     if args.[idx] is SpliceMarker then
-      set len += args.[idx + 1].length
+      set len += enforceArray(args.[idx + 1]).length
       set idx += 2
     else
       set len += 1

--- a/hkmc2/shared/src/test/mlscript-compile/LazyArray.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/LazyArray.mls
@@ -10,7 +10,8 @@ fun normIdx(i, len) =
   else i
 
 fun enforceArray = case
-  Array | LazyArr as a then a
+  Array | String | LazyArr as a then a
+  a and typeof(a) === "string" || globalThis.ArrayBuffer.isView(a) then a
   ow then throw Error("Expected an Array, got: " + ow.toString())
 
 fun concatHelper(a, l, ...args) =
@@ -48,7 +49,7 @@ fun sliceHelper(beg, fin, arr) =
   if arr is
     View(itr, start, end) then View of itr, start + beg, end + (len - fin)
     Splice(bits, l) as s then View of s.materialize().slice(beg, fin), 0, 0
-    _ as itr then View of enforceArray(itr), beg, (arr.length - fin)
+    else View of enforceArray(arr), beg, (arr.length - fin)
 
 // Marker base class for View and Splice
 class LazyArr extends IterableBase with

--- a/hkmc2/shared/src/test/mlscript-compile/LazyArray.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/LazyArray.mls
@@ -10,8 +10,7 @@ fun normIdx(i, len) =
   else i
 
 fun enforceArray = case
-  Array | String | LazyArr as a then a
-  a and typeof(a) === "string" || globalThis.ArrayBuffer.isView(a) then a
+  Array | String | Str | TypedArray | LazyArr as a then a
   ow then throw Error("Expected an Array, got: " + ow.toString())
 
 fun concatHelper(a, l, ...args) =

--- a/hkmc2/shared/src/test/mlscript-compile/apps/parsing/Keywords.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/apps/parsing/Keywords.mls
@@ -143,7 +143,7 @@ fun extended = all
 
 pattern Letter = "a" ..= "z" | "A" ..= "Z"
 
-fun hasLetter(s) = [...s].some((ch, _, _) => ch is Letter)
+fun hasLetter(s) = s Iter.some((ch, _, _) => ch is Letter)
 
 pattern FloatOperator = "+." | "-." | "*." | "/."
 

--- a/hkmc2/shared/src/test/mlscript-compile/apps/parsing/Keywords.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/apps/parsing/Keywords.mls
@@ -143,7 +143,7 @@ fun extended = all
 
 pattern Letter = "a" ..= "z" | "A" ..= "Z"
 
-fun hasLetter(s) = [..s].some((ch, _, _) => ch is Letter)
+fun hasLetter(s) = [...s].some((ch, _, _) => ch is Letter)
 
 pattern FloatOperator = "+." | "-." | "*." | "/."
 

--- a/hkmc2/shared/src/test/mlscript/bbml/bbPrelude.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbPrelude.mls
@@ -11,6 +11,7 @@ declare class Unit
 declare class Bool
 declare class Int
 declare class Num
+declare class TypedArray
 
 data
   class

--- a/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
+++ b/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
@@ -21,6 +21,21 @@ declare class RangeError
 declare class Symbol
 declare class Date
 
+declare class ArrayBuffer
+declare class TypedArray
+declare class Int8Array
+declare class Uint8Array
+declare class Uint8ClampedArray
+declare class Int16Array
+declare class Uint16Array
+declare class Int32Array
+declare class Uint32Array
+declare class Float16Array
+declare class Float32Array
+declare class Float64Array
+declare class BigInt64Array
+declare class BigUint64Array
+
 // MLscript-specific types
 declare class Unit
 declare class Bool

--- a/hkmc2/shared/src/test/mlscript/llir/nofib/atom.mls
+++ b/hkmc2/shared/src/test/mlscript/llir/nofib/atom.mls
@@ -33,7 +33,7 @@ fun show(s) =
     component :: t then Cons(stringConcat(stringOfFloat(component), "\t"), lscomp(t))
   if s is State(pos, vel) then
     stringListConcat of lscomp(pos)
-//│ ═══[COMPILATION ERROR] Name not found: member:stringConcat
+//│ ═══[COMPILATION ERROR] Name not found: member:stringOfFloat
 //│ Stopped due to an error during the Llir generation
 
 fun propagate(dt, aforce, state) = if state is State(pos, vel) then

--- a/hkmc2/shared/src/test/mlscript/llir/nofib/awards.mls
+++ b/hkmc2/shared/src/test/mlscript/llir/nofib/awards.mls
@@ -40,7 +40,7 @@ fun rqpart(le, x, yss, rle, rgt, r) = if yss is
 //│ ————————————————————————————————————————————————————————————————————————————————
 
 fun sort(l) = qsort((a, b) => ltTup2(a, b, (a, b) => a < b, (a, b) => a > b, (a, b) => ltList(a, b, (a, b) => a < b, (a, b) => a > b)), l, Nil)
-//│ ═══[COMPILATION ERROR] Name not found: member:ltTup2
+//│ ═══[COMPILATION ERROR] Name not found: member:ltList
 //│ Stopped due to an error during the Llir generation
 
 fun perms(m, nns) = if
@@ -88,7 +88,7 @@ fun competitors(i) =
 
 fun testAwards_nofib(n) =
   map(x => print(findallawards(competitors(intMod(x, 100)))), enumFromTo(1, n))
-//│ ═══[COMPILATION ERROR] Name not found: member:print
+//│ ═══[COMPILATION ERROR] Name not found: member:findallawards
 //│ Stopped due to an error during the Llir generation
 
 testAwards_nofib(100)

--- a/hkmc2/shared/src/test/mlscript/llir/nofib/awards.mls
+++ b/hkmc2/shared/src/test/mlscript/llir/nofib/awards.mls
@@ -88,7 +88,7 @@ fun competitors(i) =
 
 fun testAwards_nofib(n) =
   map(x => print(findallawards(competitors(intMod(x, 100)))), enumFromTo(1, n))
-//│ ═══[COMPILATION ERROR] Name not found: member:findallawards
+//│ ═══[COMPILATION ERROR] Name not found: member:print
 //│ Stopped due to an error during the Llir generation
 
 testAwards_nofib(100)

--- a/hkmc2/shared/src/test/mlscript/llir/nofib/constraints.mls
+++ b/hkmc2/shared/src/test/mlscript/llir/nofib/constraints.mls
@@ -78,7 +78,7 @@ fun inconsistencies(csp, as_) = if csp is CSP(vars, vals, rel) then
       lscomp2(reverse(as_))
   
   lscomp1(as_)
-//│ ═══[COMPILATION ERROR] Name not found: member:not
+//│ ═══[COMPILATION ERROR] Name not found: member:reverse
 //│ Stopped due to an error during the Llir generation
 
 fun consistent(csp)(x) = null_(inconsistencies(csp, x))
@@ -209,7 +209,7 @@ fun bt(csp, t) =
   fun f3(s) = [s, (if earliestInconsistency(csp, s) is Some([a, b]) then Known(a :: b :: Nil) else checkComplete(csp, s))]
   
   mapTree(f3, t)
-//│ ═══[COMPILATION ERROR] Name not found: $runtime
+//│ ═══[COMPILATION ERROR] Name not found: member:earliestInconsistency
 //│ Stopped due to an error during the Llir generation
 
 // -- Figure 8. Backmarking.
@@ -245,7 +245,7 @@ fun fillTable(s, csp, tbl) = if s is
         lscomp2(enumFromTo(1, vals)) :: lscomp1(t1)
     
     zipWith((x, y) => zipWith(f4, x, y), tbl, lscomp1(enumFromTo(var_ + 1, vars)))
-//│ ═══[COMPILATION ERROR] Name not found: member:not
+//│ ═══[COMPILATION ERROR] Name not found: $runtime
 //│ Stopped due to an error during the Llir generation
 
 
@@ -258,7 +258,7 @@ fun lookupCache(csp, t) =
       [[a :: as_, cs], tbl]
   
   mapTree(x => f5(csp, x), t)
-//│ ═══[COMPILATION ERROR] Name not found: member:atIndex
+//│ ═══[COMPILATION ERROR] Name not found: member:head
 //│ Stopped due to an error during the Llir generation
 
 
@@ -289,7 +289,7 @@ fun bj_(csp, t) =
       else Node([a, cs_], chs)
   
   foldTree(f7, t)
-//│ ═══[COMPILATION ERROR] Name not found: member:map
+//│ ═══[COMPILATION ERROR] Name not found: member:combine
 //│ Stopped due to an error during the Llir generation
 
 
@@ -299,7 +299,7 @@ fun bj(csp, t) =
     [a, Unknown] then Node([a, Known(combine(map(label, chs), Nil))], chs)
   
   foldTree(f6, t)
-//│ ═══[COMPILATION ERROR] Name not found: member:map
+//│ ═══[COMPILATION ERROR] Name not found: member:combine
 //│ Stopped due to an error during the Llir generation
 
 
@@ -331,7 +331,7 @@ fun domainWipeout(csp, t) = if csp is CSP(vars, vals, rel) then
     [as_, cs_]
   
   mapTree(f8, t)
-//│ ═══[COMPILATION ERROR] Name not found: member:collect
+//│ ═══[COMPILATION ERROR] Name not found: member:head
 //│ Stopped due to an error during the Llir generation
 
 

--- a/hkmc2/shared/src/test/mlscript/llir/nofib/constraints.mls
+++ b/hkmc2/shared/src/test/mlscript/llir/nofib/constraints.mls
@@ -78,7 +78,7 @@ fun inconsistencies(csp, as_) = if csp is CSP(vars, vals, rel) then
       lscomp2(reverse(as_))
   
   lscomp1(as_)
-//│ ═══[COMPILATION ERROR] Name not found: member:reverse
+//│ ═══[COMPILATION ERROR] Name not found: member:not
 //│ Stopped due to an error during the Llir generation
 
 fun consistent(csp)(x) = null_(inconsistencies(csp, x))
@@ -209,7 +209,7 @@ fun bt(csp, t) =
   fun f3(s) = [s, (if earliestInconsistency(csp, s) is Some([a, b]) then Known(a :: b :: Nil) else checkComplete(csp, s))]
   
   mapTree(f3, t)
-//│ ═══[COMPILATION ERROR] Name not found: member:earliestInconsistency
+//│ ═══[COMPILATION ERROR] Name not found: $runtime
 //│ Stopped due to an error during the Llir generation
 
 // -- Figure 8. Backmarking.
@@ -245,7 +245,7 @@ fun fillTable(s, csp, tbl) = if s is
         lscomp2(enumFromTo(1, vals)) :: lscomp1(t1)
     
     zipWith((x, y) => zipWith(f4, x, y), tbl, lscomp1(enumFromTo(var_ + 1, vars)))
-//│ ═══[COMPILATION ERROR] Name not found: $runtime
+//│ ═══[COMPILATION ERROR] Name not found: member:not
 //│ Stopped due to an error during the Llir generation
 
 
@@ -258,7 +258,7 @@ fun lookupCache(csp, t) =
       [[a :: as_, cs], tbl]
   
   mapTree(x => f5(csp, x), t)
-//│ ═══[COMPILATION ERROR] Name not found: member:head
+//│ ═══[COMPILATION ERROR] Name not found: member:atIndex
 //│ Stopped due to an error during the Llir generation
 
 
@@ -289,7 +289,7 @@ fun bj_(csp, t) =
       else Node([a, cs_], chs)
   
   foldTree(f7, t)
-//│ ═══[COMPILATION ERROR] Name not found: member:combine
+//│ ═══[COMPILATION ERROR] Name not found: member:map
 //│ Stopped due to an error during the Llir generation
 
 
@@ -299,7 +299,7 @@ fun bj(csp, t) =
     [a, Unknown] then Node([a, Known(combine(map(label, chs), Nil))], chs)
   
   foldTree(f6, t)
-//│ ═══[COMPILATION ERROR] Name not found: member:combine
+//│ ═══[COMPILATION ERROR] Name not found: member:map
 //│ Stopped due to an error during the Llir generation
 
 

--- a/hkmc2/shared/src/test/mlscript/llir/nofib/secretary.mls
+++ b/hkmc2/shared/src/test/mlscript/llir/nofib/secretary.mls
@@ -34,7 +34,7 @@ fun sim(n, k) =
     listEq(best :: Nil, take(1, afterk))
   
   simulate(n, 100, proc)
-//│ ═══[COMPILATION ERROR] Name not found: member:drop
+//│ ═══[COMPILATION ERROR] Name not found: member:take_lz
 //│ Stopped due to an error during the Llir generation
 
 

--- a/hkmc2/shared/src/test/mlscript/llir/nofib/secretary.mls
+++ b/hkmc2/shared/src/test/mlscript/llir/nofib/secretary.mls
@@ -11,7 +11,7 @@ fun infRand(m, s) =
   fun f(x) = lazy(() => LzCons((intMod(x, m) + 1), f(intMod((97 * x + 11), power(2, 7)))))
   
   f(s)
-//│ ═══[COMPILATION ERROR] Name not found: member:intMod
+//│ ═══[COMPILATION ERROR] Name not found: member:lazy
 //│ Stopped due to an error during the Llir generation
 
 
@@ -34,7 +34,7 @@ fun sim(n, k) =
     listEq(best :: Nil, take(1, afterk))
   
   simulate(n, 100, proc)
-//│ ═══[COMPILATION ERROR] Name not found: member:listEq
+//│ ═══[COMPILATION ERROR] Name not found: member:drop
 //│ Stopped due to an error during the Llir generation
 
 

--- a/hkmc2/shared/src/test/mlscript/std/LazyArrayTest.mls
+++ b/hkmc2/shared/src/test/mlscript/std/LazyArrayTest.mls
@@ -257,15 +257,24 @@ s.slice(0, 0)
 
 // LazyArray on non-arrays
 
+slice(1, 1)("hello")
+//│ = [e, l, l]
+
 val mm = MutMap.empty
 //│ mm = MutMap(Map{})
 
 mm |> MutMap.insert of "a", 1
 
+val uint8Arr = new globalThis.Uint8Array([1, 2, 3, 4, 5]) 
+//│ uint8Arr = 1,2,3,4,5
+
+slice(1, 1)(uint8Arr)
+//│ = [2, 3, 4]
+
 :re
-concat([1, 2, 3], mm)
+concat([1, 2, 3], "hello", uint8Arr, mm)
 //│ ═══[RUNTIME ERROR] Error: Expected an Array, got: MutMap(Map{["a", 1]})
 
 :re
-slice(1, 1)("hello")
-//│ ═══[RUNTIME ERROR] Error: Expected an Array, got: hello
+slice(0, 0)(mm)
+//│ ═══[RUNTIME ERROR] Error: Expected an Array, got: MutMap(Map{["a", 1]})

--- a/hkmc2/shared/src/test/mlscript/std/LazyArrayTest.mls
+++ b/hkmc2/shared/src/test/mlscript/std/LazyArrayTest.mls
@@ -265,7 +265,7 @@ val mm = MutMap.empty
 
 mm |> MutMap.insert of "a", 1
 
-val uint8Arr = new globalThis.Uint8Array([1, 2, 3, 4, 5]) 
+val uint8Arr = new Uint8Array([1, 2, 3, 4, 5]) 
 //│ uint8Arr = 1,2,3,4,5
 
 slice(1, 1)(uint8Arr)

--- a/hkmc2/shared/src/test/mlscript/std/LazyArrayTest.mls
+++ b/hkmc2/shared/src/test/mlscript/std/LazyArrayTest.mls
@@ -1,6 +1,7 @@
 :js
 
 import "../../mlscript-compile/LazyArray.mls"
+import "../../mlscript-compile/MutMap.mls"
 
 open LazyArray
 
@@ -254,3 +255,17 @@ s.slice(0, 0)
 //│ = []
 
 
+// LazyArray on non-arrays
+
+val mm = MutMap.empty
+//│ mm = MutMap(Map{})
+
+mm |> MutMap.insert of "a", 1
+
+:re
+concat([1, 2, 3], mm)
+//│ ═══[RUNTIME ERROR] Error: Expected an Array, got: MutMap(Map{["a", 1]})
+
+:re
+slice(1, 1)("hello")
+//│ ═══[RUNTIME ERROR] Error: Expected an Array, got: hello


### PR DESCRIPTION
In #318, the following requirement was made of users of lazy spreads:
> While lazy spreads will still work with iterables that are not arrays, they require that the iterable is constant-time indexable for reasonable performance, and don't guarantee that the output iterable is the same as the input iterable.

However, since not adhering to this requirement could silently result in reasonable-looking programs having bad asymptotic complexity, let's enforce at runtime that only Arrays and some common array-like constant time indexables are used with LazyArrays.