### PR TITLE
Use existing TermSymbol for ValDefn

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -348,7 +348,6 @@ final case class ValDefn(
     rhs: Path,
 ) extends Defn:
   val innerSym = S(tsym)
-  val k = tsym.k
   val owner: Opt[InnerSymbol] = tsym.owner
 
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -174,7 +174,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
             subTerm_nonTail(bod)(r =>
               // Assign(td.sym, r,
               //   term(st.Blk(stats, res))(k)))
-              Define(ValDefn.mk(td.owner, knd, td.sym, r),
+              Define(ValDefn(td.tsym, td.sym, r),
                 blockImpl(stats, res)(k)))
           case syntax.Fun =>
             val (paramLists, bodyBlock) = setupFunctionOrByNameDef(td.params, bod, S(td.sym.nme))
@@ -184,7 +184,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
             // Implicit instances are not parameterized for now.
             assert(td.params.isEmpty)
             subTerm(bod)(r =>
-              Define(ValDefn.mk(td.owner, syntax.ImmutVal, td.sym, r),
+              Define(ValDefn(td.tsym, td.sym, r),
                 blockImpl(stats, res)(k)))
           case syntax.LetBind | syntax.ParamBind | syntax.HandlerBind => fail:
             ErrorReport(


### PR DESCRIPTION
This ensures that class fields and `ValDefn`s in the constructor body refer refer to the same symbol.