### PR TITLE
Propagate Constructor Symbol

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -465,7 +465,7 @@ sealed abstract class Defn:
   lazy val freeVars: Set[Local] = this match
     case FunDefn(own, sym, dSym, params, body) => body.freeVars -- params.flatMap(_.paramSyms) - sym
     case ValDefn(tsym, sym, rhs) => rhs.freeVars
-    case ClsLikeDefn(own, isym, sym, k, paramsOpt, auxParams, parentSym, 
+    case ClsLikeDefn(own, isym, sym, ctorSym, k, paramsOpt, auxParams, parentSym, 
         methods, privateFields, publicFields, preCtor, ctor, stat, bufferable) =>
       preCtor.freeVars
         ++ ctor.freeVars ++ methods.flatMap(_.freeVars) ++ stat.iterator.flatMap(_.freeVars)
@@ -474,7 +474,7 @@ sealed abstract class Defn:
   lazy val freeVarsLLIR: Set[Local] = this match
     case FunDefn(own, sym, dSym, params, body) => body.freeVarsLLIR -- params.flatMap(_.paramSyms) - sym
     case ValDefn(tsym, sym, rhs) => rhs.freeVarsLLIR
-    case ClsLikeDefn(own, isym, sym, k, paramsOpt, auxParams, parentSym, 
+    case ClsLikeDefn(own, isym, sym, ctorSym, k, paramsOpt, auxParams, parentSym, 
         methods, privateFields, publicFields, preCtor, ctor, stat, bufferable) =>
       preCtor.freeVarsLLIR
         ++ ctor.freeVarsLLIR ++ methods.flatMap(_.freeVarsLLIR) ++ stat.iterator.flatMap(_.freeVarsLLIR)
@@ -556,6 +556,7 @@ final case class ClsLikeDefn(
     owner: Opt[InnerSymbol],
     isym: DefinitionSymbol[? <: ClassLikeDef] & InnerSymbol,
     sym: BlockMemberSymbol,
+    ctorSym: Opt[TermSymbol],
     k: syntax.ClsLikeKind,
     paramsOpt: Opt[ParamList],
     auxParams: List[ParamList],

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
@@ -203,12 +203,13 @@ class BlockTransformer(subst: SymbolSubst):
   def applyDefn(defn: Defn)(k: Defn => Block): Block = defn match
     case defn: FunDefn => k(applyFunDefn(defn))
     case defn: ValDefn => applyValDefn(defn)(k)
-    case ClsLikeDefn(own, isym, sym, kind, paramsOpt, auxParams, parentPath, methods,
+    case ClsLikeDefn(own, isym, sym, ctorSym, kind, paramsOpt, auxParams, parentPath, methods,
         privateFields, publicFields, preCtor, ctor, mod, bufferable)
     =>
       val own2 = own.mapConserve(_.subst)
       val isym2 = isym.subst
       val sym2 = sym.subst
+      val ctorSym2 = ctorSym.mapConserve(_.subst)
       val paramsOpt2 = paramsOpt.mapConserve(applyParamList)
       val auxParams2 = auxParams.mapConserve(applyParamList)
       val withoutParentPath = (parentPath2: Opt[Path]) =>
@@ -219,7 +220,7 @@ class BlockTransformer(subst: SymbolSubst):
         val ctor2 = applyFunBodyLikeBlock(ctor)
         val mod2 = mod.mapConserve(applyObjBody)
         k:
-          if (own2 is own) && (isym2 is isym) && (sym2 is sym) &&
+          if (own2 is own) && (isym2 is isym) && (sym2 is sym) && (ctorSym2 is ctorSym) &&
               (paramsOpt2 is paramsOpt) &&
               (auxParams2 is auxParams) &&
               (parentPath2 is parentPath) &&
@@ -228,7 +229,7 @@ class BlockTransformer(subst: SymbolSubst):
               (publicFields2 is publicFields) &&
               (preCtor2 is preCtor) && (ctor2 is ctor) &&
               (mod2 is mod)
-            then defn else ClsLikeDefn(own2, isym2, sym2, kind, paramsOpt2, 
+            then defn else ClsLikeDefn(own2, isym2, sym2, ctorSym2, kind, paramsOpt2, 
               auxParams2, parentPath2, methods2, privateFields2, publicFields2, preCtor2, ctor2, mod2, bufferable)
       parentPath match
         case Some(pp) => applyPath(pp): pp2 =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTraverser.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTraverser.scala
@@ -90,12 +90,13 @@ class BlockTraverser:
   def applyDefn(defn: Defn): Unit = defn match
     case defn: FunDefn => applyFunDefn(defn)
     case defn: ValDefn => applyValDefn(defn)
-    case ClsLikeDefn(own, isym, sym, k, paramsOpt, auxParams, parentPath, methods,
+    case ClsLikeDefn(own, isym, sym, ctorSym, k, paramsOpt, auxParams, parentPath, methods,
         privateFields, publicFields, preCtor, ctor, mod, bufferable)
     =>
       own.foreach(_.traverse)
       isym.traverse
       sym.traverse
+      ctorSym.foreach(_.traverse)
       paramsOpt.foreach(applyParamList)
       auxParams.foreach(applyParamList)
       parentPath.foreach(applyPath)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BufferableTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BufferableTransform.scala
@@ -87,6 +87,7 @@ class BufferableTransform()(using Ctx, State, Raise):
                 cls.owner,
                 cls.isym,
                 cls.sym,
+                cls.ctorSym,
                 cls.k,
                 if bufferable then cls.paramsOpt else N,
                 if bufferable then cls.auxParams else Nil,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -724,6 +724,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
       N, // no owner
       h.cls,
       BlockMemberSymbol(h.cls.id.name, Nil),
+      N,
       syntax.Cls,
       N, Nil,
       S(h.par), handlerMtds, Nil, Nil,
@@ -949,6 +950,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
       N, // no owner
       clsSym,
       BlockMemberSymbol(clsSym.nme, Nil),
+      N,
       syntax.Cls,
       N,
       PlainParamList({

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -294,6 +294,7 @@ class Lifter(handlerPaths: Opt[HandlerPaths])(using State, Raise):
     
     val defn = ClsLikeDefn(
       None, clsSym, BlockMemberSymbol(nme, Nil),
+      S(TermSymbol(syntax.Fun, S(clsSym), clsSym.id)),
       syntax.Cls,
       N,
       PlainParamList(sortedVars.iterator.map(_._2).toList) :: Nil, None, Nil, Nil, 
@@ -471,7 +472,7 @@ class Lifter(handlerPaths: Opt[HandlerPaths])(using State, Raise):
           tsym.owner.foreach(_.traverse)
           sym.traverse
           applyPath(rhs)
-        case ClsLikeDefn(own, isym, sym, k, paramsOpt, auxParams, parentPath, methods,
+        case ClsLikeDefn(own, isym, sym, ctorSym, k, paramsOpt, auxParams, parentPath, methods,
             privateFields, publicFields, preCtor, ctor, mod, bufferable)
         =>
           own.foreach(_.traverse)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -331,7 +331,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
         defn.ext match
         case N =>
           Define(
-            ClsLikeDefn(defn.owner, defn.sym, defn.bsym, defn.kind, defn.paramsOpt, defn.auxParams, N,
+            ClsLikeDefn(defn.owner, defn.sym, defn.bsym, defn.ctorSym, defn.kind, defn.paramsOpt, defn.auxParams, N,
               mtds,
               privateFlds,
               publicFlds,
@@ -347,7 +347,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
             val pctor = inScopedBlock(parentConstructor(ext.cls, ext.args))
             Define(
               ClsLikeDefn(
-                defn.owner, defn.sym, defn.bsym, defn.kind, defn.paramsOpt, defn.auxParams, S(clsp),
+                defn.owner, defn.sym, defn.bsym, defn.ctorSym, defn.kind, defn.paramsOpt, defn.auxParams, S(clsp),
                 mtds, privateFlds, publicFlds, pctor, ctor, mod, bufferable,
               ),
               blockImpl(stats, res)(k)
@@ -737,7 +737,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
           loweringCtx.collectScopedSym(sym)
           val (mtds, publicFlds, privateFlds, ctor) = gatherMembers(rft)
           val pctor = parentConstructor(cls, as)
-          val clsDef = ClsLikeDefn(N, isym, sym, syntax.Cls, N, Nil, S(sr),
+          val clsDef = ClsLikeDefn(N, isym, sym, N, syntax.Cls, N, Nil, S(sr),
             mtds, privateFlds, publicFlds, pctor, ctor, N, N)
           val inner = new New(sym.ref().resolved(isym), Nil, N)(N)
           Define(clsDef, term_nonTail(if mut then Mut(inner) else inner)(k))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
@@ -67,7 +67,7 @@ object Printer:
       doc"fun ${sym.nme}${docParams} { #{  # ${docBody} #}  # }"
     case ValDefn(tsym, sym, rhs) =>
       doc"val ${tsym.nme} = ${mkDocument(rhs)}"
-    case ClsLikeDefn(own, isym, sym, k, paramsOpt, auxParams, parentSym, methods,
+    case ClsLikeDefn(own, isym, sym, ctorSym, k, paramsOpt, auxParams, parentSym, methods,
         privateFields, publicFields, preCtor, ctor, mod, bufferable)
     =>
       def optFldBody(t: semantics.TermDefinition) =

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
@@ -106,10 +106,10 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, doUnwindMap: Map[
   def rewriteCls(defn: ClsLikeDefn, isTopLevel: Bool): ClsLikeDefn = defn.parentPath match
     case Some(value) if value eq paths.contClsPath => defn
     case _ =>
-      val ClsLikeDefn(owner, isym, sym, k, paramsOpt, auxParams,
+      val ClsLikeDefn(owner, isym, sym, ctorSym, k, paramsOpt, auxParams,
         parentPath, methods, privateFields, publicFields, preCtor, ctor, mod, bufferable) = defn
       ClsLikeDefn(
-        owner, isym, sym, k, paramsOpt, auxParams, parentPath,
+        owner, isym, sym, ctorSym, k, paramsOpt, auxParams, parentPath,
         methods.map(rewriteFn),
         privateFields,
         publicFields, 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -261,7 +261,7 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
               // * which is not meaningful, here.
               doc"${getVar(sym, dSym.toLoc)} = (undefined, function ($params) ${ braced(bodyDoc) });"
             
-          case ClsLikeDefn(ownr, isym, sym, kind, paramsOpt, auxParams, par, mtds,
+          case ClsLikeDefn(ownr, isym, sym, ctorSym, kind, paramsOpt, auxParams, par, mtds,
               privFlds, pubFlds, preCtor, ctor, modo, bufferable)
           =>
             val clsParams = paramsOpt.fold(Nil)(_.paramSyms)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Builder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Builder.scala
@@ -214,7 +214,7 @@ final class LlirBuilder(using Elaborator.State)(tl: TraceLogger, uid: FreshInt):
   private def bClsLikeDef(e: ClsLikeDefn)(using ctx: Ctx)(using Raise, Scope): ClassInfo =
     trace[ClassInfo](s"bClsLikeDef begin", x => s"bClsLikeDef end: ${x.show}"):
       val ClsLikeDefn(
-        _own, isym, _sym, kind, paramsOpt, auxParams, parentSym, methods, privateFields, publicFields, preCtor, ctor, mod, bufferable) = e
+        _own, isym, _sym, _ctorSym, kind, paramsOpt, auxParams, parentSym, methods, privateFields, publicFields, preCtor, ctor, mod, bufferable) = e
       if !ctx.isTopLevel then
         bErrStop(msg"Non top-level definition ${isym.toString()} not supported")
       else
@@ -530,7 +530,7 @@ final class LlirBuilder(using Elaborator.State)(tl: TraceLogger, uid: FreshInt):
   
   def registerClasses(b: Block)(using ctx: Ctx)(using Raise, Scope): Ctx =
     b match
-    case Define(cd @ ClsLikeDefn(_own, isym, sym, kind, _paramsOpt, auxParams,
+    case Define(cd @ ClsLikeDefn(_own, isym, sym, ctorSym, kind, _paramsOpt, auxParams,
         parentSym, methods, privateFields, publicFields, preCtor, ctor, mod, bufferable), rest) =>
       if !auxParams.isEmpty then
         bErrStop(msg"The class ${sym.nme} has auxiliary parameters, which are not yet supported")

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
@@ -264,7 +264,7 @@ object Elaborator:
       val id = new Ident("NonLocalReturn")
       val sym = ClassSymbol(DummyTypeDef(syntax.Cls), id)
       val bsym = BlockMemberSymbol("ret", Nil, true)
-      val defn = ClassDef(N, syntax.Cls, sym, bsym, Nil, Nil, N, ObjBody(Blk(Nil, Term.Lit(UnitLit(false)))), Nil, N)
+      val defn = ClassDef(N, syntax.Cls, sym, bsym, N, Nil, Nil, N, ObjBody(Blk(Nil, Term.Lit(UnitLit(false)))), Nil, N)
       sym.defn = S(defn)
       Term.Sel(runtimeSymbol.ref(), id)(S(sym), N)
     val nonLocalRet =
@@ -280,7 +280,7 @@ object Elaborator:
         Param(flag, VarSymbol(Ident("output")), N, Modulefulness(N)(false)) ::
         Param(flag, VarSymbol(Ident("bindings")), N, Modulefulness(N)(false)) ::
         Nil)
-      cs.defn = S(ClassDef.Parameterized(N, syntax.Cls, cs, BlockMemberSymbol(cs.name, Nil),
+      cs.defn = S(ClassDef.Parameterized(N, syntax.Cls, cs, BlockMemberSymbol(cs.name, Nil), N,
         Nil, ps, Nil, N, ObjBody(Blk(Nil, Term.Lit(UnitLit(false)))), N, Nil))
       cs -> ts
     val (matchFailureClsSymbol, matchFailureTrmSymbol) =
@@ -290,7 +290,7 @@ object Elaborator:
       val ts = TermSymbol(syntax.Fun, N, id)
       val flag = FldFlags.empty.copy(isVal = true)
       val ps = PlainParamList(Param(flag, VarSymbol(Ident("errors")), N, Modulefulness(N)(false)) :: Nil)
-      cs.defn = S(ClassDef.Parameterized(N, syntax.Cls, cs, BlockMemberSymbol(cs.name, td :: Nil),
+      cs.defn = S(ClassDef.Parameterized(N, syntax.Cls, cs, BlockMemberSymbol(cs.name, td :: Nil), N,
         Nil, ps, Nil, N, ObjBody(Blk(Nil, Term.Lit(UnitLit(false)))), N, Nil))
       cs -> ts
     val builtinOpsMap =
@@ -430,7 +430,7 @@ extends Importer with ucs.SplitElaborator:
       val derivedClsSym = ClassSymbol(Tree.DummyTypeDef(syntax.Cls), Tree.Ident(s"Handler$$${id.name}$$"))
       derivedClsSym.defn = S(ClassDef(
         N, syntax.Cls, derivedClsSym,
-        BlockMemberSymbol(derivedClsSym.name, Nil),
+        BlockMemberSymbol(derivedClsSym.name, Nil), N,
         Nil, Nil, N, ObjBody(Blk(Nil, Term.Lit(Tree.UnitLit(false)))), Nil, N))
       
       val elabed = ctx.nestInner(derivedClsSym).givenIn:
@@ -1378,11 +1378,7 @@ extends Importer with ucs.SplitElaborator:
             trace(s"Processing class definition $nme"):
               val comp = sym.asMod
               log(s"Companion: ${comp}")
-              val cd =
-                val (bod, c) = mkBody
-                ClassDef(owner, Cls, clsSym, sym, tps, pss, newOf(td), ObjBody(bod), annotations, comp)
-              clsSym.defn = S(cd)
-              if pss.nonEmpty then
+              val tsym = if pss.nonEmpty then
                 val ctsym = TermSymbol(Fun, S(clsSym), clsSym.id)
                 val ctdef =
                   TermDefinition(
@@ -1403,6 +1399,12 @@ extends Importer with ucs.SplitElaborator:
                   )
                 ctsym.defn = S(ctdef)
                 sym.tsym = S(ctsym)
+                S(ctsym)
+              else N
+              val cd =
+                val (bod, c) = mkBody
+                ClassDef(owner, Cls, clsSym, sym, tsym, tps, pss, newOf(td), ObjBody(bod), annotations, comp)
+              clsSym.defn = S(cd)
               cd
         go(sts, Nil, defn :: acc)
       case Annotated(annotation, target) :: sts =>

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
@@ -280,7 +280,8 @@ object Elaborator:
         Param(flag, VarSymbol(Ident("output")), N, Modulefulness(N)(false)) ::
         Param(flag, VarSymbol(Ident("bindings")), N, Modulefulness(N)(false)) ::
         Nil)
-      cs.defn = S(ClassDef.Parameterized(N, syntax.Cls, cs, BlockMemberSymbol(cs.name, Nil), N,
+      val ctsym = TermSymbol(Fun, S(cs), cs.id)
+      cs.defn = S(ClassDef.Parameterized(N, syntax.Cls, cs, BlockMemberSymbol(cs.name, Nil), S(ctsym),
         Nil, ps, Nil, N, ObjBody(Blk(Nil, Term.Lit(UnitLit(false)))), N, Nil))
       cs -> ts
     val (matchFailureClsSymbol, matchFailureTrmSymbol) =
@@ -290,7 +291,8 @@ object Elaborator:
       val ts = TermSymbol(syntax.Fun, N, id)
       val flag = FldFlags.empty.copy(isVal = true)
       val ps = PlainParamList(Param(flag, VarSymbol(Ident("errors")), N, Modulefulness(N)(false)) :: Nil)
-      cs.defn = S(ClassDef.Parameterized(N, syntax.Cls, cs, BlockMemberSymbol(cs.name, td :: Nil), N,
+      val ctsym = TermSymbol(Fun, S(cs), cs.id)
+      cs.defn = S(ClassDef.Parameterized(N, syntax.Cls, cs, BlockMemberSymbol(cs.name, td :: Nil), S(ctsym),
         Nil, ps, Nil, N, ObjBody(Blk(Nil, Term.Lit(UnitLit(false)))), N, Nil))
       cs -> ts
     val builtinOpsMap =

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
@@ -785,6 +785,7 @@ sealed abstract class ClassLikeDef extends TypeLikeDef:
   val kind: ClsLikeKind
   val sym: DefinitionSymbol[? <: ClassLikeDef] & InnerSymbol
   val bsym: BlockMemberSymbol
+  val ctorSym: Opt[TermSymbol]
   val tparams: Ls[TyParam]
   val paramsOpt: Opt[ParamList]
   val auxParams: Ls[ParamList]
@@ -819,7 +820,8 @@ case class ModuleOrObjectDef(
   body: ObjBody,
   companion: Opt[ModuleCompanionSymbol],
   annotations: Ls[Annot],
-) extends ClassLikeDef, CompanionValue
+) extends ClassLikeDef, CompanionValue:
+  val ctorSym: Option[TermSymbol] = N
 
 case class PatternDef(
     owner: Opt[InnerSymbol],
@@ -851,11 +853,13 @@ case class PatternDef(
   val paramsOpt: Opt[ParamList] = N
   val auxParams: Ls[ParamList] = Nil
   val companion: Opt[CompanionSymbol] = N // TODO support
+  val ctorSym: Option[TermSymbol] = N
 
 
 sealed abstract class ClassDef extends ClassLikeDef:
   val kind: ClsLikeKind
   val sym: ClassSymbol
+  val ctorSym: Opt[TermSymbol]
   val tparams: Ls[TyParam]
   val paramsOpt: Opt[ParamList]
   val auxParams: Ls[ParamList]
@@ -874,6 +878,7 @@ object ClassDef:
       kind: ClsLikeKind,
       sym: InnerSymbol,
       bsym: BlockMemberSymbol,
+      ctorSym: Opt[TermSymbol],
       tparams: Ls[TyParam],
       params: Ls[ParamList],
       ext: Opt[New],
@@ -883,7 +888,7 @@ object ClassDef:
   ): ClassDef =
     params match
       case ps :: pss => Parameterized(owner, kind, sym.asInstanceOf// TODO: improve
-        , bsym
+        , bsym, ctorSym
         , tparams, ps, pss, ext, body, comp, annotations)
       case Nil => Plain(owner, kind, sym.asInstanceOf// TODO: improve
         , bsym
@@ -897,6 +902,7 @@ object ClassDef:
       kind: ClsLikeKind,
       sym: ClassSymbol,
       bsym: BlockMemberSymbol,
+      ctorSym: Opt[TermSymbol],
       tparams: Ls[TyParam],
       params: ParamList,
       auxParams: Ls[ParamList],
@@ -920,6 +926,7 @@ object ClassDef:
   ) extends ClassDef:
     val paramsOpt: Opt[ParamList] = N
     val auxParams: List[ParamList] = Nil
+    val ctorSym: Opt[TermSymbol] = N
   
 end ClassDef
 

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
@@ -888,7 +888,7 @@ object ClassDef:
   ): ClassDef =
     params match
       case ps :: pss => Parameterized(owner, kind, sym.asInstanceOf// TODO: improve
-        , bsym, S(ctorSym.get)
+        , bsym, ctorSym.getOrElse(lastWords("Parameterized classes should have a ctor symbol."))
         , tparams, ps, pss, ext, body, comp, annotations)
       case Nil => Plain(owner, kind, sym.asInstanceOf// TODO: improve
         , bsym

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
@@ -888,7 +888,7 @@ object ClassDef:
   ): ClassDef =
     params match
       case ps :: pss => Parameterized(owner, kind, sym.asInstanceOf// TODO: improve
-        , bsym, ctorSym
+        , bsym, S(ctorSym.get)
         , tparams, ps, pss, ext, body, comp, annotations)
       case Nil => Plain(owner, kind, sym.asInstanceOf// TODO: improve
         , bsym
@@ -902,7 +902,7 @@ object ClassDef:
       kind: ClsLikeKind,
       sym: ClassSymbol,
       bsym: BlockMemberSymbol,
-      ctorSym: Opt[TermSymbol],
+      ctorSym: S[TermSymbol],
       tparams: Ls[TyParam],
       params: ParamList,
       auxParams: Ls[ParamList],

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
@@ -888,7 +888,7 @@ object ClassDef:
   ): ClassDef =
     params match
       case ps :: pss => Parameterized(owner, kind, sym.asInstanceOf// TODO: improve
-        , bsym, ctorSym.getOrElse(lastWords("Parameterized classes should have a ctor symbol."))
+        , bsym, S(ctorSym.getOrElse(lastWords("Parameterized classes should have a ctor symbol.")))
         , tparams, ps, pss, ext, body, comp, annotations)
       case Nil => Plain(owner, kind, sym.asInstanceOf// TODO: improve
         , bsym

--- a/hkmc2/shared/src/test/mlscript/codegen/FieldSymbols.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/FieldSymbols.mls
@@ -102,7 +102,7 @@ case
 //│                 modulefulness = Modulefulness of N
 //│             restParam = N
 //│         body = Scoped:
-//│           syms = HashSet($argument0$, a)
+//│           syms = HashSet(a, $argument0$)
 //│           body = Match:
 //│             scrut = Ref:
 //│               l = caseScrut


### PR DESCRIPTION
The constructor symbol for class-like definitions was never propagated into the elaborated tree or the IR, but it could appear in resolved BMS references. For example:
```fs
:rt
class Bruh()
fun f() = Bruh()
//│ Elab: { Cls BruhParamList(‹›,List(),None) { }; fun member:f‹553›() = member:Bruh‹554›#666(); }
//│ Resolved tree:
//│ Blk:
//│   stats = Ls of 
//│     Parameterized:
//│       owner = N
//│       kind = Cls
//│       sym = class:Bruh‹555›
//│       bsym = member:Bruh‹554›
//│       tparams = Nil
//│       params = ParamList:
//│         flags = ()
//│         params = Nil
//│         restParam = N
//│       auxParams = Nil
//│       ext = N
//│       body = ObjBody of Blk:
//│         stats = Nil
//│         res = Lit of UnitLit of false
//│       companion = N
//│       annotations = Nil
//│     TermDefinition:
//│       k = Fun
//│       sym = member:f‹553›
//│       tsym = term:f‹562›
//│       params = Ls of 
//│         ParamList:
//│           flags = ()
//│           params = Nil
//│           restParam = N
//│       tparams = N
//│       sign = N
//│       body = S of App{typ=class:Bruh‹555›}:
//│         lhs = Resolved{sym=term:class:Bruh‹555›.Bruh‹557›}:
//│           t = Ref{sym=member:Bruh‹554›} of member:Bruh‹554›
//│           sym = term:class:Bruh‹555›.Bruh‹557› <-------- HERE
//│         rhs = Tup of Nil
//│       resSym = ‹result of member:f‹553››‹561›
//│       flags = ()
//│       modulefulness = Modulefulness of N
//│       annotations = Nil
//│       companion = N
//│   res = Lit of UnitLit of false
```
This PR adds the symbol to the `ClassLikeDef` class in the term IR and propagates it all the way to the block IR.

Note that, previously, the only way to access this symbol was by accessing the `.tsym` field of the class's BlockMemberSymbol.