### PR TITLE
Switch specialization

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -88,8 +88,8 @@ sealed abstract class Block extends Product:
   
   // TODO conserve if no changes
   def mapTail(f: BlockTail => Block): Block = this match
-    case Scoped(syms, body) => Scoped(syms, body.mapTail(f))
     case b: BlockTail => f(b)
+    case Scoped(syms, body) => Scoped(syms, body.mapTail(f))
     case Begin(sub, rst) => Begin(sub, rst.mapTail(f))
     case Assign(lhs, rhs, rst) => Assign(lhs, rhs, rst.mapTail(f))
     case Define(defn, rst) => Define(defn, rst.mapTail(f))
@@ -293,12 +293,15 @@ end Block
 
 sealed abstract class BlockTail extends Block
 
+sealed abstract trait NonBlockTail:
+  val rest: Block
+
 case class Match(
   scrut: Path,
   arms: Ls[Case -> Block],
   dflt: Opt[Block],
   rest: Block,
-) extends Block with ProductWithTail
+) extends Block with ProductWithTail with NonBlockTail
 
 // * `implct`: whether it's a JS implicit return, without the `return` keyword
 // * TODO could just remove this flag and add a flag in Scope instead
@@ -306,27 +309,30 @@ case class Return(res: Result, implct: Bool) extends BlockTail
 
 case class Throw(exc: Result) extends BlockTail
 
-case class Label(label: LabelSymbol, loop: Bool, body: Block, rest: Block) extends Block
+case class Label(label: LabelSymbol, loop: Bool, body: Block, rest: Block) extends Block with NonBlockTail
 
 case class Break(label: LabelSymbol) extends BlockTail
 case class Continue(label: LabelSymbol) extends BlockTail
 
 
-case class Scoped(syms: collection.Set[Local], body: Block) extends BlockTail
+case class Scoped(syms: collection.Set[Local], body: Block) extends Block with NonBlockTail:
+  val rest = body
 
 // TODO: remove this form?
-case class Begin(sub: Block, rest: Block) extends Block with ProductWithTail
+case class Begin(sub: Block, rest: Block) extends Block with ProductWithTail with NonBlockTail
 
-case class TryBlock(sub: Block, finallyDo: Block, rest: Block) extends Block with ProductWithTail
+case class TryBlock(sub: Block, finallyDo: Block, rest: Block) extends Block with ProductWithTail with NonBlockTail
 
-case class Assign(lhs: Local, rhs: Result, rest: Block) extends Block with ProductWithTail
+case class Assign(lhs: Local, rhs: Result, rest: Block) extends Block with ProductWithTail with NonBlockTail
 // case class Assign(lhs: Path, rhs: Result, rest: Block) extends Block with ProductWithTail
 
-case class AssignField(lhs: Path, nme: Tree.Ident, rhs: Result, rest: Block)(val symbol: Opt[MemberSymbol]) extends Block with ProductWithTail
+case class AssignField(lhs: Path, nme: Tree.Ident, rhs: Result, rest: Block)(val symbol: Opt[MemberSymbol])
+  extends Block with ProductWithTail with NonBlockTail
 
-case class AssignDynField(lhs: Path, fld: Path, arrayIdx: Bool, rhs: Result, rest: Block) extends Block with ProductWithTail
+case class AssignDynField(lhs: Path, fld: Path, arrayIdx: Bool, rhs: Result, rest: Block)
+  extends Block with ProductWithTail with NonBlockTail
 
-case class Define(defn: Defn, rest: Block) extends Block with ProductWithTail
+case class Define(defn: Defn, rest: Block) extends Block with ProductWithTail with NonBlockTail
 
 inline def whenValidatingIR(inline code: => Unit): Unit =
   () // code // * uncomment to run on-the fly IR validations
@@ -407,7 +413,7 @@ case class HandleBlock(
     handlers: Ls[Handler],
     body: Block,
     rest: Block
-) extends Block with ProductWithTail
+) extends Block with ProductWithTail with NonBlockTail
 
 object HandleBlock:
   def apply(

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -215,8 +215,10 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
     * switch (scrut) {
     *   case a1:
     *     body1
+    *     scrut = a2;
     *   case a2:
     *     body2
+    *     scrut = a3;
     *   ...
     *   case an:
     *     bodyn

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -17,6 +17,7 @@ import Scope.scope
 import hkmc2.syntax.Tree.UnitLit
 import hkmc2.semantics.Elaborator.ctx
 import hkmc2.syntax.Tree.{IntLit, StrLit}
+import scala.annotation.tailrec
 
 
 // TODO factor some logic for other codegen backends
@@ -193,6 +194,87 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
           case RcdArg(N, v) => doc"...${result(v)}"
         .mkDocument(doc", # ")
       if mut then inner else doc"$freeze(${inner})"
+  
+  /**
+    * Specializes the following, where ai are ints:
+    * 
+    * ```
+    * if scrut is a1 do
+    *   body1
+    *   set scrut = a2
+    * if scrut is a2 do
+    *   body2
+    *   set scrut = a3
+    * if scrut is an do
+    *   bodyn
+    * ```
+    * 
+    * into a switch statement:
+    * 
+    * ```js
+    * switch (scrut) {
+    *   case a1:
+    *     body1
+    *   case a2:
+    *     body2
+    *   ...
+    *   case an:
+    *     bodyn
+    * }
+    * ```
+    * Note that `scrut` is guaranteed to not change between `set scrut = ai` and `if scrut is ai`,
+    * because the JS event loop waits until the entire call stack is cleared before running any other
+    * code. Hence, this transformation is safe.
+    */
+  object IfIntChain:
+    @tailrec
+    private def lastBlkAssign(b: Block): Opt[Assign] = b match
+      case a @ Assign(lhs, rhs, End(_)) => S(a)
+      case Match(rest = rest) => lastBlkAssign(rest)
+      case Scoped(body = rest) => lastBlkAssign(rest)
+      case Label(rest = rest) => lastBlkAssign(rest)
+      case Begin(rest = rest) => lastBlkAssign(rest)
+      case TryBlock(rest = rest) => lastBlkAssign(rest)
+      case Assign(rest = rest) => lastBlkAssign(rest)
+      case AssignField(rest = rest) => lastBlkAssign(rest)
+      case AssignDynField(rest = rest) => lastBlkAssign(rest)
+      case Define(rest = rest) => lastBlkAssign(rest)
+      case HandleBlock(rest = rest) => lastBlkAssign(rest)
+      case _: BlockTail => N
+    
+    @tailrec
+    private def unapplyImpl(
+      b: Block, 
+      acc: List[(BigInt, Block)],
+      scrutSym: Local,
+      curVal: BigInt
+    ): (List[(BigInt, Block)], Block) = b match
+      case Match(
+        Value.Ref(`scrutSym`, _),                    // the scrutinee is ref to `scrutSym`
+        (Case.Lit(Tree.IntLit(`curVal`)), b) :: Nil, // there is only one case matching the previously set int literal
+        S(End(_)), rest)                             // default case exists and does nothing
+        => lastBlkAssign(b) match
+          // the one branch ends by assigning `nextInt` to `scrutSym`
+          case S(Assign(`scrutSym`, Value.Lit(Tree.IntLit(nextInt)), _)) =>
+            unapplyImpl(rest, (curVal, b) :: acc, scrutSym, nextInt)
+          case _ =>
+            ((curVal, b) :: acc, rest)
+      case _ => (acc, b)
+    
+    def unapply(b: Block): Opt[(scrut: Value.Ref, cases: List[(BigInt, Block)], rest: Block)] = b match
+      case Match(
+        scrut @ Value.Ref(scrutSym, _),               // the scrutinee is a ref to scrutSym
+        (Case.Lit(Tree.IntLit(i)), b) :: Nil,         // there is only one case matching an int literal
+        S(End(_)), rest)                              // default case exists and does nothing
+        => lastBlkAssign(b) match
+          // the one branch ends by assigning `nextInt` to `scrutSym`
+          case S(Assign(`scrutSym`, Value.Lit(Tree.IntLit(nextInt)), _)) =>
+            // start searching for more match blocks that match on `scrutSym` and have
+            // one case that matches `nextInt`
+            val (cases, rest_) = unapplyImpl(rest, (i, b) :: Nil, scrutSym, nextInt)
+            if cases.length === 1 then N else S((scrut, cases, rest_))
+          case _ => N 
+      case _ => N
   
   def returningTerm(t: Block, endSemi: Bool)(using Raise, Scope): Document =
     def mkSemi = if endSemi then ";" else ""
@@ -482,6 +564,12 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
       case S(el) => nonNestedScoped(el)(bod => returningTerm(bod, endSemi = true))
       case N => doc""
       e :: returningTerm(rest, endSemi)
+    case IfIntChain(scrut, cases, rest) =>
+      val switchBod = cases.foldRight(doc""): (arm, acc) =>
+        acc :: doc" # case ${arm._1.toString}: #{ ${
+          nonNestedScoped(arm._2)(bd => returningTerm(bd, endSemi = true))
+        } #} "
+      doc" # switch (${result(scrut)}) { #{ ${switchBod} #}  # }" :: returningTerm(rest, endSemi)
     case Match(scrut, (Case.Lit(lit), End(msg)) :: Nil, S(el), rest) =>
       val sd = result(scrut)
       val e = braced(nonNestedScoped(el)(res => returningTerm(res, endSemi = false)))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -248,35 +248,33 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
     private def unapplyImpl(
       b: Block, 
       acc: List[(BigInt, Block)],
-      scrutSym: Local,
-      curVal: BigInt
-    ): (List[(BigInt, Block)], Block) = b match
+      scrut: Opt[Value.Ref],
+      curVal: Opt[BigInt]
+    ): Opt[(Value.Ref, List[(BigInt, Block)], Block)] = 
+      val scrutSym = scrut.map(_.l)
+      b match
       case Match(
-        Value.Ref(`scrutSym`, _),                    // the scrutinee is ref to `scrutSym`
-        (Case.Lit(Tree.IntLit(`curVal`)), b) :: Nil, // there is only one case matching the previously set int literal
-        S(End(_)), rest)                             // default case exists and does nothing
-        => lastBlkAssign(b) match
+        scrut_ @ Value.Ref(scrutSym_, _),                   // the scrutinee is ref
+        (Case.Lit(Tree.IntLit(curVal_)), b) :: Nil,         // there is only one case matching an int literal
+        S(End(_)), rest                                     // default case exists and does nothing
+      )
+        if scrutSym.map(_ === scrutSym_).getOrElse(true)    // the scrutinee is the same as the one before
+        && curVal.map(_ === curVal_).getOrElse(true)        // the matched int literal is one previously set
+        =>
+          lastBlkAssign(b) match
           // the one branch ends by assigning `nextInt` to `scrutSym`
-          case S(Assign(`scrutSym`, Value.Lit(Tree.IntLit(nextInt)), _)) =>
-            unapplyImpl(rest, (curVal, b) :: acc, scrutSym, nextInt)
+          case S(Assign(`scrutSym_`, Value.Lit(Tree.IntLit(nextInt)), _)) =>
+            unapplyImpl(rest, (curVal_, b) :: acc, S(scrut_), S(nextInt))
           case _ =>
-            ((curVal, b) :: acc, rest)
-      case _ => (acc, b)
+            S((scrut_, (curVal_, b) :: acc, rest))
+      case _ => scrut match
+        case Some(value) => S((value, acc, b))
+        case None => N
     
-    def unapply(b: Block): Opt[(scrut: Value.Ref, cases: List[(BigInt, Block)], rest: Block)] = b match
-      case Match(
-        scrut @ Value.Ref(scrutSym, _),               // the scrutinee is a ref to scrutSym
-        (Case.Lit(Tree.IntLit(i)), b) :: Nil,         // there is only one case matching an int literal
-        S(End(_)), rest)                              // default case exists and does nothing
-        => lastBlkAssign(b) match
-          // the one branch ends by assigning `nextInt` to `scrutSym`
-          case S(Assign(`scrutSym`, Value.Lit(Tree.IntLit(nextInt)), _)) =>
-            // start searching for more match blocks that match on `scrutSym` and have
-            // one case that matches `nextInt`
-            val (cases, rest_) = unapplyImpl(rest, (i, b) :: Nil, scrutSym, nextInt)
-            if cases.length === 1 then N else S((scrut, cases, rest_))
-          case _ => N 
-      case _ => N
+    def unapply(b: Block): Opt[(scrut: Value.Ref, cases: List[(BigInt, Block)], rest: Block)] =
+      unapplyImpl(b, Nil, N, N) match
+        case Some(value) if value._2.length > 1 => S(value)
+        case _ => N
   
   def returningTerm(t: Block, endSemi: Bool)(using Raise, Scope): Document =
     def mkSemi = if endSemi then ";" else ""

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -232,16 +232,7 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
     @tailrec
     private def lastBlkAssign(b: Block): Opt[Assign] = b match
       case a @ Assign(lhs, rhs, End(_)) => S(a)
-      case Match(rest = rest) => lastBlkAssign(rest)
-      case Scoped(body = rest) => lastBlkAssign(rest)
-      case Label(rest = rest) => lastBlkAssign(rest)
-      case Begin(rest = rest) => lastBlkAssign(rest)
-      case TryBlock(rest = rest) => lastBlkAssign(rest)
-      case Assign(rest = rest) => lastBlkAssign(rest)
-      case AssignField(rest = rest) => lastBlkAssign(rest)
-      case AssignDynField(rest = rest) => lastBlkAssign(rest)
-      case Define(rest = rest) => lastBlkAssign(rest)
-      case HandleBlock(rest = rest) => lastBlkAssign(rest)
+      case b: NonBlockTail => lastBlkAssign(b.rest)
       case _: BlockTail => N
     
     @tailrec
@@ -254,12 +245,12 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
       val scrutSym = scrut.map(_.l)
       b match
       case Match(
-        scrut_ @ Value.Ref(scrutSym_, _),                   // the scrutinee is ref
-        (Case.Lit(Tree.IntLit(curVal_)), b) :: Nil,         // there is only one case matching an int literal
-        S(End(_)), rest                                     // default case exists and does nothing
+        scrut_ @ Value.Ref(scrutSym_, _),                   // The scrutinee is a ref.
+        (Case.Lit(Tree.IntLit(curVal_)), b) :: Nil,         // There is only one case matching an int literal.
+        S(End(_)), rest                                     // Default case exists and does nothing.
       )
-        if scrutSym.map(_ === scrutSym_).getOrElse(true)    // the scrutinee is the same as the one before
-        && curVal.map(_ === curVal_).getOrElse(true)        // the matched int literal is one previously set
+        if scrutSym.map(_ === scrutSym_).getOrElse(true)    // The scrutinee is the same as the one before.
+        && curVal.map(_ === curVal_).getOrElse(true)        // The matched int literal is one previously set.
         =>
           lastBlkAssign(b) match
           // the one branch ends by assigning `nextInt` to `scrutSym`

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -196,7 +196,7 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
       if mut then inner else doc"$freeze(${inner})"
   
   /**
-    * Specializes the following, where ai are ints:
+    * Matches the following kind of if statement, where ai are ints:
     * 
     * ```
     * if scrut is a1 do
@@ -209,7 +209,7 @@ class JSBuilder(using TL, State, Ctx) extends CodeBuilder:
     *   bodyn
     * ```
     * 
-    * into a switch statement:
+    * The intention is that this can be compiled efficiently into a switch statement:
     * 
     * ```js
     * switch (scrut) {

--- a/hkmc2/shared/src/test/mlscript/codegen/SwitchSpecialization.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/SwitchSpecialization.mls
@@ -1,0 +1,95 @@
+:js
+
+
+
+let x = 1
+//│ x = 1
+
+:sjs
+:expect "b"
+if x is 0 then
+  "a"
+else if x is 1 then
+  "b"
+else if x is 2 then
+  "c"
+else if x is 3 then
+  "d"
+else
+  "e"
+//│ JS (unsanitized):
+//│ switch (x) {
+//│   case 0:
+//│     "a";
+//│     break;
+//│   case 1:
+//│     "b";
+//│     break;
+//│   case 2:
+//│     "c";
+//│     break;
+//│   case 3:
+//│     "d";
+//│     break;
+//│   default:
+//│     "e";
+//│     break;
+//│ }
+//│ = "b"
+
+let x = 2
+let acc = ""
+//│ acc = ""
+//│ x = 2
+
+// Chains of if statements in the following form, which is essentially a jump table,
+// can be converted into a switch statement.
+// (This can be used to very efficiently compile resumable functions, i.e. for effect handlers and co-routines.)
+:sjs
+if x is 0 do
+  set acc += "a"
+  set x = 1
+if x is 1 do
+  set acc += "b"
+  set x = 2
+if x is 2 do
+  set acc += "c"
+  set x = 3
+if x is 3 do
+  set acc += "d"
+  set x = 4
+if x is 4 do
+  set acc += "e"
+//│ JS (unsanitized):
+//│ let tmp, tmp1, tmp2, tmp3, tmp4;
+//│ switch (x1) {
+//│   case 0:
+//│     tmp = acc + "a";
+//│     acc = tmp;
+//│     x1 = 1;
+//│   case 1:
+//│     tmp1 = acc + "b";
+//│     acc = tmp1;
+//│     x1 = 2;
+//│   case 2:
+//│     tmp2 = acc + "c";
+//│     acc = tmp2;
+//│     x1 = 3;
+//│   case 3:
+//│     tmp3 = acc + "d";
+//│     acc = tmp3;
+//│     x1 = 4;
+//│   case 4:
+//│     tmp4 = acc + "e";
+//│     acc = tmp4;
+//│ }
+//│ runtime.Unit
+
+:expect 4
+x
+//│ = 4
+
+:expect "cde"
+acc
+//│ = "cde"
+

--- a/hkmc2DiffTests/src/test/scala/hkmc2/JSBackendDiffMaker.scala
+++ b/hkmc2DiffTests/src/test/scala/hkmc2/JSBackendDiffMaker.scala
@@ -120,7 +120,6 @@ abstract class JSBackendDiffMaker extends MLsDiffMaker:
         case Return(res, implct) =>
           assert(implct)
           Assign(resSym, res, Return(Value.Lit(syntax.Tree.UnitLit(false)), true))
-        case _: Scoped => lastWords("impossible: mapTail should have handled this case specially")
         case tl: (Throw | Break | Continue) => tl
       )
       if showLoweredTree.isSet then


### PR DESCRIPTION
Specialize the following, where `ai` are ints:

```fs
if scrut is a1 do
  body1
  set scrut = a2
if scrut is a2 do
  body2
  set scrut = a3
if scrut is an do
  bodyn
```

into a switch statement:

```js
switch (scrut) {
  case a1:
    body1
    scrut = a2;
  case a2:
    body2
    scrut = a3;
  // ...
  case an:
    bodyn
}
```
Note that `scrut` is guaranteed to not change between `set scrut = ai` and `if scrut is ai`, because the JS event loop waits until the entire call stack is cleared before running any other code. Hence, this transformation is safe.

This can be used to reduce the overhead of the state machine transformation for effect handlers.