### PR TITLE
Helpers

### DIFF
--- a/hkmc2/shared/src/test/mlscript-compile/CachedHash.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/CachedHash.mls
@@ -1,6 +1,6 @@
 class CachedHash with
   let _hash = null
   fun hash() = if _hash !== null then _hash else
-    let h = this.toString()
+    let h = this.toString() // TODO: use a proper hash function!!
     set _hash = h
     h

--- a/hkmc2/shared/src/test/mlscript-compile/CachedHash.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/CachedHash.mls
@@ -1,0 +1,6 @@
+class CachedHash with
+  let _hash = null
+  fun hash() = if _hash !== null then _hash else
+    let h = this.toString()
+    set _hash = h
+    h

--- a/hkmc2/shared/src/test/mlscript-compile/Predef.mjs
+++ b/hkmc2/shared/src/test/mlscript-compile/Predef.mjs
@@ -98,6 +98,142 @@ globalThis.Object.freeze(class Predef {
       return f.call(receiver, ...args)
     }
   } 
+  static eq(a, b) {
+    let scrut, scrut1, scrut2, ac, bc, scrut3, md, scrut4, scrut5, scrut6, scrut7, scrut8, scrut9, scrut10, scrut11, tmp, lambda, tmp1, lambda1, tmp2, tmp3, tmp4;
+    split_root$: {
+      split_1$: {
+        scrut = a === b;
+        if (scrut === true) {
+          tmp = true;
+          break split_root$
+        } else {
+          if (a instanceof globalThis.Array) {
+            if (b instanceof globalThis.Array) {
+              scrut1 = a.length === b.length;
+              if (scrut1 === true) {
+                lambda = (undefined, function (a1, i) {
+                  let tmp5;
+                  tmp5 = runtime.safeCall(b.at(i));
+                  return Predef.eq(a1, tmp5)
+                });
+                tmp = runtime.safeCall(a.every(lambda));
+                break split_root$
+              } else {
+                break split_1$
+              }
+            } else {
+              break split_1$
+            }
+          } else {
+            break split_1$
+          }
+        }
+      }
+      split_root$1: {
+        split_1$1: {
+          scrut2 = a !== undefined;
+          if (scrut2 === true) {
+            scrut11 = a !== null;
+            if (scrut11 === true) {
+              scrut10 = b !== undefined;
+              if (scrut10 === true) {
+                scrut9 = b !== null;
+                if (scrut9 === true) {
+                  ac = a.constructor;
+                  bc = b.constructor;
+                  split_root$2: {
+                    split_1$2: {
+                      scrut3 = ac !== undefined;
+                      if (scrut3 === true) {
+                        scrut7 = ac === bc;
+                        if (scrut7 === true) {
+                          tmp1 = globalThis.Symbol.for("mlscript.definitionMetadata");
+                          md = ac[tmp1];
+                          split_root$3: {
+                            split_1$3: {
+                              scrut4 = md !== undefined;
+                              if (scrut4 === true) {
+                                lambda1 = (undefined, function (field) {
+                                  let scrut12, scrut13, tmp5;
+                                  split_root$4: {
+                                    split_1$4: {
+                                      scrut12 = field !== null;
+                                      if (scrut12 === true) {
+                                        scrut13 = Predef.eq(a[field], b[field]);
+                                        if (scrut13 === true) {
+                                          tmp5 = true;
+                                          break split_root$4
+                                        } else {
+                                          break split_1$4
+                                        }
+                                      } else {
+                                        break split_1$4
+                                      }
+                                    }
+                                    tmp5 = false;
+                                  }
+                                  return tmp5
+                                });
+                                scrut5 = runtime.safeCall(md[2].every(lambda1));
+                                if (scrut5 === true) {
+                                  tmp2 = true;
+                                  break split_root$3
+                                } else {
+                                  break split_1$3
+                                }
+                              } else {
+                                break split_1$3
+                              }
+                            }
+                            tmp2 = false;
+                          }
+                          scrut6 = tmp2;
+                          if (scrut6 === true) {
+                            tmp3 = true;
+                            break split_root$2
+                          } else {
+                            break split_1$2
+                          }
+                        } else {
+                          break split_1$2
+                        }
+                      } else {
+                        break split_1$2
+                      }
+                    }
+                    tmp3 = false;
+                  }
+                  scrut8 = tmp3;
+                  if (scrut8 === true) {
+                    tmp4 = true;
+                    break split_root$1
+                  } else {
+                    break split_1$1
+                  }
+                } else {
+                  break split_1$1
+                }
+              } else {
+                break split_1$1
+              }
+            } else {
+              break split_1$1
+            }
+          } else {
+            break split_1$1
+          }
+        }
+        tmp4 = false;
+      }
+      tmp = tmp4;
+    }
+    return tmp
+  } 
+  static neq(a, b) {
+    let tmp;
+    tmp = Predef.eq(a, b);
+    return ! tmp
+  } 
   static print(...xs) {
     let tmp, tmp1;
     tmp = runtime.safeCall(Predef.map(Predef.renderAsStr));
@@ -126,7 +262,7 @@ globalThis.Object.freeze(class Predef {
     return (first, ...rest) => {
       let len, scrut, i, init, scrut1, tmp, tmp1, tmp2, tmp3;
       len = rest.length;
-      scrut = len == 0;
+      scrut = len === 0;
       if (scrut === true) {
         return first
       } else {

--- a/hkmc2/shared/src/test/mlscript-compile/Predef.mjs
+++ b/hkmc2/shared/src/test/mlscript-compile/Predef.mjs
@@ -20,6 +20,7 @@ globalThis.Object.freeze(class Predef {
       }
       constructor() {
         this.prettyPrint = RuntimeJS.symbols.prettyPrint;
+        this.definitionMetadata = RuntimeJS.symbols.definitionMetadata;
         Object.defineProperty(this, "class", {
           value: Symbols
         })
@@ -98,8 +99,8 @@ globalThis.Object.freeze(class Predef {
       return f.call(receiver, ...args)
     }
   } 
-  static eq(a, b) {
-    let scrut, scrut1, scrut2, ac, bc, scrut3, md, scrut4, scrut5, scrut6, scrut7, scrut8, scrut9, scrut10, scrut11, tmp, lambda, tmp1, lambda1, tmp2, tmp3, tmp4;
+  static equals(a, b) {
+    let scrut, scrut1, scrut2, ac, scrut3, md, scrut4, scrut5, scrut6, scrut7, scrut8, scrut9, scrut10, scrut11, tmp, lambda, lambda1, tmp1, tmp2, tmp3;
     split_root$: {
       split_1$: {
         scrut = a === b;
@@ -112,9 +113,9 @@ globalThis.Object.freeze(class Predef {
               scrut1 = a.length === b.length;
               if (scrut1 === true) {
                 lambda = (undefined, function (a1, i) {
-                  let tmp5;
-                  tmp5 = runtime.safeCall(b.at(i));
-                  return Predef.eq(a1, tmp5)
+                  let tmp4;
+                  tmp4 = runtime.safeCall(b.at(i));
+                  return Predef.equals(a1, tmp4)
                 });
                 tmp = runtime.safeCall(a.every(lambda));
                 break split_root$
@@ -140,28 +141,26 @@ globalThis.Object.freeze(class Predef {
                 scrut9 = b !== null;
                 if (scrut9 === true) {
                   ac = a.constructor;
-                  bc = b.constructor;
                   split_root$2: {
                     split_1$2: {
                       scrut3 = ac !== undefined;
                       if (scrut3 === true) {
-                        scrut7 = ac === bc;
+                        scrut7 = ac === b.constructor;
                         if (scrut7 === true) {
-                          tmp1 = globalThis.Symbol.for("mlscript.definitionMetadata");
-                          md = ac[tmp1];
+                          md = ac[Predef.Symbols.definitionMetadata];
                           split_root$3: {
                             split_1$3: {
                               scrut4 = md !== undefined;
                               if (scrut4 === true) {
                                 lambda1 = (undefined, function (field) {
-                                  let scrut12, scrut13, tmp5;
+                                  let scrut12, scrut13, tmp4;
                                   split_root$4: {
                                     split_1$4: {
                                       scrut12 = field !== null;
                                       if (scrut12 === true) {
-                                        scrut13 = Predef.eq(a[field], b[field]);
+                                        scrut13 = Predef.equals(a[field], b[field]);
                                         if (scrut13 === true) {
-                                          tmp5 = true;
+                                          tmp4 = true;
                                           break split_root$4
                                         } else {
                                           break split_1$4
@@ -170,13 +169,13 @@ globalThis.Object.freeze(class Predef {
                                         break split_1$4
                                       }
                                     }
-                                    tmp5 = false;
+                                    tmp4 = false;
                                   }
-                                  return tmp5
+                                  return tmp4
                                 });
                                 scrut5 = runtime.safeCall(md[2].every(lambda1));
                                 if (scrut5 === true) {
-                                  tmp2 = true;
+                                  tmp1 = true;
                                   break split_root$3
                                 } else {
                                   break split_1$3
@@ -185,11 +184,11 @@ globalThis.Object.freeze(class Predef {
                                 break split_1$3
                               }
                             }
-                            tmp2 = false;
+                            tmp1 = false;
                           }
-                          scrut6 = tmp2;
+                          scrut6 = tmp1;
                           if (scrut6 === true) {
-                            tmp3 = true;
+                            tmp2 = true;
                             break split_root$2
                           } else {
                             break split_1$2
@@ -201,11 +200,11 @@ globalThis.Object.freeze(class Predef {
                         break split_1$2
                       }
                     }
-                    tmp3 = false;
+                    tmp2 = false;
                   }
-                  scrut8 = tmp3;
+                  scrut8 = tmp2;
                   if (scrut8 === true) {
-                    tmp4 = true;
+                    tmp3 = true;
                     break split_root$1
                   } else {
                     break split_1$1
@@ -223,15 +222,15 @@ globalThis.Object.freeze(class Predef {
             break split_1$1
           }
         }
-        tmp4 = false;
+        tmp3 = false;
       }
-      tmp = tmp4;
+      tmp = tmp3;
     }
     return tmp
   } 
-  static neq(a, b) {
+  static nequals(a, b) {
     let tmp;
-    tmp = Predef.eq(a, b);
+    tmp = Predef.equals(a, b);
     return ! tmp
   } 
   static print(...xs) {

--- a/hkmc2/shared/src/test/mlscript-compile/Predef.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/Predef.mls
@@ -42,6 +42,20 @@ fun (|.) passToLo(receiver, f)(...args) = f(receiver, ...args)
 // x |>. foo(a, b, c) == foo.call(x, a, b, c)
 fun (|>.) call(receiver, f)(...args) = f.call(receiver, ...args)
 
+// allow data classes to be equal if all fields are equal
+fun (==) eq(a, b) = if
+  a === b then true
+  a is Array and b is Array and a.length === b.length then a.every((a, i) => eq(a, b.at(i)))
+  else a !== undefined and a !== null and b !== undefined and b !== null and 
+    let ac = a.constructor
+    let bc = b.constructor
+    ac !== undefined and ac === bc and
+      let md = ac.(Symbol.for("mlscript.definitionMetadata"))
+      md !== undefined and
+        md.2.every(field => field !== null and eq(a.(field), b.(field)))
+
+fun (!=) neq(a, b) = not a == b
+
 object Symbols with
   val prettyPrint = RuntimeJS.symbols.prettyPrint
 
@@ -74,7 +88,7 @@ val foldl = fold
 // fun foldr(f)(...rest, init) = // TODO allow this syntax
 fun foldr(f)(first, ...rest) =
   let len = rest.length
-  if len == 0 then first else...
+  if len === 0 then first else...
   let
     i = len - 1
     init = rest.at(i)

--- a/hkmc2/shared/src/test/mlscript-compile/Predef.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/Predef.mls
@@ -42,22 +42,31 @@ fun (|.) passToLo(receiver, f)(...args) = f(receiver, ...args)
 // x |>. foo(a, b, c) == foo.call(x, a, b, c)
 fun (|>.) call(receiver, f)(...args) = f.call(receiver, ...args)
 
-// allow data classes to be equal if all fields are equal
-fun (==) eq(a, b) = if
-  a === b then true
-  a is Array and b is Array and a.length === b.length then a.every((a, i) => eq(a, b.at(i)))
-  else a !== undefined and a !== null and b !== undefined and b !== null and 
-    let ac = a.constructor
-    let bc = b.constructor
-    ac !== undefined and ac === bc and
-      let md = ac.(Symbol.for("mlscript.definitionMetadata"))
-      md !== undefined and
-        md.2.every(field => field !== null and eq(a.(field), b.(field)))
-
-fun (!=) neq(a, b) = not a == b
 
 object Symbols with
   val prettyPrint = RuntimeJS.symbols.prettyPrint
+  val definitionMetadata = RuntimeJS.symbols.definitionMetadata
+  // val definitionMetadata = Symbol.for("mlscript.definitionMetadata")
+
+
+// * A generic equality comparison.
+// * Returns true for:
+// * - values that compare equal according to strict equality (===), which includes reference equality;
+// * - arrays of values that are pairwise recursively equal;
+// * - instances of the same parameterized MLscript class when all fields are public and recursively equal.
+// TODO: compare lazy arrays and other sequences and collections
+fun (==) equals(a, b) = if
+  a === b then true
+  a is Array and b is Array and a.length === b.length then a.every((a, i) => a == b.at(i))
+  else a !== undefined and a !== null and b !== undefined and b !== null and 
+    let ac = a.constructor
+    ac !== undefined and ac === b.constructor and
+      let md = ac.(Symbols.definitionMetadata)
+      md !== undefined and
+        md.2.every(field => field !== null and a.(field) == b.(field))
+
+fun (!=) nequals(a, b) = not a == b
+
 
 val pass1 = Rendering.pass1
 val pass2 = Rendering.pass2

--- a/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
+++ b/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
@@ -46,18 +46,6 @@ else 0
 
 // ——— ——— ———
 
-// TODO we should give reasonable meaning to `==`
-//  notably taking into account arrays and data classes;
-//  and deprecated `===` (notably does not work for arrays)
-
-undefined == null
-//│ = false
-
-undefined === null
-//│ = false
-
-// ——— ——— ———
-
 Infinity
 //│ = Infinity
 
@@ -127,7 +115,7 @@ object Cls(val x) with
 :e
 Cls.x
 //│ ╔══[ERROR] Object 'Cls' does not contain member 'x'
-//│ ║  l.128: 	Cls.x
+//│ ║  l.116: 	Cls.x
 //│ ╙──       	   ^^
 //│ ═══[RUNTIME ERROR] TypeError: Cannot read properties of undefined (reading 'x')
 
@@ -137,7 +125,7 @@ Cls.huh
 
 let c = new Cls(123)
 //│ ╔══[ERROR] Expected a statically known class; found reference of type Cls.
-//│ ║  l.138: 	let c = new Cls(123)
+//│ ║  l.126: 	let c = new Cls(123)
 //│ ║         	            ^^^
 //│ ╙── The 'new' keyword requires a statically known class; use the 'new!' operator for dynamic instantiation.
 //│ ═══[RUNTIME ERROR] TypeError: Cls1 is not a constructor
@@ -150,7 +138,7 @@ c.x
 
 class Foo' with
   class Bar'
-//│ > let Foo$_1;try { globalThis.Object.freeze(class Foo$_ {   static {     Foo$_1 = this   }   constructor() {     const this$Foo$_ = this;     globalThis.Object.freeze(class Bar$_ {       static {         this$Foo$_.Bar' = this       }       constructor() {}       toString() { return runtime.render(this); }       static [definitionMetadata] = ["class", "Bar'"];      });   }   toString() { return runtime.render(this); }   static [definitionMetadata] = ["class", "Foo'"];  }); block$res20 = undefined; } catch (e) { console.log('\u200B' + e + '\u200B'); }
+//│ > let Foo$_1;try { globalThis.Object.freeze(class Foo$_ {   static {     Foo$_1 = this   }   constructor() {     const this$Foo$_ = this;     globalThis.Object.freeze(class Bar$_ {       static {         this$Foo$_.Bar' = this       }       constructor() {}       toString() { return runtime.render(this); }       static [definitionMetadata] = ["class", "Bar'"];      });   }   toString() { return runtime.render(this); }   static [definitionMetadata] = ["class", "Foo'"];  }); block$res18 = undefined; } catch (e) { console.log('\u200B' + e + '\u200B'); }
 //│ >                                                                                                                                                                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ═══[COMPILATION ERROR] [Uncaught SyntaxError] Unexpected string
 
@@ -160,28 +148,28 @@ module Example with
 // whoops
   val a = this
 //│ ╔══[PARSE ERROR] Expected start of expression in this position; found new line instead
-//│ ║  l.159: 	module Example with
+//│ ║  l.147: 	module Example with
 //│ ║         	                   ^
-//│ ║  l.160: 	// whoops
+//│ ║  l.148: 	// whoops
 //│ ╙──       	
 //│ ╔══[PARSE ERROR] Expected an expression; found block instead
-//│ ║  l.161: 	  val a = this
+//│ ║  l.149: 	  val a = this
 //│ ╙──       	  ^
 //│ ╔══[PARSE ERROR] Expected end of input; found indented block instead
-//│ ║  l.161: 	  val a = this
+//│ ║  l.149: 	  val a = this
 //│ ╙──       	^^
 
 // ——— ——— ———
 
 let xs = new Oopsie
 //│ ╔══[ERROR] Name not found: Oopsie
-//│ ║  l.176: 	let xs = new Oopsie
+//│ ║  l.164: 	let xs = new Oopsie
 //│ ╙──       	             ^^^^^^
 //│ ╔══[ERROR] Expected a statically known class; found ‹error›.
 //│ ╙── The 'new' keyword requires a statically known class; use the 'new!' operator for dynamic instantiation.
 //│ ╔══[COMPILATION ERROR] No definition found in scope for member 'xs'
 //│ ╟── which references the symbol introduced here
-//│ ║  l.176: 	let xs = new Oopsie
+//│ ║  l.164: 	let xs = new Oopsie
 //│ ╙──       	    ^^
 //│ ═══[RUNTIME ERROR] ReferenceError: xs is not defined
 
@@ -202,7 +190,7 @@ class C
 :sjs
 class D extends id(C)
 //│ ╔══[ERROR] Expected a statically known class; found selection.
-//│ ║  l.203: 	class D extends id(C)
+//│ ║  l.191: 	class D extends id(C)
 //│ ║         	                ^^
 //│ ╙── The 'new' keyword requires a statically known class; use the 'new!' operator for dynamic instantiation.
 //│ JS (unsanitized):
@@ -230,13 +218,13 @@ let x = 0
 :fixme
 set x += 1; ()
 //│ ╔══[ERROR] Expected a right-hand side for this assignment
-//│ ║  l.231: 	set x += 1; ()
+//│ ║  l.219: 	set x += 1; ()
 //│ ╙──       	    ^^^^^^^^^^
 
 :e
 set (x += 1; ())
 //│ ╔══[ERROR] Expected a right-hand side for this assignment
-//│ ║  l.237: 	set (x += 1; ())
+//│ ║  l.225: 	set (x += 1; ())
 //│ ╙──       	    ^^^^^^^^^^^^
 
 (set x += 1); ()
@@ -244,7 +232,7 @@ set (x += 1; ())
 :fixme
 [x, set x += 1; x]
 //│ ╔══[ERROR] Expected a right-hand side for this assignment
-//│ ║  l.245: 	[x, set x += 1; x]
+//│ ║  l.233: 	[x, set x += 1; x]
 //│ ╙──       	        ^^^^^^^^^
 //│ = [1]
 
@@ -266,13 +254,13 @@ import "../../mlscript-compile/Stack.mls"
 // The parser rejects this, but it should be allowed.
 open Stack { ::, Nil }
 //│ ╔══[ERROR] Illegal 'open' statement shape.
-//│ ║  l.267: 	open Stack { ::, Nil }
+//│ ║  l.255: 	open Stack { ::, Nil }
 //│ ╙──       	     ^^^^^^^^^^^^^^^
 
 // Instead, if we parenthesize the operator, it is rejected by the elaborator.
 open Stack { (::), Nil }
 //│ ╔══[ERROR] Illegal 'open' statement element.
-//│ ║  l.273: 	open Stack { (::), Nil }
+//│ ║  l.261: 	open Stack { (::), Nil }
 //│ ╙──       	             ^^^^
 
 open Stack { Nil, :: }
@@ -280,7 +268,7 @@ open Stack { Nil, :: }
 :sjs
 1 :: Nil
 //│ ╔══[ERROR] Module 'Stack' does not contain member '::'
-//│ ║  l.281: 	1 :: Nil
+//│ ║  l.269: 	1 :: Nil
 //│ ╙──       	  ^^
 //│ JS (unsanitized):
 //│ Stack["::"](1, Stack.Nil)
@@ -291,9 +279,9 @@ open Stack { Nil, :: }
 mkStr of ... // hello
 "oops"
 //│ ╔══[PARSE ERROR] Expected start of expression in this position; found new line instead
-//│ ║  l.291: 	mkStr of ... // hello
+//│ ║  l.279: 	mkStr of ... // hello
 //│ ║         	                     ^
-//│ ║  l.292: 	"oops"
+//│ ║  l.280: 	"oops"
 //│ ╙──       	
 //│ = "oops"
 
@@ -316,25 +304,25 @@ Foo(1, 2, 3).args
 :todo
 if Foo(1, 2, 3) is Foo(...args) then args
 //│ ╔══[ERROR] Unrecognized pattern (spread).
-//│ ║  l.317: 	if Foo(1, 2, 3) is Foo(...args) then args
+//│ ║  l.305: 	if Foo(1, 2, 3) is Foo(...args) then args
 //│ ╙──       	                       ^^^^^^^
 //│ ╔══[ERROR] Name not found: args
-//│ ║  l.317: 	if Foo(1, 2, 3) is Foo(...args) then args
+//│ ║  l.305: 	if Foo(1, 2, 3) is Foo(...args) then args
 //│ ╙──       	                                     ^^^^
 //│ ╔══[ERROR] The constructor does not take any arguments but found one argument.
-//│ ║  l.317: 	if Foo(1, 2, 3) is Foo(...args) then args
+//│ ║  l.305: 	if Foo(1, 2, 3) is Foo(...args) then args
 //│ ╙──       	                   ^^^
 //│ ═══[RUNTIME ERROR] Error: match error
 
 if Foo(1, 2, 3) is Foo(a, b, c) then [a, b, c]
 //│ ╔══[ERROR] The constructor does not take any arguments but found three arguments.
-//│ ║  l.329: 	if Foo(1, 2, 3) is Foo(a, b, c) then [a, b, c]
+//│ ║  l.317: 	if Foo(1, 2, 3) is Foo(a, b, c) then [a, b, c]
 //│ ╙──       	                       ^^^^^^^
 //│ ═══[RUNTIME ERROR] Error: match error
 
 if Foo(1, 2, 3) is Foo(arg) then arg
 //│ ╔══[ERROR] The constructor does not take any arguments but found one argument.
-//│ ║  l.335: 	if Foo(1, 2, 3) is Foo(arg) then arg
+//│ ║  l.323: 	if Foo(1, 2, 3) is Foo(arg) then arg
 //│ ╙──       	                       ^^^
 //│ ═══[RUNTIME ERROR] Error: match error
 
@@ -368,10 +356,10 @@ fun foo() =
   let bar(x: Str): Str = x + x
   bar("test")
 //│ ╔══[ERROR] Unsupported let binding shape
-//│ ║  l.368: 	  let bar(x: Str): Str = x + x
+//│ ║  l.356: 	  let bar(x: Str): Str = x + x
 //│ ╙──       	      ^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╔══[ERROR] Expected 0 arguments, got 1
-//│ ║  l.369: 	  bar("test")
+//│ ║  l.357: 	  bar("test")
 //│ ╙──       	     ^^^^^^^^
 
 // ——— ——— ———
@@ -381,7 +369,7 @@ fun foo() =
 module Foo(x)
 //│ ╔══[COMPILATION ERROR] No definition found in scope for member 'x'
 //│ ╟── which references the symbol introduced here
-//│ ║  l.381: 	module Foo(x)
+//│ ║  l.369: 	module Foo(x)
 //│ ╙──       	           ^
 //│ JS (unsanitized):
 //│ let Foo5;
@@ -405,7 +393,7 @@ module Foo(x)
 module Foo(val x)
 //│ ╔══[COMPILATION ERROR] No definition found in scope for member 'x'
 //│ ╟── which references the symbol introduced here
-//│ ║  l.405: 	module Foo(val x)
+//│ ║  l.393: 	module Foo(val x)
 //│ ╙──       	               ^
 //│ JS (unsanitized):
 //│ let Foo7;
@@ -428,7 +416,7 @@ module Foo(val x)
 // TODO support syntax?
 data class Foo(mut x)
 //│ ╔══[ERROR] Expected a valid parameter, found 'mut'-modified identifier
-//│ ║  l.429: 	data class Foo(mut x)
+//│ ║  l.417: 	data class Foo(mut x)
 //│ ╙──       	                   ^
 
 // ——— ——— ———
@@ -445,10 +433,10 @@ set this.pc = 0
 set
   (this).pc = 0
 //│ ╔══[ERROR] Cannot use 'this' outside of an object scope.
-//│ ║  l.444: 	set this.pc = 0
+//│ ║  l.432: 	set this.pc = 0
 //│ ╙──       	    ^^^^
 //│ ╔══[ERROR] Cannot use 'this' outside of an object scope.
-//│ ║  l.446: 	  (this).pc = 0
+//│ ║  l.434: 	  (this).pc = 0
 //│ ╙──       	   ^^^^
 
 // But this doesn't...
@@ -457,10 +445,10 @@ set
 set
   this.pc = 0
 //│ ╔══[PARSE ERROR] Unexpected static selector here
-//│ ║  l.458: 	  this.pc = 0
+//│ ║  l.446: 	  this.pc = 0
 //│ ╙──       	      ^^^
 //│ ╔══[ERROR] Expected a right-hand side for this assignment
-//│ ║  l.458: 	  this.pc = 0
+//│ ║  l.446: 	  this.pc = 0
 //│ ╙──       	  ^^^^
 
 // ——— ——— ———
@@ -472,7 +460,7 @@ pattern A(pattern B) = B
 
 fun foo(x) = if x is @annotations.compile A(0) as y then y
 //│ ╔══[COMPILATION ERROR] No definition found in scope for member 'y'
-//│ ║  l.473: 	fun foo(x) = if x is @annotations.compile A(0) as y then y
+//│ ║  l.461: 	fun foo(x) = if x is @annotations.compile A(0) as y then y
 //│ ╙──       	                                                         ^
 
 // ——— ——— ———

--- a/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
+++ b/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
@@ -51,7 +51,7 @@ else 0
 //  and deprecated `===` (notably does not work for arrays)
 
 undefined == null
-//│ = true
+//│ = false
 
 undefined === null
 //│ = false

--- a/hkmc2/shared/src/test/mlscript/bbml/bbGPCE.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbGPCE.mls
@@ -22,7 +22,7 @@ run(x `=> id(x) `* x)
 
 fun assertNotZero: [C] -> CodeBase[out Num, out C, out Any] -> CodeBase[out Num, out C, out Any]
 fun assertNotZero(x) =
-  `if (x `== `0.0) then `error else x
+  `if (x `=== `0.0) then `error else x
 let checkedDiv = x `=> y `=> x `/. (assertNotZero(y))
 run(checkedDiv)
 //│ Type: Num -> (Num -> Num)

--- a/hkmc2/shared/src/test/mlscript/bbml/bbPrelude.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbPrelude.mls
@@ -92,6 +92,8 @@ declare fun (<=): (Int, Int) -> Bool
 declare fun (>=): (Int, Int) -> Bool
 declare fun (==): [T] -> (T, T) -> Bool
 declare fun (!=): [T] -> (T, T) -> Bool
+declare fun (===): [T] -> (T, T) -> Bool
+declare fun (!==): [T] -> (T, T) -> Bool
 
 declare fun (&&): (Bool, Bool) -> Bool
 declare fun (||): (Bool, Bool) -> Bool

--- a/hkmc2/shared/src/test/mlscript/bbml/bbQQ.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbQQ.mls
@@ -81,7 +81,7 @@ f `=> x `=> y `=> f`(x, y)
 
 
 
-x `=> `if x `== `0.0 then `1.0 else x
+x `=> `if x `=== `0.0 then `1.0 else x
 //│ Type: CodeBase[out 'x -> ('x ∨ Num), ⊥, ?]
 
 run(`1)

--- a/hkmc2/shared/src/test/mlscript/codegen/BlockPrinter.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/BlockPrinter.mls
@@ -21,7 +21,7 @@ let x = x + 1
 //│ Pretty Lowered:
 //│  
 //│ set x1 = 1 in
-//│ set scrut = ==(x1, 0) in
+//│ set scrut = Predef.equals(x1, 0) in
 //│ match scrut
 //│   true =>
 //│     set tmp = 1 in

--- a/hkmc2/shared/src/test/mlscript/codegen/PartialApps.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/PartialApps.mls
@@ -266,7 +266,7 @@ fun f(x) =
 //│ let f16;
 //│ f16 = function f(x3) {
 //│   let scrut;
-//│   scrut = x3 == 0;
+//│   scrut = Predef.equals(x3, 0);
 //│   if (scrut === true) { return 1 } else { return 2 }
 //│ };
 

--- a/hkmc2/shared/src/test/mlscript/codegen/QQImport.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/QQImport.mls
@@ -82,10 +82,10 @@ Term.print(`if `true then `true else `false)
 //│ >   else false
 
 
-Term.print(x `=> `if x `== `0.0 then `1.0 else x)
+Term.print(x `=> `if x `=== `0.0 then `1.0 else x)
 //│ > (x_0) =>
 //│ >   if 
-//│ >     let scrut_0 = (==)(x_0, 0)
+//│ >     let scrut_0 = (===)(x_0, 0)
 //│ >     scrut_0 is true then 1
 //│ >     else x_0
 

--- a/hkmc2/shared/src/test/mlscript/codegen/Quasiquotes.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Quasiquotes.mls
@@ -145,14 +145,14 @@ f`(`0)
 //│ )
 
 
-x `=> `if x `== `0.0 then `1.0 else x
+x `=> `if x `=== `0.0 then `1.0 else x
 //│ = Lam(
 //│   [Symbol("x")],
 //│   IfLike(
 //│     If,
 //│     Let(
 //│       Symbol("scrut"),
-//│       App(Builtin("=="), Tup([Ref(Symbol("x")), Lit(0)])),
+//│       App(Builtin("==="), Tup([Ref(Symbol("x")), Lit(0)])),
 //│       Cons(
 //│         Branch(Ref(Symbol("scrut")), LitPattern(true), Else(Lit(1))),
 //│         Else(Ref(Symbol("x")))
@@ -160,4 +160,11 @@ x `=> `if x `== `0.0 then `1.0 else x
 //│     )
 //│   )
 //│ )
+
+:fixme // FIXME: weird error
+x `=> `if x `== `0.0 then `1.0 else x
+//│ ═══[COMPILATION ERROR] No definition found in scope for member 'import'
+//│ > let x6, scrut2, tmp57, tmp58, tmp59, tmp60, tmp61, tmp62, arr10, tmp63, tmp64, tmp65, tmp66, tmp67, tmp68, tmp69, tmp70, tmp71, tmp72, tmp73, arr11, tmp74, tmp75;try { tmp57 = globalThis.Object.freeze(new Term.Symbol("x")); x6 = globalThis.Object.freeze(new Term.Ref(tmp57)); tmp58 = globalThis.Object.freeze(new Term.Symbol("scrut")); scrut2 = globalThis.Object.freeze(new Term.Ref(tmp58)); tmp70 = globalThis.Object.freeze(new Term.Symbol("Predef")); tmp71 = globalThis.Object.freeze(new Term.CSRef(tmp70, import.meta.url, "../../mlscript-compile/Predef.mls")); tmp72 = x6; tmp73 = globalThis.Object.freeze(new Term.Lit(0.0)); arr11 = globalThis.Object.freeze([   tmp72,   tmp73 ]); tmp74 = globalThis.Object.freeze(new Term.Sel(tmp71, "equals")); tmp75 = globalThis.Object.freeze(new Term.Tup(arr11)); tmp59 = globalThis.Object.freeze(new Term.App(tmp74, tmp75)); tmp63 = scrut2; tmp64 = globalThis.Object.freeze(new Term.LitPattern(true)); tmp69 = globalThis.Object.freeze(new Term.Lit(1.0)); tmp65 = globalThis.Object.freeze(new Term.Else(tmp69)); tmp66 = globalThis.Object.freeze(new Term.Branch(tmp63, tmp64, tmp65)); tmp68 = x6; tmp67 = globalThis.Object.freeze(new Term.Else(tmp68)); tmp60 = globalThis.Object.freeze(new Term.Cons(tmp66, tmp67)); tmp61 = globalThis.Object.freeze(new Term.Let(tmp58, tmp59, tmp60)); arr10 = globalThis.Object.freeze([   tmp57 ]); tmp62 = globalThis.Object.freeze(new Term.IfLike(Term.Keyword.If, tmp61)); block$res16 = globalThis.Object.freeze(new Term.Lam(arr10, tmp62)); undefined } catch (e) { console.log('\u200B' + e + '\u200B'); }
+//│ >                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ^^^^
+//│ ═══[COMPILATION ERROR] [Uncaught SyntaxError] Cannot use 'import.meta' outside a module
 

--- a/hkmc2/shared/src/test/mlscript/codegen/SanityChecks.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/SanityChecks.mls
@@ -290,7 +290,7 @@ if M.A(1).y is
 //│ }
 //│ scrut = selRes2;
 //│ x = scrut;
-//│ scrut1 = x == 1;
+//│ scrut1 = Predef.equals(x, 1);
 //│ if (scrut1 === true) { block$res13 = x; undefined } else { block$res13 = 0; undefined }
 //│ ═══[RUNTIME ERROR] Error: Access to required field 'y' yielded 'undefined'
 

--- a/hkmc2/shared/src/test/mlscript/ctx/Summon.mls
+++ b/hkmc2/shared/src/test/mlscript/ctx/Summon.mls
@@ -19,8 +19,8 @@ use[Num]
 //│ ║  l.17: 	use[Num]
 //│ ║        	^^^^^^^^
 //│ ╟── Required by contextual parameter declaration: 
-//│ ║  l.92: 	fun use[T](using instance: T) = instance
-//│ ║        	                 ^^^^^^^^^^^
+//│ ║  l.115: 	fun use[T](using instance: T) = instance
+//│ ║         	                 ^^^^^^^^^^^
 //│ ╙── Missing instance: Expected: Num (type parameter T); Available: Int, Str
 //│ ═══[RUNTIME ERROR] Error: MLscript call unexpectedly returned `undefined`, the forbidden value.
 
@@ -55,8 +55,8 @@ fun f(using Int) = use[Num]
 //│ ║  l.53: 	fun f(using Int) = use[Num]
 //│ ║        	                   ^^^^^^^^
 //│ ╟── Required by contextual parameter declaration: 
-//│ ║  l.92: 	fun use[T](using instance: T) = instance
-//│ ║        	                 ^^^^^^^^^^^
+//│ ║  l.115: 	fun use[T](using instance: T) = instance
+//│ ║         	                 ^^^^^^^^^^^
 //│ ╙── Missing instance: Expected: Num (type parameter T); Available: Int, Str
 
 
@@ -79,8 +79,8 @@ use{[Some[Int]].value}
 //│ ║  l.74: 	use{[Some[Int]].value}
 //│ ║        	^^^
 //│ ╟── Required by contextual parameter declaration: 
-//│ ║  l.92: 	fun use[T](using instance: T) = instance
-//│ ║        	                 ^^^^^^^^^^^
+//│ ║  l.115: 	fun use[T](using instance: T) = instance
+//│ ║         	                 ^^^^^^^^^^^
 //│ ╙── Illegal query for an unspecified type variable T.
 //│ ═══[RUNTIME ERROR] Error: MLscript call unexpectedly returned `undefined`, the forbidden value.
 
@@ -91,8 +91,8 @@ use([Some[Int]].value)
 //│ ║  l.89: 	use([Some[Int]].value)
 //│ ║        	^^^
 //│ ╟── Required by contextual parameter declaration: 
-//│ ║  l.92: 	fun use[T](using instance: T) = instance
-//│ ║        	                 ^^^^^^^^^^^
+//│ ║  l.115: 	fun use[T](using instance: T) = instance
+//│ ║         	                 ^^^^^^^^^^^
 //│ ╙── Illegal query for an unspecified type variable T.
 //│ ═══[RUNTIME ERROR] Error: MLscript call unexpectedly returned `undefined`, the forbidden value.
 

--- a/hkmc2/shared/src/test/mlscript/handlers/Debugging.mls
+++ b/hkmc2/shared/src/test/mlscript/handlers/Debugging.mls
@@ -54,25 +54,42 @@ fun f() =
 //│     }
 //│     resume(value$) {
 //│       if (this.pc === 1) {
-//│         tmp = value$;
+//│         scrut = value$;
 //│       } else if (this.pc === 2) {
+//│         tmp = value$;
+//│       } else if (this.pc === 3) {
 //│         tmp1 = value$;
 //│       }
 //│       contLoop: while (true) {
-//│         if (this.pc === 3) {
+//│         if (this.pc === 4) {
 //│           return j / i
-//│         } else if (this.pc === 4) {
-//│           tmp1 = Predef.print(tmp);
-//│           if (tmp1 instanceof runtime.EffectSig.class) {
-//│             return this.doUnwind(tmp1, 2)
-//│           }
-//│           this.pc = 2;
-//│           continue contLoop
 //│         } else if (this.pc === 1) {
+//│           if (scrut === true) {
+//│             tmp = Predef.raiseUnhandledEffect();
+//│             if (tmp instanceof runtime.EffectSig.class) {
+//│               return this.doUnwind(tmp, 2)
+//│             }
+//│             this.pc = 2;
+//│             continue contLoop
+//│           } else {
+//│             tmp1 = runtime.Unit;
+//│             this.pc = 4;
+//│             continue contLoop
+//│           }
 //│           this.pc = 4;
 //│           continue contLoop
-//│         } else if (this.pc === 2) {
+//│         } else if (this.pc === 5) {
+//│           tmp1 = Predef.print(tmp);
+//│           if (tmp1 instanceof runtime.EffectSig.class) {
+//│             return this.doUnwind(tmp1, 3)
+//│           }
 //│           this.pc = 3;
+//│           continue contLoop
+//│         } else if (this.pc === 2) {
+//│           this.pc = 5;
+//│           continue contLoop
+//│         } else if (this.pc === 3) {
+//│           this.pc = 4;
 //│           continue contLoop
 //│         }
 //│         break;
@@ -83,8 +100,10 @@ fun f() =
 //│     } 
 //│     get getLoc() {
 //│       if (this.pc === 1) {
-//│         return "Debugging.mls:17:14"
+//│         return "Debugging.mls:16:6"
 //│       } else if (this.pc === 2) {
+//│         return "Debugging.mls:17:14"
+//│       } else if (this.pc === 3) {
 //│         return "Debugging.mls:17:5"
 //│       }
 //│     }
@@ -99,15 +118,18 @@ fun f() =
 //│   i = 0;
 //│   j = 100;
 //│   k = 2000;
-//│   scrut = i == 0;
+//│   scrut = Predef.equals(i, 0);
+//│   if (scrut instanceof runtime.EffectSig.class) {
+//│     return doUnwind(scrut, 1)
+//│   }
 //│   if (scrut === true) {
 //│     tmp = Predef.raiseUnhandledEffect();
 //│     if (tmp instanceof runtime.EffectSig.class) {
-//│       return doUnwind(tmp, 1)
+//│       return doUnwind(tmp, 2)
 //│     }
 //│     tmp1 = Predef.print(tmp);
 //│     if (tmp1 instanceof runtime.EffectSig.class) {
-//│       return doUnwind(tmp1, 2)
+//│       return doUnwind(tmp1, 3)
 //│     }
 //│   } else { tmp1 = runtime.Unit; }
 //│   return j / i
@@ -126,8 +148,8 @@ lambda_test(() =>
   raiseUnhandledEffect()
   100)
 //│ ═══[RUNTIME ERROR] Error: Unhandled effect FatalEffect
-//│ 	at lambda (Debugging.mls:126:3)
-//│ 	at lambda_test (Debugging.mls:123:3)
+//│ 	at lambda (Debugging.mls:148:3)
+//│ 	at lambda_test (Debugging.mls:145:3)
 
 
 import "../../mlscript-compile/Runtime.mls"
@@ -150,7 +172,7 @@ Runtime.debugEff(res.reified)
 //│ > handlerFun:  null
 //│ > resumed:  false
 //│ > <lastHandler is self>
-//│ > Cont$func$f$(pc=1, last) -> (null)
+//│ > Cont$func$f$(pc=2, last) -> (null)
 //│ > 
 
 res.resumeWith(42)
@@ -206,9 +228,9 @@ fun f() =
 f()
 //│ > [FnLocalsInfo("‹top level›", [LocalVarInfo("i", 100)]), FnLocalsInfo("f", [LocalVarInfo("j", 200)])]
 //│ > Stack Trace:
-//│ > 	at f (Debugging.mls:199:3) with locals: j=200
+//│ > 	at f (Debugging.mls:221:3) with locals: j=200
 //│ > Stack Trace:
-//│ > 	at f (Debugging.mls:201:3)
+//│ > 	at f (Debugging.mls:223:3)
 //│ > Stack Trace:
-//│ > 	at f (Debugging.mls:202:3) with locals: j=300
+//│ > 	at f (Debugging.mls:224:3) with locals: j=300
 //│ > [FnLocalsInfo("‹top level›", [LocalVarInfo("i", 100)]), FnLocalsInfo("f", [LocalVarInfo("j", 300)])]

--- a/hkmc2/shared/src/test/mlscript/handlers/StackSafety.mls
+++ b/hkmc2/shared/src/test/mlscript/handlers/StackSafety.mls
@@ -1,5 +1,7 @@
 :js
 
+// * FIXME: Why doesn't the following work when using Predef function `(==) equals`?
+
 // sanity check
 :expect 5050
 fun sum(n) =
@@ -10,13 +12,13 @@ sum(100)
 //│ = 5050
 
 // preserve tail calls
-// MUST see "return hi1(tmp)" in the output
+// MUST see "return hi(tmp)" in the output
 :stackSafe 5
 :effectHandlers
 :expect 0
 :sjs
 fun hi(n) =
-  if n == 0 then 0
+  if n === 0 then 0
   else hi(n - 1)
 hi(0)
 //│ JS (unsanitized):
@@ -48,7 +50,7 @@ hi(0)
 //│   if (stackDelayRes instanceof runtime.EffectSig.class) {
 //│     return doUnwind(stackDelayRes, 0)
 //│   }
-//│   scrut = n == 0;
+//│   scrut = n === 0;
 //│   if (scrut === true) {
 //│     return 0
 //│   } else {
@@ -69,7 +71,7 @@ hi(0)
 :expect 50005000
 :sjs
 fun sum(n) =
-  if n == 0 then 0
+  if n === 0 then 0
   else
     n + sum(n - 1)
 sum(10000)
@@ -116,7 +118,7 @@ sum(10000)
 //│   if (stackDelayRes instanceof runtime.EffectSig.class) {
 //│     return doUnwind(stackDelayRes, 0)
 //│   }
-//│   scrut = n == 0;
+//│   scrut = n === 0;
 //│   if (scrut === true) {
 //│     return 0
 //│   } else {
@@ -283,7 +285,7 @@ hi(0)
 :effectHandlers
 :expect 100010000
 fun sum(n) =
-  if n == 0 then 0
+  if n === 0 then 0
   else
     n + sum(n - 1)
 fun bad() = sum(10000) + sum(10000)

--- a/hkmc2/shared/src/test/mlscript/handlers/ZCombinator.mls
+++ b/hkmc2/shared/src/test/mlscript/handlers/ZCombinator.mls
@@ -28,8 +28,9 @@ fun mkrec(g) =
   selfApp of self =>
     g of y => selfApp(self)(y)
 
+// * FIXME: Why doesn't the following work when using Predef function `(==) equals`?
 let fact = mkrec of self => x =>
-  if x == 0 then 1 
+  if x === 0 then 1 
   else self(x - 1) * x
 //│ fact = fun
 

--- a/hkmc2/shared/src/test/mlscript/interop/Null.mls
+++ b/hkmc2/shared/src/test/mlscript/interop/Null.mls
@@ -2,7 +2,7 @@
 
 
 null == undefined
-//│ = true
+//│ = false
 
 null === undefined
 //│ = false

--- a/hkmc2/shared/src/test/mlscript/lifter/StackSafetyLift.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/StackSafetyLift.mls
@@ -1,10 +1,12 @@
 :js
 :lift
 
+// * FIXME: Why doesn't the following work when using Predef function `(==) equals`?
+
 // sanity check
 :expect 5050
 fun sum(n) =
-  if n == 0 then 0
+  if n === 0 then 0
   else
     n + sum(n - 1)
 sum(100)
@@ -17,7 +19,7 @@ sum(100)
 :expect 0
 :sjs
 fun hi(n) =
-  if n == 0 then 0
+  if n === 0 then 0
   else hi(n - 1)
 hi(0)
 //│ JS (unsanitized):
@@ -66,7 +68,7 @@ hi(0)
 //│   if (stackDelayRes instanceof runtime.EffectSig.class) {
 //│     return doUnwind$(n, stackDelayRes, 0)
 //│   }
-//│   scrut = n == 0;
+//│   scrut = n === 0;
 //│   if (scrut === true) {
 //│     return 0
 //│   } else {
@@ -87,7 +89,7 @@ hi(0)
 :effectHandlers
 :expect 50005000
 fun sum(n) =
-  if n == 0 then 0
+  if n === 0 then 0
   else
     n + sum(n - 1)
 sum(10000)
@@ -155,7 +157,7 @@ sum(10000)
 //│   if (stackDelayRes instanceof runtime.EffectSig.class) {
 //│     return doUnwind$1(n, tmp1, stackDelayRes, 0)
 //│   }
-//│   scrut = n == 0;
+//│   scrut = n === 0;
 //│   if (scrut === true) {
 //│     return 0
 //│   } else {
@@ -179,7 +181,7 @@ sum(10000)
 // stack-overflows without :stackSafe
 :re
 fun sum(n) =
-  if n == 0 then 0
+  if n === 0 then 0
   else
     n + sum(n - 1)
 sum(10000)
@@ -299,7 +301,7 @@ hi(0)
 :effectHandlers
 :expect 100010000
 fun sum(n) =
-  if n == 0 then 0
+  if n === 0 then 0
   else
     n + sum(n - 1)
 fun bad() = sum(10000) + sum(10000)

--- a/hkmc2/shared/src/test/mlscript/llir/BasisLLIR.mls
+++ b/hkmc2/shared/src/test/mlscript/llir/BasisLLIR.mls
@@ -197,8 +197,8 @@ fib(20)
 //│ 6765
 
 :intl
-fun odd(x) = if x == 0 then false else even(x-1)
-fun even(x) = if x == 0 then true else odd(x-1)
+fun odd(x) = if x === 0 then false else even(x-1)
+fun even(x) = if x === 0 then true else odd(x-1)
 fun foo() = odd(10)
 foo()
 //│ = false
@@ -370,7 +370,7 @@ abstract class List[out T]: Cons[T] | Nil
 data class (::) Cons[out T](head: T, tail: List[T]) extends List[T]
 object Nil extends List
 fun mk_list(n) =
-  if n == 0 then Nil else Cons(n, mk_list(n - 1))
+  if n === 0 then Nil else Cons(n, mk_list(n - 1))
 fun head_opt(l) =
   if l is
     Nil then None
@@ -398,7 +398,7 @@ abstract class List[out T]: Cons[T] | Nil
 data class (::) Cons[out T](head: T, tail: List[T]) extends List[T]
 object Nil extends List
 fun mk_list(n) =
-  if n == 0 then Nil else Cons(n, mk_list(n - 1))
+  if n === 0 then Nil else Cons(n, mk_list(n - 1))
 fun last_opt(l) =
   if l is
     Nil then None
@@ -473,7 +473,7 @@ fun to_int(n) =
     O then 0
     S(p) then 1 + to_int(p)
 fun to_nat(n) =
-  if n == 0 then O
+  if n === 0 then O
   else S(to_nat(n - 1))
 fun main() =
   to_int(fib(to_nat(10)))

--- a/hkmc2/shared/src/test/mlscript/llir/ControlFlow.mls
+++ b/hkmc2/shared/src/test/mlscript/llir/ControlFlow.mls
@@ -28,14 +28,14 @@ f1()
 :intl
 fun f2() =
   let x = 0
-  if x == 1 then 2 else 3
+  if x === 1 then 2 else 3
 f2()
 //│ = 3
 //│ LLIR:
 //│   
 //│   def f2() =
 //│     let x = 0 in
-//│     let x1 = ==(x,1) in
+//│     let x1 = ===(x,1) in
 //│     case x1 of
 //│       Lit(BoolLit(true)) =>
 //│         2
@@ -82,7 +82,7 @@ f3()
 :intl
 fun f4() =
   let x = 0
-  let x = if x == 1 then 2 else 3
+  let x = if x === 1 then 2 else 3
   x
 f4()
 //│ = 3
@@ -90,7 +90,7 @@ f4()
 //│   
 //│   def f4() =
 //│     let x = 0 in
-//│     let x1 = ==(x,1) in
+//│     let x1 = ===(x,1) in
 //│     case x1 of
 //│       Lit(BoolLit(true)) =>
 //│         let x2 = 2 in
@@ -112,8 +112,8 @@ f4()
 :intl
 fun f5() =
   let x = 0
-  let x = if x == 1 then 2 else 3
-  let x = if x == 2 then 4 else 5
+  let x = if x === 1 then 2 else 3
+  let x = if x === 2 then 4 else 5
   x
 f5()
 //│ = 5
@@ -121,7 +121,7 @@ f5()
 //│   
 //│   def f5() =
 //│     let x = 0 in
-//│     let x1 = ==(x,1) in
+//│     let x1 = ===(x,1) in
 //│     case x1 of
 //│       Lit(BoolLit(true)) =>
 //│         let x2 = 2 in
@@ -130,7 +130,7 @@ f5()
 //│         let x3 = 3 in
 //│         jump j(x3)
 //│   def j(tmp) =
-//│     let x4 = ==(tmp,2) in
+//│     let x4 = ===(tmp,2) in
 //│     case x4 of
 //│       Lit(BoolLit(true)) =>
 //│         let x5 = 4 in

--- a/hkmc2/shared/src/test/mlscript/llir/HigherOrder.mls
+++ b/hkmc2/shared/src/test/mlscript/llir/HigherOrder.mls
@@ -82,7 +82,7 @@ fun filter(f, ls) = if ls is
 fun nubBy(eq, ls) = if ls is
   Nil then Nil
   h :: t then h :: nubBy(eq, filter(y => nott(eq(h, y)), t))
-nubBy((x, y) => x == y, 1 :: 2 :: 3 :: 3 :: Nil)
+nubBy((x, y) => x === y, 1 :: 2 :: 3 :: 3 :: Nil)
 //│ = Cons(1, Cons(2, Cons(3, Nil)))
 //│ 
 //│ Interpreted:
@@ -91,7 +91,7 @@ nubBy((x, y) => x == y, 1 :: 2 :: 3 :: 3 :: Nil)
 :intl
 fun f(x) =
   fun self_rec(x) =
-    if x == 0 then 0
+    if x === 0 then 0
     else x + self_rec(x - 1)
   self_rec(x)
 f(3)
@@ -103,11 +103,11 @@ f(3)
 fun f(x) =
   fun even(x) =
     fun odd(x) =
-      if x == 0 then true
-      else if x == 1 then false
+      if x === 0 then true
+      else if x === 1 then false
       else even(x - 1)
-    if x == 0 then true
-    else if x == 1 then false
+    if x === 0 then true
+    else if x === 1 then false
     else odd(x - 1)
   even(x)
 f(3)

--- a/hkmc2/shared/src/test/mlscript/std/PredefTest.mls
+++ b/hkmc2/shared/src/test/mlscript/std/PredefTest.mls
@@ -116,7 +116,11 @@ tuple passing(1, 2, 3) of 4, 5, 6
 
 
 Symbols
-//│ = Symbols { prettyPrint: Symbol("mlscript.prettyPrint"), class: object Symbols }
+//│ = Symbols {
+//│   prettyPrint: Symbol("mlscript.prettyPrint"),
+//│   definitionMetadata: Symbol("mlscript.definitionMetadata"),
+//│   class: object Symbols
+//│ }
 
 
 // * Function composition is associative
@@ -180,7 +184,7 @@ foldr(tuple)(0, 1, 2, 3)
 :re
 foldr(+)()
 //│ ╔══[ERROR] Expected at least 1 arguments, got 0
-//│ ║  l.181: 	foldr(+)()
+//│ ║  l.185: 	foldr(+)()
 //│ ╙──       	        ^^
 
 

--- a/hkmc2/shared/src/test/mlscript/std/PredefTest.mls
+++ b/hkmc2/shared/src/test/mlscript/std/PredefTest.mls
@@ -246,6 +246,12 @@ mkStr of
 null == undefined
 //│ = false
 
+undefined == null
+//│ = false
+
+undefined === null
+//│ = false
+
 [] == false
 //│ = false
 
@@ -255,7 +261,7 @@ null == undefined
 1 == true
 //│ = false
 
-// arrays are compared elementwise
+// * Arrays are compared elementwise
 
 [1, 2, 3] == [1, 2, 3]
 //│ = true

--- a/hkmc2/shared/src/test/mlscript/std/PredefTest.mls
+++ b/hkmc2/shared/src/test/mlscript/std/PredefTest.mls
@@ -237,4 +237,55 @@ mkStr of
 //│ 
 //│ = "01"
 
+// loose equality is disabled
 
+null == undefined
+//│ = false
+
+[] == false
+//│ = false
+
+"0" == false
+//│ = false
+
+1 == true
+//│ = false
+
+// arrays are compared elementwise
+
+[1, 2, 3] == [1, 2, 3]
+//│ = true
+
+// non-data classes unchanged
+
+:silent
+class B(val a, b)
+let x = B(1, 2)
+let y = B(1, 4)
+
+x == y
+//│ = false
+
+// data classes are equal from arguments
+
+:silent
+data class A(a, b, c)
+module M with
+  data class A(a, b, c)
+let x = A(1, 2, 3)
+let y = A(1, 2, 3)
+
+x == y
+//│ = true
+
+x != y
+//│ = false
+
+x == A(2, 3, 4)
+//│ = false
+
+x == M.A(1, 2, 3)
+//│ = false
+
+A([x], 2, 3) == A([y], 2, 3)
+//│ = true

--- a/hkmc2/shared/src/test/mlscript/ucs/syntax/NestedOpSplits.mls
+++ b/hkmc2/shared/src/test/mlscript/ucs/syntax/NestedOpSplits.mls
@@ -10,13 +10,13 @@ fun f(x) =
 //│ Split with nested patterns:
 //│ >  if
 //│ >    let $scrut = 1
-//│ >    let $scrut = builtin:==(x, builtin:+($scrut, 2))
+//│ >    let $scrut = (member:Predef.)equals‹member:equals›(x, builtin:+($scrut, 2))
 //│ >    $scrut is true then 0
 //│ >    else 1
 //│ Expanded split with flattened patterns:
 //│ >  if
 //│ >    let $scrut = 1
-//│ >    let $scrut = builtin:==(x, builtin:+($scrut, 2))
+//│ >    let $scrut = (member:Predef.)equals‹member:equals›(x, builtin:+($scrut, 2))
 //│ >    $scrut is true then 0
 //│ >    else 1
 


### PR DESCRIPTION
This fails some tests:
- `ToTriage.mls`, `Null.mls`: detects we no longer allow loose equality with `==` 
- `bbml/*`: ``` `== ``` cannot be quoted, as the builtin `==` became `SynthSel(Ref(member:Predef),Ident(eq))`
- `llir/*`: `Uncaught error: hkmc2.codegen.llir.InterpreterError: Stuck evaluation: StuckExpr(..., undefined class Predef)`
- `ZCombinator.mls`, `StackSafetyLift.mls`: the new `eq` function overflows the stack

the rest i will look at a bit later