### PR TITLE
Explicit Symbol Type for Labels

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -330,10 +330,10 @@ case class Return(res: Result, implct: Bool) extends BlockTail
 
 case class Throw(exc: Result) extends BlockTail
 
-case class Label(label: Local, loop: Bool, body: Block, rest: Block) extends Block
+case class Label(label: LabelSymbol, loop: Bool, body: Block, rest: Block) extends Block
 
-case class Break(label: Local) extends BlockTail
-case class Continue(label: Local) extends BlockTail
+case class Break(label: LabelSymbol) extends BlockTail
+case class Continue(label: LabelSymbol) extends BlockTail
 
 
 case class Scoped(syms: collection.Set[Local], body: Block) extends BlockTail
@@ -356,7 +356,7 @@ inline def whenValidatingIR(inline code: => Unit): Unit =
   () // code // * uncomment to run on-the fly IR validations
   
 object Label:
-  def apply(label: Local, loop: Bool, body: Block, rest: Block): Block = rest match
+  def apply(label: LabelSymbol, loop: Bool, body: Block, rest: Block): Block = rest match
     case Scoped(syms, rest) => Scoped(syms, Label(label, loop, body, rest))
     case _ => new Label(label, loop, body, rest)
 object Scoped:
@@ -769,13 +769,13 @@ extension (k: Block => Block)
   
   def assign(l: Local, r: Result) = k.chain(Assign(l, r, _))
   def assignFieldN(lhs: Path, nme: Tree.Ident, rhs: Result) = k.chain(AssignField(lhs, nme, rhs, _)(N))
-  def break(l: Local): Block = k.rest(Break(l))
-  def continue(l: Local): Block = k.rest(Continue(l))
+  def break(l: LabelSymbol): Block = k.rest(Break(l))
+  def continue(l: LabelSymbol): Block = k.rest(Continue(l))
   def define(defn: Defn) = k.chain(Define(defn, _))
   def end = k.rest(End())
   def ifthen(scrut: Path, cse: Case, trm: Block, els: Opt[Block] = N): Block => Block =
     k.chain(Match(scrut, cse -> trm :: Nil, els, _))
-  def label(label: Local, loop: Bool, body: Block) = k.chain(Label(label, loop, body, _))
+  def label(label: LabelSymbol, loop: Bool, body: Block) = k.chain(Label(label, loop, body, _))
   def ret(r: Result) = k.rest(Return(r, false))
   def staticif(b: Boolean, f: (Block => Block) => (Block => Block)) = if b then k.transform(f) else k
   def foldLeft[A](xs: Iterable[A])(f: (Block => Block, A) => Block => Block) = xs.foldLeft(k)(f)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
@@ -18,10 +18,10 @@ class BlockTransformer(subst: SymbolSubst):
   def applyBlock(b: Block): Block = b match
     case _: End => b
     case Break(lbl) =>
-      val lbl2 = applyLocal(lbl)
+      val lbl2 = lbl.subst
       if lbl2 is lbl then b else Break(lbl2)
     case Continue(lbl) =>
-      val lbl2 = applyLocal(lbl)
+      val lbl2 = lbl.subst
       if lbl2 is lbl then b else Continue(lbl2)
     case Return(res, implct) =>
       applyResult(res): res2 =>
@@ -46,7 +46,7 @@ class BlockTransformer(subst: SymbolSubst):
                 (dflt2 is dflt) && (rst2 is rst)
               then b else Match(scrut2, arms2, dflt2, rst2)
     case Label(lbl, loop, bod, rst) =>
-      val lbl2 = applyLocal(lbl)
+      val lbl2 = lbl.subst
       val bod2 = if loop then applyScopedBlock(bod) else applySubBlock(bod)
       val rst2 = applySubBlock(rst)
       if (lbl2 is lbl) && (bod2 is bod) && (rst2 is rst) then b else Label(lbl2, loop, bod2, rst2)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -153,7 +153,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
   private def handlerCtx(using HandlerCtx): HandlerCtx = summon
   
   private def freshTmp(dbgNme: Str = "tmp") = new TempSymbol(N, dbgNme)
-  private def freshLabel(nme: Str) = new LabelSymbol(nme)
+  private def freshLabel(nme: Str) = new LabelSymbol(N, nme)
   
   private def rtThrowMsg(msg: Str) = Throw(
     Instantiate(mut = false, State.globalThisSymbol.asPath.selN(Tree.Ident("Error")),

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -153,6 +153,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
   private def handlerCtx(using HandlerCtx): HandlerCtx = summon
   
   private def freshTmp(dbgNme: Str = "tmp") = new TempSymbol(N, dbgNme)
+  private def freshLabel(nme: Str) = new LabelSymbol(nme)
   
   private def rtThrowMsg(msg: Str) = Throw(
     Instantiate(mut = false, State.globalThisSymbol.asPath.selN(Tree.Ident("Error")),
@@ -329,7 +330,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
 
     states.filter(state => visited.contains(state.id))
 
-  def partitionBlock(blk: Block, inclEntryPoint: Bool, labelIds: Map[Symbol, (StateId, StateId)] = Map.empty): Ls[BlockState] =
+  def partitionBlock(blk: Block, inclEntryPoint: Bool, labelIds: Map[LabelSymbol, (StateId, StateId)] = Map.empty): Ls[BlockState] =
     // for readability :)
     case class PartRet(head: Block, states: Ls[BlockState])
     
@@ -341,7 +342,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
     // * afterEnd: what state End should jump to, if at all 
     // TODO: don't split within Match, Begin and Labels when not needed, ideally keep it intact.
     // Need careful analysis for this.
-    def go(blk: Block)(implicit labelIds: Map[Symbol, (StateId, StateId)], afterEnd: Option[StateId]): PartRet =
+    def go(blk: Block)(implicit labelIds: Map[LabelSymbol, (StateId, StateId)], afterEnd: Option[StateId]): PartRet =
       blk match
       case ResumptionPoint(result, uid, rest) =>
         resumptionPoints ::= uid
@@ -760,7 +761,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
     
     val pcVar = VarSymbol(pcIdent)
     
-    val loopLbl = freshTmp("contLoop")
+    val loopLbl = freshLabel("contLoop")
     val pcSymbol = TermSymbol(ParamBind, S(clsSym), pcIdent)
 
     // This maps each state id to an optional location

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -730,7 +730,7 @@ class Lifter(handlerPaths: Opt[HandlerPaths])(using State, Raise):
                   then b else Match(scrut2, arms2, dflt2, rst2)
             
         case Label(lbl, loop, bod, rst) =>
-          val lbl2 = applyLocal(lbl)
+          val lbl2 = lbl.subst
           val bod2 = applySubBlockAndReset(bod)
           val rst2 = applySubBlock(rst)
           if (lbl2 is lbl) && (bod2 is bod) && (rst2 is rst) then b else Label(lbl2, loop, bod2, rst2)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
@@ -209,7 +209,7 @@ class TailRecOpt(using State, TL, Raise):
     val dSym =
       if funs.size === 1 then funs.head.dSym
       else TermSymbol(syntax.Fun, owner, Tree.Ident(bms.nme))
-    val loopSym = TempSymbol(N, "loopLabel")
+    val loopSym = LabelSymbol("loopLabel")
     val curIdSym = VarSymbol(Tree.Ident("id"))
     
     class FunRewriter(f: FunDefn) extends BlockTransformerShallow(SymbolSubst()):

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
@@ -209,7 +209,7 @@ class TailRecOpt(using State, TL, Raise):
     val dSym =
       if funs.size === 1 then funs.head.dSym
       else TermSymbol(syntax.Fun, owner, Tree.Ident(bms.nme))
-    val loopSym = LabelSymbol("loopLabel")
+    val loopSym = LabelSymbol(N, "loopLabel")
     val curIdSym = VarSymbol(Tree.Ident("id"))
     
     class FunRewriter(f: FunDefn) extends BlockTransformerShallow(SymbolSubst()):

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
@@ -165,10 +165,10 @@ sealed trait NamedSymbol extends Symbol:
   def id: Ident
   def subst(using s: SymbolSubst): NamedSymbol
 
-class LabelSymbol(name: Str = "lbl")(using State) extends LocalSymbol:
+class LabelSymbol(val trm: Opt[Term], name: Str = "lbl")(using State) extends LocalSymbol:
   def nme = name
   def subst(using s: SymbolSubst): LabelSymbol = s.mapLabelSym(this)
-  def toLoc = N
+  def toLoc = trm.flatMap(_.toLoc)
   override def toString: Str = s"label:$nme${State.dbgUid(uid)}"
 
 abstract class BlockLocalSymbol(name: Str)(using State) extends FlowSymbol(name):

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
@@ -165,6 +165,12 @@ sealed trait NamedSymbol extends Symbol:
   def id: Ident
   def subst(using s: SymbolSubst): NamedSymbol
 
+class LabelSymbol(name: Str = "lbl")(using State) extends LocalSymbol:
+  def nme = name
+  def subst(using s: SymbolSubst): LabelSymbol = s.mapLabelSym(this)
+  def toLoc = N
+  override def toString: Str = s"label:$nme${State.dbgUid(uid)}"
+
 abstract class BlockLocalSymbol(name: Str)(using State) extends FlowSymbol(name):
   self: LocalSymbol => // * using `with LocalSymbol` in the `extends` clause makes Scala think there's a bad override
   var decl: Opt[Declaration] = N

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -226,9 +226,9 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State) e
     rec(split)
     val consequents =
       counts.iterator.filter(_._2.count > 1).toSeq.sortBy(_._2.order).zipWithIndex.map:
-        case ((term, _), i) => (term, LabelSymbol(s"split_${i + 1}$$"))
+        case ((term, _), i) => (term, LabelSymbol(S(term), s"split_${i + 1}$$"))
       .toList
-    val default = if throwCount > 1 then S(LabelSymbol(s"split_default$$")) else N
+    val default = if throwCount > 1 then S(LabelSymbol(N, s"split_default$$")) else N
     Labels(consequents, default)
   
   private def lowerSplit(
@@ -335,7 +335,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State) e
         outerCtx.collectScopedSym(res)
         res
       // The symbol for the loop label if the term is a `while`.
-      lazy val loopLabel = new LabelSymbol()
+      lazy val loopLabel = new LabelSymbol(t)
       lazy val f =
         val res = new BlockMemberSymbol("while", Nil, false)
         outerCtx.collectScopedSym(res)
@@ -347,7 +347,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State) e
         tl.log(s"Normalized:\n${normalized.prettyPrint}")
       // Collect consequents that are shared in more than one branch.
       given labels: Labels = createLabelsForDuplicatedBranches(normalized)
-      lazy val rootBreakLabel = new LabelSymbol("split_root$")
+      lazy val rootBreakLabel = new LabelSymbol(N, "split_root$")
       lazy val breakRoot = (r: Result) => Assign(l, r, Break(rootBreakLabel))
       lazy val assignResult = (r: Result) => Assign(l, r, End())
       // NOTE: `shouldRewriteWhile` is not the same as `config.rewriteWhileLoops`

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -226,9 +226,9 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State) e
     rec(split)
     val consequents =
       counts.iterator.filter(_._2.count > 1).toSeq.sortBy(_._2.order).zipWithIndex.map:
-        case ((term, _), i) => (term, TempSymbol(S(term), s"split_${i + 1}$$"))
+        case ((term, _), i) => (term, LabelSymbol(s"split_${i + 1}$$"))
       .toList
-    val default = if throwCount > 1 then S(TempSymbol(N, s"split_default$$")) else N
+    val default = if throwCount > 1 then S(LabelSymbol(s"split_default$$")) else N
     Labels(consequents, default)
   
   private def lowerSplit(
@@ -335,7 +335,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State) e
         outerCtx.collectScopedSym(res)
         res
       // The symbol for the loop label if the term is a `while`.
-      lazy val loopLabel = new TempSymbol(t)
+      lazy val loopLabel = new LabelSymbol()
       lazy val f =
         val res = new BlockMemberSymbol("while", Nil, false)
         outerCtx.collectScopedSym(res)
@@ -347,7 +347,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State) e
         tl.log(s"Normalized:\n${normalized.prettyPrint}")
       // Collect consequents that are shared in more than one branch.
       given labels: Labels = createLabelsForDuplicatedBranches(normalized)
-      lazy val rootBreakLabel = new TempSymbol(N, "split_root$")
+      lazy val rootBreakLabel = new LabelSymbol("split_root$")
       lazy val breakRoot = (r: Result) => Assign(l, r, Break(rootBreakLabel))
       lazy val assignResult = (r: Result) => Assign(l, r, End())
       // NOTE: `shouldRewriteWhile` is not the same as `config.rewriteWhileLoops`
@@ -387,7 +387,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State) e
         val innerBlock: Block = labels.consequents match
           case Nil => innermostBlock
           case all @ (head :: tail) =>
-            def wrap(consequents: Ls[(Term, TempSymbol)]): Block =
+            def wrap(consequents: Ls[(Term, LabelSymbol)]): Block =
               consequents.foldRight(innermostBlock):
                 case ((term, label), innerBlock) =>
                   Label(label, false, innerBlock, term_nonTail(term)(breakRoot))
@@ -446,12 +446,12 @@ end Normalization
 object Normalization:
   /** This contains the labels for duplicated consequents and the default
    *  branch which throws match errors. */
-  private class Labels(val consequents: Ls[(Term, TempSymbol)], val default: Opt[TempSymbol]):
+  private class Labels(val consequents: Ls[(Term, LabelSymbol)], val default: Opt[LabelSymbol]):
     private val map = consequents.toMap
     
     inline def isEmpty: Bool = consequents.isEmpty && default.isEmpty
     
-    inline def get(term: Term): Opt[TempSymbol] = map.get(term)
+    inline def get(term: Term): Opt[LabelSymbol] = map.get(term)
   
   /**
     * Hard-coded subtyping relations used in normalization and coverage checking.

--- a/hkmc2/shared/src/main/scala/hkmc2/utils/SymbolSubst.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/utils/SymbolSubst.scala
@@ -17,3 +17,4 @@ class SymbolSubst:
   def mapPatSym(s: PatternSymbol): PatternSymbol = s
   def mapTopLevelSym(s: TopLevelSymbol): TopLevelSymbol = s
   def mapErrorSym(s: ErrorSymbol): ErrorSymbol = s
+  def mapLabelSym(s: LabelSymbol): LabelSymbol = s

--- a/hkmc2/shared/src/test/mlscript-compile/Predef.mjs
+++ b/hkmc2/shared/src/test/mlscript-compile/Predef.mjs
@@ -268,17 +268,17 @@ let Predef1;
       } else {
         i = len - 1;
         init = runtime.safeCall(rest.at(i));
-        tmp1: while (true) {
-          let scrut1, tmp2, tmp3, tmp4;
+        lbl: while (true) {
+          let scrut1, tmp1, tmp2, tmp3;
           scrut1 = i > 0;
           if (scrut1 === true) {
-            tmp2 = i - 1;
-            i = tmp2;
-            tmp3 = runtime.safeCall(rest.at(i));
-            tmp4 = runtime.safeCall(f(tmp3, init));
-            init = tmp4;
+            tmp1 = i - 1;
+            i = tmp1;
+            tmp2 = runtime.safeCall(rest.at(i));
+            tmp3 = runtime.safeCall(f(tmp2, init));
+            init = tmp3;
             tmp = runtime.Unit;
-            continue tmp1
+            continue lbl
           } else {
             tmp = runtime.Unit;
           }

--- a/hkmc2/shared/src/test/mlscript-compile/Runtime.mjs
+++ b/hkmc2/shared/src/test/mlscript-compile/Runtime.mjs
@@ -524,17 +524,17 @@ let Runtime1;
   } 
   static topLevelEffect(tr, debug) {
     let tmp, tmp1;
-    tmp2: while (true) {
-      let scrut, tmp3, tmp4, tmp5, tmp6;
+    lbl: while (true) {
+      let scrut, tmp2, tmp3, tmp4, tmp5;
       scrut = tr.handler === Runtime.PrintStackEffect;
       if (scrut === true) {
-        tmp3 = Runtime.showStackTrace("Stack Trace:", tr, debug, tr.handlerFun);
-        tmp4 = runtime.safeCall(globalThis.console.log(tmp3));
-        tmp5 = Runtime.resume(tr.contTrace);
-        tmp6 = runtime.safeCall(tmp5(runtime.Unit));
-        tr = tmp6;
+        tmp2 = Runtime.showStackTrace("Stack Trace:", tr, debug, tr.handlerFun);
+        tmp3 = runtime.safeCall(globalThis.console.log(tmp2));
+        tmp4 = Runtime.resume(tr.contTrace);
+        tmp5 = runtime.safeCall(tmp4(runtime.Unit));
+        tr = tmp5;
         tmp = runtime.Unit;
-        continue tmp2
+        continue lbl
       } else {
         tmp = runtime.Unit;
       }
@@ -553,39 +553,39 @@ let Runtime1;
     curHandler = tr.contTrace;
     atTail = true;
     if (debug === true) {
-      tmp4: while (true) {
-        let scrut, cur, scrut1, tmp5, tmp6, tmp7, tmp8;
+      lbl: while (true) {
+        let scrut, cur, scrut1, tmp4, tmp5, tmp6, tmp7;
         scrut = curHandler !== null;
         if (scrut === true) {
           cur = curHandler.next;
-          tmp9: while (true) {
-            let scrut2, locals, curLocals, loc, loc1, localsMsg, scrut3, tmp10, tmp11, lambda, tmp12, tmp13, tmp14, tmp15, tmp16, tmp17, tmp18, tmp19, tmp20;
+          lbl1: while (true) {
+            let scrut2, locals, curLocals, loc, loc1, localsMsg, scrut3, tmp8, tmp9, lambda, tmp10, tmp11, tmp12, tmp13, tmp14, tmp15, tmp16, tmp17, tmp18;
             scrut2 = cur !== null;
             if (scrut2 === true) {
               locals = cur.getLocals;
-              tmp10 = locals.length - 1;
-              curLocals = runtime.safeCall(locals.at(tmp10));
+              tmp8 = locals.length - 1;
+              curLocals = runtime.safeCall(locals.at(tmp8));
               loc = cur.getLoc;
               if (loc === null) {
-                tmp11 = "pc=" + cur.pc;
+                tmp9 = "pc=" + cur.pc;
               } else {
-                tmp11 = loc;
+                tmp9 = loc;
               }
-              loc1 = tmp11;
+              loc1 = tmp9;
               split_root$: {
                 split_1$: {
                   if (showLocals === true) {
                     scrut3 = curLocals.locals.length > 0;
                     if (scrut3 === true) {
                       lambda = (undefined, function (l) {
-                        let tmp21, tmp22;
-                        tmp21 = l.localName + "=";
-                        tmp22 = Rendering.render(l.value);
-                        return tmp21 + tmp22
+                        let tmp19, tmp20;
+                        tmp19 = l.localName + "=";
+                        tmp20 = Rendering.render(l.value);
+                        return tmp19 + tmp20
                       });
-                      tmp12 = runtime.safeCall(curLocals.locals.map(lambda));
-                      tmp13 = runtime.safeCall(tmp12.join(", "));
-                      tmp14 = " with locals: " + tmp13;
+                      tmp10 = runtime.safeCall(curLocals.locals.map(lambda));
+                      tmp11 = runtime.safeCall(tmp10.join(", "));
+                      tmp12 = " with locals: " + tmp11;
                       break split_root$
                     } else {
                       break split_1$
@@ -594,39 +594,39 @@ let Runtime1;
                     break split_1$
                   }
                 }
-                tmp14 = "";
+                tmp12 = "";
               }
-              localsMsg = tmp14;
-              tmp15 = "\n\tat " + curLocals.fnName;
-              tmp16 = tmp15 + " (";
-              tmp17 = tmp16 + loc1;
-              tmp18 = tmp17 + ")";
-              tmp19 = msg + tmp18;
-              msg = tmp19;
-              tmp20 = msg + localsMsg;
-              msg = tmp20;
+              localsMsg = tmp12;
+              tmp13 = "\n\tat " + curLocals.fnName;
+              tmp14 = tmp13 + " (";
+              tmp15 = tmp14 + loc1;
+              tmp16 = tmp15 + ")";
+              tmp17 = msg + tmp16;
+              msg = tmp17;
+              tmp18 = msg + localsMsg;
+              msg = tmp18;
               cur = cur.next;
               atTail = false;
-              tmp5 = runtime.Unit;
-              continue tmp9
+              tmp4 = runtime.Unit;
+              continue lbl1
             } else {
-              tmp5 = runtime.Unit;
+              tmp4 = runtime.Unit;
             }
             break;
           }
           curHandler = curHandler.nextHandler;
           scrut1 = curHandler !== null;
           if (scrut1 === true) {
-            tmp6 = "\n\twith handler " + curHandler.handler.constructor.name;
-            tmp7 = msg + tmp6;
-            msg = tmp7;
+            tmp5 = "\n\twith handler " + curHandler.handler.constructor.name;
+            tmp6 = msg + tmp5;
+            msg = tmp6;
             atTail = false;
-            tmp8 = runtime.Unit;
+            tmp7 = runtime.Unit;
           } else {
-            tmp8 = runtime.Unit;
+            tmp7 = runtime.Unit;
           }
-          tmp = tmp8;
-          continue tmp4
+          tmp = tmp7;
+          continue lbl
         } else {
           tmp = runtime.Unit;
         }
@@ -781,15 +781,15 @@ let Runtime1;
       tmp9 = Runtime.showFunctionContChain(contTrace.next, hl, vis, 0);
       tmp10 = runtime.safeCall(globalThis.console.log(tmp9));
       cur = contTrace.nextHandler;
-      tmp13: while (true) {
-        let scrut2, tmp14, tmp15;
+      lbl: while (true) {
+        let scrut2, tmp13, tmp14;
         scrut2 = cur !== null;
         if (scrut2 === true) {
-          tmp14 = Runtime.showHandlerContChain(cur, hl, vis, 0);
-          tmp15 = runtime.safeCall(globalThis.console.log(tmp14));
+          tmp13 = Runtime.showHandlerContChain(cur, hl, vis, 0);
+          tmp14 = runtime.safeCall(globalThis.console.log(tmp13));
           cur = cur.nextHandler;
           tmp11 = runtime.Unit;
-          continue tmp13
+          continue lbl
         } else {
           tmp11 = runtime.Unit;
         }
@@ -840,8 +840,8 @@ let Runtime1;
   } 
   static handleEffects(cur) {
     let tmp;
-    tmp1: while (true) {
-      let nxt, scrut, tmp2;
+    lbl: while (true) {
+      let nxt, scrut, tmp1;
       if (cur instanceof Runtime.EffectSig.class) {
         nxt = Runtime.handleEffect(cur);
         scrut = cur === nxt;
@@ -849,10 +849,10 @@ let Runtime1;
           return cur
         } else {
           cur = nxt;
-          tmp2 = runtime.Unit;
+          tmp1 = runtime.Unit;
         }
-        tmp = tmp2;
-        continue tmp1
+        tmp = tmp1;
+        continue lbl
       } else {
         return cur
       }
@@ -863,7 +863,7 @@ let Runtime1;
   static handleEffect(cur) {
     let prevHandlerFrame, scrut, handlerFrame, saved, scrut1, scrut2, tmp, tmp1, tmp2, tmp3, tmp4, tmp5;
     prevHandlerFrame = cur.contTrace;
-    tmp6: while (true) {
+    lbl: while (true) {
       let scrut3, scrut4;
       split_root$: {
         split_1$: {
@@ -873,7 +873,7 @@ let Runtime1;
             if (scrut4 === true) {
               prevHandlerFrame = prevHandlerFrame.nextHandler;
               tmp = runtime.Unit;
-              continue tmp6
+              continue lbl
             } else {
               break split_1$
             }
@@ -941,11 +941,11 @@ let Runtime1;
     cont = contTrace.next;
     handlerCont = contTrace.nextHandler;
     curDepth = Runtime.stackDepth;
-    tmp1: while (true) {
-      let scrut, scrut1, tmp2, tmp3, tmp4, tmp5;
+    lbl: while (true) {
+      let scrut, scrut1, tmp1, tmp2, tmp3, tmp4;
       if (cont instanceof Runtime.FunctionContFrame.class) {
-        tmp2 = runtime.safeCall(cont.resume(value));
-        value = tmp2;
+        tmp1 = runtime.safeCall(cont.resume(value));
+        value = tmp1;
         Runtime.stackDepth = curDepth;
         if (value instanceof Runtime.EffectSig.class) {
           value.contTrace.last.next = cont.next;
@@ -953,30 +953,30 @@ let Runtime1;
           scrut = contTrace.last !== cont;
           if (scrut === true) {
             value.contTrace.last = contTrace.last;
-            tmp3 = runtime.Unit;
+            tmp2 = runtime.Unit;
           } else {
-            tmp3 = runtime.Unit;
+            tmp2 = runtime.Unit;
           }
           scrut1 = handlerCont !== null;
           if (scrut1 === true) {
             value.contTrace.lastHandler = contTrace.lastHandler;
-            tmp4 = runtime.Unit;
+            tmp3 = runtime.Unit;
           } else {
-            tmp4 = runtime.Unit;
+            tmp3 = runtime.Unit;
           }
           return value
         } else {
           cont = cont.next;
-          tmp5 = runtime.Unit;
+          tmp4 = runtime.Unit;
         }
-        tmp = tmp5;
-        continue tmp1
+        tmp = tmp4;
+        continue lbl
       } else {
         if (handlerCont instanceof Runtime.HandlerContFrame.class) {
           cont = handlerCont.next;
           handlerCont = handlerCont.nextHandler;
           tmp = runtime.Unit;
-          continue tmp1
+          continue lbl
         } else {
           return value
         }
@@ -1005,17 +1005,17 @@ let Runtime1;
     Runtime.stackHandler = Runtime.StackDelayHandler;
     result = Runtime.enterHandleBlock(Runtime.StackDelayHandler, f);
     Runtime.stackDepth = 1;
-    tmp1: while (true) {
-      let scrut, saved, tmp2;
+    lbl: while (true) {
+      let scrut, saved, tmp1;
       scrut = Runtime.stackResume !== null;
       if (scrut === true) {
         saved = Runtime.stackResume;
         Runtime.stackResume = null;
-        tmp2 = runtime.safeCall(saved());
-        result = tmp2;
+        tmp1 = runtime.safeCall(saved());
+        result = tmp1;
         Runtime.stackDepth = 1;
         tmp = runtime.Unit;
-        continue tmp1
+        continue lbl
       } else {
         tmp = runtime.Unit;
       }

--- a/hkmc2/shared/src/test/mlscript/codegen/ScopedBlocks.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/ScopedBlocks.mls
@@ -151,12 +151,12 @@ fun f(x) =
 //│ let f6;
 //│ f6 = function f(x1) {
 //│   let tmp2;
-//│   tmp3: while (true) {
+//│   lbl: while (true) {
 //│     let y1;
 //│     if (x1 === true) {
 //│       y1 = x1;
 //│       tmp2 = x1;
-//│       continue tmp3
+//│       continue lbl
 //│     } else { tmp2 = runtime.Unit; }
 //│     break;
 //│   }

--- a/hkmc2/shared/src/test/mlscript/codegen/While.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/While.mls
@@ -7,12 +7,12 @@
 //│ let lambda;
 //│ lambda = (undefined, function () {
 //│   let tmp;
-//│   tmp1: while (true) {
+//│   lbl: while (true) {
 //│     let scrut;
 //│     scrut = true;
 //│     if (scrut === true) {
 //│       tmp = 0;
-//│       continue tmp1
+//│       continue lbl
 //│     } else {
 //│       throw globalThis.Object.freeze(new globalThis.Error("match error"))
 //│     }
@@ -54,18 +54,18 @@ while x
     set x = false
   else 42
 //│ JS (unsanitized):
-//│ let tmp4;
-//│ tmp5: while (true) {
-//│   let tmp6;
+//│ let tmp2;
+//│ lbl2: while (true) {
+//│   let tmp3;
 //│   if (x2 === true) {
-//│     tmp6 = Predef.print("Hello World");
+//│     tmp3 = Predef.print("Hello World");
 //│     x2 = false;
-//│     tmp4 = runtime.Unit;
-//│     continue tmp5
-//│   } else { tmp4 = 42; }
+//│     tmp2 = runtime.Unit;
+//│     continue lbl2
+//│   } else { tmp2 = 42; }
 //│   break;
 //│ }
-//│ tmp4
+//│ tmp2
 //│ > Hello World
 //│ = 42
 
@@ -107,20 +107,20 @@ while
 //│ JS (unsanitized):
 //│ let lambda2;
 //│ lambda2 = (undefined, function () {
-//│   let tmp19;
-//│   tmp20: while (true) {
-//│     let i2, scrut3, tmp21;
+//│   let tmp13;
+//│   lbl6: while (true) {
+//│     let i2, scrut3, tmp14;
 //│     i2 = 0;
 //│     scrut3 = i2 < 10;
 //│     if (scrut3 === true) {
-//│       tmp21 = i2 + 1;
-//│       i2 = tmp21;
-//│       tmp19 = runtime.Unit;
-//│       continue tmp20
-//│     } else { tmp19 = runtime.Unit; }
+//│       tmp14 = i2 + 1;
+//│       i2 = tmp14;
+//│       tmp13 = runtime.Unit;
+//│       continue lbl6
+//│     } else { tmp13 = runtime.Unit; }
 //│     break;
 //│   }
-//│   return tmp19
+//│   return tmp13
 //│ });
 //│ lambda2
 //│ = fun
@@ -200,8 +200,8 @@ fun f(ls) =
 //│ JS (unsanitized):
 //│ let f;
 //│ f = function f(ls) {
-//│   let tmp28;
-//│   tmp29: while (true) {
+//│   let tmp19;
+//│   lbl9: while (true) {
 //│     let tl, h, argument0$, argument1$;
 //│     if (ls instanceof Cons1.class) {
 //│       argument0$ = ls.hd;
@@ -209,12 +209,12 @@ fun f(ls) =
 //│       tl = argument1$;
 //│       h = argument0$;
 //│       ls = tl;
-//│       tmp28 = Predef.print(h);
-//│       continue tmp29
-//│     } else { tmp28 = Predef.print("Done!"); }
+//│       tmp19 = Predef.print(h);
+//│       continue lbl9
+//│     } else { tmp19 = Predef.print("Done!"); }
 //│     break;
 //│   }
-//│   return tmp28
+//│   return tmp19
 //│ };
 
 f(0)
@@ -252,19 +252,19 @@ let x = 1
 :sjs
 while x is {} do()
 //│ JS (unsanitized):
-//│ let tmp37;
-//│ tmp38: while (true) {
+//│ let tmp27;
+//│ lbl10: while (true) {
 //│   split_root$: {
 //│     split_1$: {
 //│       if (x3 instanceof Object) {
 //│         break split_1$
 //│       } else { break split_1$ }
 //│     }
-//│     tmp37 = runtime.Unit;
+//│     tmp27 = runtime.Unit;
 //│   }
 //│   break;
 //│ }
-//│ tmp37
+//│ tmp27
 
 
 // ——— FIXME: ———

--- a/hkmc2/shared/src/test/mlscript/lifter/Loops.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/Loops.mls
@@ -58,12 +58,12 @@ fun foo() =
 //│   let x, tmp2;
 //│   let lambda$here;
 //│   x = 1;
-//│   tmp3: while (true) {
-//│     let scrut, tmp4;
+//│   lbl: while (true) {
+//│     let scrut, tmp3;
 //│     scrut = true;
 //│     if (scrut === true) {
-//│       tmp4 = x + 1;
-//│       x = tmp4;
+//│       tmp3 = x + 1;
+//│       x = tmp3;
 //│       lambda$here = runtime.safeCall(lambda2(x));
 //│       return lambda$here
 //│     } else { tmp2 = runtime.Unit; }

--- a/hkmc2/shared/src/test/mlscript/ucs/general/LogicalConnectives.mls
+++ b/hkmc2/shared/src/test/mlscript/ucs/general/LogicalConnectives.mls
@@ -25,21 +25,21 @@ fun test(x) =
 :sjs
 true and test(42)
 //│ JS (unsanitized):
-//│ let scrut6, scrut7, tmp4;
+//│ let scrut6, scrut7, tmp3;
 //│ split_root$3: {
 //│   split_1$3: {
 //│     scrut6 = true;
 //│     if (scrut6 === true) {
 //│       scrut7 = test(42);
 //│       if (scrut7 === true) {
-//│         tmp4 = true;
+//│         tmp3 = true;
 //│         break split_root$3
 //│       } else { break split_1$3 }
 //│     } else { break split_1$3 }
 //│   }
-//│   tmp4 = false;
+//│   tmp3 = false;
 //│ }
-//│ tmp4
+//│ tmp3
 //│ > 42
 //│ = false
 


### PR DESCRIPTION
The `Label` class previously accepted any symbol type for labels, which is quite loose, and forces IR passes analyzing/modifying `Label` blocks to have loose types as well if they use this symbol as an identifier.

This PR adds a new symbol type `LabelSymbol`, and forces its usage for `Label`, `Continue` and `Break`.

@chengluyu The UCS normalization uses `TempSymbol` for label symbols, which has an optional `Term` parameter, but I noticed this term is never used. Therefore, I did not include it in `LabelSymbol`. Is this OK?
Edit: I just realized it's used in toLoc, whoops