### PR TITLE
Fix `.sbtopts`

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -8,7 +8,12 @@
 
 # The options below were inspired by a message I got on some runs with more than usual memory retention:
 #   [warn] In the last 10 seconds, 5.067 (50.7%) were spent in GC. [Heap: 0.01GB free of 1.00GB, max 1.00GB] Consider increasing the JVM heap using `-Xmx` or try a different collector, e.g. `-XX:+UseG1GC`, for better performance.
--J-Xms2G # reduces warm-up time the first time the tests are run
--J-Xmx4G # reduces time spent doing GC
+
+# Reduces warm-up time the first time the tests are run
+-J-Xms2G
+
+# Reduces time spent doing GC
+-J-Xmx4G
+
 #-J-XX:+UseG1GC # does not seem to make much of a difference
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import org.scalajs.linker.interface.OutputPatterns
 
 enablePlugins(ScalaJSPlugin)
 
-val scala3Version = "3.8.1"
+val scala3Version = "3.7.4"
 val directoryWatcherVersion = "0.18.0"
 val scalaTestVersion = "3.2.19"
 

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       (system:
       let 
         sbtOverlay = self: super: {
-          sbt = super.sbt.override { jre = super.jdk11_headless; };
+          sbt = super.sbt.override { jre = super.jdk17_headless; };
         };
         pkgs = import nixpkgs { 
           inherit system;


### PR DESCRIPTION
The newest version of sbt seems to not parse `.sbtopts` correctly. It seems to parse some of the comments as commands, and results in the following error:
```
Error: Could not find or load main class #
Caused by: java.lang.ClassNotFoundException: #
mkdir: cannot create directory ‘’: No such file or directory
Error: Could not find or load main class #
Caused by: java.lang.ClassNotFoundException: #
Error: Could not find or load main class #
Caused by: java.lang.ClassNotFoundException: #
```
I've changed the file to work around this error for now.