### PR TITLE
Top-level constraints syntax

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
@@ -564,7 +564,7 @@ extends Importer with ucs.SplitElaborator:
           val (syms, nestCtx) = funParams(lhs)
           Term.Lam(syms, term(rhs)(using nestCtx))
       case TyTup(tys) =>
-        val constraints = tys.flatMap(constraint)
+        val constraints = tys.flatMap(maybeConstraint)
         val body = term(rhs)
         Term.Constrained(constraints, body)
     case InfixApp(lhs, Keywrd(Keyword.`as`), rhs) =>
@@ -576,6 +576,8 @@ extends Importer with ucs.SplitElaborator:
         PlainFld(subterm(rhs, inAppPrefix = true)) :: Nil)(DummyTup))(DummyApp, N, FlowSymbol("not-app"))
     case tree @ InfixApp(lhs, Keywrd(Keyword.`is` | Keyword.`and` | Keyword.`or`), rhs) =>
       Term.IfLike(Keyword.`if`, IfLikeForm.ReturningIf, shorthandSplit(tree))
+    case InfixApp(lhs, Keywrd(op : (Keyword.`<:`.type | Keyword.`:>`.type)), rhs) =>
+      Term.SubConstr(constraint(lhs, op, rhs))
     case InfixApp(lhs, kw, rhs) =>
       raise:
         ErrorReport(msg"Unexpected infix use of keyword '${kw.name}' here" -> tree.toLoc :: Nil)
@@ -1534,15 +1536,19 @@ extends Importer with ucs.SplitElaborator:
     ps_ctx
   
   /** Elaborate a subtyping constraint. */
-  def constraint(t: Tree): Ctxl[Option[SubConstraint]] =
+  def constraint(lhs: Tree, op: Keyword.`<:`.type | Keyword.`:>`.type, rhs: Tree): Ctxl[SubConstraint] =
+    val l = term(lhs)
+    val r = term(rhs)
+    val dir = op match
+      case Keyword.`<:` => SubDir.Sub
+      case Keyword.`:>` => SubDir.Sup
+    SubConstraint(l, r, dir)
+ 
+  /** Elaborate a subtyping constraint that may be malformed. */
+  def maybeConstraint(t: Tree): Ctxl[Option[SubConstraint]] =
     t match
-    case InfixApp(lhs, op @ (Keywrd(Keyword.`<:`) | Keywrd(Keyword.`:>`)), rhs) =>
-      val l = term(lhs)
-      val r = term(rhs)
-      val dir = op match
-        case Keywrd(Keyword.`<:`) => SubDir.Sub
-        case Keywrd(Keyword.`:>`) => SubDir.Sup
-      S(SubConstraint(l, r, dir))
+    case InfixApp(lhs, Keywrd(op : (Keyword.`<:`.type | Keyword.`:>`.type)), rhs) =>
+      S(constraint(lhs, op, rhs))
     case _ =>
       raise(ErrorReport(msg"Illegal constraint syntax." -> t.toLoc :: Nil))
       N

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
@@ -572,8 +572,6 @@ extends Importer with ucs.SplitElaborator:
         PlainFld(subterm(rhs, inAppPrefix = true)) :: Nil)(DummyTup))(DummyApp, N, FlowSymbol("not-app"))
     case tree @ InfixApp(lhs, Keywrd(Keyword.`is` | Keyword.`and` | Keyword.`or`), rhs) =>
       Term.IfLike(Keyword.`if`, IfLikeForm.ReturningIf, shorthandSplit(tree))
-    case InfixApp(lhs, Keywrd(op : (Keyword.`<:`.type | Keyword.`:>`.type)), rhs) =>
-      Term.SubConstr(constraint(lhs, op, rhs))
     case InfixApp(lhs, kw, rhs) =>
       raise:
         ErrorReport(msg"Unexpected infix use of keyword '${kw.name}' here" -> tree.toLoc :: Nil)
@@ -1532,18 +1530,18 @@ extends Importer with ucs.SplitElaborator:
     ps_ctx
   
   /** Elaborate a subtyping constraint. */
-  def constraint(lhs: Tree, op: Keyword.`<:`.type | Keyword.`:>`.type, rhs: Tree): Ctxl[SubConstraint] =
+  def constraint(lhs: Tree, op: "<:<" | ">:>", rhs: Tree): Ctxl[SubConstraint] =
     val l = term(lhs)
     val r = term(rhs)
     val dir = op match
-      case Keyword.`<:` => SubDir.Sub
-      case Keyword.`:>` => SubDir.Sup
+      case "<:<" => SubDir.Sub
+      case ">:>" => SubDir.Sup
     SubConstraint(l, r, dir)
  
   /** Elaborate a subtyping constraint that may be malformed. */
   def maybeConstraint(t: Tree): Ctxl[Option[SubConstraint]] =
     t match
-    case InfixApp(lhs, Keywrd(op : (Keyword.`<:`.type | Keyword.`:>`.type)), rhs) =>
+    case OpApp(lhs, Ident(op : ("<:<" | ">:>")), rhs :: Nil) =>
       S(constraint(lhs, op, rhs))
     case _ =>
       raise(ErrorReport(msg"Illegal constraint syntax." -> t.toLoc :: Nil))

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
@@ -276,6 +276,9 @@ enum Term extends Statement:
   case Error
   case UnitVal()
   case Missing // Placeholder terms that were not elaborated due to the "lightweight" elaboration mode `Mode.Light`
+  /** A subtyping constraint. This term is mostly useful at the top-level for testing purposes and
+   *  is not meant to be used in a real program. */
+  case SubConstr(constraint: SubConstraint) extends Term
   case Lit(lit: Literal)
   /** A term that wraps another term, indicating that the symbol of the inner term is resolved.
     * This is mainly used to disambiguate overloaded definitions. */
@@ -512,6 +515,7 @@ sealed trait Statement extends AutoLocated, ProductWithExtraInfo:
   def describe: Str =
     val desc = this match
       case Error => "‹error›"
+      case SubConstr(_) => "subtyping constraint"
       case UnitVal() => "unit value"
       case Lit(lit) => lit.describeLit
       case Ref(sym) => "reference"
@@ -572,6 +576,7 @@ sealed trait Statement extends AutoLocated, ProductWithExtraInfo:
     case _ => subTerms
   def subTerms: Vector[Term] = this match
     case Error | Missing | _: Lit | _: Ref | _: UnitVal => Vector.empty
+    case SubConstr(constraint) => Vector.double(constraint.lhs, constraint.rhs)
     case Resolved(t, sym) => Vector.single(t)
     case App(lhs, rhs) => Vector.double(lhs, rhs)
     case RcdField(lhs, rhs) => Vector.double(lhs, rhs)

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
@@ -277,7 +277,7 @@ enum Term extends Statement:
   case UnitVal()
   case Missing // Placeholder terms that were not elaborated due to the "lightweight" elaboration mode `Mode.Light`
   /** A subtyping constraint. This term is mostly useful at the top-level for testing purposes and
-   *  is not meant to be used in a real program. */
+    * is not meant to be used in a real program. */
   case SubConstr(constraint: SubConstraint) extends Term
   case Lit(lit: Literal)
   /** A term that wraps another term, indicating that the symbol of the inner term is resolved.

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
@@ -276,9 +276,6 @@ enum Term extends Statement:
   case Error
   case UnitVal()
   case Missing // Placeholder terms that were not elaborated due to the "lightweight" elaboration mode `Mode.Light`
-  /** A subtyping constraint. This term is mostly useful at the top-level for testing purposes and
-    * is not meant to be used in a real program. */
-  case SubConstr(constraint: SubConstraint) extends Term
   case Lit(lit: Literal)
   /** A term that wraps another term, indicating that the symbol of the inner term is resolved.
     * This is mainly used to disambiguate overloaded definitions. */
@@ -515,7 +512,6 @@ sealed trait Statement extends AutoLocated, ProductWithExtraInfo:
   def describe: Str =
     val desc = this match
       case Error => "‹error›"
-      case SubConstr(_) => "subtyping constraint"
       case UnitVal() => "unit value"
       case Lit(lit) => lit.describeLit
       case Ref(sym) => "reference"
@@ -576,7 +572,6 @@ sealed trait Statement extends AutoLocated, ProductWithExtraInfo:
     case _ => subTerms
   def subTerms: Vector[Term] = this match
     case Error | Missing | _: Lit | _: Ref | _: UnitVal => Vector.empty
-    case SubConstr(constraint) => Vector.double(constraint.lhs, constraint.rhs)
     case Resolved(t, sym) => Vector.single(t)
     case App(lhs, rhs) => Vector.double(lhs, rhs)
     case RcdField(lhs, rhs) => Vector.double(lhs, rhs)

--- a/hkmc2/shared/src/main/scala/hkmc2/syntax/Keyword.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/syntax/Keyword.scala
@@ -56,6 +56,11 @@ object Keyword:
   
   val `val` = Keyword("val", N, curPrec)
   
+  /** The subtyping operator. */
+  val `<:` = Keyword("<:", curPrec, curPrec)
+  /** The supertyping operator. */
+  val `:>` = Keyword(":>", curPrec, curPrec)
+
   val eqPrec = nextPrec
   val ascPrec = nextPrec // * `x => x : T` should parsed as `x => (x : T)`
   val `=` = Keyword("=", eqPrec, eqPrec)
@@ -138,11 +143,6 @@ object Keyword:
   // * Currently, the precedence of normal operators starts at the maximum precedence of keywords,
   // * so we need to start the precedence of `=>` to account for that.
   val `=>` = Keyword("=>", S(maxPrec.get + charPrecList.length), eqPrec)
-  
-  /** The subtyping operator. */
-  val `<:` = Keyword("<:", nextPrec, curPrec)
-  /** The supertyping operator. */
-  val `:>` = Keyword(":>", nextPrec, curPrec)
 
   // * `new` is a strange keyword:
   // * it has a very high precedence that sits between that of selection and that of application.

--- a/hkmc2/shared/src/main/scala/hkmc2/syntax/Keyword.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/syntax/Keyword.scala
@@ -55,11 +55,6 @@ object Keyword:
   val `with` = Keyword("with", curPrec, curPrec)
   
   val `val` = Keyword("val", N, curPrec)
-  
-  /** The subtyping operator. */
-  val `<:` = Keyword("<:", curPrec, curPrec)
-  /** The supertyping operator. */
-  val `:>` = Keyword(":>", curPrec, curPrec)
 
   val eqPrec = nextPrec
   val ascPrec = nextPrec // * `x => x : T` should parsed as `x => (x : T)`
@@ -163,12 +158,12 @@ object Keyword:
     `do`.type | `drop`.type | `not`.type | `new!`.type | `else`.type | `return`.type | `throw`.type | `import`.type
   
   type Infix =
-    `is`.type | `:`.type | `->`.type | `=>`.type | `<:`.type | `:>`.type | `extends`.type | `restricts`.type |
-    `as`.type | `do`.type | `where`.type | `with`.type | `and`.type | `or`.type | `then`.type | `else`.type
+    `is`.type | `:`.type | `->`.type | `=>`.type | `extends`.type | `restricts`.type | `as`.type | `do`.type |
+    `where`.type | `with`.type | `and`.type | `or`.type | `then`.type | `else`.type
   
   type InfixSplittable =
-    `is`.type | `:`.type | `->`.type | `=>`.type | `<:`.type | `:>`.type | `extends`.type | `restricts`.type |
-    `as`.type | `do`.type | `where`.type | `with`.type | `of`.type
+    `is`.type | `:`.type | `->`.type | `=>`.type | `extends`.type | `restricts`.type | `as`.type | `do`.type |
+    `where`.type | `with`.type | `of`.type
   
   type Ellipsis = `...`.type | `..`.type
   

--- a/hkmc2/shared/src/main/scala/hkmc2/syntax/ParseRule.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/syntax/ParseRule.scala
@@ -467,8 +467,6 @@ class ParseRules(using State):
     makeInfixRule(`do`),
     makeInfixRule(`where`),
     makeInfixRule(`with`),
-    makeInfixRule(`<:`),
-    makeInfixRule(`:>`),
   )
 
 end ParseRules

--- a/hkmc2/shared/src/test/mlscript-compile/Predef.mjs
+++ b/hkmc2/shared/src/test/mlscript-compile/Predef.mjs
@@ -30,6 +30,42 @@ let Predef1;
       toString() { return runtime.render(this); }
       static [definitionMetadata] = ["object", "Symbols"]; 
     });
+    (class Sub {
+      static {
+        Predef.Sub = this
+      }
+      constructor() {}
+      toString() { return runtime.render(this); }
+      static [definitionMetadata] = ["class", "Sub"]; 
+    });
+    (class Eq extends Predef.Sub {
+      static {
+        Predef.Eq = this
+      }
+      constructor() {
+        super();
+      }
+      toString() { return runtime.render(this); }
+      static [definitionMetadata] = ["class", "Eq"]; 
+    });
+    (class Refl extends Predef.Eq {
+      static {
+        new this
+      }
+      constructor() {
+        super();
+        Predef.Refl = this;
+        Object.defineProperty(this, "class", {
+          value: Refl
+        });
+        globalThis.Object.freeze(this);
+      }
+      apply(x) {
+        return x
+      }
+      toString() { return runtime.render(this); }
+      static [definitionMetadata] = ["object", "Refl"]; 
+    });
     this.pass1 = Rendering.pass1;
     this.pass2 = Rendering.pass2;
     this.pass3 = Rendering.pass3;

--- a/hkmc2/shared/src/test/mlscript-compile/Predef.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/Predef.mls
@@ -49,6 +49,14 @@ object Symbols with
   val definitionMetadata = RuntimeJS.symbols.definitionMetadata
   // val definitionMetadata = Symbol.for("mlscript.definitionMetadata")
 
+abstract class (<:<) Sub[A, B] with
+  fun apply(x: A): B
+abstract class (=:=) Eq[A, B] extends Sub[A, B] with
+  fun apply(x: A): B
+object Refl[A] extends Eq[A, A] with
+  fun apply(x: A): A = x
+
+type (>:>) Sup[A, B] = Sub[B, A]
 
 // * A generic equality comparison.
 // * Returns true for:

--- a/hkmc2/shared/src/test/mlscript/ctx/Summon.mls
+++ b/hkmc2/shared/src/test/mlscript/ctx/Summon.mls
@@ -19,7 +19,7 @@ use[Num]
 //│ ║  l.17: 	use[Num]
 //│ ║        	^^^^^^^^
 //│ ╟── Required by contextual parameter declaration: 
-//│ ║  l.117: 	fun use[T](using instance: T) = instance
+//│ ║  l.125: 	fun use[T](using instance: T) = instance
 //│ ║         	                 ^^^^^^^^^^^
 //│ ╙── Missing instance: Expected: Num (type parameter T); Available: Int, Str
 //│ ═══[RUNTIME ERROR] This code cannot be run as its compilation yielded an error.
@@ -55,7 +55,7 @@ fun f(using Int) = use[Num]
 //│ ║  l.53: 	fun f(using Int) = use[Num]
 //│ ║        	                   ^^^^^^^^
 //│ ╟── Required by contextual parameter declaration: 
-//│ ║  l.117: 	fun use[T](using instance: T) = instance
+//│ ║  l.125: 	fun use[T](using instance: T) = instance
 //│ ║         	                 ^^^^^^^^^^^
 //│ ╙── Missing instance: Expected: Num (type parameter T); Available: Int, Str
 
@@ -79,7 +79,7 @@ use{[Some[Int]].value}
 //│ ║  l.74: 	use{[Some[Int]].value}
 //│ ║        	^^^
 //│ ╟── Required by contextual parameter declaration: 
-//│ ║  l.117: 	fun use[T](using instance: T) = instance
+//│ ║  l.125: 	fun use[T](using instance: T) = instance
 //│ ║         	                 ^^^^^^^^^^^
 //│ ╙── Illegal query for an unspecified type variable T.
 //│ ═══[RUNTIME ERROR] This code cannot be run as its compilation yielded an error.
@@ -91,7 +91,7 @@ use([Some[Int]].value)
 //│ ║  l.89: 	use([Some[Int]].value)
 //│ ║        	^^^
 //│ ╟── Required by contextual parameter declaration: 
-//│ ║  l.117: 	fun use[T](using instance: T) = instance
+//│ ║  l.125: 	fun use[T](using instance: T) = instance
 //│ ║         	                 ^^^^^^^^^^^
 //│ ╙── Illegal query for an unspecified type variable T.
 //│ ═══[RUNTIME ERROR] This code cannot be run as its compilation yielded an error.

--- a/hkmc2/shared/src/test/mlscript/parser/ConstrainedTypes.mls
+++ b/hkmc2/shared/src/test/mlscript/parser/ConstrainedTypes.mls
@@ -5,10 +5,10 @@
 //│ Parsed:
 //│ 	InfixApp(TyTup(List()),Keywrd(keyword '=>'),Ident(Int))
 
-[Bot <: Top] => Int
+[Bot :<: Top] => Int
 //│ Parsed:
-//│ 	InfixApp(TyTup(List(InfixApp(Ident(Bot),Keywrd(keyword '<:'),Ident(Top)))),Keywrd(keyword '=>'),Ident(Int))
+//│ 	InfixApp(TyTup(List(OpApp(Ident(Bot),Ident(:<:),List(Ident(Top))))),Keywrd(keyword '=>'),Ident(Int))
 
-[Int & Str <: Int | Str] => Int
+[(Int & Str) :<: (Int | Str)] => Int
 //│ Parsed:
-//│ 	InfixApp(TyTup(List(InfixApp(OpApp(Ident(Int),Ident(&),List(Ident(Str))),Keywrd(keyword '<:'),OpApp(Ident(Int),Ident(|),List(Ident(Str)))))),Keywrd(keyword '=>'),Ident(Int))
+//│ 	InfixApp(TyTup(List(OpApp(Bra(Round,OpApp(Ident(Int),Ident(&),List(Ident(Str)))),Ident(:<:),List(Bra(Round,OpApp(Ident(Int),Ident(|),List(Ident(Str)))))))),Keywrd(keyword '=>'),Ident(Int))

--- a/hkmc2/shared/src/test/mlscript/parser/ConstrainedTypes.mls
+++ b/hkmc2/shared/src/test/mlscript/parser/ConstrainedTypes.mls
@@ -5,10 +5,10 @@
 //│ Parsed:
 //│ 	InfixApp(TyTup(List()),Keywrd(keyword '=>'),Ident(Int))
 
-[Bot :<: Top] => Int
+[Bot <:< Top] => Int
 //│ Parsed:
-//│ 	InfixApp(TyTup(List(OpApp(Ident(Bot),Ident(:<:),List(Ident(Top))))),Keywrd(keyword '=>'),Ident(Int))
+//│ 	InfixApp(TyTup(List(OpApp(Ident(Bot),Ident(<:<),List(Ident(Top))))),Keywrd(keyword '=>'),Ident(Int))
 
-[(Int & Str) :<: (Int | Str)] => Int
+[(Int & Str) <:< (Int | Str)] => Int
 //│ Parsed:
-//│ 	InfixApp(TyTup(List(OpApp(Bra(Round,OpApp(Ident(Int),Ident(&),List(Ident(Str)))),Ident(:<:),List(Bra(Round,OpApp(Ident(Int),Ident(|),List(Ident(Str)))))))),Keywrd(keyword '=>'),Ident(Int))
+//│ 	InfixApp(TyTup(List(OpApp(Bra(Round,OpApp(Ident(Int),Ident(&),List(Ident(Str)))),Ident(<:<),List(Bra(Round,OpApp(Ident(Int),Ident(|),List(Ident(Str)))))))),Keywrd(keyword '=>'),Ident(Int))


### PR DESCRIPTION
Allow writing subtyping constraints at the top level, which is not meant to appear in real programs but can be useful to write tests (I do that !).

Example:
```
Int <: [Bot <: Top] => Int
//│ OK

A & B <: A
//│ OK

:te
A <: A & B
//│ ═══[TYPE ERROR] Cannot solve judgment A ≤ A ∧ B.
```