### PR TITLE
Add `TermSymbol` to `FunDefn`

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -225,7 +225,7 @@ sealed abstract class Block extends Product:
           val newPreCtor = c.preCtor.flattened
           val newCtor = c.ctor.flattened
           val newMethods = c.methods.mapConserve:
-            case f@FunDefn(owner, sym, params, body) =>
+            case f@FunDefn(owner, dSym, sym, params, body) =>
               val newBody = body.flattened
               if newBody is body then f else f.copy(body = newBody)(isTailRec = f.isTailRec)
           if (newPreCtor is c.preCtor) && (newCtor is c.ctor) && (newMethods is c.methods)
@@ -316,7 +316,7 @@ sealed abstract class Defn:
   // * At some point we'll want to make `Local` more specific than `Symbol` to express this
   // * in the type system.
   lazy val freeVars: Set[Local] = this match
-    case FunDefn(own, sym, params, body) => body.freeVars -- params.flatMap(_.paramSyms) - sym
+    case FunDefn(own, sym, dSym, params, body) => body.freeVars -- params.flatMap(_.paramSyms) - sym
     case ValDefn(tsym, sym, rhs) => rhs.freeVars
     case ClsLikeDefn(own, isym, sym, k, paramsOpt, auxParams, parentSym, 
         methods, privateFields, publicFields, preCtor, ctor, stat, bufferable) =>
@@ -325,7 +325,7 @@ sealed abstract class Defn:
         -- auxParams.flatMap(_.paramSyms)
   
   lazy val freeVarsLLIR: Set[Local] = this match
-    case FunDefn(own, sym, params, body) => body.freeVarsLLIR -- params.flatMap(_.paramSyms) - sym
+    case FunDefn(own, sym, dSym, params, body) => body.freeVarsLLIR -- params.flatMap(_.paramSyms) - sym
     case ValDefn(tsym, sym, rhs) => rhs.freeVarsLLIR
     case ClsLikeDefn(own, isym, sym, k, paramsOpt, auxParams, parentSym, 
         methods, privateFields, publicFields, preCtor, ctor, stat, bufferable) =>
@@ -339,6 +339,7 @@ sealed abstract class Defn:
 final case class FunDefn(
     owner: Opt[InnerSymbol],
     sym: BlockMemberSymbol,
+    dSym: TermSymbol,
     params: Ls[ParamList],
     body: Block,
   )(

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -225,7 +225,7 @@ sealed abstract class Block extends Product:
           val newPreCtor = c.preCtor.flattened
           val newCtor = c.ctor.flattened
           val newMethods = c.methods.mapConserve:
-            case f@FunDefn(owner, dSym, sym, params, body) =>
+            case f@FunDefn(owner, sym, dSym, params, body) =>
               val newBody = body.flattened
               if newBody is body then f else f.copy(body = newBody)(isTailRec = f.isTailRec)
           if (newPreCtor is c.preCtor) && (newCtor is c.ctor) && (newMethods is c.methods)
@@ -346,7 +346,9 @@ final case class FunDefn(
     val isTailRec: Bool,
 ) extends Defn:
   val innerSym = N
-
+object FunDefn:
+  def withFreshSymbol(owner: Opt[InnerSymbol], sym: BlockMemberSymbol, params: Ls[ParamList], body: Block)(isTailRec: Bool)(using State) =
+    FunDefn(owner, sym, TermSymbol(syntax.Fun, owner, Tree.Ident(sym.nme)), params, body)(isTailRec)
 
 final case class ValDefn(
     tsym: TermSymbol,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
@@ -157,10 +157,11 @@ class BlockTransformer(subst: SymbolSubst):
   def applyFunDefn(fun: FunDefn): FunDefn =
     val own2 = fun.owner.mapConserve(_.subst)
     val sym2 = fun.sym.subst
+    val dSym2 = fun.dSym.subst
     val params2 = fun.params.mapConserve(applyParamList)
     val body2 = applySubBlock(fun.body)
-    if (own2 is fun.owner) && (sym2 is fun.sym) && (params2 is fun.params) && (body2 is fun.body)
-      then fun else FunDefn(own2, sym2, params2, body2)(fun.isTailRec)
+    if (own2 is fun.owner) && (sym2 is fun.sym) && (dSym2 is fun.dSym) && (params2 is fun.params) && (body2 is fun.body)
+      then fun else FunDefn(own2, sym2, dSym2, params2, body2)(fun.isTailRec)
   
   def applyValDefn(defn: ValDefn)(k: ValDefn => Block): Block =
     val ValDefn(tsym, sym, rhs) = defn

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTraverser.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTraverser.scala
@@ -78,6 +78,7 @@ class BlockTraverser:
   def applyFunDefn(fun: FunDefn): Unit =
     fun.owner.foreach(_.traverse)
     fun.sym.traverse
+    fun.dSym.traverse
     fun.params.foreach(applyParamList)
     applySubBlock(fun.body)
   

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BufferableTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BufferableTransform.scala
@@ -69,10 +69,9 @@ class BufferableTransform()(using Ctx, State, Raise):
               FunDefn(f.owner, f.sym, f.dSym, PlainParamList(
                 Param(FldFlags.empty, buf, N, Modulefulness.none) :: Param(FldFlags.empty, idx, N, Modulefulness.none) :: Nil) :: f.params,
                 if isCtor then Begin(blk, Return(idx.asPath, false)) else blk)(isTailRec = f.isTailRec)
-            val fakeCtor = transformFunDefn(FunDefn(
+            val fakeCtor = transformFunDefn(FunDefn.withFreshSymbol(
                 S(companionSym), 
                 BlockMemberSymbol("ctor", Nil, false), 
-                TermSymbol(syntax.Fun, S(companionSym), Tree.Ident("ctor")),
                 cls.paramsOpt.toList,
                 Begin(cls.preCtor, cls.ctor),
               )(false), true)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BufferableTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BufferableTransform.scala
@@ -66,10 +66,16 @@ class BufferableTransform()(using Ctx, State, Raise):
               val buf = VarSymbol(new Tree.Ident("buf"))
               val idx = VarSymbol(new Tree.Ident("idx"))
               val blk = mkFieldReplacer(buf, idx).applyBlock(f.body)
-              FunDefn(f.owner, f.sym, PlainParamList(
+              FunDefn(f.owner, f.sym, f.dSym, PlainParamList(
                 Param(FldFlags.empty, buf, N, Modulefulness.none) :: Param(FldFlags.empty, idx, N, Modulefulness.none) :: Nil) :: f.params,
                 if isCtor then Begin(blk, Return(idx.asPath, false)) else blk)(isTailRec = f.isTailRec)
-            val fakeCtor = transformFunDefn(FunDefn(S(companionSym), BlockMemberSymbol("ctor", Nil, false), cls.paramsOpt.toList, Begin(cls.preCtor, cls.ctor))(false), true)
+            val fakeCtor = transformFunDefn(FunDefn(
+                S(companionSym), 
+                BlockMemberSymbol("ctor", Nil, false), 
+                TermSymbol(syntax.Fun, S(companionSym), Tree.Ident("ctor")),
+                cls.paramsOpt.toList,
+                Begin(cls.preCtor, cls.ctor),
+              )(false), true)
             val fakeCompanion = ClsLikeBody(
               companionSym,
               fakeCtor :: cls.methods.map(transformFunDefn(_, false)),

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -15,6 +15,9 @@ import semantics.Elaborator.State
 import hkmc2.Config.EffectHandlers
 
 object HandlerLowering:
+  
+  private final val getLocalsNme = "getLocals"
+  private final val doUnwindNme = "doUnwind"
 
   private val pcIdent: Tree.Ident = Tree.Ident("pc")
   private val nextIdent: Tree.Ident = Tree.Ident("next")
@@ -455,7 +458,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
       .assign(TempSymbol(N, ""), Call(startSym.asPath.selSN("push"), thisInfo.asPath.asArg :: Nil)(false, false, false))
       .ret(startSym.asPath)
 
-    FunDefn(N, BlockMemberSymbol("getLocals", Nil), TermSymbol(syntax.Fun, N, Tree.Ident("getLocals")), PlainParamList(Nil) :: Nil, body)(false)
+    FunDefn.withFreshSymbol(N, BlockMemberSymbol(getLocalsNme, Nil), PlainParamList(Nil) :: Nil, body)(false)
     
   var doUnwindMap: Map[FnOrCls, Path] = Map.empty
     
@@ -542,16 +545,15 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
       case None => genNormalBody(b, BlockMemberSymbol("", Nil), N)
       case Some(cls) => 
         // create the doUnwind function
-        val doUnwindSym = BlockMemberSymbol("doUnwind", Nil, true)
+        val doUnwindSym = BlockMemberSymbol(doUnwindNme, Nil, true)
         doUnwindMap += fnOrCls -> doUnwindSym.asPath
         val pcSym = VarSymbol(Tree.Ident("pc"))
         val resSym = VarSymbol(Tree.Ident("res"))
         val doUnwindBlk = h.linkAndHandle(
           LinkState(resSym, cls.sym.asPath, pcSym.asPath)
         )
-        val doUnwindDef = FunDefn(
+        val doUnwindDef = FunDefn.withFreshSymbol(
           N, doUnwindSym,
-          TermSymbol(syntax.Fun, N, Tree.Ident("doUnwind")),
           PlainParamList(Param.simple(resSym) :: Param.simple(pcSym) :: Nil) :: Nil,
           doUnwindBlk
         )(false)
@@ -649,16 +651,14 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
       val mtdBdy = translateBlock(handler.body,
         handler.params.flatMap(_.paramSyms).toSet, N, L(sym), // TODO: callSelf
         handlerMtdCtx(s"Cont$$handler$$${symToStr(h.lhs)}$$${symToStr(handler.sym)}$$", handler.sym.nme))
-      val fDef = FunDefn(
+      val fDef = FunDefn.withFreshSymbol(
         N, sym, 
-        TermSymbol(syntax.Fun, N, Tree.Ident("hdlrFun")),
         PlainParamList(Param(FldFlags.empty, handler.resumeSym, N, Modulefulness.none) :: Nil) :: Nil,
         mtdBdy 
         )(false)
-      FunDefn(
+      FunDefn.withFreshSymbol(
         S(h.cls),
         handler.sym,
-        TermSymbol(syntax.Fun, S(h.cls), Tree.Ident(handler.sym.nme)),
         handler.params,
         Define(
           fDef,
@@ -695,11 +695,9 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
       .assign(h.lhs, Instantiate(mut = true, Value.Ref(clsDefn.sym, S(h.cls)), Nil))
       .rest(handlerBody)
     
-    val defn = FunDefn(
+    val defn = FunDefn.withFreshSymbol(
       N, // no owner
-      sym,
-      TermSymbol(syntax.Fun, N, Tree.Ident(sym.nme)),
-      PlainParamList(Nil) :: Nil, body)(false)
+      sym, PlainParamList(Nil) :: Nil, body)(false)
     
     val result = blockBuilder
       .define(defn)
@@ -726,7 +724,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
     var containsCall = false
     
     // Create the DoUnwind function
-    doUnwindMap += R(clsSym) -> Select(clsSym.asPath, Tree.Ident("doUnwind"))(
+    doUnwindMap += R(clsSym) -> Select(clsSym.asPath, Tree.Ident(doUnwindNme))(
       N /* this refers to the method defined in Runtime.FunctionContFrame */
     )
     val newPcSym = VarSymbol(Tree.Ident("newPc"))
@@ -798,7 +796,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         val transform = new BlockTransformerShallow(SymbolSubst()):
           override def applyBlock(b: Block): Block = b match
             case ReturnCont(res, uid) => Return(Call(
-                Select(clsSym.asPath, Tree.Ident("doUnwind"))(
+                Select(clsSym.asPath, Tree.Ident(doUnwindNme))(
                   N /* this refers to the method defined in Runtime.FunctionContFrame */
                 ),
                 res.asPath.asArg :: Value.Lit(Tree.IntLit(uid)).asArg :: Nil)(true, false, false),
@@ -863,35 +861,32 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
       
     
     val resumeSym = BlockMemberSymbol("resume", List())
-    val resumeFnDef = FunDefn(
+    val resumeFnDef = FunDefn.withFreshSymbol(
       S(clsSym), // owner
       resumeSym,
-      TermSymbol(syntax.Fun, S(clsSym), Tree.Ident("resume")),
       List(PlainParamList(List(Param(FldFlags.empty, resumedVal, N, Modulefulness.none)))),
       resumeBody
     )(false)
 
     val debugMtds = if !opt.debug then Nil else
     
-      val getLocalsSym = BlockMemberSymbol("getLocals", List())
+      val getLocalsSym = BlockMemberSymbol(getLocalsNme, List())
       
       val localsRes = h.debugInfo.prevLocalsFn match
         case Some(value) => PureCall(value, Nil)
         case None => Tuple(mut = true, Nil)
       
-      val getLocalsFnDef = FunDefn(
+      val getLocalsFnDef = FunDefn.withFreshSymbol(
         S(clsSym),
         getLocalsSym,
-        TermSymbol(syntax.Fun, S(clsSym), Tree.Ident("getLocals")),
         List(),
         Return(localsRes, false)
       )(false)
 
       val getLocSym = BlockMemberSymbol("getLoc", List())
-      val getLocFnDef = FunDefn(
+      val getLocFnDef = FunDefn.withFreshSymbol(
         S(clsSym),
         getLocSym,
-        TermSymbol(syntax.Fun, S(clsSym), Tree.Ident("getLoc")),
         List(),
         Match(pcSymbol.asPath, pcToLoc.toSortedMap.iterator.map: (stateId, loc) =>
           Case.Lit(Tree.IntLit(stateId)) -> Return(Value.Lit(loc.fold(Tree.UnitLit(true)): loc =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -455,7 +455,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
       .assign(TempSymbol(N, ""), Call(startSym.asPath.selSN("push"), thisInfo.asPath.asArg :: Nil)(false, false, false))
       .ret(startSym.asPath)
 
-    FunDefn(N, BlockMemberSymbol("getLocals", Nil), PlainParamList(Nil) :: Nil, body)(false)
+    FunDefn(N, BlockMemberSymbol("getLocals", Nil), TermSymbol(syntax.Fun, N, Tree.Ident("getLocals")), PlainParamList(Nil) :: Nil, body)(false)
     
   var doUnwindMap: Map[FnOrCls, Path] = Map.empty
     
@@ -551,6 +551,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         )
         val doUnwindDef = FunDefn(
           N, doUnwindSym,
+          TermSymbol(syntax.Fun, N, Tree.Ident("doUnwind")),
           PlainParamList(Param.simple(resSym) :: Param.simple(pcSym) :: Nil) :: Nil,
           doUnwindBlk
         )(false)
@@ -594,7 +595,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
           S(Call(Select(owner.asPath, Tree.Ident(f.sym.nme))(N), params)(true, true, false))
       case _ => None // TODO: more than one plist
     
-    FunDefn(f.owner, f.sym, f.params, translateBlock(f.body,
+    FunDefn(f.owner, f.sym, f.dSym, f.params, translateBlock(f.body,
       f.params.flatMap(_.paramSyms).toSet,
       callSelf,
       L(f.sym),
@@ -649,12 +650,16 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         handler.params.flatMap(_.paramSyms).toSet, N, L(sym), // TODO: callSelf
         handlerMtdCtx(s"Cont$$handler$$${symToStr(h.lhs)}$$${symToStr(handler.sym)}$$", handler.sym.nme))
       val fDef = FunDefn(
-        N, sym, PlainParamList(Param(FldFlags.empty, handler.resumeSym, N, Modulefulness.none) :: Nil) :: Nil,
+        N, sym, 
+        TermSymbol(syntax.Fun, N, Tree.Ident("hdlrFun")),
+        PlainParamList(Param(FldFlags.empty, handler.resumeSym, N, Modulefulness.none) :: Nil) :: Nil,
         mtdBdy 
         )(false)
       FunDefn(
         S(h.cls),
-        handler.sym, handler.params,
+        handler.sym,
+        TermSymbol(syntax.Fun, S(h.cls), Tree.Ident(handler.sym.nme)),
+        handler.params,
         Define(
           fDef,
           Return(PureCall(paths.mkEffectPath, h.cls.asPath :: Value.Ref(sym, N) :: Nil), false)))(false)
@@ -692,7 +697,9 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
     
     val defn = FunDefn(
       N, // no owner
-      sym, PlainParamList(Nil) :: Nil, body)(false)
+      sym,
+      TermSymbol(syntax.Fun, N, Tree.Ident(sym.nme)),
+      PlainParamList(Nil) :: Nil, body)(false)
     
     val result = blockBuilder
       .define(defn)
@@ -859,6 +866,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
     val resumeFnDef = FunDefn(
       S(clsSym), // owner
       resumeSym,
+      TermSymbol(syntax.Fun, S(clsSym), Tree.Ident("resume")),
       List(PlainParamList(List(Param(FldFlags.empty, resumedVal, N, Modulefulness.none)))),
       resumeBody
     )(false)
@@ -874,6 +882,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
       val getLocalsFnDef = FunDefn(
         S(clsSym),
         getLocalsSym,
+        TermSymbol(syntax.Fun, S(clsSym), Tree.Ident("getLocals")),
         List(),
         Return(localsRes, false)
       )(false)
@@ -882,6 +891,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
       val getLocFnDef = FunDefn(
         S(clsSym),
         getLocSym,
+        TermSymbol(syntax.Fun, S(clsSym), Tree.Ident("getLoc")),
         List(),
         Match(pcSymbol.asPath, pcToLoc.toSortedMap.iterator.map: (stateId, loc) =>
           Case.Lit(Tree.IntLit(stateId)) -> Return(Value.Lit(loc.fold(Tree.UnitLit(true)): loc =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/LambdaRewriter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/LambdaRewriter.scala
@@ -18,7 +18,7 @@ object LambdaRewriter:
           nameIsMeaningful = true // TODO: lhs.nme is not always meaningful
         )
         val blk = blockBuilder
-          .define(FunDefn(N, newSym, TermSymbol(syntax.Fun, N, Tree.Ident(lhs.nme)), params :: Nil, body)(false))
+          .define(FunDefn.withFreshSymbol(N, newSym, params :: Nil, body)(false))
           .assign(lhs, newSym.asPath)
           .rest(rest)
         (blk, Nil)
@@ -39,7 +39,7 @@ object LambdaRewriter:
         val (newBlk, lambdasList) = rewriteOneBlk(b)
         val lambdaDefns = lambdasList.map:
           case (sym, Lambda(params, body)) =>
-            FunDefn(N, sym, TermSymbol(syntax.Fun, N, Tree.Ident(sym.nme)), params :: Nil, body)(false)
+            FunDefn.withFreshSymbol(N, sym, params :: Nil, body)(false)
         val ret = lambdaDefns.foldLeft(newBlk):
           case (acc, defn) => Define(defn, acc)
         super.applyBlock(ret)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/LambdaRewriter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/LambdaRewriter.scala
@@ -6,6 +6,7 @@ import utils.*
 import hkmc2.codegen.*
 import hkmc2.semantics.*
 import semantics.Elaborator.State
+import hkmc2.syntax.Tree
 
 object LambdaRewriter:
   
@@ -17,7 +18,7 @@ object LambdaRewriter:
           nameIsMeaningful = true // TODO: lhs.nme is not always meaningful
         )
         val blk = blockBuilder
-          .define(FunDefn(N, newSym, params :: Nil, body)(false))
+          .define(FunDefn(N, newSym, TermSymbol(syntax.Fun, N, Tree.Ident(lhs.nme)), params :: Nil, body)(false))
           .assign(lhs, newSym.asPath)
           .rest(rest)
         (blk, Nil)
@@ -38,7 +39,7 @@ object LambdaRewriter:
         val (newBlk, lambdasList) = rewriteOneBlk(b)
         val lambdaDefns = lambdasList.map:
           case (sym, Lambda(params, body)) =>
-            FunDefn(N, sym, params :: Nil, body)(false)
+            FunDefn(N, sym, TermSymbol(syntax.Fun, N, Tree.Ident(sym.nme)), params :: Nil, body)(false)
         val ret = lambdaDefns.foldLeft(newBlk):
           case (acc, defn) => Define(defn, acc)
         super.applyBlock(ret)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -117,9 +117,6 @@ object Lifter:
   def modOrObj(d: Defn) = d match
     case c: ClsLikeDefn => (c.companion.isDefined) || (c.k is syntax.Obj) // TODO: refine handling of companions
     case _ => false
-  
-  def mkTermSym(bms: BlockMemberSymbol, owner: Opt[InnerSymbol] = N)(using State) =
-    TermSymbol(syntax.Fun, owner, Tree.Ident(bms.nme))
 
 
 /**
@@ -503,7 +500,7 @@ class Lifter(handlerPaths: Opt[HandlerPaths])(using State, Raise):
           mod.foreach(applyClsLikeBody)
       
       def isFun(d: Defn) = d match
-        case FunDefn(owner, sym, dSym, params, body) => true
+        case _: FunDefn => true
         case _ => false
       
       override def applyValue(v: Value): Unit = v match
@@ -950,7 +947,7 @@ class Lifter(handlerPaths: Opt[HandlerPaths])(using State, Raise):
             .ret(Call(singleCallBms.asPath, args1 ++ args2)(true, false, false)) // TODO: restParams not considered
 
           val mainDefn = FunDefn(f.owner, f.sym, f.dSym, PlainParamList(extraParamsCpy) :: headPlistCopy :: Nil, bdy)(false)
-          val auxDefn = FunDefn(N, singleCallBms, mkTermSym(singleCallBms), flatPlist, lifted.body)(isTailRec = f.isTailRec)
+          val auxDefn = FunDefn.withFreshSymbol(N, singleCallBms, flatPlist, lifted.body)(isTailRec = f.isTailRec)
           
           if ctx.firstClsFns.contains(f.sym) then
             Lifted(mainDefn, auxDefn :: extras)
@@ -1081,7 +1078,7 @@ class Lifter(handlerPaths: Opt[HandlerPaths])(using State, Raise):
               
               case Some(value) => (ParamList(value.flags, extraPlist.params ++ value.params, value.restParam), auxPlist)
             
-            val auxCtorDefn_ = FunDefn(None, singleCallBms, mkTermSym(singleCallBms), headParams :: newAuxPlist, bod)(false)
+            val auxCtorDefn_ = FunDefn.withFreshSymbol(None, singleCallBms, headParams :: newAuxPlist, bod)(false)
             val auxCtorDefn = BlockTransformer(subst).applyFunDefn(auxCtorDefn_)
             
             // Lifted(lifted, extras ::: (fakeCtorDefn :: auxCtorDefn :: Nil))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -117,6 +117,9 @@ object Lifter:
   def modOrObj(d: Defn) = d match
     case c: ClsLikeDefn => (c.companion.isDefined) || (c.k is syntax.Obj) // TODO: refine handling of companions
     case _ => false
+  
+  def mkTermSym(bms: BlockMemberSymbol, owner: Opt[InnerSymbol] = N)(using State) =
+    TermSymbol(syntax.Fun, owner, Tree.Ident(bms.nme))
 
 
 /**
@@ -500,7 +503,7 @@ class Lifter(handlerPaths: Opt[HandlerPaths])(using State, Raise):
           mod.foreach(applyClsLikeBody)
       
       def isFun(d: Defn) = d match
-        case FunDefn(owner, sym, params, body) => true
+        case FunDefn(owner, sym, dSym, params, body) => true
         case _ => false
       
       override def applyValue(v: Value): Unit = v match
@@ -936,7 +939,7 @@ class Lifter(handlerPaths: Opt[HandlerPaths])(using State, Raise):
             case Nil => PlainParamList(extraParams) :: Nil
 
           val newDef = FunDefn(
-            base.owner, f.sym, PlainParamList(extraParams) :: f.params, f.body
+            base.owner, f.sym, f.dSym, PlainParamList(extraParams) :: f.params, f.body
           )(f.isTailRec)
           val Lifted(lifted, extras) = liftDefnsInFn(newDef, newCtx)
 
@@ -946,8 +949,8 @@ class Lifter(handlerPaths: Opt[HandlerPaths])(using State, Raise):
           val bdy = blockBuilder
             .ret(Call(singleCallBms.asPath, args1 ++ args2)(true, false, false)) // TODO: restParams not considered
 
-          val mainDefn = FunDefn(f.owner, f.sym, PlainParamList(extraParamsCpy) :: headPlistCopy :: Nil, bdy)(false)
-          val auxDefn = FunDefn(N, singleCallBms, flatPlist, lifted.body)(isTailRec = f.isTailRec)
+          val mainDefn = FunDefn(f.owner, f.sym, f.dSym, PlainParamList(extraParamsCpy) :: headPlistCopy :: Nil, bdy)(false)
+          val auxDefn = FunDefn(N, singleCallBms, mkTermSym(singleCallBms), flatPlist, lifted.body)(isTailRec = f.isTailRec)
           
           if ctx.firstClsFns.contains(f.sym) then
             Lifted(mainDefn, auxDefn :: extras)
@@ -1078,7 +1081,7 @@ class Lifter(handlerPaths: Opt[HandlerPaths])(using State, Raise):
               
               case Some(value) => (ParamList(value.flags, extraPlist.params ++ value.params, value.restParam), auxPlist)
             
-            val auxCtorDefn_ = FunDefn(None, singleCallBms, headParams :: newAuxPlist, bod)(false)
+            val auxCtorDefn_ = FunDefn(None, singleCallBms, mkTermSym(singleCallBms), headParams :: newAuxPlist, bod)(false)
             val auxCtorDefn = BlockTransformer(subst).applyFunDefn(auxCtorDefn_)
             
             // Lifted(lifted, extras ::: (fakeCtorDefn :: auxCtorDefn :: Nil))
@@ -1245,7 +1248,7 @@ class Lifter(handlerPaths: Opt[HandlerPaths])(using State, Raise):
     val transformed = BlockRewriter(ctx.inScopeISyms, captureCtx.addreplacedDefns(ignoredRewrite)).applyBlock(blk)
 
     if thisVars.reqCapture.size == 0 then
-      Lifted(FunDefn(f.owner, f.sym, f.params, transformed)(isTailRec = f.isTailRec), newDefns)
+      Lifted(FunDefn(f.owner, f.sym, f.dSym, f.params, transformed)(isTailRec = f.isTailRec), newDefns)
     else
       // move the function's parameters to the capture
       val paramsSet = f.params.flatMap(_.paramSyms)
@@ -1256,7 +1259,7 @@ class Lifter(handlerPaths: Opt[HandlerPaths])(using State, Raise):
         .assign(captureSym, Instantiate(mut = true, // * Note: `mut` is needed for capture classes
           captureCls.sym.asPath, paramsList))
         .rest(transformed)
-      Lifted(FunDefn(f.owner, f.sym, f.params, bod)(isTailRec = f.isTailRec), captureCls :: newDefns)
+      Lifted(FunDefn(f.owner, f.sym, f.dSym, f.params, bod)(isTailRec = f.isTailRec), captureCls :: newDefns)
 
   end liftDefnsInFn
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -254,7 +254,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
               case (sym, params, split) =>
                 val paramLists = params :: Nil
                 val bodyBlock = ucs.Normalization(this)(split)(Ret)
-                FunDefn(N, sym, TermSymbol(syntax.Fun, N, Tree.Ident(sym.nme)), paramLists, bodyBlock)(false)
+                FunDefn.withFreshSymbol(N, sym, paramLists, bodyBlock)(isTailRec = false)
             // The return type is intended to be consistent with `gatherMembers`
             (mtds, Nil, Nil, End())
           case _ => gatherMembers(defn.body)
@@ -468,9 +468,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
           val isOr = sym is State.orSymbol
           if isAnd || isOr then
             val lamSym = BlockMemberSymbol("lambda", Nil, false)
-            val lamDef = FunDefn(
-              N, lamSym, TermSymbol(syntax.Fun, N, Tree.Ident(lamSym.nme)),
-              PlainParamList(Nil) :: Nil, returnedTerm(arg2))(false)
+            val lamDef = FunDefn.withFreshSymbol(N, lamSym, PlainParamList(Nil) :: Nil, returnedTerm(arg2))(isTailRec = false)
             Define(
               lamDef,
               k(Call(
@@ -601,9 +599,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
       then k(Lambda(paramLists.head, bodyBlock))
       else
         val lamSym = new BlockMemberSymbol("lambda", Nil, false)
-        val lamDef = FunDefn(
-          N, lamSym, TermSymbol(syntax.Fun, N, Tree.Ident(lamSym.nme)),
-          paramLists, bodyBlock)(false)
+        val lamDef = FunDefn.withFreshSymbol(N, lamSym, paramLists, bodyBlock)(isTailRec = false)
         Define(
           lamDef,
           k(Value.Ref(lamSym, N)))
@@ -943,9 +939,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
       case p: Path => k(p)
       case Lambda(params, body) =>
         val lamSym = BlockMemberSymbol("lambda", Nil, false)
-        val lamDef = FunDefn(
-          N, lamSym, TermSymbol(syntax.Fun, N, Tree.Ident(lamSym.nme)),
-          params :: Nil, body)(false)
+        val lamDef = FunDefn.withFreshSymbol(N, lamSym, params :: Nil, body)(isTailRec = false)
         Define(lamDef, k(Value.Ref(lamSym, N)))
       case r =>
         val l = new TempSymbol(N)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -182,7 +182,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
                 blockImpl(stats, res)(k)))(using LoweringCtx.nestFunc)
           case syntax.Fun =>
             val (paramLists, bodyBlock) = setupFunctionOrByNameDef(td.params, bod, S(td.sym.nme))
-            Define(FunDefn(td.owner, td.sym, paramLists, bodyBlock)(td.extraAnnotations.contains(Annot.TailRec)),
+            Define(FunDefn(td.owner, td.sym, td.tsym, paramLists, bodyBlock)(td.extraAnnotations.contains(Annot.TailRec)),
               blockImpl(stats, res)(k))
           case syntax.Ins =>
             // Implicit instances are not parameterized for now.
@@ -254,7 +254,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
               case (sym, params, split) =>
                 val paramLists = params :: Nil
                 val bodyBlock = ucs.Normalization(this)(split)(Ret)
-                FunDefn(N, sym, paramLists, bodyBlock)(false)
+                FunDefn(N, sym, TermSymbol(syntax.Fun, N, Tree.Ident(sym.nme)), paramLists, bodyBlock)(false)
             // The return type is intended to be consistent with `gatherMembers`
             (mtds, Nil, Nil, End())
           case _ => gatherMembers(defn.body)
@@ -468,7 +468,9 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
           val isOr = sym is State.orSymbol
           if isAnd || isOr then
             val lamSym = BlockMemberSymbol("lambda", Nil, false)
-            val lamDef = FunDefn(N, lamSym, PlainParamList(Nil) :: Nil, returnedTerm(arg2))(false)
+            val lamDef = FunDefn(
+              N, lamSym, TermSymbol(syntax.Fun, N, Tree.Ident(lamSym.nme)),
+              PlainParamList(Nil) :: Nil, returnedTerm(arg2))(false)
             Define(
               lamDef,
               k(Call(
@@ -599,7 +601,9 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
       then k(Lambda(paramLists.head, bodyBlock))
       else
         val lamSym = new BlockMemberSymbol("lambda", Nil, false)
-        val lamDef = FunDefn(N, lamSym, paramLists, bodyBlock)(false)
+        val lamDef = FunDefn(
+          N, lamSym, TermSymbol(syntax.Fun, N, Tree.Ident(lamSym.nme)),
+          paramLists, bodyBlock)(false)
         Define(
           lamDef,
           k(Value.Ref(lamSym, N)))
@@ -862,7 +866,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
         td.body.map: bod =>
           val (paramLists, bodyBlock) = setupFunctionDef(td.params, bod, S(td.sym.nme))
           reportAnnotations(td, td.extraAnnotations)
-          FunDefn(td.owner, td.sym, paramLists, bodyBlock)(td.extraAnnotations.contains(Annot.TailRec))
+          FunDefn(td.owner, td.sym, td.tsym, paramLists, bodyBlock)(td.extraAnnotations.contains(Annot.TailRec))
     val publicFlds = clsBody.publicFlds.map(f => f.sym -> f.tsym)
     val privateFlds = clsBody.nonMethods.collect:
       case decl @ LetDecl(sym: TermSymbol, annotations) =>
@@ -939,7 +943,9 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
       case p: Path => k(p)
       case Lambda(params, body) =>
         val lamSym = BlockMemberSymbol("lambda", Nil, false)
-        val lamDef = FunDefn(N, lamSym, params :: Nil, body)(false)
+        val lamDef = FunDefn(
+          N, lamSym, TermSymbol(syntax.Fun, N, Tree.Ident(lamSym.nme)),
+          params :: Nil, body)(false)
         Define(lamDef, k(Value.Ref(lamSym, N)))
       case r =>
         val l = new TempSymbol(N)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
@@ -60,7 +60,7 @@ object Printer:
     case _ => TODO(blk)
   
   def mkDocument(defn: Defn)(using Raise, Scope): Document = defn match
-    case FunDefn(own, sym, params, body) =>
+    case FunDefn(own, sym, dSym, params, body) =>
       val docParams = doc"${own.fold("")(_.toString+"::")}${params.map(_.params.map(x => summon[Scope].allocateName(x.sym)).mkDocument("(", ", ", ")")).mkDocument("")}"
       val docBody = mkDocument(body)
       doc"fun ${sym.nme}${docParams} { #{  # ${docBody} #}  # }"

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
@@ -40,7 +40,9 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, doUnwindMap: Map[
   
   def wrapStackSafe(body: Block, resSym: Local, rest: Block) =
     val bodSym = BlockMemberSymbol("‹stack safe body›", Nil, false)
-    val bodFun = FunDefn(N, bodSym, ParamList(ParamListFlags.empty, Nil, N) :: Nil, body)(false)
+    val bodFun = FunDefn(
+      N, bodSym, TermSymbol(syntax.Fun, N, Tree.Ident(bodSym.nme)),
+      ParamList(ParamListFlags.empty, Nil, N) :: Nil, body)(false)
     Define(bodFun, Assign(resSym, Call(runStackSafePath, intLit(depthLimit).asArg :: bodSym.asPath.asArg :: Nil)(true, true, false), rest))
 
   def extractResTopLevel(res: Result, isTailCall: Bool, f: Result => Block, sym: Option[Symbol], curDepth: => Symbol) =
@@ -173,6 +175,6 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, doUnwindMap: Map[
      
   def rewriteFn(defn: FunDefn) = 
     if doUnwindFns.contains(defn.sym) then defn
-    else FunDefn(defn.owner, defn.sym, defn.params, rewriteBlk(defn.body, L(defn.sym), 1))(defn.isTailRec)
+    else FunDefn(defn.owner, defn.sym, defn.dSym, defn.params, rewriteBlk(defn.body, L(defn.sym), 1))(defn.isTailRec)
 
   def transformTopLevel(b: Block) = transform(b, TempSymbol(N), true)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
@@ -40,9 +40,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, doUnwindMap: Map[
   
   def wrapStackSafe(body: Block, resSym: Local, rest: Block) =
     val bodSym = BlockMemberSymbol("‹stack safe body›", Nil, false)
-    val bodFun = FunDefn(
-      N, bodSym, TermSymbol(syntax.Fun, N, Tree.Ident(bodSym.nme)),
-      ParamList(ParamListFlags.empty, Nil, N) :: Nil, body)(false)
+    val bodFun = FunDefn.withFreshSymbol(N, bodSym, ParamList(ParamListFlags.empty, Nil, N) :: Nil, body)(isTailRec = false)
     Define(bodFun, Assign(resSym, Call(runStackSafePath, intLit(depthLimit).asArg :: bodSym.asPath.asArg :: Nil)(true, true, false), rest))
 
   def extractResTopLevel(res: Result, isTailCall: Bool, f: Result => Block, sym: Option[Symbol], curDepth: => Symbol) =

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -226,7 +226,7 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
             defn.innerSym.collectFirst{ case s: InnerSymbol => s }):
           defn match
             
-          case FunDefn(params = Nil, body = body) =>
+          case FunDefn(params = Nil) =>
             lastWords("cannot generate function with no parameter list")
           case FunDefn(own, sym, dSym, ps :: pss, bod) =>
             val result = pss.foldRight(bod):

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -226,7 +226,7 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
             defn.innerSym.collectFirst{ case s: InnerSymbol => s }):
           defn match
             
-          case FunDefn(own, sym, dSym, Nil, body) =>
+          case FunDefn(params = Nil, body = body) =>
             lastWords("cannot generate function with no parameter list")
           case FunDefn(own, sym, dSym, ps :: pss, bod) =>
             val result = pss.foldRight(bod):
@@ -251,14 +251,14 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
             
             def mkMethods(mtds: Ls[FunDefn], mtdPrefix: Str)(using Scope): Document =
               mtds.map:
-                case td @ FunDefn(_, _, _, ps :: pss, bod) =>
+                case td @ FunDefn(params = ps :: pss, body = bod) =>
                   val result = pss.foldRight(bod):
                     case (ps, block) =>
                       Return(Lambda(ps, block), false)
                   val (params, bodyDoc) = scope.nest.givenIn:
                     setupFunction(S(td.sym.nme), ps, result)
                   doc" # $mtdPrefix${td.sym.nme}($params) ${ braced(bodyDoc) }"
-                case td @ FunDefn(_, _, _, Nil, bod) =>
+                case td @ FunDefn(params = Nil, body = bod) =>
                   doc" # ${mtdPrefix}get ${td.sym.nme}() ${ braced(body(bod, endSemi = true)) }"
               .mkDocument(" ")
             
@@ -357,7 +357,7 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
                   if checkSelections
                   then mtds
                     .flatMap:
-                      case td @ FunDefn(_, _, _, ps :: pss, bod) => S:
+                      case td @ FunDefn(params = ps :: pss, body = bod) => S:
                         doc" # get ${td.sym.nme}$$__checkNotMethod() { ${
                           runtimeVar
                         }.deboundMethod(${makeStringLiteral(td.sym.nme)}, ${

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -226,9 +226,9 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
             defn.innerSym.collectFirst{ case s: InnerSymbol => s }):
           defn match
             
-          case FunDefn(own, sym, Nil, body) =>
+          case FunDefn(own, sym, dSym, Nil, body) =>
             lastWords("cannot generate function with no parameter list")
-          case FunDefn(own, sym, ps :: pss, bod) =>
+          case FunDefn(own, sym, dSym, ps :: pss, bod) =>
             val result = pss.foldRight(bod):
               case (ps, block) => 
                 Return(Lambda(ps, block), false)
@@ -251,14 +251,14 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
             
             def mkMethods(mtds: Ls[FunDefn], mtdPrefix: Str)(using Scope): Document =
               mtds.map:
-                case td @ FunDefn(_, _, ps :: pss, bod) =>
+                case td @ FunDefn(_, _, _, ps :: pss, bod) =>
                   val result = pss.foldRight(bod):
                     case (ps, block) =>
                       Return(Lambda(ps, block), false)
                   val (params, bodyDoc) = scope.nest.givenIn:
                     setupFunction(S(td.sym.nme), ps, result)
                   doc" # $mtdPrefix${td.sym.nme}($params) ${ braced(bodyDoc) }"
-                case td @ FunDefn(_, _, Nil, bod) =>
+                case td @ FunDefn(_, _, _, Nil, bod) =>
                   doc" # ${mtdPrefix}get ${td.sym.nme}() ${ braced(body(bod, endSemi = true)) }"
               .mkDocument(" ")
             
@@ -357,7 +357,7 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
                   if checkSelections
                   then mtds
                     .flatMap:
-                      case td @ FunDefn(_, _, ps :: pss, bod) => S:
+                      case td @ FunDefn(_, _, _, ps :: pss, bod) => S:
                         doc" # get ${td.sym.nme}$$__checkNotMethod() { ${
                           runtimeVar
                         }.deboundMethod(${makeStringLiteral(td.sym.nme)}, ${

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Builder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Builder.scala
@@ -169,7 +169,7 @@ final class LlirBuilder(using Elaborator.State)(tl: TraceLogger, uid: FreshInt):
           case rs: Ls[TrivialExpr] => k(r :: rs)
   
   private def bNestedFunDef(e: FunDefn)(k: TrivialExpr => Ctx ?=> Node)(using ctx: Ctx)(using Raise, Scope): Node =
-    val FunDefn(_own, sym, params, body) = e
+    val FunDefn(_own, sym, dSym, params, body) = e
     // generate it as a single named lambda expression that may be self-recursing
     if params.length === 0 then
       bErrStop(msg"Function without arguments not supported: ${params.length.toString}")
@@ -180,7 +180,7 @@ final class LlirBuilder(using Elaborator.State)(tl: TraceLogger, uid: FreshInt):
 
   private def bFunDef(e: FunDefn)(using ctx: Ctx)(using Raise, Scope): Func =
     trace[Func](s"bFunDef begin: ${e.sym}", x => s"bFunDef end: ${x.show}"):
-      val FunDefn(_own, sym, params, body) = e
+      val FunDefn(_own, sym, dSym, params, body) = e
       assert(ctx.isTopLevel)
       if params.length === 0 then
         bErrStop(msg"Function without arguments not supported: ${params.length.toString}")
@@ -196,7 +196,7 @@ final class LlirBuilder(using Elaborator.State)(tl: TraceLogger, uid: FreshInt):
 
   private def bMethodDef(e: FunDefn)(using ctx: Ctx)(using Raise, Scope): Func =
     trace[Func](s"bFunDef begin: ${e.sym}", x => s"bFunDef end: ${x.show}"):
-      val FunDefn(_own, sym, params, body) = e
+      val FunDefn(_own, sym, dSym, params, body) = e
       if !ctx.isTopLevel then
         bErrStop(msg"Non top-level definition ${sym.nme} not supported")
       else if params.length === 0 then
@@ -512,7 +512,7 @@ final class LlirBuilder(using Elaborator.State)(tl: TraceLogger, uid: FreshInt):
       case Assign(lhs, rhs, rest) =>
         bBind(S(lhs), rhs, rest)(k)(ct)
       case AssignField(lhs, nme, rhs, rest) => TODO("AssignField not supported")
-      case Define(fd @ FunDefn(_own, sym, params, body), rest) =>
+      case Define(fd @ FunDefn(_own, sym, dSym, params, body), rest) =>
         if ctx.isTopLevel then
           val f = bFunDef(fd)
           ctx.def_acc += f
@@ -574,7 +574,7 @@ final class LlirBuilder(using Elaborator.State)(tl: TraceLogger, uid: FreshInt):
         case _ => ()
   
       override def applyFunDefn(fun: FunDefn): Unit =
-        val FunDefn(_own, sym, params, body) = fun
+        val FunDefn(_own, sym, dSym, params, body) = fun
         if params.length === 0 then
           bErrStop(msg"Function without arguments not supported: ${params.length.toString}")
         ctx2 = ctx2.addFuncName(sym, params.head.params.length)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Builder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Builder.scala
@@ -512,7 +512,7 @@ final class LlirBuilder(using Elaborator.State)(tl: TraceLogger, uid: FreshInt):
       case Assign(lhs, rhs, rest) =>
         bBind(S(lhs), rhs, rest)(k)(ct)
       case AssignField(lhs, nme, rhs, rest) => TODO("AssignField not supported")
-      case Define(fd @ FunDefn(_own, sym, dSym, params, body), rest) =>
+      case Define(fd: FunDefn, rest) =>
         if ctx.isTopLevel then
           val f = bFunDef(fd)
           ctx.def_acc += f

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -360,7 +360,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
           ):
             boundary:
               defn match
-                case FunDefn(own, sym, dSym, Nil, body) =>
+                case FunDefn(params = Nil) =>
                   lastWords("cannot generate function with no parameter list")
                 case FunDefn(own, sym, dSym, ps :: pss, bod) =>
                   if own.nonEmpty then

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -360,9 +360,9 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
           ):
             boundary:
               defn match
-                case FunDefn(own, sym, Nil, body) =>
+                case FunDefn(own, sym, dSym, Nil, body) =>
                   lastWords("cannot generate function with no parameter list")
-                case FunDefn(own, sym, ps :: pss, bod) =>
+                case FunDefn(own, sym, dSym, ps :: pss, bod) =>
                   if own.nonEmpty then
                     break(errExpr(
                       Ls(

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -398,9 +398,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State) e
             Select(Value.Ref(State.runtimeSymbol), Tree.Ident("LoopEnd"))(S(State.loopEndSymbol))
           val blk = blockBuilder
             .assign(l, Value.Lit(Tree.UnitLit(false)))
-            .define(FunDefn(N, f, TermSymbol(syntax.Fun, N, Tree.Ident(f.nme)), PlainParamList(Nil) :: Nil,
-              Begin(body, Return(loopEnd, false))
-            )(false))
+            .define(FunDefn.withFreshSymbol(N, f, PlainParamList(Nil) :: Nil, Begin(body, Return(loopEnd, false)))(isTailRec = false))
             .assign(loopResult, Call(Value.Ref(f, N), Nil)(true, true, false))
           if summon[LoweringCtx].mayRet then
             blk

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -398,7 +398,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State) e
             Select(Value.Ref(State.runtimeSymbol), Tree.Ident("LoopEnd"))(S(State.loopEndSymbol))
           val blk = blockBuilder
             .assign(l, Value.Lit(Tree.UnitLit(false)))
-            .define(FunDefn(N, f, PlainParamList(Nil) :: Nil,
+            .define(FunDefn(N, f, TermSymbol(syntax.Fun, N, Tree.Ident(f.nme)), PlainParamList(Nil) :: Nil,
               Begin(body, Return(loopEnd, false))
             )(false))
             .assign(loopResult, Call(Value.Ref(f, N), Nil)(true, true, false))

--- a/hkmc2/shared/src/test/mlscript/codegen/FieldSymbols.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/FieldSymbols.mls
@@ -88,6 +88,7 @@ case
 //│     defn = FunDefn:
 //│       owner = N
 //│       sym = member:lambda
+//│       dSym = term:lambda
 //│       params = Ls of 
 //│         ParamList:
 //│           flags = ()


### PR DESCRIPTION
Classes, modules and value definitions have their `DefinitionSymbols` propagated, but not function definitions. This PR adds a field for `TermSymbol` to `FunDefns` and propagates the term symbol from the elaborator.

Depends on https://github.com/hkust-taco/mlscript/pull/352.