### PR TITLE
Wasm: Refactor use of docstrings into direct Document calls and update tooling versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,9 @@ import Wart._
 
 enablePlugins(ScalaJSPlugin)
 
-val scala3Version = "3.7.3"
+val scala3Version = "3.7.4"
 val directoryWatcherVersion = "0.18.0"
+val scalaTestVersion = "3.2.19"
 
 ThisBuild / scalaVersion     := "2.13.14"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
@@ -44,8 +45,8 @@ lazy val hkmc2 = crossProject(JSPlatform, JVMPlatform).in(file("hkmc2"))
     libraryDependencies += "com.lihaoyi" %%% "fansi" % "0.4.0",
     libraryDependencies += "com.lihaoyi" %% "os-lib" % "0.9.3",
     
-    libraryDependencies += "org.scalactic" %%% "scalactic" % "3.2.18",
-    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.18" % "test",
+    libraryDependencies += "org.scalactic" %%% "scalactic" % scalaTestVersion,
+    libraryDependencies += "org.scalatest" %%% "scalatest" % scalaTestVersion % "test",
     
     watchSources += WatchSource(
       baseDirectory.value.getParentFile()/"shared"/"src"/"test"/"mlscript", "*.mls", NothingFilter),
@@ -66,8 +67,8 @@ lazy val hkmc2DiffTests = project.in(file("hkmc2DiffTests"))
   .settings(
     scalaVersion := scala3Version,
     
-    libraryDependencies += "org.scalactic" %%% "scalactic" % "3.2.18",
-    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.18" % "test",
+    libraryDependencies += "org.scalactic" %%% "scalactic" % scalaTestVersion,
+    libraryDependencies += "org.scalatest" %%% "scalatest" % scalaTestVersion % "test",
     
     Test/run/fork := true, // so that CTRL+C actually terminates the watcher
   )
@@ -160,7 +161,7 @@ lazy val hkmc2Benchmarks = project.in(file("hkmc2Benchmarks"))
     name := "benchmark",
     scalaVersion := scala3Version,
     sourceDirectory := baseDirectory.value/"src",
-    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.18" % "test",
+    libraryDependencies += "org.scalatest" %%% "scalatest" % scalaTestVersion % "test",
     watchSources += WatchSource(
       baseDirectory.value/"src"/"test"/"bench", "*.mls", NothingFilter),
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -77,16 +77,29 @@ class FuncInfo(
   )
 
   def toWat: Document =
-    doc"""(func ${id.fold(doc"")(_.toWat)} (type ${typeIdx.toWat})${
-        getSignatureType.toWat.surroundUnlessEmpty(doc" ")
-      } #{ ${
+    import Document.*
+
+    text("(func ") :: id.fold(empty)(_.toWat) :: text(" (type ") :: typeIdx.toWat :: text(")") ::
+      getSignatureType.toWat.surroundUnlessEmpty(text(" "))
+      ::
+      Document.nest(
         locals.map: p =>
-          doc"(local $$${p._2} ${RefType.anyref.toWat})"
-        .toSeq.mkDocument(doc" # ").surroundUnlessEmpty(doc" # ")
-      } # ${body.toWat} #} )${
-        id.fold(doc""): id =>
-          doc""" # (export "${id.id}" (func ${id.toWat})) # (elem declare func ${id.toWat})"""
-      }"""
+          text(s"(local $$${p._2} ") :: RefType.anyref.toWat :: text(")")
+        .mkDocument(break).surroundUnlessEmpty(break)
+          :: break
+          :: body.toWat
+          :: text(")")
+      )
+      ::
+      id.fold(empty): id =>
+        break
+          :: text(s"""(export "${id.id}" (func """)
+          :: id.toWat
+          :: text("))")
+          :: break
+          :: text("(elem declare func ")
+          :: id.toWat
+          :: text(")")
 end FuncInfo
 
 /**
@@ -115,16 +128,26 @@ class TypeInfo(
     compType
   )
 
-  private def idDoc: Document = id.fold(doc"")(id => doc"${id.toWat} ")
+  private def idDoc: Document =
+    import Document.*
+    id.fold(empty)(id => id.toWat :: text(" "))
 
-  def toWat: Document = compType match
-    case struct: StructType if struct.isSubtype =>
-      val parentsDoc = struct.parents.map(_.toWat).mkDocument(doc" ")
-      val parentsSuffix = if parentsDoc.isEmpty then doc"" else doc" " :: parentsDoc
-      val structDoc = struct.copy(isSubtype = false).toWat
-      doc"(type ${idDoc}(sub$parentsSuffix ${structDoc}))"
-    case _ =>
-      doc"(type ${idDoc}${compType.toWat})"
+  def toWat: Document =
+    import Document.*
+    compType match
+      case struct: StructType if struct.isSubtype =>
+        val parentsDoc = struct.parents.map(_.toWat).mkDocument(text(" "))
+        val parentsSuffix = if parentsDoc.isEmpty then empty else text(" ") :: parentsDoc
+        val structDoc = struct.copy(isSubtype = false).toWat
+        text("(type ")
+          :: idDoc
+          :: text("(sub")
+          :: parentsSuffix
+          :: text(" ")
+          :: structDoc
+          :: text("))")
+      case _ =>
+        text("(type ") :: idDoc :: compType.toWat :: text(")")
 end TypeInfo
 
 object Ctx:
@@ -293,6 +316,9 @@ class Ctx(
   def getAllWasmLocals: Ls[Seq[Local]] = locals.map(l => wasmLocalsToSeq(l.toMap))
 
   def toWat: Document =
-    doc"""(module #{  # ${(types.toSeq ++ funcs.toSeq).map(_.toWat).mkDocument(doc" # ")}) #} """
+    import Document.*
+    text("(module") :: nest(
+      break :: (types.toSeq ++ funcs.toSeq).map(_.toWat).mkDocument(break) :: text(")")
+    )
 
 end Ctx

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Instructions.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Instructions.scala
@@ -12,7 +12,8 @@ object Instructions:
       children: Seq[Expr],
       resultTypes: Seq[Result]
   ): FoldedInstr =
-    val labelWat = label.map(lbl => doc"$$$lbl")
+    import Document.*
+    val labelWat = label.map(lbl => text(s"$$$lbl"))
 
     FoldedInstr(
       mnemonic = "block",
@@ -100,21 +101,25 @@ object Instructions:
   )
 
   /** Creates a `br` (branch) instruction. */
-  def br(label: Str): FoldedInstr = FoldedInstr(
-    mnemonic = "br",
-    instrargs = Seq(doc"$$$label"),
-    stackargs = Seq.empty,
-    resultType = S(UnreachableType)
-  )
+  def br(label: Str): FoldedInstr =
+    import Document.*
+    FoldedInstr(
+      mnemonic = "br",
+      instrargs = Seq(text(s"$$$label")),
+      stackargs = Seq.empty,
+      resultType = S(UnreachableType)
+    )
 
   object i32:
     /** Creates an `i32.const` instruction. */
-    def const(value: Int): FoldedInstr = FoldedInstr(
-      mnemonic = "i32.const",
-      instrargs = Seq(doc"$value"),
-      stackargs = Seq.empty,
-      resultType = S(I32Type)
-    )
+    def const(value: Int): FoldedInstr =
+      import Document.*
+      FoldedInstr(
+        mnemonic = "i32.const",
+        instrargs = Seq(text(s"$value")),
+        stackargs = Seq.empty,
+        resultType = S(I32Type)
+      )
 
     /** Creates an `i32.add` instruction. */
     def add(lhs: Expr, rhs: Expr): FoldedInstr = FoldedInstr(

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
@@ -12,8 +12,8 @@ import scala.collection.Map
 extension (doc: Document)
   /** Surrounds a document by the given `prefix` and `suffix`, unless the document is empty. */
   private def surroundUnlessEmpty(
-      prefix: Document = Document.empty,
-      postfix: Document = Document.empty
+      prefix: => Document = Document.empty,
+      postfix: => Document = Document.empty
   ): Document =
     doc.optionUnless(_.isEmpty).fold(doc):
       prefix :: _ :: postfix
@@ -36,15 +36,15 @@ abstract sealed class Type extends ToWat:
     lastWords(s"asValType_! called on non-ValType: `$toWat` (${getClass.getName})")
 
 private case object I32Type extends Type:
-  def toWat: Document = doc"i32"
+  def toWat: Document = Document.text("i32")
 private case object I64Type extends Type:
-  def toWat: Document = doc"i64"
+  def toWat: Document = Document.text("i64")
 private case object F32Type extends Type:
-  def toWat: Document = doc"f32"
+  def toWat: Document = Document.text("f32")
 private case object F64Type extends Type:
-  def toWat: Document = doc"f64"
+  def toWat: Document = Document.text("f64")
 private case object V128Type extends Type:
-  def toWat: Document = doc"v128"
+  def toWat: Document = Document.text("v128")
 private case object UnreachableType extends Type:
   def toWat: Document = throw UnsupportedOperationException(
     s"${toString} is a compiler-internal type and cannot be converted to WAT"
@@ -61,39 +61,49 @@ object RefType:
 /** Wasm type representing a reference to a [[HeapType]]. */
 case class RefType(heapType: HeapType, nullable: Bool) extends Type:
   def toWat: Document =
-    doc"(ref${if nullable then " null" else ""} ${heapType.toWat})"
+    import Document.*
+    text(s"(ref ${if nullable then "null " else ""}")
+      :: heapType.toWat
+      :: text(")")
 
 object HeapType:
   case object Func extends ToWat:
-    def toWat: Document = doc"func"
+    def toWat: Document = Document.text("func")
   case object Ext extends ToWat:
-    def toWat: Document = doc"extern"
+    def toWat: Document = Document.text("extern")
   case object Any extends ToWat:
-    def toWat: Document = doc"any"
+    def toWat: Document = Document.text("any")
   case object Eq extends ToWat:
-    def toWat: Document = doc"eq"
+    def toWat: Document = Document.text("eq")
   case object I31 extends ToWat:
-    def toWat: Document = doc"i31"
+    def toWat: Document = Document.text("i31")
   case object Struct extends ToWat:
-    def toWat: Document = doc"struct"
+    def toWat: Document = Document.text("struct")
   case object Array extends ToWat:
-    def toWat: Document = doc"array"
+    def toWat: Document = Document.text("array")
   case object None extends ToWat:
-    def toWat: Document = doc"none"
+    def toWat: Document = Document.text("none")
   case object NoExt extends ToWat:
-    def toWat: Document = doc"noextern"
+    def toWat: Document = Document.text("noextern")
   case object NoFunc extends ToWat:
-    def toWat: Document = doc"nofunc"
+    def toWat: Document = Document.text("nofunc")
 type ValType = NumType | VecType | RefType
 
 /** A Wasm parameter clause. Appears in function signatures. */
 case class Param(id: Opt[Str], valtype: ValType) extends ToWat:
   def toWat: Document =
-    doc"(param${id.fold(doc"")(id => doc" $$$id")} ${valtype.toWat})"
+    import Document.*
+    text("(param")
+      :: id.fold(empty)(id => text(s" $$$id"))
+      :: text(" ")
+      :: valtype.toWat
+      :: text(")")
 
 /** A Wasm result clause. Appears in function signatures and some instructions. */
 case class Result(valtype: ValType) extends ToWat:
-  def toWat: Document = doc"(result ${valtype.toWat})"
+  def toWat: Document =
+    import Document.*
+    text("(result ") :: valtype.toWat :: text(")")
 
 /**
  * A type representing a function signature.
@@ -101,7 +111,9 @@ case class Result(valtype: ValType) extends ToWat:
  * Function signatures differ from [[FunctionType]] in that they do not include the `func` keyword.
  */
 case class SignatureType(params: Seq[Param], results: Seq[Result]) extends ToWat:
-  def toWat: Document = (params.map(_.toWat) ++ results.map(_.toWat)).mkDocument(doc" ")
+  def toWat: Document =
+    import Document.*
+    (params.map(_.toWat) ++ results.map(_.toWat)).mkDocument(text(" "))
 
 object FunctionType:
   def apply(params: Seq[Param], results: Seq[Result]): FunctionType =
@@ -110,7 +122,8 @@ object FunctionType:
 /** A type representing a function type. */
 case class FunctionType(sigType: SignatureType) extends ToWat:
   def toWat: Document =
-    doc"(func${sigType.toWat.surroundUnlessEmpty(doc" ")})"
+    import Document.*
+    text("(func") :: sigType.toWat.surroundUnlessEmpty(text(" ")) :: text(")")
 
 /** A type representing a struct field. */
 case class Field(
@@ -119,21 +132,26 @@ case class Field(
     id: Opt[Str]
 ) extends ToWat:
   def toWat: Document =
-    doc"(field ${id.fold(doc"")(id => doc"$$$id ")}${
-        if mutable then doc"(mut ${ty.toWat})" else ty.toWat
-      })"
+    import Document.*
+    text("(field ")
+      :: id.fold(empty)(id => text(s"$$$id "))
+      :: (if mutable then text("(mut ") :: ty.toWat :: text(")") else ty.toWat)
+      :: text(")")
 
 /** A type representing a structure type. */
 case class StructType(
-  fields: Map[DefinitionSymbol[?], NumIdx -> Field],
-  parents: Seq[TypeIdx] = Seq.empty,
-  isSubtype: Bool = false
+    fields: Map[DefinitionSymbol[?], NumIdx -> Field],
+    parents: Seq[TypeIdx] = Seq.empty,
+    isSubtype: Bool = false
 ) extends ToWat:
 
   def fieldSeq: Seq[Field] = fields.values.toSeq.sortBy(_._1.index).map(_._2)
 
   def toWat: Document =
-    doc"(struct${fieldSeq.map(_.toWat).mkDocument(doc" ").surroundUnlessEmpty(doc" ")})"
+    import Document.*
+    text("(struct")
+      :: fieldSeq.map(_.toWat).mkDocument(text(" ")).surroundUnlessEmpty(text(" "))
+      :: text(")")
 
 /** A composite type. */
 type CompType = StructType | FunctionType
@@ -155,11 +173,11 @@ abstract sealed class Index extends ToWat
 
 /** A numeric index. */
 case class NumIdx(val index: Int) extends Index:
-  def toWat: Document = doc"${index.toString}"
+  def toWat: Document = Document.text(index.toString)
 
 /** A symbolic identifier. */
 case class SymIdx(val id: Str) extends Index:
-  def toWat: Document = doc"$$$id"
+  def toWat: Document = Document.text(s"$$$id")
 
 /** An index that is bound to an index space. */
 abstract sealed class CtxIdx(idx: Index) extends ToWat:
@@ -228,16 +246,18 @@ case class FoldedInstr(
   def resultType_! : Type = resultType.getOrElse:
     lastWords(s"resultType_! called on instruction with a non-unique result type: $this")
 
-  def toWat: Document = doc"($mnemonic${
-      instrargs.map: a =>
+  def toWat: Document =
+    import Document.*
+
+    text(s"($mnemonic")
+      :: instrargs.map: a =>
         a match
           case a: ToWat => a.toWat
           case a: Document => a
-      .mkDocument(doc" ").surroundUnlessEmpty(doc" ")
-    }${
-      stackargs.map(_.toWat).optionIf(_.nonEmpty).map(_.mkDocument(doc" # ")).fold(doc""): args =>
-        doc" #{  # $args #} "
-    })"
+      .mkDocument(text(" ")).surroundUnlessEmpty(text(" "))
+      :: stackargs.map(_.toWat).optionIf(_.nonEmpty).map(_.mkDocument(break)).fold(empty): args =>
+        nest(break :: args)
+      :: text(")")
 end FoldedInstr
 
 /**

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.6
+sbt.version=1.11.7


### PR DESCRIPTION
This PR refactors all usages of `doc`-interpolated strings to `Document.*` calls to improve compilation performance.

[1f0b864](https://github.com/hkust-taco/mlscript/commit/1f0b864d6ae8334628d0be16fb60422c67eea6cb):

```
[info] Processed in  7488 ms  test/mlscript/wasm/Matching.mls
[info] Processed in  7154 ms  test/mlscript/wasm/Matching.mls
[info] Processed in  7104 ms  test/mlscript/wasm/Matching.mls
[info] Processed in  7067 ms  test/mlscript/wasm/Matching.mls
[info] Processed in  7100 ms  test/mlscript/wasm/Matching.mls
```

This PR:

```
[info] Processed in  1133 ms  test/mlscript/wasm/Matching.mls
[info] Processed in  1019 ms  test/mlscript/wasm/Matching.mls
[info] Processed in   998 ms  test/mlscript/wasm/Matching.mls
[info] Processed in   996 ms  test/mlscript/wasm/Matching.mls
[info] Processed in   994 ms  test/mlscript/wasm/Matching.mls
```