### PR TITLE
Misc fixes and improvements

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
@@ -98,8 +98,7 @@ class MLsCompiler(preludeFile: os.Path, mkOutput: ((Str => Unit) => Unit) => Uni
         utils.Scope.empty
       // * This line serves for `import.meta.url`, which retrieves directory and file names of mjs files.
       // * Having `module id"import" with ...` in `prelude.mls` will generate `globalThis.import` that is undefined.
-      baseScp.bindings += Elaborator.State.importSymbol -> "import"
-      baseScp.existingNames += "import"
+      baseScp.addToBindings(Elaborator.State.importSymbol, "import")
       val nestedScp = baseScp.nest
       val nme = file.baseName
       val exportedSymbol = parsed.definedSymbols.find(_._1 === nme).map(_._2)

--- a/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
@@ -99,6 +99,7 @@ class MLsCompiler(preludeFile: os.Path, mkOutput: ((Str => Unit) => Unit) => Uni
       // * This line serves for `import.meta.url`, which retrieves directory and file names of mjs files.
       // * Having `module id"import" with ...` in `prelude.mls` will generate `globalThis.import` that is undefined.
       baseScp.bindings += Elaborator.State.importSymbol -> "import"
+      baseScp.existingNames += "import"
       val nestedScp = baseScp.nest
       val nme = file.baseName
       val exportedSymbol = parsed.definedSymbols.find(_._1 === nme).map(_._2)

--- a/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
@@ -98,7 +98,7 @@ class MLsCompiler(preludeFile: os.Path, mkOutput: ((Str => Unit) => Unit) => Uni
         utils.Scope.empty
       // * This line serves for `import.meta.url`, which retrieves directory and file names of mjs files.
       // * Having `module id"import" with ...` in `prelude.mls` will generate `globalThis.import` that is undefined.
-      baseScp.addToBindings(Elaborator.State.importSymbol, "import")
+      baseScp.addToBindings(Elaborator.State.importSymbol, "import", shadow = false)
       val nestedScp = baseScp.nest
       val nme = file.baseName
       val exportedSymbol = parsed.definedSymbols.find(_._1 === nme).map(_._2)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -241,9 +241,13 @@ sealed abstract class Block extends Product with AutoLocated:
         case c: ClsLikeDefn =>
           val newPreCtor = c.preCtor.flattened
           val newCtor = c.ctor.flattened
-          if (newPreCtor is c.preCtor) && (newCtor is c.ctor)
+          val newMethods = c.methods.mapConserve:
+            case f@FunDefn(owner, sym, params, body) =>
+              val newBody = body.flattened
+              if newBody is body then f else f.copy(body = newBody)
+          if (newPreCtor is c.preCtor) && (newCtor is c.ctor) && (newMethods is c.methods)
           then c
-          else c.copy(preCtor = newPreCtor, ctor = newCtor)
+          else c.copy(preCtor = newPreCtor, ctor = newCtor, methods = newMethods)
       
       val newRest = rest.flatten(k)
       if (newDefn is defn) && (newRest is rest)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
@@ -29,6 +29,7 @@ object Printer:
         case Case.Lit(lit) => doc"${lit.idStr}"
         case Case.Cls(cls, path) => doc"${cls.nme}"
         case Case.Tup(len, inf) => doc"tuple$len"
+        case _ => TODO(c)
       val docCases = arms
         .map{ case (c, b) => doc"${case_doc(c)} => #{  # ${mkDocument(b)} #} " }
         .mkDocument(sep = doc" # ")
@@ -56,6 +57,7 @@ object Printer:
       doc"define ${mkDocument(defn)} in # ${mkDocument(rest)}"
     case End("") => doc"end"
     case End(msg) => doc"end ${msg}"
+    case _ => TODO(blk)
   
   def mkDocument(defn: Defn)(using Raise, Scope): Document = defn match
     case FunDefn(own, sym, params, body) =>
@@ -106,6 +108,7 @@ object Printer:
       val docQual = mkDocument(qual)
       doc"${docQual}.${name.name}"
     case x: Value => mkDocument(x)
+    case _ => TODO(path)
 
   def mkDocument(result: Result)(using Raise, Scope): Document = result match
     case Call(fun, args) => doc"${mkDocument(fun)}(${args.map(mkDocument).mkString(", ")})"
@@ -113,10 +116,10 @@ object Printer:
       doc"new ${if mut then "mut " else ""}${mkDocument(cls)}(${args.map(mkDocument).mkString(", ")})"
     case x: Path => mkDocument(x)
   
-  def mkDocument(prog: Program)(using Raise, Scope): Document = {
+  def mkDocument(prog: Program)(using Raise, Scope): Document = summon[Scope].nest.givenIn:
     val docImports = prog.imports.map:
       case (local, path) =>
         val docLocal = summon[Scope].allocateName(local)
         doc"import ${docLocal}"
     doc" ${docImports.mkDocument(sep = doc" # ")} # ${mkDocument(prog.main)}"
-  }
+  

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -236,10 +236,6 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
           case ClsLikeDefn(ownr, isym, sym, kind, paramsOpt, auxParams, par, mtds, privFlds, pubFlds, preCtor, ctor) =>
             val clsParams = paramsOpt.fold(Nil)(_.paramSyms)
             val ctorParams = clsParams.map(p => p -> scope.allocateName(p))
-            val ctorFields = ctorParams.filter: p =>
-              p._1.decl match
-              case S(Param(flags = FldFlags(isVal = true))) => true
-              case _ => false
             val ctorAuxParams = auxParams.map(ps => ps.params.map(p => p.sym -> scope.allocateName(p.sym)))
             
             val isModule = kind is syntax.Mod

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -253,7 +253,7 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
             val privs =
               val scp = isym.asInstanceOf[InnerSymbol].privatesScope
               val privDecls = allPrivFlds.map: fld =>
-                  val nme = scp.allocateName(fld)
+                  val nme = scp.allocateOrGetName(fld)
                   doc" # $mtdPrefix#$nme;"
               val accessors = mutPubFields.flatMap: (valSym, letSym) =>
                 doc" # get ${escapeField(valSym.name, "")}() { return ${getVar(letSym)}; }" ::
@@ -323,7 +323,8 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
                       val result = pss.foldRight(bod):
                         case (ps, block) => 
                           Return(Lam(ps, block), false)
-                      val (params, bodyDoc) = setupFunction(some(td.sym.nme), ps, result)
+                      val (params, bodyDoc) = scope.nest.givenIn:
+                        setupFunction(S(td.sym.nme), ps, result)
                       doc" # $mtdPrefix${td.sym.nme}($params) ${ braced(bodyDoc) }"
                     case td @ FunDefn(_, _, Nil, bod) =>
                       doc" # ${mtdPrefix}get ${td.sym.nme}() ${ braced(body(bod, endSemi = true)) }"
@@ -368,7 +369,7 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
                 case Some(value) => value :: auxParams
               
               val fun = paramsAll match
-                case ps_ :: pss_ if paramsOpt.isDefined =>
+                case ps_ :: pss_ if paramsOpt.isDefined => outerScope.nest.givenIn:
                   val (ps, _) = setupFunction(some(sym.nme), ps_, End())
                   val pss = pss_.map(setupFunction(N, _, End())._1)
                   val paramsDoc = pss.foldLeft(doc"($ps)"):
@@ -689,7 +690,7 @@ trait JSBuilderArgNumSanityChecks(using Config, Elaborator.State)
     if instrument then
       val paramsList = params.params.map(p => Scope.scope.allocateName(p.sym))
       val paramRest = params.restParam.map(p => Scope.scope.allocateName(p.sym))
-      val paramsStr = Scope.scope.allocateName(functionParamVarargSymbol)
+      val paramsStr = Scope.scope.allocateName(functionParamVarargSymbol, shadow = true)
       val functionName = JSBuilder.makeStringLiteral(name.fold("")(n => s"${JSBuilder.escapeStringCharacters(n)}"))
       val checkArgsNum = doc"\n$runtimeVar.checkArgs($functionName, ${params.paramCountLB}, ${params.paramCountUB.toString}, $paramsStr.length);"
       val paramsAssign = paramsList.zipWithIndex.map{(nme, i) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
@@ -99,7 +99,7 @@ abstract class BlockLocalSymbol(name: Str)(using State) extends FlowSymbol(name)
   var decl: Opt[Declaration] = N
 
 class TempSymbol(val trm: Opt[Term], dbgNme: Str = "tmp")(using State) extends BlockLocalSymbol(dbgNme) with LocalSymbol:
-  val nameHints: MutSet[Str] = MutSet.empty
+  // val nameHints: MutSet[Str] = MutSet.empty // * May be useful later?
   override def toLoc: Option[Loc] = trm.flatMap(_.toLoc)
   override def toString: Str = s"$$${super.toString}"
   override def subst(using s: SymbolSubst): TempSymbol = s.mapTempSym(this)

--- a/hkmc2/shared/src/main/scala/hkmc2/syntax/Tree.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/syntax/Tree.scala
@@ -327,7 +327,7 @@ object Tree:
   val DummyApp: App = App(Dummy, Dummy) // TODO change the places where this is used
   val DummyTup: Tup = Tup(Dummy :: Nil)
   def DummyTypeDef(k: TypeDefKind)(using State): TypeDef =
-    Tree.TypeDef(syntax.Cls, Tree.Dummy, N)
+    Tree.TypeDef(k, Tree.Dummy, N)
   object Block:
     def mk(stmts: Ls[Tree])(using State): Tree = stmts match
       case Nil => UnitLit(false)

--- a/hkmc2/shared/src/main/scala/hkmc2/utils/Scope.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/utils/Scope.scala
@@ -1,7 +1,7 @@
 package hkmc2
 package utils
 
-import scala.collection.mutable.{Map => MutMap}
+import scala.collection.mutable.{Map => MutMap, Set => MutSet}
 
 import mlscript.utils.*, shorthands.*
 import utils.*
@@ -25,6 +25,8 @@ import hkmc2.codegen.js.JSBuilder
 class Scope
     (val parent: Opt[Scope], val curThis: Opt[Opt[InnerSymbol]], val bindings: MutMap[Local, Str])
     (using State):
+  
+  val existingNames = MutSet.empty[Str]
   
   private var thisProxyAccessed = false
   lazy val thisProxy =
@@ -84,9 +86,9 @@ class Scope
     case S(outer) =>
       (if outer.thisProxyAccessed then S(outer.thisProxy) else N, res)
   
-  // TODO more efficient!
+  
   def inScope(name: Str): Bool =
-    bindings.valuesIterator.contains(name) || parent.exists(_.inScope(name))
+    existingNames.contains(name) || parent.exists(_.inScope(name))
   
   def lookup(l: Local): Opt[Str] =
     // curThis.filter(_ is l).map(_ => thisProxy) orElse
@@ -123,6 +125,7 @@ class Scope
         (1 to Int.MaxValue).iterator.map(i => s"$realBase$i").filterNot(inScope).next
     
     bindings += l -> name
+    existingNames += name
     
     name
 

--- a/hkmc2/shared/src/main/scala/hkmc2/utils/Scope.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/utils/Scope.scala
@@ -21,8 +21,9 @@ import hkmc2.codegen.js.JSBuilder
   * When `curThis` is Some(None), it means the scope rebinds `this`
   * to something unknown, following JavaScript's inane `this` handling in `function`s.
   * When `curThis` is Some(Some(sym)), it means the scope rebinds `this`
-  * to an inner symbol (e.g., class or module). */
-class Scope
+  * to an inner symbol (e.g., class or module).
+  * Note: I made `Scope` a case class just so that it can benefit from `printAsTree`. */
+case class Scope
     (val parent: Opt[Scope], val curThis: Opt[Opt[InnerSymbol]], private val bindings: MutMap[Local, Str])
     (using State):
   
@@ -45,7 +46,8 @@ class Scope
       source = Diagnostic.Source.Compilation))
     die
   
-  def addToBindings(symbol: Local, name: String) =
+  def addToBindings(symbol: Local, name: String, shadow: Bool) =
+    if !shadow then assert(lookup(symbol).isEmpty, (symbol, this.showAsTree))
     bindings += symbol -> name
     existingNames += name
   
@@ -112,7 +114,11 @@ class Scope
         source = Diagnostic.Source.Compilation))
       l.nme
   
-  def allocateName(l: Local, prefix: Str = ""): Str =
+  // * Note: it is sound for an existing name to have been allocated with a different prefix (which is only cosmetic)
+  def allocateOrGetName(l: Local, prefix: Str = ""): Str =
+    lookup(l).getOrElse(allocateName(l, prefix = prefix))
+  
+  def allocateName(l: Local, prefix: Str = "", shadow: Bool = false): Str =
     
     val base: Str = l match
       case tmp: semantics.TempSymbol if tmp.nameHints.sizeCompare(1) === 0 =>
@@ -128,7 +134,7 @@ class Scope
         // Try realBase with an integer.
         (1 to Int.MaxValue).iterator.map(i => s"$realBase$i").filterNot(inScope).next
     
-    addToBindings(l, name)
+    addToBindings(l, name, shadow = shadow)
     
     name
 

--- a/hkmc2/shared/src/main/scala/hkmc2/utils/Scope.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/utils/Scope.scala
@@ -120,10 +120,14 @@ case class Scope
   
   def allocateName(l: Local, prefix: Str = "", shadow: Bool = false): Str =
     
+    // Maybe useful later?
+    /* 
     val base: Str = l match
-      case tmp: semantics.TempSymbol if tmp.nameHints.sizeCompare(1) === 0 =>
+      case tmp: semantics.TempSymbol if tmp.nameHints.sizeCompare(1) =/= 0 =>
         prefix + tmp.nameHints.head
       case _ => if l.nme.isEmpty && prefix.isEmpty then "tmp" else prefix + l.nme
+    */
+    val base = if l.nme.isEmpty && prefix.isEmpty then "tmp" else prefix + l.nme
     
     val realBase = Scope.replaceInvalidCharacters(base)
     

--- a/hkmc2/shared/src/main/scala/hkmc2/utils/Scope.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/utils/Scope.scala
@@ -23,10 +23,10 @@ import hkmc2.codegen.js.JSBuilder
   * When `curThis` is Some(Some(sym)), it means the scope rebinds `this`
   * to an inner symbol (e.g., class or module). */
 class Scope
-    (val parent: Opt[Scope], val curThis: Opt[Opt[InnerSymbol]], val bindings: MutMap[Local, Str])
+    (val parent: Opt[Scope], val curThis: Opt[Opt[InnerSymbol]], private val bindings: MutMap[Local, Str])
     (using State):
   
-  val existingNames = MutSet.empty[Str]
+  private val existingNames = MutSet.empty[Str]
   
   private var thisProxyAccessed = false
   lazy val thisProxy =
@@ -44,6 +44,10 @@ class Scope
     raise(InternalError(msg"`this` not in scope: ${thisSym.toString}" -> N :: Nil,
       source = Diagnostic.Source.Compilation))
     die
+  
+  def addToBindings(symbol: Local, name: String) =
+    bindings += symbol -> name
+    existingNames += name
   
   def findThis_!(thisSym: InnerSymbol)(using Raise): Str =
     // println(s"findThis_! $thisSym")
@@ -124,8 +128,7 @@ class Scope
         // Try realBase with an integer.
         (1 to Int.MaxValue).iterator.map(i => s"$realBase$i").filterNot(inScope).next
     
-    bindings += l -> name
-    existingNames += name
+    addToBindings(l, name)
     
     name
 

--- a/hkmc2/shared/src/main/scala/hkmc2/utils/Scope.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/utils/Scope.scala
@@ -120,7 +120,7 @@ case class Scope
   
   def allocateName(l: Local, prefix: Str = "", shadow: Bool = false): Str =
     
-    // Maybe useful later?
+    // * May be useful later?
     /* 
     val base: Str = l match
       case tmp: semantics.TempSymbol if tmp.nameHints.sizeCompare(1) =/= 0 =>

--- a/hkmc2/shared/src/test/mlscript-compile/Predef.mjs
+++ b/hkmc2/shared/src/test/mlscript-compile/Predef.mjs
@@ -37,58 +37,58 @@ let Predef1;
   static apply(f, ...args) {
     return runtime.safeCall(f(...args))
   } 
-  static pipeInto(x1, f1) {
-    return runtime.safeCall(f1(x1))
+  static pipeInto(x, f) {
+    return runtime.safeCall(f(x))
   } 
-  static pipeFrom(f2, x2) {
-    return runtime.safeCall(f2(x2))
+  static pipeFrom(f, x) {
+    return runtime.safeCall(f(x))
   } 
-  static pipeIntoHi(x3, f3) {
-    return runtime.safeCall(f3(x3))
+  static pipeIntoHi(x, f) {
+    return runtime.safeCall(f(x))
   } 
-  static pipeFromHi(f4, x4) {
-    return runtime.safeCall(f4(x4))
+  static pipeFromHi(f, x) {
+    return runtime.safeCall(f(x))
   } 
-  static tap(x5, f5) {
+  static tap(x, f) {
     let tmp;
-    tmp = runtime.safeCall(f5(x5));
-    return (tmp , x5)
+    tmp = runtime.safeCall(f(x));
+    return (tmp , x)
   } 
-  static pat(f6, x6) {
+  static pat(f, x) {
     let tmp;
-    tmp = runtime.safeCall(f6(x6));
-    return (tmp , x6)
+    tmp = runtime.safeCall(f(x));
+    return (tmp , x)
   } 
-  static alsoDo(x7, eff) {
-    return x7
+  static alsoDo(x, eff) {
+    return x
   } 
-  static andThen(f7, g) {
-    return (x8) => {
+  static andThen(f, g) {
+    return (x) => {
       let tmp;
-      tmp = runtime.safeCall(f7(x8));
+      tmp = runtime.safeCall(f(x));
       return runtime.safeCall(g(tmp))
     }
   } 
-  static compose(f8, g1) {
-    return (x8) => {
+  static compose(f, g) {
+    return (x) => {
       let tmp;
-      tmp = runtime.safeCall(g1(x8));
-      return runtime.safeCall(f8(tmp))
+      tmp = runtime.safeCall(g(x));
+      return runtime.safeCall(f(tmp))
     }
   } 
-  static passTo(receiver, f9) {
-    return (...args1) => {
-      return runtime.safeCall(f9(receiver, ...args1))
+  static passTo(receiver, f) {
+    return (...args) => {
+      return runtime.safeCall(f(receiver, ...args))
     }
   } 
-  static passToLo(receiver1, f10) {
-    return (...args1) => {
-      return runtime.safeCall(f10(receiver1, ...args1))
+  static passToLo(receiver, f) {
+    return (...args) => {
+      return runtime.safeCall(f(receiver, ...args))
     }
   } 
-  static call(receiver2, f11) {
-    return (...args1) => {
-      return f11.call(receiver2, ...args1)
+  static call(receiver, f) {
+    return (...args) => {
+      return f.call(receiver, ...args)
     }
   } 
   static print(...xs) {
@@ -112,10 +112,10 @@ let Predef1;
   static get notImplementedError() {
     throw globalThis.Error("Not implemented");
   } 
-  static tuple(...xs1) {
-    return xs1
+  static tuple(...xs) {
+    return xs
   } 
-  static foldr(f12) {
+  static foldr(f) {
     return (first, ...rest) => {
       let len, i, init, scrut, scrut1, tmp, tmp1, tmp2, tmp3, tmp4, tmp5;
       len = rest.length;
@@ -133,7 +133,7 @@ let Predef1;
             tmp2 = i - 1;
             i = tmp2;
             tmp3 = runtime.safeCall(rest.at(i));
-            tmp4 = runtime.safeCall(f12(tmp3, init));
+            tmp4 = runtime.safeCall(f(tmp3, init));
             init = tmp4;
             tmp5 = runtime.Unit;
             continue tmp6
@@ -142,26 +142,26 @@ let Predef1;
           }
           break;
         }
-        return runtime.safeCall(f12(first, init))
+        return runtime.safeCall(f(first, init))
       }
     }
   } 
-  static mkStr(...xs2) {
+  static mkStr(...xs) {
     let tmp, tmp1, lambda;
-    lambda = (undefined, function (acc, x8) {
+    lambda = (undefined, function (acc, x) {
       let tmp2, tmp3, tmp4;
-      if (typeof x8 === 'string') {
+      if (typeof x === 'string') {
         tmp2 = true;
       } else {
         tmp2 = false;
       }
       tmp3 = runtime.safeCall(Predef.assert(tmp2));
-      tmp4 = acc + x8;
+      tmp4 = acc + x;
       return (tmp3 , tmp4)
     });
     tmp = lambda;
     tmp1 = runtime.safeCall(Predef.fold(tmp));
-    return runtime.safeCall(tmp1(...xs2))
+    return runtime.safeCall(tmp1(...xs))
   } 
   static use(instance) {
     return instance

--- a/hkmc2/shared/src/test/mlscript-compile/Runtime.mjs
+++ b/hkmc2/shared/src/test/mlscript-compile/Runtime.mjs
@@ -41,8 +41,8 @@ let Runtime1;
     this.short_and = RuntimeJS.short_and;
     this.short_or = RuntimeJS.short_or;
     this.try_catch = RuntimeJS.try_catch;
-    this.EffectHandle = function EffectHandle(_reified1) {
-      return globalThis.Object.freeze(new EffectHandle.class(_reified1));
+    this.EffectHandle = function EffectHandle(_reified) {
+      return globalThis.Object.freeze(new EffectHandle.class(_reified));
     };
     Object.defineProperty(this.EffectHandle, "class", {
       enumerable: true,
@@ -69,8 +69,8 @@ let Runtime1;
         static [definitionMetadata] = ["class", "EffectHandle", [null]]; 
       }
     });
-    this.MatchResult = function MatchResult(output1, bindings1) {
-      return globalThis.Object.freeze(new MatchResult.class(output1, bindings1));
+    this.MatchResult = function MatchResult(output, bindings) {
+      return globalThis.Object.freeze(new MatchResult.class(output, bindings));
     };
     Object.defineProperty(this.MatchResult, "class", {
       enumerable: true,
@@ -83,8 +83,8 @@ let Runtime1;
         static [definitionMetadata] = ["class", "MatchResult", ["output", "bindings"]]; 
       }
     });
-    this.MatchFailure = function MatchFailure(errors1) {
-      return globalThis.Object.freeze(new MatchFailure.class(errors1));
+    this.MatchFailure = function MatchFailure(errors) {
+      return globalThis.Object.freeze(new MatchFailure.class(errors));
     };
     Object.defineProperty(this.MatchFailure, "class", {
       enumerable: true,
@@ -106,33 +106,33 @@ let Runtime1;
         tmp = xs.length - j;
         return xs.slice(i, tmp)
       } 
-      static lazySlice(xs1, i1, j1) {
+      static lazySlice(xs, i, j) {
         let tmp;
-        tmp = LazyArray.dropLeftRight(i1, j1);
-        return runtime.safeCall(tmp(xs1))
+        tmp = LazyArray.dropLeftRight(i, j);
+        return runtime.safeCall(tmp(xs))
       } 
       static lazyConcat(...args) {
         return runtime.safeCall(LazyArray.__concat(...args))
       } 
-      static get(xs2, i2) {
+      static get(xs, i) {
         let scrut, scrut1, tmp, tmp1, tmp2;
-        scrut = i2 >= xs2.length;
+        scrut = i >= xs.length;
         if (scrut === true) {
           throw globalThis.RangeError("Tuple.get: index out of bounds")
         } else {
           tmp = runtime.Unit;
         }
-        tmp1 = - xs2.length;
-        scrut1 = i2 < tmp1;
+        tmp1 = - xs.length;
+        scrut1 = i < tmp1;
         if (scrut1 === true) {
           throw globalThis.RangeError("Tuple.get: negative index out of bounds")
         } else {
           tmp2 = runtime.Unit;
         }
-        return xs2.at(i2)
+        return xs.at(i)
       } 
-      static isArrayLike(xs3) {
-        return runtime.safeCall(Iter.isArrayLike(xs3))
+      static isArrayLike(xs) {
+        return runtime.safeCall(Iter.isArrayLike(xs))
       }
       static toString() { return runtime.render(this); }
       static [definitionMetadata] = ["module", "Tuple"]; 
@@ -144,20 +144,20 @@ let Runtime1;
       static startsWith(string, prefix) {
         return runtime.safeCall(string.startsWith(prefix))
       } 
-      static get(string1, i) {
+      static get(string, i) {
         let scrut;
-        scrut = i >= string1.length;
+        scrut = i >= string.length;
         if (scrut === true) {
           throw globalThis.RangeError("Str.get: index out of bounds")
         } else {
-          return runtime.safeCall(string1.at(i))
+          return runtime.safeCall(string.at(i))
         }
       } 
-      static take(string2, n) {
-        return string2.slice(0, n)
+      static take(string, n) {
+        return string.slice(0, n)
       } 
-      static leave(string3, n1) {
-        return runtime.safeCall(string3.slice(n1))
+      static leave(string, n) {
+        return runtime.safeCall(string.slice(n))
       }
       static toString() { return runtime.render(this); }
       static [definitionMetadata] = ["module", "Str"]; 
@@ -234,8 +234,8 @@ let Runtime1;
       static [definitionMetadata] = ["object", "PrintStackEffect"]; 
     };
     this.PrintStackEffect = globalThis.Object.freeze(new PrintStackEffect$class);
-    this.FunctionContFrame = function FunctionContFrame(next1) {
-      return globalThis.Object.freeze(new FunctionContFrame.class(next1));
+    this.FunctionContFrame = function FunctionContFrame(next) {
+      return globalThis.Object.freeze(new FunctionContFrame.class(next));
     };
     Object.defineProperty(this.FunctionContFrame, "class", {
       enumerable: true,
@@ -247,8 +247,8 @@ let Runtime1;
         static [definitionMetadata] = ["class", "FunctionContFrame", ["next"]]; 
       }
     });
-    this.HandlerContFrame = function HandlerContFrame(next1, nextHandler1, handler1) {
-      return globalThis.Object.freeze(new HandlerContFrame.class(next1, nextHandler1, handler1));
+    this.HandlerContFrame = function HandlerContFrame(next, nextHandler, handler) {
+      return globalThis.Object.freeze(new HandlerContFrame.class(next, nextHandler, handler));
     };
     Object.defineProperty(this.HandlerContFrame, "class", {
       enumerable: true,
@@ -262,8 +262,8 @@ let Runtime1;
         static [definitionMetadata] = ["class", "HandlerContFrame", ["next", "nextHandler", "handler"]]; 
       }
     });
-    this.ContTrace = function ContTrace(next1, last1, nextHandler1, lastHandler1, resumed1) {
-      return globalThis.Object.freeze(new ContTrace.class(next1, last1, nextHandler1, lastHandler1, resumed1));
+    this.ContTrace = function ContTrace(next, last, nextHandler, lastHandler, resumed) {
+      return globalThis.Object.freeze(new ContTrace.class(next, last, nextHandler, lastHandler, resumed));
     };
     Object.defineProperty(this.ContTrace, "class", {
       enumerable: true,
@@ -279,8 +279,8 @@ let Runtime1;
         static [definitionMetadata] = ["class", "ContTrace", ["next", "last", "nextHandler", "lastHandler", "resumed"]]; 
       }
     });
-    this.EffectSig = function EffectSig(contTrace1, handler1, handlerFun1) {
-      return globalThis.Object.freeze(new EffectSig.class(contTrace1, handler1, handlerFun1));
+    this.EffectSig = function EffectSig(contTrace, handler, handlerFun) {
+      return globalThis.Object.freeze(new EffectSig.class(contTrace, handler, handlerFun));
     };
     Object.defineProperty(this.EffectSig, "class", {
       enumerable: true,
@@ -299,8 +299,8 @@ let Runtime1;
       toString() { return runtime.render(this); }
       static [definitionMetadata] = ["class", "NonLocalReturn"]; 
     };
-    this.FnLocalsInfo = function FnLocalsInfo(fnName1, locals1) {
-      return globalThis.Object.freeze(new FnLocalsInfo.class(fnName1, locals1));
+    this.FnLocalsInfo = function FnLocalsInfo(fnName, locals) {
+      return globalThis.Object.freeze(new FnLocalsInfo.class(fnName, locals));
     };
     Object.defineProperty(this.FnLocalsInfo, "class", {
       enumerable: true,
@@ -313,8 +313,8 @@ let Runtime1;
         static [definitionMetadata] = ["class", "FnLocalsInfo", ["fnName", "locals"]]; 
       }
     });
-    this.LocalVarInfo = function LocalVarInfo(localName1, value1) {
-      return globalThis.Object.freeze(new LocalVarInfo.class(localName1, value1));
+    this.LocalVarInfo = function LocalVarInfo(localName, value) {
+      return globalThis.Object.freeze(new LocalVarInfo.class(localName, value));
     };
     Object.defineProperty(this.LocalVarInfo, "class", {
       enumerable: true,
@@ -405,11 +405,11 @@ let Runtime1;
       return x
     }
   } 
-  static checkCall(x1) {
-    if (x1 === undefined) {
+  static checkCall(x) {
+    if (x === undefined) {
       throw globalThis.Error("MLscript call unexpectedly returned `undefined`, the forbidden value.")
     } else {
-      return x1
+      return x
     }
   } 
   static deboundMethod(mtdName, clsName) {
@@ -430,9 +430,9 @@ let Runtime1;
       return res
     }
   } 
-  static printRaw(x2) {
+  static printRaw(x) {
     let tmp;
-    tmp = Runtime.render(x2, globalThis.Object.freeze({
+    tmp = Runtime.render(x, globalThis.Object.freeze({
       indent: 2,
       breakLength: 76
     }));
@@ -465,12 +465,12 @@ let Runtime1;
       return tr
     }
   } 
-  static showStackTrace(header, tr1, debug1, showLocals1) {
+  static showStackTrace(header, tr, debug, showLocals) {
     let msg, curHandler, atTail, scrut, cur, scrut1, locals, curLocals, loc, loc1, localsMsg, scrut2, scrut3, tmp, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8, tmp9, tmp10, tmp11, tmp12, tmp13, tmp14, tmp15, tmp16, tmp17, tmp18, tmp19, lambda;
     msg = header;
-    curHandler = tr1.contTrace;
+    curHandler = tr.contTrace;
     atTail = true;
-    if (debug1 === true) {
+    if (debug === true) {
       tmp20: while (true) {
         scrut = curHandler !== null;
         if (scrut === true) {
@@ -489,7 +489,7 @@ let Runtime1;
                 tmp2 = loc;
               }
               loc1 = tmp2;
-              if (showLocals1 === true) {
+              if (showLocals === true) {
                 scrut2 = curLocals.locals.length > 0;
                 if (scrut2 === true) {
                   lambda = (undefined, function (l) {
@@ -604,13 +604,13 @@ let Runtime1;
       }
     }
   } 
-  static showHandlerContChain(cont1, hl1, vis1, reps1) {
+  static showHandlerContChain(cont, hl, vis, reps) {
     let scrut, result, scrut1, scrut2, tmp, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, lambda;
-    if (cont1 instanceof Runtime.HandlerContFrame.class) {
-      result = cont1.handler.constructor.name;
+    if (cont instanceof Runtime.HandlerContFrame.class) {
+      result = cont.handler.constructor.name;
       lambda = (undefined, function (m, marker) {
         let scrut3, tmp8, tmp9;
-        scrut3 = runtime.safeCall(m.has(cont1));
+        scrut3 = runtime.safeCall(m.has(cont));
         if (scrut3 === true) {
           tmp8 = ", " + marker;
           tmp9 = result + tmp8;
@@ -621,12 +621,12 @@ let Runtime1;
         }
       });
       tmp = lambda;
-      tmp1 = runtime.safeCall(hl1.forEach(tmp));
-      scrut1 = runtime.safeCall(vis1.has(cont1));
+      tmp1 = runtime.safeCall(hl.forEach(tmp));
+      scrut1 = runtime.safeCall(vis.has(cont));
       if (scrut1 === true) {
-        tmp2 = reps1 + 1;
-        reps1 = tmp2;
-        scrut2 = reps1 > 10;
+        tmp2 = reps + 1;
+        reps = tmp2;
+        scrut2 = reps > 10;
         if (scrut2 === true) {
           throw globalThis.Error("10 repeated continuation frame (loop?)")
         } else {
@@ -636,13 +636,13 @@ let Runtime1;
         result = tmp4;
         tmp5 = runtime.Unit;
       } else {
-        tmp5 = runtime.safeCall(vis1.add(cont1));
+        tmp5 = runtime.safeCall(vis.add(cont));
       }
       tmp6 = result + " -> ";
-      tmp7 = Runtime.showFunctionContChain(cont1.next, hl1, vis1, reps1);
+      tmp7 = Runtime.showFunctionContChain(cont.next, hl, vis, reps);
       return tmp6 + tmp7
     } else {
-      scrut = cont1 === null;
+      scrut = cont === null;
       if (scrut === true) {
         return "(null)"
       } else {
@@ -650,22 +650,22 @@ let Runtime1;
       }
     }
   } 
-  static debugCont(cont2) {
+  static debugCont(cont) {
     let tmp, tmp1, tmp2;
     tmp = globalThis.Object.freeze(new globalThis.Map());
     tmp1 = globalThis.Object.freeze(new globalThis.Set());
-    tmp2 = Runtime.showFunctionContChain(cont2, tmp, tmp1, 0);
+    tmp2 = Runtime.showFunctionContChain(cont, tmp, tmp1, 0);
     return runtime.safeCall(globalThis.console.log(tmp2))
   } 
-  static debugHandler(cont3) {
+  static debugHandler(cont) {
     let tmp, tmp1, tmp2;
     tmp = globalThis.Object.freeze(new globalThis.Map());
     tmp1 = globalThis.Object.freeze(new globalThis.Set());
-    tmp2 = Runtime.showHandlerContChain(cont3, tmp, tmp1, 0);
+    tmp2 = Runtime.showHandlerContChain(cont, tmp, tmp1, 0);
     return runtime.safeCall(globalThis.console.log(tmp2))
   } 
   static debugContTrace(contTrace) {
-    let scrut, scrut1, vis2, hl2, cur, scrut2, tmp, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8, tmp9, tmp10, tmp11, tmp12, tmp13, tmp14;
+    let scrut, scrut1, vis, hl, cur, scrut2, tmp, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8, tmp9, tmp10, tmp11, tmp12, tmp13, tmp14;
     if (contTrace instanceof Runtime.ContTrace.class) {
       tmp = globalThis.console.log("resumed: ", contTrace.resumed);
       scrut = contTrace.last === contTrace;
@@ -681,24 +681,24 @@ let Runtime1;
         tmp2 = runtime.Unit;
       }
       tmp3 = globalThis.Object.freeze(new globalThis.Set());
-      vis2 = tmp3;
+      vis = tmp3;
       tmp4 = globalThis.Object.freeze(new globalThis.Map());
-      hl2 = tmp4;
+      hl = tmp4;
       tmp5 = globalThis.Object.freeze(new globalThis.Set(globalThis.Object.freeze([
         contTrace.last
       ])));
-      tmp6 = hl2.set("last", tmp5);
+      tmp6 = hl.set("last", tmp5);
       tmp7 = globalThis.Object.freeze(new globalThis.Set(globalThis.Object.freeze([
         contTrace.lastHandler
       ])));
-      tmp8 = hl2.set("last-handler", tmp7);
-      tmp9 = Runtime.showFunctionContChain(contTrace.next, hl2, vis2, 0);
+      tmp8 = hl.set("last-handler", tmp7);
+      tmp9 = Runtime.showFunctionContChain(contTrace.next, hl, vis, 0);
       tmp10 = runtime.safeCall(globalThis.console.log(tmp9));
       cur = contTrace.nextHandler;
       tmp15: while (true) {
         scrut2 = cur !== null;
         if (scrut2 === true) {
-          tmp11 = Runtime.showHandlerContChain(cur, hl2, vis2, 0);
+          tmp11 = Runtime.showHandlerContChain(cur, hl, vis, 0);
           tmp12 = runtime.safeCall(globalThis.console.log(tmp11));
           cur = cur.nextHandler;
           tmp13 = runtime.Unit;
@@ -735,54 +735,54 @@ let Runtime1;
     res.contTrace.lastHandler = res.contTrace;
     return res
   } 
-  static handleBlockImpl(cur, handler1) {
+  static handleBlockImpl(cur, handler) {
     let handlerFrame, tmp;
-    tmp = new Runtime.HandlerContFrame.class(null, null, handler1);
+    tmp = new Runtime.HandlerContFrame.class(null, null, handler);
     handlerFrame = tmp;
     cur.contTrace.lastHandler.nextHandler = handlerFrame;
     cur.contTrace.lastHandler = handlerFrame;
     cur.contTrace.last = handlerFrame;
     return Runtime.handleEffects(cur)
   } 
-  static enterHandleBlock(handler2, body) {
-    let cur1, tmp;
+  static enterHandleBlock(handler, body) {
+    let cur, tmp;
     tmp = runtime.safeCall(body());
-    cur1 = tmp;
-    if (cur1 instanceof Runtime.EffectSig.class) {
-      return Runtime.handleBlockImpl(cur1, handler2)
+    cur = tmp;
+    if (cur instanceof Runtime.EffectSig.class) {
+      return Runtime.handleBlockImpl(cur, handler)
     } else {
-      return cur1
+      return cur
     }
   } 
-  static handleEffects(cur1) {
+  static handleEffects(cur) {
     let nxt, scrut, tmp, tmp1, tmp2;
     tmp3: while (true) {
-      if (cur1 instanceof Runtime.EffectSig.class) {
-        tmp = Runtime.handleEffect(cur1);
+      if (cur instanceof Runtime.EffectSig.class) {
+        tmp = Runtime.handleEffect(cur);
         nxt = tmp;
-        scrut = cur1 === nxt;
+        scrut = cur === nxt;
         if (scrut === true) {
-          return cur1
+          return cur
         } else {
-          cur1 = nxt;
+          cur = nxt;
           tmp1 = runtime.Unit;
         }
         tmp2 = tmp1;
         continue tmp3
       } else {
-        return cur1
+        return cur
       }
       break;
     }
     return tmp2
   } 
-  static handleEffect(cur2) {
+  static handleEffect(cur) {
     let prevHandlerFrame, scrut, scrut1, scrut2, handlerFrame, saved, scrut3, scrut4, tmp, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6;
-    prevHandlerFrame = cur2.contTrace;
+    prevHandlerFrame = cur.contTrace;
     tmp7: while (true) {
       scrut = prevHandlerFrame.nextHandler !== null;
       if (scrut === true) {
-        scrut1 = prevHandlerFrame.nextHandler.handler !== cur2.handler;
+        scrut1 = prevHandlerFrame.nextHandler.handler !== cur.handler;
         if (scrut1 === true) {
           prevHandlerFrame = prevHandlerFrame.nextHandler;
           tmp = runtime.Unit;
@@ -797,91 +797,91 @@ let Runtime1;
     }
     scrut2 = prevHandlerFrame.nextHandler === null;
     if (scrut2 === true) {
-      return cur2
+      return cur
     } else {
       tmp1 = runtime.Unit;
     }
     handlerFrame = prevHandlerFrame.nextHandler;
-    tmp2 = new Runtime.ContTrace.class(handlerFrame.next, cur2.contTrace.last, handlerFrame.nextHandler, cur2.contTrace.lastHandler, false);
+    tmp2 = new Runtime.ContTrace.class(handlerFrame.next, cur.contTrace.last, handlerFrame.nextHandler, cur.contTrace.lastHandler, false);
     saved = tmp2;
-    cur2.contTrace.last = handlerFrame;
-    cur2.contTrace.lastHandler = handlerFrame;
+    cur.contTrace.last = handlerFrame;
+    cur.contTrace.lastHandler = handlerFrame;
     handlerFrame.next = null;
     handlerFrame.nextHandler = null;
-    tmp3 = Runtime.resume(cur2.contTrace);
-    tmp4 = runtime.safeCall(cur2.handlerFun(tmp3));
-    cur2 = tmp4;
-    if (cur2 instanceof Runtime.EffectSig.class) {
+    tmp3 = Runtime.resume(cur.contTrace);
+    tmp4 = runtime.safeCall(cur.handlerFun(tmp3));
+    cur = tmp4;
+    if (cur instanceof Runtime.EffectSig.class) {
       scrut3 = saved.next !== null;
       if (scrut3 === true) {
-        cur2.contTrace.last.next = saved.next;
-        cur2.contTrace.last = saved.last;
+        cur.contTrace.last.next = saved.next;
+        cur.contTrace.last = saved.last;
         tmp5 = runtime.Unit;
       } else {
         tmp5 = runtime.Unit;
       }
       scrut4 = saved.nextHandler !== null;
       if (scrut4 === true) {
-        cur2.contTrace.lastHandler.nextHandler = saved.nextHandler;
-        cur2.contTrace.lastHandler = saved.lastHandler;
+        cur.contTrace.lastHandler.nextHandler = saved.nextHandler;
+        cur.contTrace.lastHandler = saved.lastHandler;
         tmp6 = runtime.Unit;
       } else {
         tmp6 = runtime.Unit;
       }
-      return cur2
+      return cur
     } else {
-      return Runtime.resumeContTrace(saved, cur2)
+      return Runtime.resumeContTrace(saved, cur)
     }
   } 
-  static resume(contTrace1) {
+  static resume(contTrace) {
     return (value) => {
       let scrut, tmp, tmp1;
-      scrut = contTrace1.resumed;
+      scrut = contTrace.resumed;
       if (scrut === true) {
         throw globalThis.Error("Multiple resumption")
       } else {
         tmp = runtime.Unit;
       }
-      contTrace1.resumed = true;
-      tmp1 = Runtime.resumeContTrace(contTrace1, value);
+      contTrace.resumed = true;
+      tmp1 = Runtime.resumeContTrace(contTrace, value);
       return Runtime.handleEffects(tmp1)
     }
   } 
-  static resumeContTrace(contTrace2, value) {
-    let cont4, handlerCont, scrut, scrut1, tmp, tmp1, tmp2, tmp3, tmp4;
-    cont4 = contTrace2.next;
-    handlerCont = contTrace2.nextHandler;
+  static resumeContTrace(contTrace, value) {
+    let cont, handlerCont, scrut, scrut1, tmp, tmp1, tmp2, tmp3, tmp4;
+    cont = contTrace.next;
+    handlerCont = contTrace.nextHandler;
     tmp5: while (true) {
-      if (cont4 instanceof Runtime.FunctionContFrame.class) {
-        tmp = runtime.safeCall(cont4.resume(value));
+      if (cont instanceof Runtime.FunctionContFrame.class) {
+        tmp = runtime.safeCall(cont.resume(value));
         value = tmp;
         if (value instanceof Runtime.EffectSig.class) {
-          value.contTrace.last.next = cont4.next;
+          value.contTrace.last.next = cont.next;
           value.contTrace.lastHandler.nextHandler = handlerCont;
-          scrut = contTrace2.last !== cont4;
+          scrut = contTrace.last !== cont;
           if (scrut === true) {
-            value.contTrace.last = contTrace2.last;
+            value.contTrace.last = contTrace.last;
             tmp1 = runtime.Unit;
           } else {
             tmp1 = runtime.Unit;
           }
           scrut1 = handlerCont !== null;
           if (scrut1 === true) {
-            value.contTrace.lastHandler = contTrace2.lastHandler;
+            value.contTrace.lastHandler = contTrace.lastHandler;
             tmp2 = runtime.Unit;
           } else {
             tmp2 = runtime.Unit;
           }
           return value
         } else {
-          cont4 = cont4.next;
+          cont = cont.next;
           tmp3 = runtime.Unit;
         }
         tmp4 = tmp3;
         continue tmp5
       } else {
         if (handlerCont instanceof Runtime.HandlerContFrame.class) {
-          cont4 = handlerCont.next;
+          cont = handlerCont.next;
           handlerCont = handlerCont.nextHandler;
           tmp4 = runtime.Unit;
           continue tmp5
@@ -919,26 +919,26 @@ let Runtime1;
     }
     return tmp
   } 
-  static runStackSafe(limit, f1) {
-    let result, scrut, saved, tmp1, tmp2, tmp3;
+  static runStackSafe(limit, f) {
+    let result, scrut, saved, tmp, tmp1, tmp2;
     Runtime.stackLimit = limit;
     Runtime.stackDepth = 1;
     Runtime.stackOffset = 0;
     Runtime.stackHandler = Runtime.StackDelayHandler;
-    tmp1 = Runtime.enterHandleBlock(Runtime.StackDelayHandler, f1);
-    result = tmp1;
-    tmp4: while (true) {
+    tmp = Runtime.enterHandleBlock(Runtime.StackDelayHandler, f);
+    result = tmp;
+    tmp3: while (true) {
       scrut = Runtime.stackResume !== null;
       if (scrut === true) {
         saved = Runtime.stackResume;
         Runtime.stackResume = null;
         Runtime.stackOffset = Runtime.stackDepth;
-        tmp2 = runtime.safeCall(saved());
-        result = tmp2;
-        tmp3 = runtime.Unit;
-        continue tmp4
+        tmp1 = runtime.safeCall(saved());
+        result = tmp1;
+        tmp2 = runtime.Unit;
+        continue tmp3
       } else {
-        tmp3 = runtime.Unit;
+        tmp2 = runtime.Unit;
       }
       break;
     }

--- a/hkmc2/shared/src/test/mlscript/basics/AppOp.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/AppOp.mls
@@ -81,7 +81,7 @@ pipeInto of 1, inc
 
 :re
 pipeInto @ 1, inc
-//│ ═══[RUNTIME ERROR] TypeError: f1 is not a function
+//│ ═══[RUNTIME ERROR] TypeError: f is not a function
 
 pipeInto(1, _) @ inc
 //│ = fun

--- a/hkmc2/shared/src/test/mlscript/basics/CallSyntaxes.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/CallSyntaxes.mls
@@ -33,6 +33,6 @@ tuple(123, 456)
 //│ ╔══[PARSE ERROR] Unexpected period here
 //│ ║  l.29: 	123 |> tuple(., 456)
 //│ ╙──      	             ^
-//│ ═══[RUNTIME ERROR] TypeError: f1 is not a function
+//│ ═══[RUNTIME ERROR] TypeError: f is not a function
 
 

--- a/hkmc2/shared/src/test/mlscript/basics/Inheritance.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/Inheritance.mls
@@ -52,8 +52,8 @@ data class Baz(z) extends Bar(z * 1) with
   fun baz = this.bar * 2
 //│ JS (unsanitized):
 //│ let Baz1;
-//│ Baz1 = function Baz(z1) {
-//│   return globalThis.Object.freeze(new Baz.class(z1));
+//│ Baz1 = function Baz(z) {
+//│   return globalThis.Object.freeze(new Baz.class(z));
 //│ };
 //│ Object.defineProperty(Baz1, "class", {
 //│   enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/basics/MutVal.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/MutVal.mls
@@ -34,8 +34,8 @@ O.gy
 class Foo(x, val y, mut val z)
 //│ JS (unsanitized):
 //│ let Foo1;
-//│ Foo1 = function Foo(x1, y1, z1) {
-//│   return globalThis.Object.freeze(new Foo.class(x1, y1, z1));
+//│ Foo1 = function Foo(x, y, z) {
+//│   return globalThis.Object.freeze(new Foo.class(x, y, z));
 //│ };
 //│ Object.defineProperty(Foo1, "class", {
 //│   enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/bbml/bbCodeGen.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbCodeGen.mls
@@ -62,8 +62,8 @@ false
 data class Foo(x: Int)
 //│ JS (unsanitized):
 //│ let Foo1;
-//│ Foo1 = function Foo(x2) {
-//│   return globalThis.Object.freeze(new Foo.class(x2));
+//│ Foo1 = function Foo(x1) {
+//│   return globalThis.Object.freeze(new Foo.class(x1));
 //│ };
 //│ Object.defineProperty(Foo1, "class", {
 //│   enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/codegen/BlockPrinter.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/BlockPrinter.mls
@@ -20,8 +20,8 @@ let x = if x == 0 then 1 else 0
 let x = x + 1
 //│ Pretty Lowered:
 //│  
-//│ set x2 = 1 in
-//│ set scrut = ==(x2, 0) in
+//│ set x1 = 1 in
+//│ set scrut = ==(x1, 0) in
 //│ match scrut
 //│   true =>
 //│     set tmp = 1 in
@@ -30,9 +30,9 @@ let x = x + 1
 //│     set tmp = 0 in
 //│     end
 //│ in
-//│ set x3 = tmp in
-//│ set tmp1 = +(x3, 1) in
-//│ set x4 = tmp1 in
+//│ set x2 = tmp in
+//│ set tmp1 = +(x2, 1) in
+//│ set x3 = tmp1 in
 //│ set block$res3 = undefined in
 //│ end
 //│ x = 1

--- a/hkmc2/shared/src/test/mlscript/codegen/ClassInClass.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/ClassInClass.mls
@@ -15,8 +15,8 @@ data class Outer(a, b) with
   print(i.i1(1))
 //│ JS (unsanitized):
 //│ let Outer1;
-//│ Outer1 = function Outer(a1, b1) {
-//│   return globalThis.Object.freeze(new Outer.class(a1, b1));
+//│ Outer1 = function Outer(a, b) {
+//│   return globalThis.Object.freeze(new Outer.class(a, b));
 //│ };
 //│ Object.defineProperty(Outer1, "class", {
 //│   enumerable: true,
@@ -26,8 +26,8 @@ data class Outer(a, b) with
 //│       this.a = a;
 //│       this.b = b;
 //│       const this$Outer = this;
-//│       this.Inner = function Inner(c1) {
-//│         return globalThis.Object.freeze(new Inner.class(c1));
+//│       this.Inner = function Inner(c) {
+//│         return globalThis.Object.freeze(new Inner.class(c));
 //│       };
 //│       Object.defineProperty(this.Inner, "class", {
 //│         enumerable: true,
@@ -60,9 +60,9 @@ data class Outer(a, b) with
 //│     o1(c) {
 //│       return this.Inner(c)
 //│     } 
-//│     o2(c1, d) {
+//│     o2(c, d) {
 //│       let tmp;
-//│       tmp = this.Inner(c1);
+//│       tmp = this.Inner(c);
 //│       return runtime.safeCall(tmp.i1(d))
 //│     }
 //│     toString() { return runtime.render(this); }

--- a/hkmc2/shared/src/test/mlscript/codegen/ClassInFun.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/ClassInFun.mls
@@ -37,8 +37,8 @@ fun test(x) =
 //│ let test2;
 //│ test2 = function test(x) {
 //│   let Foo2, tmp;
-//│   Foo2 = function Foo(a1, b1) {
-//│     return globalThis.Object.freeze(new Foo.class(a1, b1));
+//│   Foo2 = function Foo(a, b) {
+//│     return globalThis.Object.freeze(new Foo.class(a, b));
 //│   };
 //│   Object.defineProperty(Foo2, "class", {
 //│     enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/codegen/Classes.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Classes.mls
@@ -7,8 +7,8 @@
 data class Foo(arguments)
 //│ JS (unsanitized):
 //│ let Foo1;
-//│ Foo1 = function Foo(arguments2) {
-//│   return globalThis.Object.freeze(new Foo.class(arguments2));
+//│ Foo1 = function Foo(arguments1) {
+//│   return globalThis.Object.freeze(new Foo.class(arguments1));
 //│ };
 //│ Object.defineProperty(Foo1, "class", {
 //│   enumerable: true,
@@ -25,8 +25,8 @@ data class Foo(arguments)
 data class Foo(eval)
 //│ JS (unsanitized):
 //│ let Foo3;
-//│ Foo3 = function Foo(eval2) {
-//│   return globalThis.Object.freeze(new Foo.class(eval2));
+//│ Foo3 = function Foo(eval1) {
+//│   return globalThis.Object.freeze(new Foo.class(eval1));
 //│ };
 //│ Object.defineProperty(Foo3, "class", {
 //│   enumerable: true,
@@ -43,8 +43,8 @@ data class Foo(eval)
 data class Foo(static)
 //│ JS (unsanitized):
 //│ let Foo5;
-//│ Foo5 = function Foo(static2) {
-//│   return globalThis.Object.freeze(new Foo.class(static2));
+//│ Foo5 = function Foo(static1) {
+//│   return globalThis.Object.freeze(new Foo.class(static1));
 //│ };
 //│ Object.defineProperty(Foo5, "class", {
 //│   enumerable: true,
@@ -61,8 +61,8 @@ data class Foo(static)
 data class Foo(v')
 //│ JS (unsanitized):
 //│ let Foo7;
-//│ Foo7 = function Foo(v$_1) {
-//│   return globalThis.Object.freeze(new Foo.class(v$_1));
+//│ Foo7 = function Foo(v$_) {
+//│   return globalThis.Object.freeze(new Foo.class(v$_));
 //│ };
 //│ Object.defineProperty(Foo7, "class", {
 //│   enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/codegen/FunInClass.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/FunInClass.mls
@@ -22,8 +22,8 @@ fun test(a) =
 //│ let test1;
 //│ test1 = function test(a) {
 //│   let Inner1;
-//│   Inner1 = function Inner(b1) {
-//│     return globalThis.Object.freeze(new Inner.class(b1));
+//│   Inner1 = function Inner(b) {
+//│     return globalThis.Object.freeze(new Inner.class(b));
 //│   };
 //│   Object.defineProperty(Inner1, "class", {
 //│     enumerable: true,
@@ -82,8 +82,8 @@ fun test(a) =
 //│ let test2;
 //│ test2 = function test(a) {
 //│   let C11, C21, tmp1, tmp2;
-//│   C11 = function C1(b1) {
-//│     return globalThis.Object.freeze(new C1.class(b1));
+//│   C11 = function C1(b) {
+//│     return globalThis.Object.freeze(new C1.class(b));
 //│   };
 //│   Object.defineProperty(C11, "class", {
 //│     enumerable: true,
@@ -99,8 +99,8 @@ fun test(a) =
 //│       static [definitionMetadata] = ["class", "C1", ["b"]]; 
 //│     }
 //│   });
-//│   C21 = function C2(b1) {
-//│     return globalThis.Object.freeze(new C2.class(b1));
+//│   C21 = function C2(b) {
+//│     return globalThis.Object.freeze(new C2.class(b));
 //│   };
 //│   Object.defineProperty(C21, "class", {
 //│     enumerable: true,
@@ -138,8 +138,8 @@ data class Foo(a) with
 Foo(123)
 //│ JS (unsanitized):
 //│ let Foo1;
-//│ Foo1 = function Foo(a1) {
-//│   return globalThis.Object.freeze(new Foo.class(a1));
+//│ Foo1 = function Foo(a) {
+//│   return globalThis.Object.freeze(new Foo.class(a));
 //│ };
 //│ Object.defineProperty(Foo1, "class", {
 //│   enumerable: true,
@@ -177,8 +177,8 @@ data class Bar(x) with
 Bar(1)
 //│ JS (unsanitized):
 //│ let Bar1;
-//│ Bar1 = function Bar(x1) {
-//│   return globalThis.Object.freeze(new Bar.class(x1));
+//│ Bar1 = function Bar(x) {
+//│   return globalThis.Object.freeze(new Bar.class(x));
 //│ };
 //│ Object.defineProperty(Bar1, "class", {
 //│   enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/codegen/Getters.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Getters.mls
@@ -283,8 +283,8 @@ data class Foo(x) with
   fun oops = x
 //│ JS (unsanitized):
 //│ let Foo1;
-//│ Foo1 = function Foo(x1) {
-//│   return globalThis.Object.freeze(new Foo.class(x1));
+//│ Foo1 = function Foo(x) {
+//│   return globalThis.Object.freeze(new Foo.class(x));
 //│ };
 //│ Object.defineProperty(Foo1, "class", {
 //│   enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/codegen/Hygiene.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Hygiene.mls
@@ -108,8 +108,8 @@ data class Cls(x) with
   print(this.x, x)
 //│ JS (unsanitized):
 //│ let Cls1;
-//│ Cls1 = function Cls(x3) {
-//│   return globalThis.Object.freeze(new Cls.class(x3));
+//│ Cls1 = function Cls(x2) {
+//│   return globalThis.Object.freeze(new Cls.class(x2));
 //│ };
 //│ Object.defineProperty(Cls1, "class", {
 //│   enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/codegen/ParamClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/ParamClasses.mls
@@ -186,8 +186,8 @@ class Foo(x, val y, z, val z, z) with
   print("this.z = " + this.z)
 //│ JS (unsanitized):
 //│ let Foo7;
-//│ Foo7 = function Foo(x1, y1, z3, z, z1) {
-//│   return globalThis.Object.freeze(new Foo.class(x1, y1, z3, z, z1));
+//│ Foo7 = function Foo(x1, y1, z3, z4, z5) {
+//│   return globalThis.Object.freeze(new Foo.class(x1, y1, z3, z4, z5));
 //│ };
 //│ Object.defineProperty(Foo7, "class", {
 //│   enumerable: true,
@@ -239,8 +239,8 @@ Foo(10, 20, 30, 40, 50)
 class Foo(val z, val z)
 //│ JS (unsanitized):
 //│ let Foo9;
-//│ Foo9 = function Foo(z2, z) {
-//│   return globalThis.Object.freeze(new Foo.class(z2, z));
+//│ Foo9 = function Foo(z2, z3) {
+//│   return globalThis.Object.freeze(new Foo.class(z2, z3));
 //│ };
 //│ Object.defineProperty(Foo9, "class", {
 //│   enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/codegen/ParamClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/ParamClasses.mls
@@ -38,8 +38,8 @@ Foo.class
 data class Foo(a)
 //│ JS (unsanitized):
 //│ let Foo3;
-//│ Foo3 = function Foo(a1) {
-//│   return globalThis.Object.freeze(new Foo.class(a1));
+//│ Foo3 = function Foo(a) {
+//│   return globalThis.Object.freeze(new Foo.class(a));
 //│ };
 //│ Object.defineProperty(Foo3, "class", {
 //│   enumerable: true,
@@ -77,8 +77,8 @@ foo(27)
 data class Foo(a, b)
 //│ JS (unsanitized):
 //│ let Foo5;
-//│ Foo5 = function Foo(a1, b1) {
-//│   return globalThis.Object.freeze(new Foo.class(a1, b1));
+//│ Foo5 = function Foo(a, b) {
+//│   return globalThis.Object.freeze(new Foo.class(a, b));
 //│ };
 //│ Object.defineProperty(Foo5, "class", {
 //│   enumerable: true,
@@ -145,8 +145,8 @@ data class Inner(c) with
   print(c)
 //│ JS (unsanitized):
 //│ let Inner1;
-//│ Inner1 = function Inner(c1) {
-//│   return globalThis.Object.freeze(new Inner.class(c1));
+//│ Inner1 = function Inner(c) {
+//│   return globalThis.Object.freeze(new Inner.class(c));
 //│ };
 //│ Object.defineProperty(Inner1, "class", {
 //│   enumerable: true,
@@ -186,8 +186,8 @@ class Foo(x, val y, z, val z, z) with
   print("this.z = " + this.z)
 //│ JS (unsanitized):
 //│ let Foo7;
-//│ Foo7 = function Foo(x1, y1, z3, z4, z5) {
-//│   return globalThis.Object.freeze(new Foo.class(x1, y1, z3, z4, z5));
+//│ Foo7 = function Foo(x, y, z, z1, z2) {
+//│   return globalThis.Object.freeze(new Foo.class(x, y, z, z1, z2));
 //│ };
 //│ Object.defineProperty(Foo7, "class", {
 //│   enumerable: true,
@@ -239,8 +239,8 @@ Foo(10, 20, 30, 40, 50)
 class Foo(val z, val z)
 //│ JS (unsanitized):
 //│ let Foo9;
-//│ Foo9 = function Foo(z2, z3) {
-//│   return globalThis.Object.freeze(new Foo.class(z2, z3));
+//│ Foo9 = function Foo(z, z1) {
+//│   return globalThis.Object.freeze(new Foo.class(z, z1));
 //│ };
 //│ Object.defineProperty(Foo9, "class", {
 //│   enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/codegen/PartialApps.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/PartialApps.mls
@@ -209,7 +209,7 @@ _ - _ of 1, 2
 //│ ╔══[ERROR] Expected 2 arguments, got 1
 //│ ║  l.208: 	|> (1)
 //│ ╙──       	   ^^^
-//│ ═══[RUNTIME ERROR] TypeError: f1 is not a function
+//│ ═══[RUNTIME ERROR] TypeError: f is not a function
 
 |> (1, _ - 2)
 //│ = -1

--- a/hkmc2/shared/src/test/mlscript/codegen/RandomStuff.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/RandomStuff.mls
@@ -23,8 +23,8 @@ data class Foo(x) with
     val y = x
 //│ JS (unsanitized):
 //│ let Foo1;
-//│ Foo1 = function Foo(x1) {
-//│   return globalThis.Object.freeze(new Foo.class(x1));
+//│ Foo1 = function Foo(x) {
+//│   return globalThis.Object.freeze(new Foo.class(x));
 //│ };
 //│ Object.defineProperty(Foo1, "class", {
 //│   enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/codegen/SanityChecks.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/SanityChecks.mls
@@ -102,8 +102,8 @@ data class Cls(x, y) with
   fun f(z, p) = x + y + z + p
 Cls(1, 2).f(3)
 //│ JS:
-//│ Cls1 = function Cls(x1, y1) {
-//│   return globalThis.Object.freeze(new Cls.class(x1, y1));
+//│ Cls1 = function Cls(x, y) {
+//│   return globalThis.Object.freeze(new Cls.class(x, y));
 //│ };
 //│ Object.defineProperty(Cls1, "class", {
 //│   enumerable: true,
@@ -133,8 +133,8 @@ data class Cls(x, y) with
   fun f(z, p) = x + y + z + p
 Cls(1, 2).f(3)
 //│ JS:
-//│ Cls3 = function Cls(...args1) {
-//│   return globalThis.Object.freeze(new Cls.class(...args1));
+//│ Cls3 = function Cls(...args) {
+//│   return globalThis.Object.freeze(new Cls.class(...args));
 //│ };
 //│ Object.defineProperty(Cls3, "class", {
 //│   enumerable: true,
@@ -169,8 +169,8 @@ data class Cls(x, y) with
   fun f(z, p)(q, s) = x + y + z + p + q + s
 Cls(1, 2).f(3, 4)(5)
 //│ JS:
-//│ Cls5 = function Cls(...args1) {
-//│   return globalThis.Object.freeze(new Cls.class(...args1));
+//│ Cls5 = function Cls(...args) {
+//│   return globalThis.Object.freeze(new Cls.class(...args));
 //│ };
 //│ Object.defineProperty(Cls5, "class", {
 //│   enumerable: true,
@@ -254,8 +254,8 @@ if M.A(1).y is
 //│ (class M {
 //│   static {
 //│     M1 = M;
-//│     this.A = function A(...args1) {
-//│       return globalThis.Object.freeze(new A.class(...args1));
+//│     this.A = function A(...args) {
+//│       return globalThis.Object.freeze(new A.class(...args));
 //│     };
 //│     Object.defineProperty(this.A, "class", {
 //│       enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/codegen/This.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/This.mls
@@ -51,10 +51,10 @@ module Test with
 //│   static test1(x) {
 //│     return test1(x)
 //│   } 
-//│   static test2(x1) {
+//│   static test2(x) {
 //│     return globalThis.Object.freeze([
 //│       Test.a,
-//│       x1
+//│       x
 //│     ])
 //│   }
 //│   static toString() { return runtime.render(this); }

--- a/hkmc2/shared/src/test/mlscript/ctx/ClassCtxParams.mls
+++ b/hkmc2/shared/src/test/mlscript/ctx/ClassCtxParams.mls
@@ -102,8 +102,8 @@ class Foo(using T) with
   print(T)
 //│ JS (unsanitized):
 //│ let Foo9;
-//│ Foo9 = function Foo(tmp6) {
-//│   return globalThis.Object.freeze(new Foo.class(tmp6));
+//│ Foo9 = function Foo(tmp5) {
+//│   return globalThis.Object.freeze(new Foo.class(tmp5));
 //│ };
 //│ Object.defineProperty(Foo9, "class", {
 //│   enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/handlers/EffectsInClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/handlers/EffectsInClasses.mls
@@ -11,8 +11,8 @@ data class Lol(h) with
   print(h.perform("k"))
 //│ JS (unsanitized):
 //│ let Lol1;
-//│ Lol1 = function Lol(h1) {
-//│   return globalThis.Object.freeze(new Lol.class(h1));
+//│ Lol1 = function Lol(h) {
+//│   return globalThis.Object.freeze(new Lol.class(h));
 //│ };
 //│ Object.defineProperty(Lol1, "class", {
 //│   enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/lifter/ClassInFun.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/ClassInFun.mls
@@ -246,8 +246,8 @@ f(1).get()
 //│   return tmp3
 //│ };
 //│ Test1 = function Test() {
-//│   return (x$01) => {
-//│     return globalThis.Object.freeze(new Test.class()(x$01));
+//│   return (x$0) => {
+//│     return globalThis.Object.freeze(new Test.class()(x$0));
 //│   }
 //│ };
 //│ Object.defineProperty(Test1, "class", {
@@ -317,9 +317,9 @@ f(1, 2).get()
 //│   tmp4 = tmp3(used1$0);
 //│   return tmp4
 //│ };
-//│ Test3 = function Test(a1) {
-//│   return (used1$01) => {
-//│     return globalThis.Object.freeze(new Test.class(a1)(used1$01));
+//│ Test3 = function Test(a) {
+//│   return (used1$0) => {
+//│     return globalThis.Object.freeze(new Test.class(a)(used1$0));
 //│   }
 //│ };
 //│ Object.defineProperty(Test3, "class", {
@@ -449,8 +449,8 @@ f(1)
 //│   return tmp6
 //│ };
 //│ A1 = function A() {
-//│   return (f$capture$01) => {
-//│     return globalThis.Object.freeze(new A.class()(f$capture$01));
+//│   return (f$capture$0) => {
+//│     return globalThis.Object.freeze(new A.class()(f$capture$0));
 //│   }
 //│ };
 //│ Object.defineProperty(A1, "class", {
@@ -521,8 +521,8 @@ f().foo()
 //│   return tmp7
 //│ };
 //│ Good1 = function Good() {
-//│   return (x$11, y$21, z$31, f$capture$01) => {
-//│     return globalThis.Object.freeze(new Good.class()(x$11, y$21, z$31, f$capture$01));
+//│   return (x$1, y$2, z$3, f$capture$0) => {
+//│     return globalThis.Object.freeze(new Good.class()(x$1, y$2, z$3, f$capture$0));
 //│   }
 //│ };
 //│ Object.defineProperty(Good1, "class", {
@@ -571,8 +571,8 @@ f().foo()
 //│   return tmp7
 //│ };
 //│ Bad1 = function Bad() {
-//│   return (f$capture$01) => {
-//│     return globalThis.Object.freeze(new Bad.class()(f$capture$01));
+//│   return (f$capture$0) => {
+//│     return globalThis.Object.freeze(new Bad.class()(f$capture$0));
 //│   }
 //│ };
 //│ Object.defineProperty(Bad1, "class", {

--- a/hkmc2/shared/src/test/mlscript/lifter/DefnsInClass.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/DefnsInClass.mls
@@ -18,9 +18,9 @@ data class A(x) with
 //│   tmp1 = tmp(A$instance$0);
 //│   return tmp1
 //│ };
-//│ B1 = function B(y1) {
-//│   return (A$instance$01) => {
-//│     return globalThis.Object.freeze(new B.class(y1)(A$instance$01));
+//│ B1 = function B(y) {
+//│   return (A$instance$0) => {
+//│     return globalThis.Object.freeze(new B.class(y)(A$instance$0));
 //│   }
 //│ };
 //│ Object.defineProperty(B1, "class", {
@@ -43,8 +43,8 @@ data class A(x) with
 //│     static [definitionMetadata] = ["class", "B", ["y"]]; 
 //│   }
 //│ });
-//│ A1 = function A(x1) {
-//│   return globalThis.Object.freeze(new A.class(x1));
+//│ A1 = function A(x) {
+//│   return globalThis.Object.freeze(new A.class(x));
 //│ };
 //│ Object.defineProperty(A1, "class", {
 //│   enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/lifter/FunInFun.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/FunInFun.mls
@@ -194,8 +194,8 @@ x + y
 //│   h$this = runtime.safeCall(h(capture));
 //│   return Tuple1(g$this, h$this)
 //│ };
-//│ Tuple1 = function Tuple(a1, b1) {
-//│   return globalThis.Object.freeze(new Tuple.class(a1, b1));
+//│ Tuple1 = function Tuple(a, b) {
+//│   return globalThis.Object.freeze(new Tuple.class(a, b));
 //│ };
 //│ Object.defineProperty(Tuple1, "class", {
 //│   enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/lifter/ModulesObjects.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/ModulesObjects.mls
@@ -174,8 +174,8 @@ data class A(x) with
 //│   toString() { return runtime.render(this); }
 //│   static [definitionMetadata] = ["class", "M"]; 
 //│ };
-//│ A1 = function A(x1) {
-//│   return globalThis.Object.freeze(new A.class(x1));
+//│ A1 = function A(x) {
+//│   return globalThis.Object.freeze(new A.class(x));
 //│ };
 //│ Object.defineProperty(A1, "class", {
 //│   enumerable: true,
@@ -311,8 +311,8 @@ M.A(2).newB.newA_B(3).newB.get
 //│   return tmp10
 //│ };
 //│ B2 = function B() {
-//│   return (A$instance$01) => {
-//│     return globalThis.Object.freeze(new B.class()(A$instance$01));
+//│   return (A$instance$0) => {
+//│     return globalThis.Object.freeze(new B.class()(A$instance$0));
 //│   }
 //│ };
 //│ Object.defineProperty(B2, "class", {
@@ -341,8 +341,8 @@ M.A(2).newB.newA_B(3).newB.get
 //│   static {
 //│     M21 = M20;
 //│     let scrut;
-//│     this.A = function A(x1) {
-//│       return globalThis.Object.freeze(new A.class(x1));
+//│     this.A = function A(x) {
+//│       return globalThis.Object.freeze(new A.class(x));
 //│     };
 //│     Object.defineProperty(this.A, "class", {
 //│       enumerable: true,

--- a/hkmc2/shared/src/test/mlscript/std/PredefTest.mls
+++ b/hkmc2/shared/src/test/mlscript/std/PredefTest.mls
@@ -86,7 +86,7 @@ passing(tuple, 1, 2, 3) of 4, 5, 6
 
 :re
 tuple passing(1, 2, 3) of 4, 5, 6
-//│ ═══[RUNTIME ERROR] TypeError: f3.bind is not a function
+//│ ═══[RUNTIME ERROR] TypeError: f.bind is not a function
 
 
 :re


### PR DESCRIPTION
- More efficient `inScope` function using `Set.contains` instead of `Iterator.contains`.
- `Block.flattened` now flattens class methods
- The paramter of `DummyTypeDef` is properly used
- Remove a small piece of dead code in `JSBuilder.scala`

The output of `ParamClasses.mls` changes. This is because the set `Scope.existingNames` and the values of `Scope.bindings` may not in sync: `Scope.allocateName` may get called more than once for the same symbol. One possible source of multiple `allocateName` calls is [here](https://github.com/hkust-taco/mlscript/blob/6677f788b57f069471bc546ad28971e7b8367e46/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala#L237-L238) and [here](https://github.com/hkust-taco/mlscript/blob/6677f788b57f069471bc546ad28971e7b8367e46/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala#L370-L376), where the symbols in `paramsOpt` get `allocateName`d twice.

I am not sure whether there are more places where `allocateName` get called twice or how to fix this now in this PR since the logic seems to be quite complicated...
