### PR TITLE
Inverted Match

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -614,7 +614,7 @@ final case class Handler(
 case class End(msg: Str = "") extends BlockTail with ProductWithTail
 
 enum Case:
-  case Lit(lit: Literal)
+  case Lit(lit: Literal, inverted: Bool)
   case Cls(cls: ClassLikeSymbol, path: Path)
   case Tup(len: Int, inf: Bool)
   /** checks field existence
@@ -623,13 +623,13 @@ enum Case:
   case Field(name: Tree.Ident, safe: Bool)
 
   lazy val freeVars: Set[Local] = this match
-    case Lit(_) => Set.empty
+    case Lit(_, _) => Set.empty
     case Cls(_, path) => path.freeVars
     case Tup(_, _) => Set.empty
     case Field(_, _) => Set.empty
   
   lazy val freeVarsLLIR: Set[Local] = this match
-    case Lit(_) => Set.empty
+    case Lit(_, _) => Set.empty
     case Cls(_, path) => path.freeVarsLLIR
     case Tup(_, _) => Set.empty
     case Field(_, _) => Set.empty

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
@@ -252,7 +252,7 @@ class BlockTransformer(subst: SymbolSubst):
       then pl else ParamList(pl.flags, params2, rest2)
   
   def applyCase(cse: Case)(k: Case => Block): Block = cse match
-    case Case.Lit(lit) => k(cse)
+    case Case.Lit(lit, inv) => k(cse)
     case Case.Cls(cls, path) =>
       val cls2 = cls.subst
       applyPath(path): path2 =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTraverser.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTraverser.scala
@@ -124,7 +124,7 @@ class BlockTraverser:
     pl.restParam.foreach(_.sym.traverse)
   
   def applyCase(cse: Case): Unit = cse match
-    case Case.Lit(lit) => ()
+    case Case.Lit(lit, inv) => ()
     case Case.Cls(cls, path) =>
       cls.traverse
       applyPath(path)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -859,7 +859,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         transform.applyBlock(blk)
 
       // match block representing the function body
-      val mainMatchCases = parts.toList.map(b => (Case.Lit(Tree.IntLit(b.id)), transformPart(b.blk)))
+      val mainMatchCases = parts.toList.map(b => (Case.Lit(Tree.IntLit(b.id), false), transformPart(b.blk)))
       val mainMatchBlk = Match(
         pcSymbol.asPath,
         mainMatchCases,
@@ -880,7 +880,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
       val assignedResumedCases = for 
         b   <- parts
         sym <- b.sym
-      yield Case.Lit(Tree.IntLit(b.id)) -> createAssignment(sym) // NOTE: assume sym is in localsMap
+      yield Case.Lit(Tree.IntLit(b.id), false) -> createAssignment(sym) // NOTE: assume sym is in localsMap
 
       // assigns the resumed value
       val body =
@@ -936,7 +936,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         getLocSym,
         List(),
         Match(pcSymbol.asPath, pcToLoc.toSortedMap.iterator.map: (stateId, loc) =>
-          Case.Lit(Tree.IntLit(stateId)) -> Return(Value.Lit(loc.fold(Tree.UnitLit(true)): loc =>
+          Case.Lit(Tree.IntLit(stateId), false) -> Return(Value.Lit(loc.fold(Tree.UnitLit(true)): loc =>
             val (line, _, col) = loc.origin.fph.getLineColAt(loc.spanStart)
             Tree.StrLit(s"${loc.origin.fileName.last}:${line + loc.origin.startLineNum - 1}:$col")
           ), false)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -1038,7 +1038,7 @@ class Lifter(handlerPaths: Opt[HandlerPaths])(using State, Raise):
             
             var acc: Block => Block = blk => Match(
               isMutSym.asPath,
-              Case.Lit(Tree.BoolLit(true)) -> Assign(initSym, instInner(true), End()) :: Nil,
+              Case.Lit(Tree.BoolLit(true), false) -> Assign(initSym, instInner(true), End()) :: Nil,
               S(Assign(initSym, instInner(false), End())),
               blk
             )

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -1150,7 +1150,7 @@ trait LoweringSelSanityChecks(using Config, TL, Raise, State)
         .assign(selRes, Select(p, nme)(disamb))
         .assign(discardedSym, Select(p, Tree.Ident(nme.name+"$__checkNotMethod"))(N))
           .ifthen(selRes.asPath,
-            Case.Lit(syntax.Tree.UnitLit(false)),
+            Case.Lit(syntax.Tree.UnitLit(false), false),
             Throw(Instantiate(mut = false, Select(Value.Ref(State.globalThisSymbol), Tree.Ident("Error"))(N),
               Value.Lit(syntax.Tree.StrLit(s"Access to required field '${nme.name}' yielded 'undefined'")).asArg :: Nil))
           )

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
@@ -26,7 +26,7 @@ object Printer:
   def mkDocument(blk: Block)(using Raise, Scope): Document = blk match
     case Match(scrut, arms, dflt, rest) =>
       def case_doc(c: Case) = c match
-        case Case.Lit(lit) => doc"${lit.idStr}"
+        case Case.Lit(lit, false) => doc"${lit.idStr}"
         case Case.Cls(cls, path) => doc"${cls.nme}"
         case Case.Tup(len, inf) => doc"tuple$len"
         case _ => TODO(c)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
@@ -281,7 +281,7 @@ class TailRecOpt(using State, TL, Raise):
         applyBlock(symRewriter.applyBlock(b))
     
     val arms = funs.map: f =>
-      Case.Lit(Tree.IntLit(dSymIds(f.dSym))) -> FunRewriter(f).rewrite(f.body)
+      Case.Lit(Tree.IntLit(dSymIds(f.dSym)), false) -> FunRewriter(f).rewrite(f.body)
     
     val switch = 
       if arms.length === 1 then arms.head._2

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/cpp/CodeGen.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/cpp/CodeGen.scala
@@ -159,6 +159,9 @@ class CppCodeGen(builtinClassSymbols: Set[Local], tl: TraceLogger):
       val init = exprs.map{x => toExpr(x)}
       mlsTupleValue(init)
   
+  def maybeInvert(expr: Expr, inv: Bool) =
+    if inv then Expr.Unary("!", expr) else expr
+  
   def codegenCaseWithIfs(scrut: TrivialExpr, cases: Ls[(Pat, Node)], default: Opt[Node], storeInto: Str)(using decls: Ls[Decl], stmts: Ls[Stmt])(using Ctx, Raise, Scope): (Ls[Decl], Ls[Stmt]) =
     val scrut2 = toExpr(scrut)
     val init: Stmt = 
@@ -171,13 +174,13 @@ class CppCodeGen(builtinClassSymbols: Set[Local], tl: TraceLogger):
         val (decls2, stmts2) = codegen(arm, storeInto)(using Ls.empty, Ls.empty[Stmt])
         val stmt = Stmt.If(mlsIsValueOf(cls |> mapClsLikeName, scrut2), Stmt.Block(decls2, stmts2), nextarm)
         S(stmt)
-      case ((Pat.Lit(i @ hkmc2.syntax.Tree.IntLit(_)), arm), nextarm) =>
+      case ((Pat.Lit(i @ hkmc2.syntax.Tree.IntLit(_), inv), arm), nextarm) =>
         val (decls2, stmts2) = codegen(arm, storeInto)(using Ls.empty, Ls.empty[Stmt])
-        val stmt = Stmt.If(mlsIsIntLit(scrut2, i), Stmt.Block(decls2, stmts2), nextarm)
+        val stmt = Stmt.If(maybeInvert(mlsIsIntLit(scrut2, i), inv), Stmt.Block(decls2, stmts2), nextarm)
         S(stmt)
-      case ((Pat.Lit(i @ hkmc2.syntax.Tree.BoolLit(_)), arm), nextarm) =>
+      case ((Pat.Lit(i @ hkmc2.syntax.Tree.BoolLit(_), inv), arm), nextarm) =>
         val (decls2, stmts2) = codegen(arm, storeInto)(using Ls.empty, Ls.empty[Stmt])
-        val stmt = Stmt.If(mlsIsBoolLit(scrut2, i), Stmt.Block(decls2, stmts2), nextarm)
+        val stmt = Stmt.If(maybeInvert(mlsIsBoolLit(scrut2, i), inv), Stmt.Block(decls2, stmts2), nextarm)
         S(stmt)
       case _ => TODO("codegenCaseWithIfs doesn't support these patterns currently")
     }

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -494,7 +494,7 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
     case Match(scrut, hd :: tl, els, rest) =>
       val sd = result(scrut)
       def cond(cse: Case) = cse match
-        case Case.Lit(lit, inv) => doc"$sd ${if !inv then "===" else "!=="} ${lit.idStr}"
+        case Case.Lit(lit, inv) => doc"$sd ${if inv then "!==" else "==="} ${lit.idStr}"
         case Case.Cls(cls, pth) => cls match
           // case _: semantics.ModuleSymbol => doc"=== ${result(pth)}"
           // [invariant:0] If the class represented by `cls` does not exist at

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -494,7 +494,7 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
     case Match(scrut, hd :: tl, els, rest) =>
       val sd = result(scrut)
       def cond(cse: Case) = cse match
-        case Case.Lit(lit) => doc"$sd === ${lit.idStr}"
+        case Case.Lit(lit, inv) => doc"$sd ${if !inv then "===" else "!=="} ${lit.idStr}"
         case Case.Cls(cls, pth) => cls match
           // case _: semantics.ModuleSymbol => doc"=== ${result(pth)}"
           // [invariant:0] If the class represented by `cls` does not exist at

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Builder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Builder.scala
@@ -467,8 +467,8 @@ final class LlirBuilder(using Elaborator.State)(tl: TraceLogger, uid: FreshInt):
               fvs1.map(x => ctx.findName(x)).map(sr)
             )
             val casesList: Ls[(Pat, Node)] = arms.map:
-              case (Case.Lit(lit), body) =>
-                (Pat.Lit(lit), bBlock(body)(cont)(nextCont)(using ctx))
+              case (Case.Lit(lit, inv), body) =>
+                (Pat.Lit(lit, inv), bBlock(body)(cont)(nextCont)(using ctx))
               case (Case.Cls(cls, _), body) =>
                 (Pat.Class(cls), bBlock(body)(cont)(nextCont)(using ctx))
               case (Case.Tup(len, inf), body) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Interp.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Interp.scala
@@ -175,7 +175,8 @@ class Interpreter(tl: TraceLogger):
           }
         case Value.Literal(lit) => 
           cases.find {
-            case (Pat.Lit(lit2), _) => lit === lit2
+            case (Pat.Lit(lit2, false), _) => lit === lit2
+            case (Pat.Lit(lit2, true), _) => !(lit === lit2)
             case _ => false
           } match {
             case Some((_, x)) => eval(x)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Interp.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Interp.scala
@@ -176,7 +176,7 @@ class Interpreter(tl: TraceLogger):
         case Value.Literal(lit) => 
           cases.find {
             case (Pat.Lit(lit2, false), _) => lit === lit2
-            case (Pat.Lit(lit2, true), _) => !(lit === lit2)
+            case (Pat.Lit(lit2, true), _) => lit =/= lit2
             case _ => false
           } match {
             case Some((_, x)) => eval(x)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Llir.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Llir.scala
@@ -89,7 +89,7 @@ enum Expr:
   def show = LlirDebugPrinter.mkDocument(this).toString
 
 enum Pat:
-  case Lit(lit: hkmc2.syntax.Literal)
+  case Lit(lit: hkmc2.syntax.Literal, inv: Bool)
   case Class(cls: Local)
 
 enum Node:

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Instructions.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Instructions.scala
@@ -126,7 +126,7 @@ object Instructions:
       resultType = S(I32Type)
     )
 
-    /** Creates an `i32.add` instruction. */
+    /** Creates an `i32.eq` instruction. */
     def eq(lhs: Expr, rhs: Expr): FoldedInstr = FoldedInstr(
       mnemonic = "i32.eq",
       instrargs = Seq.empty,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -718,16 +718,24 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
         val armExprs = arms.zipWithIndex.flatMap: (caseAndBody, armIdx) =>
           val (cse, body) = caseAndBody
           cse match
-            case Case.Lit(lit) =>
+            case Case.Lit(lit, inv) =>
               val testExpr: FoldedInstr = lit match
                 case BoolLit(value) =>
                   val scrutAsI31 = ref.cast(getScrutExpr, RefType.i31ref)
                   val scrutValue = i31.get(scrutAsI31, signed = true)
-                  i32.eq(scrutValue, i32.const(if value then 1 else 0))
+                  val patValue = i32.const(if value then 1 else 0)
+                  if !inv then
+                    i32.eq(scrutValue, patValue)
+                  else
+                    i32.ne(scrutValue, patValue)
                 case IntLit(value) =>
                   val scrutAsI31 = ref.cast(getScrutExpr, RefType.i31ref)
                   val scrutValue = i31.get(scrutAsI31, signed = true)
-                  i32.eq(scrutValue, i32.const(value.toInt))
+                  val patValue = i32.const(value.toInt)
+                  if !inv then
+                    i32.eq(scrutValue, patValue)
+                  else
+                    i32.ne(scrutValue, patValue)
                 case _ =>
                   break(errExpr(Ls(msg"Pattern matching for unit literals not implemented yet" -> lit.toLoc)))
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -724,18 +724,18 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                   val scrutAsI31 = ref.cast(getScrutExpr, RefType.i31ref)
                   val scrutValue = i31.get(scrutAsI31, signed = true)
                   val patValue = i32.const(if value then 1 else 0)
-                  if !inv then
-                    i32.eq(scrutValue, patValue)
-                  else
+                  if inv then
                     i32.ne(scrutValue, patValue)
+                  else
+                    i32.eq(scrutValue, patValue)
                 case IntLit(value) =>
                   val scrutAsI31 = ref.cast(getScrutExpr, RefType.i31ref)
                   val scrutValue = i31.get(scrutAsI31, signed = true)
                   val patValue = i32.const(value.toInt)
-                  if !inv then
-                    i32.eq(scrutValue, patValue)
-                  else
+                  if inv then
                     i32.ne(scrutValue, patValue)
+                  else
+                    i32.eq(scrutValue, patValue)
                 case _ =>
                   break(errExpr(Ls(msg"Pattern matching for unit literals not implemented yet" -> lit.toLoc)))
 

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -248,7 +248,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State) e
             End()
           )
         pat match
-          case FlatPattern.Lit(lit) => mkMatch(Case.Lit(lit) -> lowerSplit(tail, cont, topLevel = false))
+          case FlatPattern.Lit(lit) => mkMatch(Case.Lit(lit, false) -> lowerSplit(tail, cont, topLevel = false))
           case FlatPattern.ClassLike(ctor, symbol, argsOpt, _refined) =>
             for args <- argsOpt; (arg, _) <- args do LoweringCtx.loweringCtx.collectScopedSym(arg)
             /** Make a continuation that creates the match. */
@@ -425,7 +425,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State) e
               blk
                 .assign(isReturned, Call(Value.Ref(State.builtinOpsMap("!==")),
                   loopResult.asPath.asArg :: loopEnd.asArg :: Nil)(true, false, false))
-                .ifthen(Value.Ref(isReturned), Case.Lit(Tree.BoolLit(true)),
+                .ifthen(Value.Ref(isReturned), Case.Lit(Tree.BoolLit(true), false),
                   Return(Value.Ref(loopResult), false),
                   S(rest)
                 )

--- a/hkmc2/shared/src/test/mlscript/llir/ControlFlow.mls
+++ b/hkmc2/shared/src/test/mlscript/llir/ControlFlow.mls
@@ -38,7 +38,7 @@ f2()
 //│     let x = 0 in
 //│     let x1 = ===(x,1) in
 //│     case x1 of
-//│       Lit(BoolLit(true)) =>
+//│       Lit(BoolLit(true),false) =>
 //│         2
 //│       _ =>
 //│         3
@@ -67,7 +67,7 @@ f3()
 //│     let x1 = 1 in
 //│     let x2 = true in
 //│     case x2 of
-//│       Lit(BoolLit(true)) =>
+//│       Lit(BoolLit(true),false) =>
 //│         x
 //│       _ =>
 //│         x1
@@ -93,7 +93,7 @@ f4()
 //│     let x = 0 in
 //│     let x1 = ===(x,1) in
 //│     case x1 of
-//│       Lit(BoolLit(true)) =>
+//│       Lit(BoolLit(true),false) =>
 //│         let x2 = 2 in
 //│         jump j(x2)
 //│       _ =>
@@ -124,7 +124,7 @@ f5()
 //│     let x = 0 in
 //│     let x1 = ===(x,1) in
 //│     case x1 of
-//│       Lit(BoolLit(true)) =>
+//│       Lit(BoolLit(true),false) =>
 //│         let x2 = 2 in
 //│         jump j(x2)
 //│       _ =>
@@ -133,7 +133,7 @@ f5()
 //│   def j(tmp) =
 //│     let x4 = ===(tmp,2) in
 //│     case x4 of
-//│       Lit(BoolLit(true)) =>
+//│       Lit(BoolLit(true),false) =>
 //│         let x5 = 4 in
 //│         jump j1(x5)
 //│       _ =>
@@ -157,7 +157,7 @@ fun test() =
 //│   def test() =
 //│     let x = true in
 //│     case x of
-//│       Lit(BoolLit(true)) =>
+//│       Lit(BoolLit(true),false) =>
 //│         let* (x1) = test() in
 //│         x1
 //│       _ =>
@@ -176,7 +176,7 @@ fun test() =
 //│   def test() =
 //│     let x = true in
 //│     case x of
-//│       Lit(BoolLit(true)) =>
+//│       Lit(BoolLit(true),false) =>
 //│         let* (x1) = test() in
 //│         jump j(x1)
 //│       _ =>
@@ -204,7 +204,7 @@ f()
 //│     let x = 10 in
 //│     let x1 = true in
 //│     case x1 of
-//│       Lit(BoolLit(true)) =>
+//│       Lit(BoolLit(true),false) =>
 //│         let x2 = +(x,1) in
 //│         let x3 = undefined in
 //│         jump j(x2)


### PR DESCRIPTION
Allow Match to be inverted, which will be used to create non null checks during handler lowering.