### PR TITLE
wasm: Remove redundant `MemberSymbol` resolution by ID

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -919,19 +919,9 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     val symToField = structInfo.compType match
       case ty: StructType => ty.fieldsBySym
       case _ => lastWords(s"Cannot select field from non-struct type: ${structInfo.compType.toWat}")
-    val fieldIdx = symToField.get(sym)
-      .orElse:
-        sym match
-          case memSym: MemberSymbol if fieldOwner(memSym).contains(thisSym) =>
-            symToField.find((fieldSym, _) => fieldSym.nme == sym.nme).map((_, v) => v)
-          case _ => N
-      .map(_.id)
-    FieldIdx(SymIdx(
-      fieldIdx getOrElse:
-        lastWords(
-          s"Missing field `${sym.toString}` in struct `${thisSym.toString}` with type `${structInfo.toWat.mkString()}`",
-        ),
-    ))
+    val fieldIdx = symToField.get(sym).map(_.id).getOrElse:
+      lastWords(s"Missing field `${sym.toString}` in struct `${thisSym.toString}` with type `${structInfo.toWat.mkString()}`")
+    FieldIdx(SymIdx(fieldIdx))
   end fieldSelect
 
   def result(r: codegen.Result)(using Ctx, Raise, Scope, SessionExportCtx): Expr = r match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -918,7 +918,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     val structInfo = ctx.getTypeInfo_!(thisSym)
     val symToField = structInfo.compType match
       case ty: StructType => ty.fieldsBySym
-      case _ => lastWords(s"Cannot select field from non-struct type: ${structInfo.compType.toWat}")
+      case _ => lastWords(s"Cannot select field from non-struct type: ${structInfo.compType.toWat.mkString()}")
     val fieldIdx = symToField.get(sym).map(_.id).getOrElse:
       lastWords(
         s"Missing field `${sym.toString}` in struct `${thisSym.toString}` with type `${structInfo.toWat.mkString()}`",
@@ -1025,9 +1025,9 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                       s"Block IR: `${
                           fun.toString
                         }`\nCompiled WAT: `${
-                          base.toWat.toString
+                          base.toWat.mkString()
                         }`\n... which has type `${
-                          ty.fold("(none)")(_.toWat.toString)
+                          ty.fold("(none)")(_.toWat.mkString())
                         }`",
                     ),
                   )

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -920,7 +920,9 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       case ty: StructType => ty.fieldsBySym
       case _ => lastWords(s"Cannot select field from non-struct type: ${structInfo.compType.toWat}")
     val fieldIdx = symToField.get(sym).map(_.id).getOrElse:
-      lastWords(s"Missing field `${sym.toString}` in struct `${thisSym.toString}` with type `${structInfo.toWat.mkString()}`")
+      lastWords(
+        s"Missing field `${sym.toString}` in struct `${thisSym.toString}` with type `${structInfo.toWat.mkString()}`",
+      )
     FieldIdx(SymIdx(fieldIdx))
   end fieldSelect
 


### PR DESCRIPTION
This is no longer needed as well, and all tests pass without this ID-based lookup of struct fields.