### PR TITLE
Revert refactoring to explicit Document calls, cache DocContext regexes

### DIFF
--- a/core/shared/main/scala/utils/package.scala
+++ b/core/shared/main/scala/utils/package.scala
@@ -153,6 +153,8 @@ package object utils {
     @inline def matches(pf: PartialFunction[A, Bool]): Bool =
       pf.lift(self).contains(true)
     
+    @inline def optionIf(cond: A => Bool): Option[A] = if (cond(self)) Some(self) else None
+    
     /** 
      * A helper to write left-associative applications, mainly used to get rid of paren hell
      * Example:
@@ -168,7 +170,6 @@ package object utils {
   implicit final class LazyGenHelper[A](self: => A) {
     
     @inline def optionIf(cond: Bool): Option[A] = if (cond) Some(self) else None
-    @inline def optionIf(cond: A => Bool): Option[A] = if (cond(self)) Some(self) else None
     
     @inline def optionUnless(cond: Bool): Option[A] = if (!cond) Some(self) else None
     @inline def optionUnless(cond: A => Bool): Option[A] = if (!cond(self)) Some(self) else None

--- a/core/shared/main/scala/utils/package.scala
+++ b/core/shared/main/scala/utils/package.scala
@@ -154,6 +154,7 @@ package object utils {
       pf.lift(self).contains(true)
     
     @inline def optionIf(cond: A => Bool): Option[A] = if (cond(self)) Some(self) else None
+    @inline def optionUnless(cond: A => Bool): Option[A] = if (!cond(self)) Some(self) else None
     
     /** 
      * A helper to write left-associative applications, mainly used to get rid of paren hell
@@ -172,7 +173,6 @@ package object utils {
     @inline def optionIf(cond: Bool): Option[A] = if (cond) Some(self) else None
     
     @inline def optionUnless(cond: Bool): Option[A] = if (!cond) Some(self) else None
-    @inline def optionUnless(cond: A => Bool): Option[A] = if (!cond(self)) Some(self) else None
     
   }
   

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -78,29 +78,16 @@ class FuncInfo(
   )
 
   def toWat: Document =
-    import Document.*
-
-    text("(func ") :: id.fold(empty)(_.toWat) :: text(" (type ") :: typeIdx.toWat :: text(")") ::
-      getSignatureType.toWat.surroundUnlessEmpty(text(" "))
-      ::
-      Document.nest(
+    doc"""(func ${id.fold(doc"")(_.toWat)} (type ${typeIdx.toWat})${
+        getSignatureType.toWat.surroundUnlessEmpty(doc" ")
+      } #{ ${
         locals.map: p =>
-          text(s"(local $$${p._2} ") :: RefType.anyref.toWat :: text(")")
-        .mkDocument(break).surroundUnlessEmpty(break)
-          :: break
-          :: body.toWat
-          :: text(")")
-      )
-      ::
-      id.fold(empty): id =>
-        break
-          :: text(s"""(export "${id.id}" (func """)
-          :: id.toWat
-          :: text("))")
-          :: break
-          :: text("(elem declare func ")
-          :: id.toWat
-          :: text(")")
+          doc"(local $$${p._2} ${RefType.anyref.toWat})"
+        .mkDocument(doc" # ").surroundUnlessEmpty(doc" # ")
+      } # ${body.toWat} #} )${
+        id.fold(doc""): id =>
+          doc""" # (export "${id.id}" (func ${id.toWat})) # (elem declare func ${id.toWat})"""
+      }"""
 end FuncInfo
 
 /**
@@ -129,26 +116,16 @@ class TypeInfo(
     compType
   )
 
-  private def idDoc: Document =
-    import Document.*
-    id.fold(empty)(id => id.toWat :: text(" "))
+  private def idDoc: Document = id.fold(doc"")(_.toWat)
 
-  def toWat: Document =
-    import Document.*
-    compType match
-      case struct: StructType if struct.isSubtype =>
-        val parentsDoc = struct.parents.map(_.toWat).mkDocument(text(" "))
-        val parentsSuffix = if parentsDoc.isEmpty then empty else text(" ") :: parentsDoc
-        val structDoc = struct.copy(isSubtype = false).toWat
-        text("(type ")
-          :: idDoc
-          :: text("(sub")
-          :: parentsSuffix
-          :: text(" ")
-          :: structDoc
-          :: text("))")
-      case _ =>
-        text("(type ") :: idDoc :: compType.toWat :: text(")")
+  def toWat: Document = compType match
+    case struct: StructType if struct.isSubtype =>
+      val parentsDoc = struct.parents.optionIf(_.nonEmpty).fold(doc""): parents =>
+        parents.map(_.toWat).mkDocument(doc" ")
+      val structDoc = struct.copy(isSubtype = false).toWat
+      doc"(type${idDoc.surroundUnlessEmpty(doc" ")} (sub${parentsDoc.surroundUnlessEmpty(doc" ")} ${structDoc}))"
+    case _ =>
+      doc"(type${idDoc.surroundUnlessEmpty(doc" ")} ${compType.toWat})"
 end TypeInfo
 
 object Ctx:
@@ -348,9 +325,6 @@ class Ctx(
     wasmIntrinsicFuncs.getOrElseUpdate(name, createIntrinsic)
 
   def toWat: Document =
-    import Document.*
-    text("(module") :: nest(
-      break :: (types.toSeq ++ funcs.toSeq).map(_.toWat).mkDocument(break) :: text(")")
-    )
+    doc"(module #{  # ${(types.toSeq ++ funcs.toSeq).map(_.toWat).mkDocument(doc" # ")}) #} "
 
 end Ctx

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Instructions.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Instructions.scala
@@ -12,8 +12,7 @@ object Instructions:
       children: Seq[Expr],
       resultTypes: Seq[Result]
   ): FoldedInstr =
-    import Document.*
-    val labelWat = label.map(lbl => text(s"$$$lbl"))
+    val labelWat = label.map(lbl => doc"$$$lbl")
 
     FoldedInstr(
       mnemonic = "block",
@@ -102,10 +101,9 @@ object Instructions:
 
   /** Creates a `br` (branch) instruction. */
   def br(label: Str): FoldedInstr =
-    import Document.*
     FoldedInstr(
       mnemonic = "br",
-      instrargs = Seq(text(s"$$$label")),
+      instrargs = Seq(doc"$$$label"),
       stackargs = Seq.empty,
       resultType = S(UnreachableType)
     )
@@ -113,10 +111,9 @@ object Instructions:
   object i32:
     /** Creates an `i32.const` instruction. */
     def const(value: Int): FoldedInstr =
-      import Document.*
       FoldedInstr(
         mnemonic = "i32.const",
-        instrargs = Seq(text(s"$value")),
+        instrargs = Seq(doc"$value"),
         stackargs = Seq.empty,
         resultType = S(I32Type)
       )

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
@@ -15,8 +15,8 @@ extension (doc: Document)
       prefix: => Document = Document.empty,
       postfix: => Document = Document.empty
   ): Document =
-    doc.optionUnless(_.isEmpty).fold(doc):
-      prefix :: _ :: postfix
+    doc.optionUnless(_.isEmpty).fold(doc): doc =>
+      doc"$prefix$doc$postfix"
 
 /** Trait indicating a WAT representation is available. */
 trait ToWat:
@@ -36,15 +36,15 @@ abstract sealed class Type extends ToWat:
     lastWords(s"asValType_! called on non-ValType: `$toWat` (${getClass.getName})")
 
 private case object I32Type extends Type:
-  def toWat: Document = Document.text("i32")
+  def toWat: Document = doc"i32"
 private case object I64Type extends Type:
-  def toWat: Document = Document.text("i64")
+  def toWat: Document = doc"i64"
 private case object F32Type extends Type:
-  def toWat: Document = Document.text("f32")
+  def toWat: Document = doc"f32"
 private case object F64Type extends Type:
-  def toWat: Document = Document.text("f64")
+  def toWat: Document = doc"f64"
 private case object V128Type extends Type:
-  def toWat: Document = Document.text("v128")
+  def toWat: Document = doc"v128"
 private case object UnreachableType extends Type:
   def toWat: Document = throw UnsupportedOperationException(
     s"${toString} is a compiler-internal type and cannot be converted to WAT"
@@ -61,49 +61,39 @@ object RefType:
 /** Wasm type representing a reference to a [[HeapType]]. */
 case class RefType(heapType: HeapType, nullable: Bool) extends Type:
   def toWat: Document =
-    import Document.*
-    text(s"(ref ${if nullable then "null " else ""}")
-      :: heapType.toWat
-      :: text(")")
+    doc"(ref${if nullable then " null" else ""} ${heapType.toWat})"
 
 object HeapType:
   case object Func extends ToWat:
-    def toWat: Document = Document.text("func")
+    def toWat: Document = doc"func"
   case object Ext extends ToWat:
-    def toWat: Document = Document.text("extern")
+    def toWat: Document = doc"extern"
   case object Any extends ToWat:
-    def toWat: Document = Document.text("any")
+    def toWat: Document = doc"any"
   case object Eq extends ToWat:
-    def toWat: Document = Document.text("eq")
+    def toWat: Document = doc"eq"
   case object I31 extends ToWat:
-    def toWat: Document = Document.text("i31")
+    def toWat: Document = doc"i31"
   case object Struct extends ToWat:
-    def toWat: Document = Document.text("struct")
+    def toWat: Document = doc"struct"
   case object Array extends ToWat:
-    def toWat: Document = Document.text("array")
+    def toWat: Document = doc"array"
   case object None extends ToWat:
-    def toWat: Document = Document.text("none")
+    def toWat: Document = doc"none"
   case object NoExt extends ToWat:
-    def toWat: Document = Document.text("noextern")
+    def toWat: Document = doc"noextern"
   case object NoFunc extends ToWat:
-    def toWat: Document = Document.text("nofunc")
+    def toWat: Document = doc"nofunc"
 type ValType = NumType | VecType | RefType
 
 /** A Wasm parameter clause. Appears in function signatures. */
 case class Param(id: Opt[Str], valtype: ValType) extends ToWat:
   def toWat: Document =
-    import Document.*
-    text("(param")
-      :: id.fold(empty)(id => text(s" $$$id"))
-      :: text(" ")
-      :: valtype.toWat
-      :: text(")")
+    doc"(param${id.fold(doc"")(id => doc" $$$id")} ${valtype.toWat})"
 
 /** A Wasm result clause. Appears in function signatures and some instructions. */
 case class Result(valtype: ValType) extends ToWat:
-  def toWat: Document =
-    import Document.*
-    text("(result ") :: valtype.toWat :: text(")")
+  def toWat: Document = doc"(result ${valtype.toWat})"
 
 /**
  * A type representing a function signature.
@@ -111,9 +101,7 @@ case class Result(valtype: ValType) extends ToWat:
  * Function signatures differ from [[FunctionType]] in that they do not include the `func` keyword.
  */
 case class SignatureType(params: Seq[Param], results: Seq[Result]) extends ToWat:
-  def toWat: Document =
-    import Document.*
-    (params.map(_.toWat) ++ results.map(_.toWat)).mkDocument(text(" "))
+  def toWat: Document = (params.map(_.toWat) ++ results.map(_.toWat)).mkDocument(doc" ")
 
 object FunctionType:
   def apply(params: Seq[Param], results: Seq[Result]): FunctionType =
@@ -122,8 +110,7 @@ object FunctionType:
 /** A type representing a function type. */
 case class FunctionType(sigType: SignatureType) extends ToWat:
   def toWat: Document =
-    import Document.*
-    text("(func") :: sigType.toWat.surroundUnlessEmpty(text(" ")) :: text(")")
+    doc"(func${sigType.toWat.surroundUnlessEmpty(doc" ")})"
 
 /** A type representing a struct field. */
 case class Field(
@@ -132,11 +119,9 @@ case class Field(
     id: Opt[Str]
 ) extends ToWat:
   def toWat: Document =
-    import Document.*
-    text("(field ")
-      :: id.fold(empty)(id => text(s"$$$id "))
-      :: (if mutable then text("(mut ") :: ty.toWat :: text(")") else ty.toWat)
-      :: text(")")
+    doc"(field ${id.fold(doc"")(id => doc"$$$id ")}${
+        if mutable then doc"(mut ${ty.toWat})" else ty.toWat
+      })"
 
 /** A type representing a structure type. */
 case class StructType(
@@ -148,10 +133,7 @@ case class StructType(
   def fieldSeq: Seq[Field] = fields.values.toSeq.sortBy(_._1.index).map(_._2)
 
   def toWat: Document =
-    import Document.*
-    text("(struct")
-      :: fieldSeq.map(_.toWat).mkDocument(text(" ")).surroundUnlessEmpty(text(" "))
-      :: text(")")
+    doc"(struct${fieldSeq.map(_.toWat).mkDocument(doc" ").surroundUnlessEmpty(doc" ")})"
 
 /** A composite type. */
 type CompType = StructType | FunctionType
@@ -173,11 +155,11 @@ abstract sealed class Index extends ToWat
 
 /** A numeric index. */
 case class NumIdx(val index: Int) extends Index:
-  def toWat: Document = Document.text(index.toString)
+  def toWat: Document = doc"${index.toString}"
 
 /** A symbolic identifier. */
 case class SymIdx(val id: Str) extends Index:
-  def toWat: Document = Document.text(s"$$$id")
+  def toWat: Document = doc"$$$id"
 
 /** An index that is bound to an index space. */
 abstract sealed class CtxIdx(idx: Index) extends ToWat:
@@ -246,18 +228,15 @@ case class FoldedInstr(
   def resultType_! : Type = resultType.getOrElse:
     lastWords(s"resultType_! called on instruction with a non-unique result type: $this")
 
-  def toWat: Document =
-    import Document.*
-
-    text(s"($mnemonic")
-      :: instrargs.map: a =>
+  def toWat: Document = doc"($mnemonic${
+      instrargs.map: a =>
         a match
           case a: ToWat => a.toWat
           case a: Document => a
-      .mkDocument(text(" ")).surroundUnlessEmpty(text(" "))
-      :: stackargs.map(_.toWat).optionIf(_.nonEmpty).map(_.mkDocument(break)).fold(empty): args =>
-        nest(break :: args)
-      :: text(")")
+      .mkDocument(doc" ").surroundUnlessEmpty(doc" ")
+    } #{ ${
+      stackargs.map(_.toWat).mkDocument(doc" # ").surroundUnlessEmpty(doc" # ")
+    } #} )"
 end FoldedInstr
 
 /**

--- a/hkmc2/shared/src/main/scala/hkmc2/utils/document/DocumentContext.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/utils/document/DocumentContext.scala
@@ -26,6 +26,13 @@ import Document._
  */
 
 object DocumentContext:
+  private val nestRegex = " #\\{ ".r
+  private val unnestRegex = " #\\} ".r
+  private val beginGroupRegex = "\\\\\\{".r
+  private val endGroupRegex = "\\\\\\}".r
+  private val docBreakRegex = " # ".r
+  private val forceDocBreakRegex = """\\n""".r
+
   case object Nest; type Nest = Nest.type
   case object UnNest; type UnNest = UnNest.type
   case object BeginGroup; type BeginGroup = BeginGroup.type
@@ -37,12 +44,6 @@ import DocumentContext.*
 class DocumentContext(ctx: StringContext) {
   
   object doc {
-    private val nestRegex = " #\\{ ".r
-    private val unnestRegex = " #\\} ".r
-    private val beginGroupRegex = "\\\\\\{".r
-    private val endGroupRegex = "\\\\\\}".r
-    private val docBreakRegex = " # ".r
-    private val forceDocBreakRegex = """\\n""".r
   
     def apply(docs: Document*): Document =
       

--- a/hkmc2/shared/src/main/scala/hkmc2/utils/document/DocumentContext.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/utils/document/DocumentContext.scala
@@ -26,12 +26,12 @@ import Document._
  */
 
 object DocumentContext:
-  private val nestRegex = " #\\{ ".r
-  private val unnestRegex = " #\\} ".r
-  private val beginGroupRegex = "\\\\\\{".r
-  private val endGroupRegex = "\\\\\\}".r
-  private val docBreakRegex = " # ".r
-  private val forceDocBreakRegex = """\\n""".r
+  private val NestRegex = " #\\{ ".r
+  private val UnNestRegex = " #\\} ".r
+  private val BeginGroupRegex = "\\\\\\{".r
+  private val EndGroupRegex = "\\\\\\}".r
+  private val DocBreakRegex = " # ".r
+  private val ForceDocBreakRegex = """\\n""".r
 
   case object Nest; type Nest = Nest.type
   case object UnNest; type UnNest = UnNest.type
@@ -62,12 +62,12 @@ class DocumentContext(ctx: StringContext) {
       
       // Makes a sequence of the parts separated with Nest, UnNest and Insert (for positions where docs are to be inserted)
       val parts = (
-        splitOn(nestRegex, Nest) andThen
-        splitOn(unnestRegex, UnNest) andThen
-        splitOn(beginGroupRegex, BeginGroup) andThen
-        splitOn(endGroupRegex, EndGroup) andThen
-        splitOn(docBreakRegex, DocBreak(false)) andThen
-        splitOn(forceDocBreakRegex, DocBreak(true)) // interpolated strings don't get special chars replaced (we escape \n for the regex)
+        splitOn(NestRegex, Nest) andThen
+        splitOn(UnNestRegex, UnNest) andThen
+        splitOn(BeginGroupRegex, BeginGroup) andThen
+        splitOn(EndGroupRegex, EndGroup) andThen
+        splitOn(DocBreakRegex, DocBreak(false)) andThen
+        splitOn(ForceDocBreakRegex, DocBreak(true)) // interpolated strings don't get special chars replaced (we escape \n for the regex)
       )(interleave(ctx.parts.map(RawDocText(_)), Insert)).map:
           case RawDocText(s) => text(s) // 'text' escapes \n chars
           case d             => d

--- a/hkmc2/shared/src/main/scala/hkmc2/utils/document/DocumentContext.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/utils/document/DocumentContext.scala
@@ -1,7 +1,9 @@
 package hkmc2
 package document
 
+import collection.immutable.ArraySeq
 import collection.immutable.ArraySeq.unsafeWrapArray
+import util.matching.Regex
 
 import mlscript.utils.*, shorthands.*
 import utils.*
@@ -35,6 +37,13 @@ import DocumentContext.*
 class DocumentContext(ctx: StringContext) {
   
   object doc {
+    private val nestRegex = " #\\{ ".r
+    private val unnestRegex = " #\\} ".r
+    private val beginGroupRegex = "\\\\\\{".r
+    private val endGroupRegex = "\\\\\\}".r
+    private val docBreakRegex = " # ".r
+    private val forceDocBreakRegex = """\\n""".r
+  
     def apply(docs: Document*): Document =
       
       type DocsMarkers = Document | Nest | UnNest | BeginGroup | EndGroup | RawDocText
@@ -45,18 +54,19 @@ class DocumentContext(ctx: StringContext) {
       def interleave(docs: Seq[DocsMarkersInsert], interleaved: DocsMarkersInsert) =
         docs.head :: (docs.iterator.drop(1).map { List(interleaved, _) }.flatten.toList: Ls[DocsMarkersInsert])
       
-      def splitOn(mark: String, interleaved: DocsMarkersInsert) = (ds: Ls[DocsMarkersInsert]) => ds.flatMap:
-        case RawDocText(str) => interleave(unsafeWrapArray(str.split(mark, -1)).map(RawDocText(_)), interleaved)
+      def splitOn(mark: Regex, interleaved: DocsMarkersInsert) = (ds: Ls[DocsMarkersInsert]) => ds.flatMap:
+        case RawDocText(str) => 
+          interleave(unsafeWrapArray(mark.pattern.split(str, -1)).map(RawDocText(_)), interleaved)
         case d: DocsMarkersInsert     => Seq(d)
       
       // Makes a sequence of the parts separated with Nest, UnNest and Insert (for positions where docs are to be inserted)
       val parts = (
-        splitOn(" #\\{ ", Nest) andThen
-        splitOn(" #\\} ", UnNest) andThen
-        splitOn("\\\\\\{", BeginGroup) andThen
-        splitOn("\\\\\\}", EndGroup) andThen
-        splitOn(" # ", DocBreak(false)) andThen
-        splitOn("""\\n""", DocBreak(true)) // interpolated strings don't get special chars replaced (we escape \n for the regex)
+        splitOn(nestRegex, Nest) andThen
+        splitOn(unnestRegex, UnNest) andThen
+        splitOn(beginGroupRegex, BeginGroup) andThen
+        splitOn(endGroupRegex, EndGroup) andThen
+        splitOn(docBreakRegex, DocBreak(false)) andThen
+        splitOn(forceDocBreakRegex, DocBreak(true)) // interpolated strings don't get special chars replaced (we escape \n for the regex)
       )(interleave(ctx.parts.map(RawDocText(_)), Insert)).map:
           case RawDocText(s) => text(s) // 'text' escapes \n chars
           case d             => d


### PR DESCRIPTION
This patchset reverts the refactoring to explicit `Document.*` calls, as the root cause of the slowdowns have been identified and an alternative way to implement WAT building using `doc`-interpolation is used instead.

This patchset also contains a minor performance improvement to `doc""`-splitting by compiling and caching all regexes used during Document splitting.