### PR TITLE
Add compiler cache to avoid re-parsing and re-elaborating files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,14 @@ and then use one of the following commands.
 - `hkmc2AllTests/test` for running all hkmc2 tests.
 - `hkmc2JVM/test` for running only the compilation tests, in `hkmc2/shared/src/test/mlscript-compile`.
 - `hkmc2DiffTests/test` for running only the diff-tests, in `hkmc2/shared/src/test/mlscript`.
+- `hkmc2MostTests/test` for running the above two.
 - `~hkmc2DiffTests/Test/run` for running the test watcher,
   which updates test files as you save them and recompiles the Scala sources automatically on change.
 - `test` for compiling all JVM and JS subprojects
   and running every single test in the repository,
   including obsolete ones.
 
-Another useful SBT incantation is `; hkmc2AllTests/test; ~hkmc2DiffTests/Test/run`.
+Another useful SBT incantation is `; hkmc2MostTests/test; ~hkmc2DiffTests/Test/run`.
 This command runs all hkmc2 tests once and then starts the test watcher.
 This is a useful command to use periodically while making changes to the compiler,
 to check that you haven't broken anything.

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ lazy val hkmc2 = crossProject(JSPlatform, JVMPlatform).in(file("hkmc2"))
   .jsSettings(
     scalaJSLinkerConfig ~= {
       _.withModuleKind(ModuleKind.ESModule)
-       .withOutputPatterns(OutputPatterns.fromJSFile("MLscript.mjs"))
+        .withOutputPatterns(OutputPatterns.fromJSFile("MLscript.mjs"))
     },
     libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "2.2.0",
   )
@@ -80,6 +80,14 @@ lazy val hkmc2DiffTests = project.in(file("hkmc2DiffTests"))
     libraryDependencies += "org.scalatest" %%% "scalatest" % scalaTestVersion % "test",
     
     Test/run/fork := true, // so that CTRL+C actually terminates the watcher
+  )
+
+lazy val hkmc2MostTests = project.in(file("hkmc2MostTests"))
+  .settings(
+    Test / test := (
+      (hkmc2DiffTests / Test / test)
+        .dependsOn(hkmc2JVM / Test / test)
+    ).value
   )
 
 lazy val hkmc2AllTests = project.in(file("hkmc2AllTests"))

--- a/hkmc2/js/src/main/scala/hkmc2/Compiler.scala
+++ b/hkmc2/js/src/main/scala/hkmc2/Compiler.scala
@@ -15,10 +15,8 @@ import io.*
 import scala.collection.mutable.{ArrayBuffer, Buffer}
 
 @JSExportTopLevel("Compiler")
-class Compiler(fs: FileSystem, paths: MLsCompiler.Paths):
+class Compiler(paths: MLsCompiler.Paths)(using cctx: CompilerCtx):
   private given Config = Config.default
-  
-  private given FileSystem = fs
   
   private var pathDiagnosticsMap = MutMap.empty[Str, (Int, Buffer[Diagnostic])]
   

--- a/hkmc2/js/src/main/scala/hkmc2/io/InMemoryFileSystem.scala
+++ b/hkmc2/js/src/main/scala/hkmc2/io/InMemoryFileSystem.scala
@@ -11,7 +11,8 @@ import scala.scalajs.js.annotation.JSExportTopLevel
  */
 class InMemoryFileSystem(initialFiles: Map[String, String]) extends FileSystem:
   // We assume that all paths are normalized here.
-  private val files: MutMap[String, String] = MutMap.from(initialFiles)
+  private val files: MutMap[String, (Int, String)] = MutMap.from:
+    initialFiles.map { case (k, v) => (k, (0, v)) }
   
   def read(path: Path): String = read(path.toString)
   
@@ -20,19 +21,26 @@ class InMemoryFileSystem(initialFiles: Map[String, String]) extends FileSystem:
   
   def exists(path: Path): Bool = files.contains(path.toString)
   
+  def getLastChangedTimestamp(path: Path): Long =
+    files.get(path.toString) match
+      case Some((ts, _)) => ts.toLong
+      case None => throw new FileSystem.FileNotFoundException(path)
+  
   @JSExport("write")
   def write(path: Str, content: Str): Unit =
-    files(path) = content
+    files.updateWith(path):
+      case Some((ts, _)) => Some((ts + 1, content))
+      case None => Some((0, content))
   
   @JSExport("read")
   def read(path: Str): Str =
-    files.getOrElse(path, throw new FileSystem.FileNotFoundException(Path(path)))
+    files.getOrElse(path, throw new FileSystem.FileNotFoundException(Path(path)))._2
   
   @JSExport("list")
   def list: js.Array[Str] = allFiles.keys.toJSArray
   
   /** Get all files (for debugging) */
-  def allFiles: Map[String, String] = files.toMap
+  def allFiles: Map[String, String] = files.view.mapValues(_._2).toMap
 
 object InMemoryFileSystem:
   /** Create an empty in-memory file system. */

--- a/hkmc2/js/src/main/scala/hkmc2/io/VirtualPath.scala
+++ b/hkmc2/js/src/main/scala/hkmc2/io/VirtualPath.scala
@@ -7,7 +7,7 @@ import VirtualPath.sep
 /**
  * Pure JavaScript implementation of Path without using Node.js path module
  */
-private[io] class VirtualPath(val pathString: String) extends Path:
+private[io] case class VirtualPath(val pathString: String) extends Path:
   private def normalizePath(path: String): String =
     if path.isEmpty then path
     else

--- a/hkmc2/js/src/main/scala/hkmc2/io/node/NodeFileSystem.scala
+++ b/hkmc2/js/src/main/scala/hkmc2/io/node/NodeFileSystem.scala
@@ -19,3 +19,6 @@ private[io] class NodeFileSystem extends FileSystem:
   
   def exists(path: Path): Bool =
     fs.existsSync(path.toString)
+  
+  def getLastChangedTimestamp(path: Path): Long =
+    fs.lstatSync(path.toString).mtime.getTime().toLong

--- a/hkmc2/js/src/main/scala/hkmc2/io/node/NodePath.scala
+++ b/hkmc2/js/src/main/scala/hkmc2/io/node/NodePath.scala
@@ -10,7 +10,7 @@ import mlscript.utils._, shorthands._
 /**
  * JavaScript implementation of Path using Node.js path module
  */
-private[io] class NodePath(val pathString: String) extends Path:
+private[io] case class NodePath(val pathString: String) extends Path:
   private lazy val parsed = path.parse(pathString)
   
   override def toString: String = pathString

--- a/hkmc2/js/src/main/scala/hkmc2/io/node/package.scala
+++ b/hkmc2/js/src/main/scala/hkmc2/io/node/package.scala
@@ -21,6 +21,28 @@ package object node:
     def writeFileSync(path: Str, data: Str): Unit = js.native
     def readdirSync(path: Str): js.Array[Str] = js.native
     def existsSync(path: Str): Bool = js.native
+    def lstatSync(path: Str): Stats = js.native
+  
+  /**
+    * The facade for [[fs.Stats]]. Only a few useful members are listed here.
+    * Refer to https://nodejs.org/api/fs.html#class-fsstats for the full list
+    * of methods.
+    */
+  @js.native
+  trait Stats extends js.Object:
+    def isDirectory(): Bool = js.native
+    def isFile(): Bool = js.native
+    def isSymbolicLink(): Bool = js.native
+    /** The size of the file in bytes. */
+    val size: Long = js.native
+    /** The timestamp indicating the last time this file was accessed. */
+    def atime: js.Date = js.native
+    /** The timestamp indicating the last time this file was modified. */
+    def mtime: js.Date = js.native
+    /** The timestamp indicating the last time the file status was changed. */
+    def ctime: js.Date = js.native
+    /** The timestamp indicating the creation time of this file. */
+    def birthtime: js.Date = js.native
   
   @js.native
   trait ParsedPath extends js.Object:

--- a/hkmc2/js/src/main/scala/hkmc2/utils/PlatformCompilerCache.scala
+++ b/hkmc2/js/src/main/scala/hkmc2/utils/PlatformCompilerCache.scala
@@ -6,18 +6,6 @@ import collection.mutable.Map as MutMap
 import mlscript.utils.*, shorthands.*
 
 class PlatformCompilerCache extends CompilerCache:
-  // TODO also use hash comparison to avoid needless re-parses?
   
   val elabCache: MutMap[io.Path, Artifact] = MutMap.empty
   
-  def upsert(path: io.Path)(update: Option[Artifact] => Artifact): Artifact =
-    elabCache
-      .updateWith(path):
-        case N => S(update(N))
-        case cur @ S(oldArt) =>
-          val newArt = update(cur)
-          if newArt is oldArt then cur else S(newArt)
-      .get // * above, we always returns Some
-
-object PlatformCompilerCache:
-  def apply(): CompilerCache = new PlatformCompilerCache()

--- a/hkmc2/js/src/main/scala/hkmc2/utils/PlatformCompilerCache.scala
+++ b/hkmc2/js/src/main/scala/hkmc2/utils/PlatformCompilerCache.scala
@@ -1,0 +1,23 @@
+package hkmc2
+package utils
+
+import CompilerCache.Artifact
+import collection.mutable.Map as MutMap
+import mlscript.utils.*, shorthands.*
+
+class PlatformCompilerCache extends CompilerCache:
+  // TODO also use hash comparison to avoid needless re-parses?
+  
+  val elabCache: MutMap[io.Path, Artifact] = MutMap.empty
+  
+  def upsert(path: io.Path)(update: Option[Artifact] => Artifact): Artifact =
+    elabCache
+      .updateWith(path):
+        case N => S(update(N))
+        case cur @ S(oldArt) =>
+          val newArt = update(cur)
+          if newArt is oldArt then cur else S(newArt)
+      .get // * above, we always returns Some
+
+object PlatformCompilerCache:
+  def apply(): CompilerCache = new PlatformCompilerCache()

--- a/hkmc2/js/src/test/scala/hkmc2/CompilerTest.scala
+++ b/hkmc2/js/src/test/scala/hkmc2/CompilerTest.scala
@@ -1,12 +1,11 @@
 package hkmc2
 
 import org.scalatest.funsuite.AnyFunSuite
-import hkmc2.io.{InMemoryFileSystem, Path}
+import io.{InMemoryFileSystem, Path, node}
 import mlscript.utils._, shorthands._
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 import scala.scalajs.js.Dynamic.global
-import hkmc2.io.node
 
 class CompilerTest extends AnyFunSuite:
   private def loadStandardLibrary(): Map[String, String] =

--- a/hkmc2/js/src/test/scala/hkmc2/CompilerTest.scala
+++ b/hkmc2/js/src/test/scala/hkmc2/CompilerTest.scala
@@ -27,7 +27,8 @@ class CompilerTest extends AnyFunSuite:
   private def createCompiler(): (InMemoryFileSystem, Compiler) =
     val stdLib = loadStandardLibrary()
     val fs = new InMemoryFileSystem(stdLib)
-    (fs, new Compiler(fs, paths))
+    given CompilerCtx = CompilerCtx.fresh(fs)
+    (fs, new Compiler(paths))
   
   test("compiler can compile a simple program"):
     val (fs, compiler) = createCompiler()

--- a/hkmc2/jvm/src/main/scala/hkmc2/io/PlatformFileSystem.scala
+++ b/hkmc2/jvm/src/main/scala/hkmc2/io/PlatformFileSystem.scala
@@ -10,6 +10,8 @@ private[io] class JavaFileSystem extends FileSystem:
 
   def exists(path: Path): Bool = os.exists(unwrap(path))
   
+  def getLastChangedTimestamp(path: Path): Long = os.mtime(unwrap(path))
+  
   private def unwrap(path: Path): os.Path = path match
     case path: WrappedPath => path.underlying
     case _ => lastWords(s"The given path is not compatible with the current platform (JVM).")

--- a/hkmc2/jvm/src/main/scala/hkmc2/io/PlatformPath.scala
+++ b/hkmc2/jvm/src/main/scala/hkmc2/io/PlatformPath.scala
@@ -6,7 +6,7 @@ import mlscript.utils._, shorthands._
 /**
  * JVM implementation of [[Path]] that wraps [[os.Path]].
  */
-private[io] class WrappedPath(private[io] val underlying: os.Path) extends Path:
+private[io] case class WrappedPath(private[io] val underlying: os.Path) extends Path:
   override def toString: String = underlying.toString
 
   def last: String = underlying.last

--- a/hkmc2/jvm/src/main/scala/hkmc2/utils/PlatformCompilerCache.scala
+++ b/hkmc2/jvm/src/main/scala/hkmc2/utils/PlatformCompilerCache.scala
@@ -6,18 +6,6 @@ import collection.concurrent.{Map => ConcMap, TrieMap}
 import mlscript.utils.*, shorthands.*
 
 class PlatformCompilerCache extends CompilerCache:
-  // TODO also use hash comparison to avoid needless re-parses?
   
   val elabCache: ConcMap[io.Path, Artifact] = TrieMap.empty
   
-  def upsert(path: io.Path)(update: Option[Artifact] => Artifact): Artifact =
-    elabCache
-      .updateWith(path):
-        case N => S(update(N))
-        case cur @ S(oldArt) =>
-          val newArt = update(cur)
-          if newArt is oldArt then cur else S(newArt)
-      .get // * above, we always returns Some
-
-object PlatformCompilerCache:
-  def apply(): CompilerCache = new PlatformCompilerCache()

--- a/hkmc2/jvm/src/main/scala/hkmc2/utils/PlatformCompilerCache.scala
+++ b/hkmc2/jvm/src/main/scala/hkmc2/utils/PlatformCompilerCache.scala
@@ -1,0 +1,23 @@
+package hkmc2
+package utils
+
+import CompilerCache.Artifact
+import collection.concurrent.{Map => ConcMap, TrieMap}
+import mlscript.utils.*, shorthands.*
+
+class PlatformCompilerCache extends CompilerCache:
+  // TODO also use hash comparison to avoid needless re-parses?
+  
+  val elabCache: ConcMap[io.Path, Artifact] = TrieMap.empty
+  
+  def upsert(path: io.Path)(update: Option[Artifact] => Artifact): Artifact =
+    elabCache
+      .updateWith(path):
+        case N => S(update(N))
+        case cur @ S(oldArt) =>
+          val newArt = update(cur)
+          if newArt is oldArt then cur else S(newArt)
+      .get // * above, we always returns Some
+
+object PlatformCompilerCache:
+  def apply(): CompilerCache = new PlatformCompilerCache()

--- a/hkmc2/jvm/src/test/scala/hkmc2/CompileTestRunner.scala
+++ b/hkmc2/jvm/src/test/scala/hkmc2/CompileTestRunner.scala
@@ -8,6 +8,8 @@ import os.up
 import mlscript.utils._, shorthands._
 import io.PlatformPath.given
 
+import CompileTestRunner.given
+
 
 class CompileTestRunner
   extends funsuite.AnyFunSuite
@@ -50,8 +52,7 @@ class CompileTestRunner
         
         // Stack safety relies on the fact that runtime uses while loops for resumption
         // and does not create extra stack depth. Hence we disable while loop rewriting here.
-        given Config = Config.default.copy(rewriteWhileLoops = false)
-        given io.FileSystem = io.FileSystem.default
+        given Config = Config.default
         
         // Synchronize diagnostic output to avoid interleaving since the compiler tests run in parallel.
         val wrap: (=> Unit) => Unit = body => CompileTestRunner.synchronized(body)
@@ -73,6 +74,11 @@ class CompileTestRunner
       
 end CompileTestRunner
 
-object CompileTestRunner
+
+object CompileTestRunner:
+  
+  given cctx: CompilerCtx = CompilerCtx.fresh(io.FileSystem.default)
+  
+end CompileTestRunner
 
 

--- a/hkmc2/shared/src/main/scala/hkmc2/CompilerCtx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/CompilerCtx.scala
@@ -54,20 +54,18 @@ class CompilerCtx(
       val elabbed = elab.importFrom(resBlk)
       Artifact(resBlk, elabbed._1, lastMod)
     
-    cache.elabCache
-      .updateWith(file):
-        case N => S(mk)
-        case cur @ S(art) =>
-          if art.lastChangedTimestamp < lastMod then S(mk)
-          else cur
-      .get // * above, we always returns Some
+    cache.upsert(file):
+      case N => mk
+      case cur @ S(art) =>
+        if art.lastChangedTimestamp < lastMod then mk
+        else art
   
   
 object CompilerCtx:
   
   inline def get(using cctx: CompilerCtx) = cctx
   
-  def fresh(fs: io.FileSystem): CompilerCtx = CompilerCtx(N, Set.empty, fs, new CompilerCache)
+  def fresh(fs: io.FileSystem): CompilerCtx = CompilerCtx(N, Set.empty, fs, CompilerCache())
   
 end CompilerCtx
 
@@ -75,18 +73,17 @@ end CompilerCtx
 
 object CompilerCache:
   
+  def apply(): CompilerCache = PlatformCompilerCache()
+  
   class Artifact(val tree: syntax.Tree.Block, val term: semantics.Term.Blk, val lastChangedTimestamp: Long)
   
 end CompilerCache
 
 
-class CompilerCache:
+trait CompilerCache:
   
-  // TODO also use hash comparison to avoid needless re-parses?
-  
-  import collection.concurrent.{Map => ConcMap, TrieMap}
-  val elabCache: ConcMap[io.Path, Artifact] = TrieMap.empty
-  
+  /** Create or update an artifact at the given path in the cache. */
+  def upsert(path: io.Path)(update: Option[Artifact] => Artifact): Artifact
   
 end CompilerCache
 

--- a/hkmc2/shared/src/main/scala/hkmc2/CompilerCtx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/CompilerCtx.scala
@@ -41,7 +41,7 @@ class CompilerCtx(
     
     // println(s"Cache has: ${cache.elabCache.contains(file)} ${cache.elabCache.keys}")
     
-    val lastMod = file.lastChangedTimestamp
+    val lastMod = fs.getLastChangedTimestamp(file)
     
     def mk =
       val parse =

--- a/hkmc2/shared/src/main/scala/hkmc2/CompilerCtx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/CompilerCtx.scala
@@ -2,6 +2,7 @@ package hkmc2
 
 import scala.collection.mutable
 import scala.annotation.tailrec
+import collection.mutable.Map as MutMap
 
 import mlscript.utils.*, shorthands.*
 import hkmc2.utils.*
@@ -65,7 +66,7 @@ object CompilerCtx:
   
   inline def get(using cctx: CompilerCtx) = cctx
   
-  def fresh(fs: io.FileSystem): CompilerCtx = CompilerCtx(N, Set.empty, fs, CompilerCache())
+  def fresh(fs: io.FileSystem): CompilerCtx = CompilerCtx(N, Set.empty, fs, new PlatformCompilerCache)
   
 end CompilerCtx
 
@@ -73,17 +74,25 @@ end CompilerCtx
 
 object CompilerCache:
   
-  def apply(): CompilerCache = PlatformCompilerCache()
-  
   class Artifact(val tree: syntax.Tree.Block, val term: semantics.Term.Blk, val lastChangedTimestamp: Long)
   
 end CompilerCache
 
 
 trait CompilerCache:
+  // TODO also use hash comparison to avoid needless re-parses?
+  
+  def elabCache: MutMap[io.Path, Artifact]
   
   /** Create or update an artifact at the given path in the cache. */
-  def upsert(path: io.Path)(update: Option[Artifact] => Artifact): Artifact
+  def upsert(path: io.Path)(update: Option[Artifact] => Artifact): Artifact =
+    elabCache
+      .updateWith(path):
+        case N => S(update(N))
+        case cur @ S(oldArt) =>
+          val newArt = update(cur)
+          if newArt is oldArt then cur else S(newArt)
+      .get // * above, we always returns Some
   
 end CompilerCache
 

--- a/hkmc2/shared/src/main/scala/hkmc2/CompilerCtx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/CompilerCtx.scala
@@ -1,0 +1,94 @@
+package hkmc2
+
+import scala.collection.mutable
+import scala.annotation.tailrec
+
+import mlscript.utils.*, shorthands.*
+import hkmc2.utils.*
+import hkmc2.Message.MessageContext
+import hkmc2.io
+import utils.TraceLogger
+
+import semantics.*
+import Elaborator.*
+import hkmc2.syntax.LetBind
+import hkmc2.bbml.cctx
+
+
+import CompilerCache.*
+
+
+class CompilerCtx(
+    val importing: Opt[(io.Path, CompilerCtx)],
+    val beingCompiled: Set[io.Path],
+    val fs: io.FileSystem,
+    cache: CompilerCache,
+):
+  
+  def allFilesBeingImported: Ls[io.Path] =
+    importing match
+    case S((path, parent)) => path :: parent.allFilesBeingImported
+    case N => Nil
+  
+  def derive(newFile: io.Path): CompilerCtx =
+    CompilerCtx(S(newFile, this), beingCompiled + newFile, fs, cache)
+  
+  def getElaboratedBlock
+        (file: io.Path, prelude: Ctx)
+        (using TL, State, Raise, Config)
+        : Artifact =
+    
+    // println(s"Cache has: ${cache.elabCache.contains(file)} ${cache.elabCache.keys}")
+    
+    val lastMod = file.lastChangedTimestamp
+    
+    def mk =
+      val parse =
+        given CompilerCtx = this
+        ParserSetup(file, dbgParsing = false)
+      val resBlk = parse.resultBlk
+      given Elaborator.Ctx = prelude.copy(mode = Mode.Light).nestLocal("prelude")
+      val elab =
+        given CompilerCtx = derive(parse.origin.fileName)
+        Elaborator(tl, file.up, prelude)
+      val elabbed = elab.importFrom(resBlk)
+      Artifact(resBlk, elabbed._1, lastMod)
+    
+    cache.elabCache
+      .updateWith(file):
+        case N => S(mk)
+        case cur @ S(art) =>
+          if art.lastChangedTimestamp < lastMod then S(mk)
+          else cur
+      .get // * above, we always returns Some
+  
+  
+object CompilerCtx:
+  
+  inline def get(using cctx: CompilerCtx) = cctx
+  
+  def fresh(fs: io.FileSystem): CompilerCtx = CompilerCtx(N, Set.empty, fs, new CompilerCache)
+  
+end CompilerCtx
+
+
+
+object CompilerCache:
+  
+  class Artifact(val tree: syntax.Tree.Block, val term: semantics.Term.Blk, val lastChangedTimestamp: Long)
+  
+end CompilerCache
+
+
+class CompilerCache:
+  
+  // TODO also use hash comparison to avoid needless re-parses?
+  
+  import collection.concurrent.{Map => ConcMap, TrieMap}
+  val elabCache: ConcMap[io.Path, Artifact] = TrieMap.empty
+  
+  
+end CompilerCache
+
+
+

--- a/hkmc2/shared/src/main/scala/hkmc2/CompilerCtx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/CompilerCtx.scala
@@ -13,7 +13,6 @@ import utils.TraceLogger
 import semantics.*
 import Elaborator.*
 import hkmc2.syntax.LetBind
-import hkmc2.bbml.cctx
 
 
 import CompilerCache.*

--- a/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
@@ -6,17 +6,14 @@ import mlscript.utils.*, shorthands.*
 import hkmc2.io
 import utils.*
 
-import hkmc2.semantics.MemberSymbol
-import hkmc2.semantics.Elaborator
-import hkmc2.semantics.Resolver
-import hkmc2.semantics.{Import, Term}
+import hkmc2.semantics.*
 import hkmc2.syntax.Keyword.`override`
 import semantics.Elaborator.{Ctx, State}
 
 
-class ParserSetup(file: io.Path, dbgParsing: Bool)(using state: Elaborator.State, raise: Raise, fs: io.FileSystem):
+class ParserSetup(file: io.Path, dbgParsing: Bool)(using state: Elaborator.State, raise: Raise, cctx: CompilerCtx):
   
-  val block = fs.read(file)
+  val block = cctx.fs.read(file)
   val fph = new FastParseHelpers(block)
   val origin = Origin(file, 0, fph)
   
@@ -51,7 +48,9 @@ object MLsCompiler:
   * @param config the compiler's configuration object
   * @param fs the file system interface
   */
-class MLsCompiler(paths: MLsCompiler.Paths, mkRaise: io.Path => Raise)(using config: Config, fs: io.FileSystem):
+class MLsCompiler
+    (paths: MLsCompiler.Paths, mkRaise: io.Path => Raise)
+    (using cctx: CompilerCtx, config: Config):
   import paths.*
   
   
@@ -59,6 +58,7 @@ class MLsCompiler(paths: MLsCompiler.Paths, mkRaise: io.Path => Raise)(using con
   // TODO adapt logic
   val etl = new TraceLogger{override def doTrace: Bool = false}
   val ltl = new TraceLogger{override def doTrace: Bool = false}
+  // val ltl = new TraceLogger{override def doTrace: Bool = true}
   val rtl = new TraceLogger{override def doTrace: Bool = false}
   
   
@@ -71,7 +71,8 @@ class MLsCompiler(paths: MLsCompiler.Paths, mkRaise: io.Path => Raise)(using con
     
     given Raise = mkRaise(file)
     
-    given Elaborator.State = new Elaborator.State
+    given Elaborator.State = new Elaborator.State:
+      override def dbg: Bool = true
     
     val preludeParse = ParserSetup(preludeFile, dbgParsing)
     val mainParse = ParserSetup(file, dbgParsing)
@@ -83,6 +84,7 @@ class MLsCompiler(paths: MLsCompiler.Paths, mkRaise: io.Path => Raise)(using con
     val (pblk, newCtx) = elab.importFrom(preludeParse.resultBlk)(using initState)
     
     newCtx.nestLocal("file:"+file.baseName).givenIn:
+      given CompilerCtx = cctx.derive(file)
       val elab = Elaborator(etl, wd, newCtx)
       val parsed = mainParse.resultBlk
       val (blk0, _) = elab.importFrom(parsed)
@@ -120,7 +122,7 @@ class MLsCompiler(paths: MLsCompiler.Paths, mkRaise: io.Path => Raise)(using con
         jsb.program(le, exportedSymbol, wd)
       val jsStr = je.stripBreaks.mkString(100)
       val out = file.up / io.RelPath(file.baseName + ".mjs")
-      fs.write(out, jsStr)
+      cctx.fs.write(out, jsStr)
   
   
 end MLsCompiler

--- a/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
@@ -63,6 +63,7 @@ class MLsCompiler
   
   
   var dbgParsing = false
+  var dbgElab = false
   
   
   def compileModule(file: io.Path): Unit =
@@ -72,7 +73,7 @@ class MLsCompiler
     given Raise = mkRaise(file)
     
     given Elaborator.State = new Elaborator.State:
-      override def dbg: Bool = true
+      override def dbg: Bool = dbgElab
     
     val preludeParse = ParserSetup(preludeFile, dbgParsing)
     val mainParse = ParserSetup(file, dbgParsing)

--- a/hkmc2/shared/src/main/scala/hkmc2/io/FileSystem.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/io/FileSystem.scala
@@ -21,6 +21,13 @@ trait FileSystem:
   /** Check if a file exists at the given path. */
   def exists(path: Path): Bool
   
+  /**
+    * Get the last changed timestamp of the file at the given path. The meaning
+    * of the timestamp is platform-dependent. The caller should ensure that the
+    * file exists before calling this method.
+    */
+  def getLastChangedTimestamp(path: Path): Long
+  
 object FileSystem:
   /** Get the platform default file system by delegating to the platform. */
   def default: FileSystem = PlatformFileSystem.default

--- a/hkmc2/shared/src/main/scala/hkmc2/io/Path.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/io/Path.scala
@@ -20,8 +20,6 @@ abstract class Path:
   /** Get the file extension (without dot) */
   def ext: String
   
-  def lastChangedTimestamp: Long = 0 // TODO
-  
   /** Navigate to parent directory */
   def up: Path
   

--- a/hkmc2/shared/src/main/scala/hkmc2/io/Path.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/io/Path.scala
@@ -20,6 +20,8 @@ abstract class Path:
   /** Get the file extension (without dot) */
   def ext: String
   
+  def lastChangedTimestamp: Long = 0 // TODO
+  
   /** Navigate to parent directory */
   def up: Path
   

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
@@ -318,7 +318,7 @@ import Elaborator.*
 
 
 class Elaborator(val tl: TraceLogger, val wd: io.Path, val prelude: Ctx)
-(using val raise: Raise, val state: State, val fs: io.FileSystem)
+(using val raise: Raise, val state: State, val cctx: CompilerCtx)
 extends Importer with ucs.SplitElaborator:
   import tl.*
   

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Importer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Importer.scala
@@ -5,6 +5,7 @@ import scala.collection.mutable
 import scala.annotation.tailrec
 
 import mlscript.utils.*, shorthands.*
+import hkmc2.utils.*
 import hkmc2.Message.MessageContext
 import hkmc2.io
 import utils.TraceLogger
@@ -12,11 +13,12 @@ import utils.TraceLogger
 import Elaborator.*
 import hkmc2.syntax.LetBind
 
+
 class Importer:
   self: Elaborator =>
   import tl.*
   
-  def importPath(path: Str)(using cfg: Config, fs: io.FileSystem): Import =
+  def importPath(path: Str)(using cfg: Config): Import =
     // log(s"pwd: ${os.pwd}")
     // log(s"wd: ${wd}")
     
@@ -41,39 +43,28 @@ class Importer:
       case "mjs" | "js" =>
         Import(sym, file.toString, file)
         
-      case "mls" =>
-        
-        val block = fs.read(file)
-        val fph = new FastParseHelpers(block)
-        val origin = Origin(file, 0, fph)
+      case "mls" if {
+        !cctx.beingCompiled.contains(file) `||`:
+          raise:
+            ErrorReport:
+                msg"Circular imports of `mls` files are not yet supported" -> N
+                :: (cctx.allFilesBeingImported :+ file).map(f => msg"  importing ${f.toString}" -> N)
+          false
+      } =>
         
         val sym = tl.trace(s">>> Importing $file"):
-          
-          // TODO add parser option to omit internal impls
-          
-          val lexer = new syntax.Lexer(origin, dbg = tl.doTrace)
-          val tokens = lexer.bracketedTokens
-          val rules = syntax.ParseRules()
-          val p = new syntax.Parser(origin, tokens, rules, raise, dbg = tl.doTrace):
-            def doPrintDbg(msg: => Str): Unit =
-              // if dbg then output(msg)
-              if dbg then tl.log(msg)
-          val res = p.parseAll(p.block(allowNewlines = true))
-          val resBlk = new syntax.Tree.Block(res)
-          
-          given Elaborator.Ctx = prelude.copy(mode = Mode.Light).nestLocal("prelude")
-          val elab = Elaborator(tl, file.up, prelude)
-          elab.importFrom(resBlk)
-          
-          resBlk.definedSymbols.find(_._1 === nme) match
-          case Some(nme -> sym) => sym
+          given TL = tl
+          val artifact = cctx.getElaboratedBlock(file, prelude)
+          artifact.tree.definedSymbols.find(_._1 === nme) match
+          case Some(nme -> imsym) => imsym
           case None => lastWords(s"File $file does not define a symbol named $nme")
         
         val jsFile = file.up / io.RelPath(file.baseName + ".mjs")
         Import(sym, jsFile.toString, jsFile)
         
       case _ =>
-        raise(ErrorReport(msg"Unsupported file extension: ${file.ext}" -> N :: Nil))
+        if file.ext =/= "mls" then raise:
+          ErrorReport(msg"Unsupported file extension: ${file.ext}" -> N :: Nil)
         Import(sym, path, file)
       
     else

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
@@ -125,9 +125,7 @@ abstract class Symbol(using State) extends Located:
     case (sym, S(_)) =>
       lastWords(s"Cannot disambiguate non-BlockMember symbol ${sym.nme}: disambiguation provided")
   
-  override def equals(x: Any): Bool = x match
-    case that: Symbol => uid === that.uid
-    case _ => false
+  override def equals(x: Any): Bool = this is x
   override def hashCode: Int = uid.hashCode
   
   def subst(using SymbolSubst): Symbol

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
@@ -743,8 +743,11 @@ case class ObjBody(blk: Term.Blk):
   override def toString: String = blk.showDbg
 
 
-/** Note that the `file` Path may not represent a real file; eg when importing "fs". */
-case class Import(sym: Symbol, str: Str, file: io.Path) extends Statement
+/** `sym` is a `MemberSymbol` when the import is made by the user and can be referred to by name,
+  * in which case it is a `BlockMemberSymbol` when importing files explicitly
+  * and a `TermSymbol` when the import is made implicitly by the compiler (eg, importing "Predef").
+  * Note that the `file` Path may not represent a real file; eg when importing "fs". */
+case class Import(sym: TempSymbol | MemberSymbol, str: Str, file: io.Path) extends Statement
 
 
 sealed abstract class Declaration:

--- a/hkmc2/shared/src/main/scala/hkmc2/utils/ReportFormatter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/utils/ReportFormatter.scala
@@ -17,6 +17,8 @@ class ReportFormatter(
   val colorize: Bool,
   val wrap: Opt[(=> Unit) => Unit] = N
 ):
+  val MaxLineCount = 5
+  
   /** Output main text. */
   private def text(str: Str) =
     output(if colorize then fansi.Color.Red(str).toString else str)
@@ -64,12 +66,12 @@ class ReportFormatter(
       val lastMsgNum = diag.allMsgs.size - 1
       var globalLineNum = blockLineNum
       diag.allMsgs.zipWithIndex.foreach { case ((msg, loco), msgNum) =>
-        val isLast = msgNum =:= lastMsgNum
+        val isLastMsg = msgNum =:= lastMsgNum
         val msgStr = msg.showIn(using sctx)
         if msgNum =:= 0 then text(headStr + msgStr)
         else if loco.isEmpty && diag.allMsgs.size =:= 1 then
           if !onlyOneLine then text("╙──")
-        else text(s"${if isLast && loco.isEmpty then "╙──" else "╟──"} ${msgStr}")
+        else text(s"${if isLastMsg && loco.isEmpty then "╙──" else "╟──"} ${msgStr}")
         loco.foreach { loc =>
           val (startLineNum, startLineStr, startLineCol) =
             loc.origin.fph.getLineColAt(loc.spanStart)
@@ -79,7 +81,10 @@ class ReportFormatter(
             loc.origin.fph.getLineColAt(loc.spanEnd)
           var l = startLineNum
           var c = startLineCol
-          while l <= endLineNum do
+          var lineCount = 0
+          while l <= endLineNum && lineCount < MaxLineCount do
+            val isLastLineOfLoc = l === endLineNum || lineCount === MaxLineCount - 1
+            lineCount += 1
             val globalLineNum = loc.origin.startLineNum + l - 1
             val relativeLineNum = globalLineNum - blockLineNum + 1
             val shownLineNum =
@@ -87,11 +92,13 @@ class ReportFormatter(
               else "l." + globalLineNum
             val prepre = "║  "
             val pre = s"$shownLineNum: "
-            val curLine = loc.origin.fph.lines(l - 1)
+            val curLine = if lineCount < MaxLineCount
+              then loc.origin.fph.lines(l - 1)
+              else "... (more lines omitted) ..."
             text(prepre + pre + "\t" + curLine)
             val tickBuilder = new StringBuilder()
             tickBuilder ++= (
-              (if isLast && l =:= endLineNum then "╙──" else prepre)
+              (if isLastMsg && isLastLineOfLoc then "╙──" else prepre)
               + " " * pre.length + "\t" + " " * (c - 1))
             val lastCol = if l =:= endLineNum then endLineCol else curLine.length + 1
             while c < lastCol do { tickBuilder += ('^'); c += 1 }

--- a/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing.mls
@@ -82,14 +82,8 @@ letreg of r =>
 //│ ║        	^^^^^^^^^^
 //│ ║  l.71: 	  let k = iterate(b) of it =>
 //│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.72: 	    next(it)
-//│ ║        	^^^^^^^^^^^^
-//│ ║  l.73: 	    123
-//│ ║        	^^^^^^^
-//│ ║  l.74: 	    () => next(it)
-//│ ║        	^^^^^^^^^^^^^^^^^^
-//│ ║  l.75: 	  k()
-//│ ║        	^^^^^
+//│ ║  l.72: 	... (more lines omitted) ...
+//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
 //│ ╟── because: cannot constrain  'E  <:  ⊥
 //│ ╟── because: cannot constrain  ¬'Rg  <:  ⊥
@@ -108,24 +102,16 @@ letreg of r =>
   clear(b)
   r
 //│ ╔══[ERROR] Type error in block
-//│ ║  l.101: 	letreg of r =>
-//│ ║         	^^^^^^^^^^^^^^
-//│ ║  l.102: 	  let b = mkVec(r)
-//│ ║         	^^^^^^^^^^^^^^^^^^
-//│ ║  l.103: 	  clear(b)
-//│ ║         	^^^^^^^^^^
-//│ ║  l.104: 	  iterate(b) of it =>
-//│ ║         	^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.105: 	    next(it)
-//│ ║         	^^^^^^^^^^^^
-//│ ║  l.106: 	    clear(b)
-//│ ║         	^^^^^^^^^^^^
-//│ ║  l.107: 	    123
-//│ ║         	^^^^^^^
-//│ ║  l.108: 	  clear(b)
-//│ ║         	^^^^^^^^^^
-//│ ║  l.109: 	  r
-//│ ║         	^^^
+//│ ║  l.95: 	letreg of r =>
+//│ ║        	^^^^^^^^^^^^^^
+//│ ║  l.96: 	  let b = mkVec(r)
+//│ ║        	^^^^^^^^^^^^^^^^^^
+//│ ║  l.97: 	  clear(b)
+//│ ║        	^^^^^^^^^^
+//│ ║  l.98: 	  iterate(b) of it =>
+//│ ║        	^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.99: 	... (more lines omitted) ...
+//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
 //│ ╟── because: cannot constrain  'E  <:  ⊥
 //│ ╟── because: cannot constrain  'Rg  <:  ⊥
@@ -156,20 +142,16 @@ letreg of r =>
   use_(r)
   r
 //│ ╔══[ERROR] Type error in block
-//│ ║  l.151: 	letreg of r =>
+//│ ║  l.137: 	letreg of r =>
 //│ ║         	^^^^^^^^^^^^^^
-//│ ║  l.152: 	  use_(r)
+//│ ║  l.138: 	  use_(r)
 //│ ║         	^^^^^^^^^
-//│ ║  l.153: 	  integers(r) of it =>
+//│ ║  l.139: 	  integers(r) of it =>
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.154: 	    use_(r)
+//│ ║  l.140: 	    use_(r)
 //│ ║         	^^^^^^^^^^^
-//│ ║  l.155: 	    next(it)
-//│ ║         	^^^^^^^^^^^^
-//│ ║  l.156: 	  use_(r)
-//│ ║         	^^^^^^^^^
-//│ ║  l.157: 	  r
-//│ ║         	^^^
+//│ ║  l.141: 	... (more lines omitted) ...
+//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
 //│ ╟── because: cannot constrain  'E  <:  ⊥
 //│ ╟── because: cannot constrain  'Rg  <:  ⊥

--- a/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing2.mls
+++ b/hkmc2/shared/src/test/mlscript/bbml/bbBorrowing2.mls
@@ -43,10 +43,8 @@ letreg of r =>
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
 //│ ║  l.34: 	    write(r)
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.35: 	    read(r)
-//│ ║        	^^^^^^^^^^^
-//│ ║  l.36: 	  write(r)
-//│ ║        	^^^^^^^^^^
+//│ ║  l.35: 	... (more lines omitted) ...
+//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
 //│ ╟── because: cannot constrain  'E  <:  ⊥
 //│ ╟── because: cannot constrain  'Rg  <:  ⊥
@@ -74,18 +72,16 @@ letreg of r =>
     read(r)
   write(r)
 //│ ╔══[ERROR] Type error in block
-//│ ║  l.70: 	letreg of r =>
+//│ ║  l.68: 	letreg of r =>
 //│ ║        	^^^^^^^^^^^^^^
-//│ ║  l.71: 	  read(r)
+//│ ║  l.69: 	  read(r)
 //│ ║        	^^^^^^^^^
-//│ ║  l.72: 	  borrow(r) of () =>
+//│ ║  l.70: 	  borrow(r) of () =>
 //│ ║        	^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.73: 	    write(r)
+//│ ║  l.71: 	    write(r)
 //│ ║        	^^^^^^^^^^^^
-//│ ║  l.74: 	    read(r)
-//│ ║        	^^^^^^^^^^^
-//│ ║  l.75: 	  write(r)
-//│ ║        	^^^^^^^^^^
+//│ ║  l.72: 	... (more lines omitted) ...
+//│ ║        	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── because: cannot constrain  'E  <:  ⊥
 //│ ╟── because: cannot constrain  'E  <:  ⊥
 //│ ╟── because: cannot constrain  'Rg  <:  ⊥

--- a/hkmc2Benchmarks/src/test/scala/hkmc2/BenchDiffMaker.scala
+++ b/hkmc2Benchmarks/src/test/scala/hkmc2/BenchDiffMaker.scala
@@ -4,10 +4,15 @@ import mlscript.utils._, shorthands._
 import hkmc2.syntax.Tree
 import hkmc2.syntax.Keyword
 
-class BenchDiffMaker(val rootPath: Str, val file: io.Path, val preludeFile: io.Path, val predefFile: io.Path, val relativeName: Str)
+
+class BenchDiffMaker
+    (val rootPath: Str, val file: io.Path, val preludeFile: io.Path, val predefFile: io.Path, val relativeName: Str)
+    (using val cctx: CompilerCtx)
   extends LlirDiffMaker:
   
   override def fs = io.FileSystem.default
 
   override def processTerm(blk: semantics.Term.Blk, inImport: Bool)(using Config, Raise): Unit =
     super.processTerm(blk, inImport)
+
+

--- a/hkmc2Benchmarks/src/test/scala/hkmc2/BenchDiffMaker.scala
+++ b/hkmc2Benchmarks/src/test/scala/hkmc2/BenchDiffMaker.scala
@@ -10,8 +10,6 @@ class BenchDiffMaker
     (using val cctx: CompilerCtx)
   extends LlirDiffMaker:
   
-  override def fs = io.FileSystem.default
-
   override def processTerm(blk: semantics.Term.Blk, inImport: Bool)(using Config, Raise): Unit =
     super.processTerm(blk, inImport)
 

--- a/hkmc2Benchmarks/src/test/scala/hkmc2/BenchTestRunner.scala
+++ b/hkmc2Benchmarks/src/test/scala/hkmc2/BenchTestRunner.scala
@@ -15,9 +15,12 @@ object BenchTestState extends DiffTestRunner.State:
 
   override val TimeLimit = Span(1, Hour)
 
-class BenchTestRunner
+class BenchTestRunner(using CompilerCtx)
   extends DiffTestRunnerBase(BenchTestState)
   with ParallelTestExecution
 :
-  override protected def createDiffMaker(file: Path, preludePath: Path, predefPath: Path, relativeName: String): DiffMaker =
+  override protected def createDiffMaker
+      (file: Path, preludePath: Path, predefPath: Path, relativeName: String)
+      : DiffMaker =
     new BenchDiffMaker((os.pwd/"hkmc2Benchmarks").toString, file, preludePath, predefPath, relativeName)
+

--- a/hkmc2DiffTests/src/test/scala/hkmc2/DiffMaker.scala
+++ b/hkmc2DiffTests/src/test/scala/hkmc2/DiffMaker.scala
@@ -27,7 +27,9 @@ class Outputter(val out: java.io.PrintWriter):
 
 
 abstract class DiffMaker:
-  protected given fs: io.FileSystem
+  
+  def cctx: CompilerCtx
+  given CompilerCtx = cctx
   
   val file: io.Path
   val relativeName: Str
@@ -136,7 +138,7 @@ abstract class DiffMaker:
   
   val fileName = file.last
   
-  val fileContents = fs.read(file)
+  val fileContents = cctx.fs.read(file)
   val allLines = fileContents.splitSane('\n').toList
   val strw = new java.io.StringWriter
   val out = new java.io.PrintWriter(strw)
@@ -351,7 +353,7 @@ abstract class DiffMaker:
     val result = strw.toString
     if result =/= fileContents then
       println(s"Updating $file...")
-      fs.write(file, result)
+      cctx.fs.write(file, result)
   
   // * Called after the very first command block
   // * and every time a further command block with `:init` finishes

--- a/hkmc2DiffTests/src/test/scala/hkmc2/DiffTestRunner.scala
+++ b/hkmc2DiffTests/src/test/scala/hkmc2/DiffTestRunner.scala
@@ -22,6 +22,8 @@ object DiffTestRunner:
   
   class State:
     
+    val cctx: CompilerCtx = CompilerCtx.fresh(io.FileSystem.default)
+    
     val pwd = os.pwd
     
     // println(s"INITIALIZING DiffTestRunner.State in ${pwd}")
@@ -120,7 +122,7 @@ class DiffTestRunnerBase(state: DiffTestRunner.State)
     relativeName: String
   ): DiffMaker =
     new MainDiffMaker(workingDir.toString, file, preludePath, predefPath, relativeName):
-      override def fs = FileSystem.default
+      def cctx = state.cctx
   
   diffTestFiles.foreach: file =>
     

--- a/hkmc2DiffTests/src/test/scala/hkmc2/MLsDiffMaker.scala
+++ b/hkmc2DiffTests/src/test/scala/hkmc2/MLsDiffMaker.scala
@@ -180,7 +180,7 @@ abstract class MLsDiffMaker extends DiffMaker:
       output(s"Error: $d")
       ()
     
-    val block = fs.read(file)
+    val block = cctx.fs.read(file)
     val fph = new FastParseHelpers(block)
     val origin = Origin(file, 0, fph)
     

--- a/hkmc2DiffTests/src/test/scala/hkmc2/MainDiffMaker.scala
+++ b/hkmc2DiffTests/src/test/scala/hkmc2/MainDiffMaker.scala
@@ -7,7 +7,8 @@ import org.scalatest.concurrent.{TimeLimitedTests, Signaler}
 import mlscript.utils._, shorthands._
 
 
-abstract class MainDiffMaker(val rootPath: Str, val file: io.Path, val preludeFile: io.Path, val predefFile: io.Path, val relativeName: Str)
+abstract class MainDiffMaker
+    (val rootPath: Str, val file: io.Path, val preludeFile: io.Path, val predefFile: io.Path, val relativeName: Str)
   extends WasmDiffMaker
 
 

--- a/hkmc2DiffTests/src/test/scala/hkmc2/Watcher.scala
+++ b/hkmc2DiffTests/src/test/scala/hkmc2/Watcher.scala
@@ -29,6 +29,8 @@ class Watcher(dirs: Ls[File]):
   val completionTime = mutable.Map.empty[File, LocalDateTime]
   val fileHasher = FileHasher.DEFAULT_FILE_HASHER
   
+  given cctx: CompilerCtx = CompilerCtx.fresh(FileSystem.default)
+  
   val watcher: DirectoryWatcher = DirectoryWatcher.builder()
     .logger(org.slf4j.helpers.NOPLogger.NOP_LOGGER)
     .paths(dirs.map(_.toJava.toPath).asJava)
@@ -70,8 +72,9 @@ class Watcher(dirs: Ls[File]):
               case StandardWatchEventKinds.ENTRY_DELETE => onDelete(file, count)
         completionTime(event.path) = LocalDateTime.now()
       catch ex =>
-        System.err.println("Unexpected error in watcher: " + ex)
-        ex.printStackTrace()
+        // System.err.println("Unexpected error in watcher: " + ex)
+        // ex.printStackTrace()
+        System.err.println("Unexpected error in watcher (" + ex.getClass() + ")")
         watcher.close()
         throw ex
     })
@@ -98,7 +101,6 @@ class Watcher(dirs: Ls[File]):
       if isModuleFile
       then
         given Config = Config.default
-        given FileSystem = FileSystem.default
         MLsCompiler(
           paths = new MLsCompiler.Paths:
             val preludeFile = preludePath
@@ -108,7 +110,7 @@ class Watcher(dirs: Ls[File]):
         ).compileModule(path)
       else
         val dm = new MainDiffMaker(rootPath.toString, path, preludePath, predefPath, relativeName):
-          override def fs = FileSystem.default
+          def cctx = Watcher.this.cctx
           override def unhandled(blockLineNum: Int, exc: Throwable): Unit =
             exc.printStackTrace()
             super.unhandled(blockLineNum, exc)


### PR DESCRIPTION
The JVM tests pass, but `concurrent.TrieMap` does not work in JS and we'll need to make a façade for it.