### PR TITLE
Wasm: Implement `FunctionCtx` to track locals and remove locals from `Ctx`

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -395,6 +395,10 @@ class FunctionCtx(_params: Ls[ParamList], thisSym: Opt[InnerSymbol])(using Raise
   def lookupLocal(sym: Local): Opt[LocalIdx] =
     localScp.lookup(sym).map(idx => LocalIdx(SymIdx(idx)))
 
+  /** Similar to [[lookupLocal]], but throws an exception if `sym` is not in this context. */
+  def lookupLocal_!(sym: Local, loc: Opt[Loc]): LocalIdx =
+    LocalIdx(SymIdx(localScp.lookup_!(sym, loc)))
+
   /** The locals of this function, represented by a tuple of the symbol representing the parameter and its symbolic
     * identifier.
     */

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -8,7 +8,7 @@ import hkmc2.utils.*
 
 import document.*
 import document.Document
-import semantics.{BlockMemberSymbol, Elaborator, LabelSymbol, ModuleOrObjectSymbol, Symbol, TempSymbol},
+import semantics.{BlockMemberSymbol, Elaborator, InnerSymbol, LabelSymbol, ModuleOrObjectSymbol, Symbol, TempSymbol},
   Elaborator.State
 import text.Param as WasmParam
 import Instructions.*
@@ -359,7 +359,7 @@ object FunctionCtx:
   * @param _params
   *   The parameters of this function.
   */
-class FunctionCtx(_params: Seq[Local], thisSym: Opt[Symbol])(using Raise, State):
+class FunctionCtx(_params: Seq[Local], thisSym: Opt[InnerSymbol])(using Raise, State):
 
   /** [[Scope]] for generating WAT identifiers of locals. */
   private[text] val localScp = Scope.empty(Scope.Cfg.default)
@@ -407,7 +407,7 @@ end FunctionCtx
   *
   * Returns the result of the `mkBody` function along with the [[FunctionCtx]].
   */
-def genFuncBody[T](params: Seq[Local], thisSym: Opt[Symbol] = N)(mkBody: FunctionCtx ?=> T)(using Raise, State): T -> FunctionCtx =
+def genFuncBody[T](params: Seq[Local], thisSym: Opt[InnerSymbol])(mkBody: FunctionCtx ?=> T)(using Raise, State): T -> FunctionCtx =
   val funcCtx = FunctionCtx(params, thisSym)
   val result = mkBody(using funcCtx)
   result -> funcCtx

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -8,7 +8,7 @@ import hkmc2.utils.*
 
 import document.*
 import document.Document
-import semantics.{BlockMemberSymbol, Elaborator, InnerSymbol, LabelSymbol, ModuleOrObjectSymbol, Symbol, TempSymbol},
+import semantics.{BlockMemberSymbol, Elaborator, InnerSymbol, LabelSymbol, ModuleOrObjectSymbol, ParamList, Symbol, TempSymbol},
   Elaborator.State
 import text.Param as WasmParam
 import Instructions.*
@@ -361,7 +361,7 @@ object FunctionCtx:
   * @param thisSym
   *   The implicit `this` parameter symbol if this function is generated from a non-static method, or `N` otherwise.
   */
-class FunctionCtx(_params: Seq[Local], thisSym: Opt[InnerSymbol])(using Raise, State):
+class FunctionCtx(_params: Ls[ParamList], thisSym: Opt[InnerSymbol])(using Raise, State):
 
   /** [[Scope]] for generating WAT identifiers of locals. */
   private[text] val localScp = Scope.empty(Scope.Cfg.default)
@@ -370,9 +370,11 @@ class FunctionCtx(_params: Seq[Local], thisSym: Opt[InnerSymbol])(using Raise, S
     * identifier.
     */
   val params: Seq[Local -> SymIdx] =
+    if _params.length > 1 then
+      lastWords("Multiple parameter lists are not yet supported")
     val thisParam = thisSym.map: dis =>
       dis -> SymIdx(localScp.addToBindings(dis, "this", shadow = false))
-    thisParam.toSeq ++ _params.map(p => p -> SymIdx(localScp.allocateName(p)))
+    thisParam.toSeq ++ _params.flatMap(_.paramSyms).map(p => p -> SymIdx(localScp.allocateName(p)))
   private val _locals = ArrayBuf.empty[Local]
 
   /** Adds a Wasm local into this context.
@@ -402,7 +404,7 @@ end FunctionCtx
   *
   * Returns the result of the `mkBody` function along with the [[FunctionCtx]].
   */
-def genFuncBody[T](params: Seq[Local], thisSym: Opt[InnerSymbol])(mkBody: FunctionCtx ?=> T)(using Raise, State): T -> FunctionCtx =
+def genFuncBody[T](params: Ls[ParamList], thisSym: Opt[InnerSymbol])(mkBody: FunctionCtx ?=> T)(using Raise, State): T -> FunctionCtx =
   val funcCtx = FunctionCtx(params, thisSym)
   val result = mkBody(using funcCtx)
   result -> funcCtx

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -358,6 +358,8 @@ object FunctionCtx:
   *
   * @param _params
   *   The parameters of this function.
+  * @param thisSym
+  *   The implicit `this` parameter symbol if this function is generated from a non-static method, or `N` otherwise.
   */
 class FunctionCtx(_params: Seq[Local], thisSym: Opt[InnerSymbol])(using Raise, State):
 
@@ -386,16 +388,9 @@ class FunctionCtx(_params: Seq[Local], thisSym: Opt[InnerSymbol])(using Raise, S
     _locals += local
     LocalIdx(SymIdx(localScp.lookup_!(local, N)))
 
-  /** Returns `true` if a local or a parameter is already defined in this function context. */
-  def containsLocal(sym: Local): Bool = _params.contains(sym) || _locals.contains(sym)
-
   /** Looks up the given `sym` in this function context, returning its [[LocalIdx]] if it exists. */
   def lookupLocal(sym: Local): Opt[LocalIdx] =
     localScp.lookup(sym).map(idx => LocalIdx(SymIdx(idx)))
-
-  /** Similar to [[lookupLocal]], but throws an exception if `sym` is not in this context. */
-  def lookupLocal_!(sym: Local, loc: Opt[Loc]): LocalIdx =
-    LocalIdx(SymIdx(localScp.lookup_!(sym, loc)))
 
   /** The locals of this function, represented by a tuple of the symbol representing the parameter and its symbolic
     * identifier.

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -403,14 +403,14 @@ class FunctionCtx(_params: Seq[Local], thisSym: Opt[Symbol])(using Raise, State)
   def locals: Seq[Local -> SymIdx] = _locals.map(l => l -> SymIdx(localScp.lookup_!(l, N))).toSeq
 end FunctionCtx
   
-  /** Generates a function body, providing an instance of [[FunctionCtx]] for parameter and locals tracking.
-    *
-    * Returns the result of the `mkBody` function along with the [[FunctionCtx]].
-    */
-  def genFuncBody[T](params: Seq[Local], thisSym: Opt[Symbol] = N)(mkBody: FunctionCtx ?=> T)(using Raise, State): T -> FunctionCtx =
-    val funcCtx = FunctionCtx(params, thisSym)
-    val result = mkBody(using funcCtx)
-    result -> funcCtx
+/** Generates a function body, providing an instance of [[FunctionCtx]] for parameter and locals tracking.
+  *
+  * Returns the result of the `mkBody` function along with the [[FunctionCtx]].
+  */
+def genFuncBody[T](params: Seq[Local], thisSym: Opt[Symbol] = N)(mkBody: FunctionCtx ?=> T)(using Raise, State): T -> FunctionCtx =
+  val funcCtx = FunctionCtx(params, thisSym)
+  val result = mkBody(using funcCtx)
+  result -> funcCtx
 
 object Ctx:
   case class SingletonInfo(

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -8,7 +8,9 @@ import hkmc2.utils.*
 
 import document.*
 import document.Document
-import semantics.{BlockMemberSymbol, Elaborator, InnerSymbol, LabelSymbol, ModuleOrObjectSymbol, ParamList, Symbol, TempSymbol},
+import semantics.{
+  BlockMemberSymbol, Elaborator, InnerSymbol, LabelSymbol, ModuleOrObjectSymbol, ParamList, Symbol, TempSymbol,
+},
   Elaborator.State
 import text.Param as WasmParam
 import Instructions.*
@@ -349,7 +351,6 @@ end TagInfo
 enum WasmIntrinsicType:
   case TupleArray(mutable: Bool)
 
-
 object FunctionCtx:
 
   def funcCtx(using funcCtx: FunctionCtx): FunctionCtx = funcCtx
@@ -404,7 +405,10 @@ end FunctionCtx
   *
   * Returns the result of the `mkBody` function along with the [[FunctionCtx]].
   */
-def genFuncBody[T](params: Ls[ParamList], thisSym: Opt[InnerSymbol])(mkBody: FunctionCtx ?=> T)(using Raise, State): T -> FunctionCtx =
+def genFuncBody[T](
+    params: Ls[ParamList],
+    thisSym: Opt[InnerSymbol],
+)(mkBody: FunctionCtx ?=> T)(using Raise, State): T -> FunctionCtx =
   val funcCtx = FunctionCtx(params, thisSym)
   val result = mkBody(using funcCtx)
   result -> funcCtx

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -349,6 +349,69 @@ end TagInfo
 enum WasmIntrinsicType:
   case TupleArray(mutable: Bool)
 
+
+object FunctionCtx:
+
+  def funcCtx(using funcCtx: FunctionCtx): FunctionCtx = funcCtx
+
+/** Context associated with codegen for a Wasm function.
+  *
+  * @param _params
+  *   The parameters of this function.
+  */
+class FunctionCtx(_params: Seq[Local], thisSym: Opt[Symbol])(using Raise, State):
+
+  /** [[Scope]] for generating WAT identifiers of locals. */
+  private[text] val localScp = Scope.empty(Scope.Cfg.default)
+
+  /** The parameter of this function, represented by a tuple of the symbol representing the parameter and its symbolic
+    * identifier.
+    */
+  val params: Seq[Local -> SymIdx] =
+    val thisParam = thisSym.map: dis =>
+      dis -> SymIdx(localScp.addToBindings(dis, "this", shadow = false))
+    thisParam.toSeq ++ _params.map(p => p -> SymIdx(localScp.allocateName(p)))
+  private val _locals = ArrayBuf.empty[Local]
+
+  /** Adds a Wasm local into this context.
+    *
+    * @param customName
+    *   An optional name for the local variable. If provided, the local will be emitted with the given name instead of
+    *   an auto-generated one.
+    */
+  def addLocal(local: Local, customName: Opt[Str] = N): LocalIdx =
+    customName match
+      case S(name) => localScp.addToBindings(local, name, shadow = false)
+      case N => localScp.allocateName(local)
+    _locals += local
+    LocalIdx(SymIdx(localScp.lookup_!(local, N)))
+
+  /** Returns `true` if a local or a parameter is already defined in this function context. */
+  def containsLocal(sym: Local): Bool = _params.contains(sym) || _locals.contains(sym)
+
+  /** Looks up the given `sym` in this function context, returning its [[LocalIdx]] if it exists. */
+  def lookupLocal(sym: Local): Opt[LocalIdx] =
+    localScp.lookup(sym).map(idx => LocalIdx(SymIdx(idx)))
+
+  /** Similar to [[lookupLocal]], but throws an exception if `sym` is not in this context. */
+  def lookupLocal_!(sym: Local, loc: Opt[Loc]): LocalIdx =
+    LocalIdx(SymIdx(localScp.lookup_!(sym, loc)))
+
+  /** The locals of this function, represented by a tuple of the symbol representing the parameter and its symbolic
+    * identifier.
+    */
+  def locals: Seq[Local -> SymIdx] = _locals.map(l => l -> SymIdx(localScp.lookup_!(l, N))).toSeq
+end FunctionCtx
+  
+  /** Generates a function body, providing an instance of [[FunctionCtx]] for parameter and locals tracking.
+    *
+    * Returns the result of the `mkBody` function along with the [[FunctionCtx]].
+    */
+  def genFuncBody[T](params: Seq[Local], thisSym: Opt[Symbol] = N)(mkBody: FunctionCtx ?=> T)(using Raise, State): T -> FunctionCtx =
+    val funcCtx = FunctionCtx(params, thisSym)
+    val result = mkBody(using funcCtx)
+    result -> funcCtx
+
 object Ctx:
   case class SingletonInfo(
       globalName: Str,
@@ -426,8 +489,6 @@ class Ctx extends ToWat:
   /** [[MutMap]] containing global symbols mapped to their corresponding [[GlobalInfo]] or [[Import]] instance. */
   private val namedGlobals = MutMap.empty[Symbol, GlobalInfo | Import[ExternType.Global]]
 
-  /** Stack of [[ListMap]] from local variable symbols to their symbolic indices within the current function scope. */
-  private var locals = ListMap.empty[Local, SymIdx] :: Nil
   private var startFunc = N: Opt[FuncIdx]
 
   /** Counter for generating object tags. */
@@ -747,25 +808,6 @@ class Ctx extends ToWat:
     getGlobalInfo(globalref).getOrElse:
       lastWords(s"Missing global definition for ${globalref.prettyString}")
 
-  /** Pushes a new local variable scope into this context. */
-  def pushLocal(): Unit = locals = ListMap() :: locals
-
-  /** Pops the top-most level local variable scope into this context. */
-  def popLocal(): Unit = locals = locals.tail
-
-  /** Adds a new local variable into the top-most variable scope. */
-  def addLocal(sym: Local): LocalIdx =
-    val idx = SymIdx(sym.nme)
-    locals = (locals.head + (sym -> idx)) :: locals.tail
-    LocalIdx(idx)
-
-  /** Adds a [[Seq]] of local variables into the top-most variable scope. */
-  def addLocals(syms: Seq[Local]): Seq[LocalIdx] =
-    syms.map(addLocal)
-
-  /** Checks whether the top-most level local variable scope contains the local variable `sym`. */
-  def containsLocal(sym: Local): Bool = locals.head.contains(sym)
-
   /** Adds a new variable into the global variable scope. */
   def addGlobal(sym: Symbol, globalInfo: GlobalInfo): GlobalIdx =
     val id = globalInfo.id
@@ -779,6 +821,9 @@ class Ctx extends ToWat:
 
   /** Checks whether the global variable scope contains the variable `sym`. */
   def containsGlobal(sym: Symbol): Bool = namedGlobals.contains(sym)
+  
+  /** Returns all globals in this context. */
+  def getGlobals: Seq[Symbol] = namedGlobals.keys.toSeq
 
   /** Checks whether singleton metadata has been registered for class symbol `sym`. */
   def containsSingleton(sym: BlockMemberSymbol): Bool = singletonByBms.contains(sym)
@@ -820,16 +865,6 @@ class Ctx extends ToWat:
   /** Configures the module start function. */
   def setStartFunc(funcIdx: FuncIdx): Unit =
     startFunc = S(funcIdx)
-
-  /** Returns a tuple containing the variables in the current `global` and `local` scopes respectively.
-    */
-  def getWasmLocals: Seq[Symbol] -> Opt[Seq[Local]] =
-    namedGlobals.keys.toSeq -> locals.headOption.map(l => l.keys.toSeq)
-
-  /** Returns all local variable scopes and their variables. */
-  def getAllWasmLocals: Ls[Seq[Local]] = locals match
-    case Nil => namedGlobals.keys.toSeq :: Nil
-    case locals => locals.init.map(l => l.keys.toSeq) :+ namedGlobals.keys.toSeq
 
   /** Returns the cached [[FuncIdx]] for the intrinsic named `name`, creating it with `createIntrinsic` if it does not
     * yet exist in this context.

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -608,8 +608,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   private def setupInitLocals(
       clsLikeDefn: ClsLikeDefn,
   )(using Ctx, Raise, Scope, SessionExportCtx): (Expr, FunctionCtx) =
-    val clsParams = clsLikeDefn.paramsOpt.fold(Nil)(_.paramSyms)
-    genFuncBody(clsParams, thisSym = S(clsLikeDefn.isym)):
+    genFuncBody(clsLikeDefn.paramsOpt.toList, thisSym = S(clsLikeDefn.isym)):
       val thisVar = funcCtx.lookupLocal(clsLikeDefn.isym).get
       val preCtorWat = compilePreCtor(clsLikeDefn, thisVar)
       val ctorWat = block(clsLikeDefn.ctor)
@@ -1532,7 +1531,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                       lastWords(s"Expected class ${clsLikeDefn.sym} to have an object tag")
 
                     val initFuncRef = initFuncSym(clsLikeDefn.sym)
-                    val (ctorCode, ctorFnCtx) = genFuncBody(clsLikeDefn.paramsOpt.fold(Nil)(_.paramSyms), thisSym = N):
+                    val (ctorCode, ctorFnCtx) = genFuncBody(clsLikeDefn.paramsOpt.toList, thisSym = N):
                       val thisVar = bindCtorThis(clsLikeDefn.isym)
                       val initCall = call(
                         funcidx = ctx.getFunc_!(initFuncRef),
@@ -2030,7 +2029,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
       // Compile the entry function under a dedicated local scope so that any temp locals introduced
       // during codegen (e.g., via `local.tee`) are declared in the entry function.
-      val (entryFnExpr, entryFnCtx) = genFuncBody(Seq.empty, thisSym = N):
+      val (entryFnExpr, entryFnCtx) = genFuncBody(Nil, thisSym = N):
         val rawEntryFnExpr = block(p.main)
         normalizeEntryExpr(rawEntryFnExpr, p.main.isAbortive)
 
@@ -2132,7 +2131,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       params: ParamList,
       body: Block,
   )(using Ctx, Raise, Scope, SessionExportCtx): (Expr, FunctionCtx) =
-    genFuncBody(params.params.map(_.sym).toSeq, thisSym = N):
+    genFuncBody(params :: Nil, thisSym = N):
       block(body)
 
 end WatBuilder

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -830,7 +830,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                       ts.toLoc,
                   ),
                   extraInfo = S(
-                    s"Block IR: `${l.toString}`\nLocals${(funcCtx.params ++ funcCtx.locals).toString}\nGlobals: ${ctx.getGlobals.toString}",
+                    s"Block IR: `${l.toString}`\nLocals: ${(funcCtx.params ++ funcCtx.locals).toString}\nGlobals: ${ctx.getGlobals.toString}",
                   ),
                 )
           case l =>
@@ -843,11 +843,11 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                 Ls(
                   msg"WatBuilder::getVar for ${
                       l.getClass.getSimpleName
-                    } (symbol not in top-level scope) not implemented yet" ->
+                    } (symbol not in global or local scope) not implemented yet" ->
                     l.toLoc,
                 ),
                 extraInfo = S(
-                  s"Block IR: `${l.toString}`\nLocals${(funcCtx.params ++ funcCtx.locals).toString}\nGlobals: ${ctx.getGlobals.toString}",
+                  s"Block IR: `${l.toString}`\nLocals: ${(funcCtx.params ++ funcCtx.locals).toString}\nGlobals: ${ctx.getGlobals.toString}",
                 ),
               )
   end getVar

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -609,7 +609,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       clsLikeDefn: ClsLikeDefn,
   )(using Ctx, Raise, Scope, SessionExportCtx): (Expr, FunctionCtx) =
     genFuncBody(clsLikeDefn.paramsOpt.toList, thisSym = S(clsLikeDefn.isym)):
-      val thisVar = funcCtx.lookupLocal(clsLikeDefn.isym).get
+      val thisVar = funcCtx.lookupLocal_!(clsLikeDefn.isym, N)
       val preCtorWat = compilePreCtor(clsLikeDefn, thisVar)
       val ctorWat = block(clsLikeDefn.ctor)
       blockInstr(
@@ -890,7 +890,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     case Value.This(sym) =>
       // TODO(Derppening): Add type tracking and refinement for locals, remove the `ref.cast`
       ref.cast(
-        local.get(funcCtx.lookupLocal(sym).get, RefType.anyref),
+        local.get(funcCtx.lookupLocal_!(sym, sym.toLoc), RefType.anyref),
         RefType(
           sym.asBlkMember.fold(baseObjectTypeIdx)(ctx.getType_!(_)),
           nullable = false,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -1673,6 +1673,10 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                         overwriteMethod(sym, PlainParamList(Nil), bod)
                       case FunDefn(_, sym, _, ps :: Nil, bod) =>
                         overwriteMethod(sym, ps, bod)
+                      case methodDefn =>
+                        lastWords(
+                          s"Class method `$methodDefn` with multiple parameter lists should be rejected in predeclaration pass",
+                        )
                     if summon[SessionExportCtx].shouldExport(clsLikeDefn.sym) then
                       summon[SessionExportCtx].emit(SessionClass(
                         sym = clsLikeDefn.sym,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -610,7 +610,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   )(using Ctx, Raise, Scope, SessionExportCtx): (Expr, FunctionCtx) =
     val clsParams = clsLikeDefn.paramsOpt.fold(Nil)(_.paramSyms)
     genFuncBody(clsParams, thisSym = S(clsLikeDefn.isym)):
-      val thisVar = funcCtx.lookupLocal_!(clsLikeDefn.isym, N)
+      val thisVar = funcCtx.lookupLocal(clsLikeDefn.isym).get
       val preCtorWat = compilePreCtor(clsLikeDefn, thisVar)
       val ctorWat = block(clsLikeDefn.ctor)
       blockInstr(
@@ -834,20 +834,20 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                   ),
                 )
           case l =>
-            if funcCtx.containsLocal(l) then
-              local.get(funcCtx.lookupLocal_!(l, l.toLoc), RefType.anyref)
-            else if ctx.containsGlobal(l) then
-              global.get(GlobalIdx(SymIdx(scope.lookup_!(l, l.toLoc))), ctx.getGlobalType_!(l).globalType.valType)
-            else
-              errExpr(
-                Ls(
-                  msg"Cannot find variable `${l.toString}` (${l.getClass.getSimpleName}) in local or global scope." ->
-                    l.toLoc,
-                ),
-                extraInfo = S(
-                  s"Locals: ${(funcCtx.params ++ funcCtx.locals).toString}\nGlobals: ${ctx.getGlobals.toString}",
-                ),
-              )
+            funcCtx.lookupLocal(l) match
+              case S(localIdx) => local.get(localIdx, RefType.anyref)
+              case N if ctx.containsGlobal(l) =>
+                global.get(GlobalIdx(SymIdx(scope.lookup_!(l, l.toLoc))), ctx.getGlobalType_!(l).globalType.valType)
+              case _ =>
+                errExpr(
+                  Ls(
+                    msg"Cannot find variable `${l.toString}` (${l.getClass.getSimpleName}) in local or global scope." ->
+                      l.toLoc,
+                  ),
+                  extraInfo = S(
+                    s"Locals: ${(funcCtx.params ++ funcCtx.locals).toString}\nGlobals: ${ctx.getGlobals.toString}",
+                  ),
+                )
   end getVar
 
   def argument(a: Arg)(using Ctx, FunctionCtx, Raise, Scope, SessionExportCtx): Expr =
@@ -891,7 +891,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     case Value.This(sym) =>
       // TODO(Derppening): Add type tracking and refinement for locals, remove the `ref.cast`
       ref.cast(
-        local.get(funcCtx.lookupLocal_!(sym, sym.toLoc), RefType.anyref),
+        local.get(funcCtx.lookupLocal(sym).get, RefType.anyref),
         RefType(
           sym.asBlkMember.fold(baseObjectTypeIdx)(ctx.getType_!(_)),
           nullable = false,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -810,13 +810,13 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       case N => l match
           case ts: semantics.TermSymbol =>
             errExpr(
-              Ls(msg"WatBuilder::getVar for TermSymbol not implemented yet" -> l.toLoc),
+              Ls(msg"WatBuilder::getVar for TermSymbol not implemented yet" -> ts.toLoc),
               extraInfo = S(ts.toString),
             )
           case ts: semantics.ModuleOrObjectSymbol if ts.asMod.isDefined =>
             errExpr(
               Ls(
-                msg"WatBuilder::getVar for ModuleOrObjectSymbol (`ts.asMod.isDefined`) not implemented yet" -> l.toLoc,
+                msg"WatBuilder::getVar for ModuleOrObjectSymbol (`ts.asMod.isDefined`) not implemented yet" -> ts.toLoc,
               ),
               extraInfo = S(ts.toString),
             )
@@ -826,11 +826,11 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
               case N =>
                 errExpr(
                   Ls(
-                    msg"WatBuilder::getVar for InnerSymbol (symbol not in top-level scope) not implemented yet" ->
+                    msg"WatBuilder::getVar for InnerSymbol `${ts.toString}` (symbol not in top-level scope) not implemented yet" ->
                       ts.toLoc,
                   ),
                   extraInfo = S(
-                    s"Block IR: `${l.toString}`\nLocals: ${(funcCtx.params ++ funcCtx.locals).toString}\nGlobals: ${ctx.getGlobals.toString}",
+                    s"Locals: ${(funcCtx.params ++ funcCtx.locals).toString}\nGlobals: ${ctx.getGlobals.toString}",
                   ),
                 )
           case l =>
@@ -841,13 +841,11 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
             else
               errExpr(
                 Ls(
-                  msg"WatBuilder::getVar for ${
-                      l.getClass.getSimpleName
-                    } (symbol not in global or local scope) not implemented yet" ->
+                  msg"Cannot find variable `${l.toString}` (${l.getClass.getSimpleName}) in local or global scope." ->
                     l.toLoc,
                 ),
                 extraInfo = S(
-                  s"Block IR: `${l.toString}`\nLocals: ${(funcCtx.params ++ funcCtx.locals).toString}\nGlobals: ${ctx.getGlobals.toString}",
+                  s"Locals: ${(funcCtx.params ++ funcCtx.locals).toString}\nGlobals: ${ctx.getGlobals.toString}",
                 ),
               )
   end getVar

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -609,7 +609,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       clsLikeDefn: ClsLikeDefn,
   )(using Ctx, Raise, Scope, SessionExportCtx): (Expr, FunctionCtx) =
     val clsParams = clsLikeDefn.paramsOpt.fold(Nil)(_.paramSyms)
-    genFuncBody(clsParams, S(clsLikeDefn.isym)):
+    genFuncBody(clsParams, thisSym = S(clsLikeDefn.isym)):
       val thisVar = funcCtx.lookupLocal_!(clsLikeDefn.isym, N)
       val preCtorWat = compilePreCtor(clsLikeDefn, thisVar)
       val ctorWat = block(clsLikeDefn.ctor)
@@ -1532,7 +1532,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                       lastWords(s"Expected class ${clsLikeDefn.sym} to have an object tag")
 
                     val initFuncRef = initFuncSym(clsLikeDefn.sym)
-                    val (ctorCode, ctorFnCtx) = genFuncBody(clsLikeDefn.paramsOpt.fold(Nil)(_.paramSyms)):
+                    val (ctorCode, ctorFnCtx) = genFuncBody(clsLikeDefn.paramsOpt.fold(Nil)(_.paramSyms), thisSym = N):
                       val thisVar = bindCtorThis(clsLikeDefn.isym)
                       val initCall = call(
                         funcidx = ctx.getFunc_!(initFuncRef),
@@ -2030,7 +2030,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
       // Compile the entry function under a dedicated local scope so that any temp locals introduced
       // during codegen (e.g., via `local.tee`) are declared in the entry function.
-      val (entryFnExpr, entryFnCtx) = genFuncBody(Seq.empty):
+      val (entryFnExpr, entryFnCtx) = genFuncBody(Seq.empty, thisSym = N):
         val rawEntryFnExpr = block(p.main)
         normalizeEntryExpr(rawEntryFnExpr, p.main.isAbortive)
 
@@ -2132,7 +2132,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       params: ParamList,
       body: Block,
   )(using Ctx, Raise, Scope, SessionExportCtx): (Expr, FunctionCtx) =
-    genFuncBody(params.params.map(_.sym).toSeq):
+    genFuncBody(params.params.map(_.sym).toSeq, thisSym = N):
       block(body)
 
 end WatBuilder

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -40,6 +40,7 @@ object WatBuilder:
 class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   import Ctx.ctx
   import Ctx.{SingletonInfo, binaryOps, unaryOps, wasmIntrinsicArities, wasmIntrinsicNameSet}
+  import FunctionCtx.funcCtx
   import Instructions.{block as blockInstr, *}
   import WatBuilder.ExternIntrinsics
 
@@ -102,7 +103,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     )(N)
 
   /** Registers the synthetic `Unit` singleton. */
-  private def RegisterUnitSingleton()(using Ctx, Raise, Scope, SessionExportCtx): Unit =
+  private def RegisterUnitSingleton()(using Ctx, FunctionCtx, Raise, Scope, SessionExportCtx): Unit =
     val unitDefn = syntheticUnitDefn
     val singletonOwner = unitDefn.isym match
       case mos: ModuleOrObjectSymbol => S(mos)
@@ -114,9 +115,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       predeclareClassInit(unitDefn)
       predeclareClassConstructor(unitDefn)
 
-    ctx.pushLocal()
     returningTerm(Define(unitDefn, End("")))
-    ctx.popLocal()
 
     val typeInfo = ctx.getTypeInfo_!(unitDefn.sym)
     val singletonInfo = ctx.getSingletonInfo(unitDefn.sym).getOrElse:
@@ -597,62 +596,32 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
   /** Allocates a fresh temp local (typed `anyref`) and returns its `LocalIdx`.
     */
-  private def mkTempLocal(base: Str)(using Ctx, Scope, Raise): LocalIdx =
-    val sym = TempSymbol(N, base)
-    val nme = scope.allocateName(sym)
-    ctx.addLocal(sym)
-    LocalIdx(SymIdx(nme))
+  private def mkTempLocal(base: Str)(using Ctx, FunctionCtx, Scope, Raise): LocalIdx =
+    funcCtx.addLocal(TempSymbol(N, base))
 
-  /** Binds constructor self (`thisSym`) to the Wasm local name `this` in the current scope/context.
+  /** Binds constructor self (`thisSym`) to the Wasm local name `this` in the current function context.
     */
-  private def bindCtorThis(thisSym: Local)(using Ctx, Raise, Scope): LocalIdx -> Str =
-    val thisName = "this"
-    scope.lookup(thisSym) match
-      case S(`thisName`) => ()
-      case _ => scope.addToBindings(thisSym, thisName, shadow = true)
-    if !ctx.containsLocal(thisSym) then
-      ctx.addLocal(thisSym)
-    LocalIdx(SymIdx(thisName)) -> thisName
-
-  /** Sets up an allocating constructor wrapper with params and a local `this`. */
-  private def setupCtorWrapperLocals(
-      clsLikeDefn: ClsLikeDefn,
-  )(using Ctx, Raise, Scope, SessionExportCtx): (Seq[Local -> Str], LocalIdx, Seq[Local -> Str]) =
-    ctx.pushLocal()
-    val clsParams = clsLikeDefn.paramsOpt.fold(Nil)(_.paramSyms)
-    val ctorParams = clsParams.map: p =>
-      ctx.addLocal(p)
-      p -> scope.allocateOrGetName(p)
-    val (thisVar, thisVarName) = bindCtorThis(clsLikeDefn.isym)
-    ctx.popLocal()
-    (ctorParams, thisVar, Seq(clsLikeDefn.isym -> thisVarName))
+  private def bindCtorThis(thisSym: Local)(using Ctx, FunctionCtx, Raise): LocalIdx =
+    funcCtx.addLocal(thisSym, S("this"))
 
   /** Compiles a class init body under its own Wasm-local frame with explicit `this`. */
   private def setupInitLocals(
       clsLikeDefn: ClsLikeDefn,
-  )(using Ctx, Raise, Scope, SessionExportCtx): (Seq[Local -> Str], Expr, Seq[Local -> Str]) =
-    ctx.pushLocal()
+  )(using Ctx, Raise, Scope, SessionExportCtx): (Expr, FunctionCtx) =
     val clsParams = clsLikeDefn.paramsOpt.fold(Nil)(_.paramSyms)
-    val initParams = clsParams.map: p =>
-      ctx.addLocal(p)
-      p -> scope.allocateOrGetName(p)
-    val (thisVar, thisVarName) = bindCtorThis(clsLikeDefn.isym)
-    val (preCtorWat, preCtorLocals) = compilePreCtor(clsLikeDefn, thisVar)
-    val (ctorWat, ctorLocals) = block(clsLikeDefn.ctor)
-    val initWat = blockInstr(
-      label = N,
-      children = Seq(
-        preCtorWat,
-        ctorWat,
-        `return`(S(local.get(thisVar, RefType.anyref))),
-      ),
-      resultTypes = Seq(Result(RefType.anyref)),
-    )
-    val initLocals = preCtorLocals ++ ctorLocals.filterNot(preCtorLocals.toSet)
-    val localsWithNames = initLocals.map(l => l -> scope.lookup_!(l, l.toLoc))
-    ctx.popLocal()
-    ((clsLikeDefn.isym -> thisVarName) +: initParams, initWat, localsWithNames)
-  end setupInitLocals
+    genFuncBody(clsParams, S(clsLikeDefn.isym)):
+      val thisVar = funcCtx.lookupLocal_!(clsLikeDefn.isym, N)
+      val preCtorWat = compilePreCtor(clsLikeDefn, thisVar)
+      val ctorWat = block(clsLikeDefn.ctor)
+      blockInstr(
+        label = N,
+        children = Seq(
+          preCtorWat,
+          ctorWat,
+          `return`(S(local.get(thisVar, RefType.anyref))),
+        ),
+        resultTypes = Seq(Result(RefType.anyref)),
+      )
 
   /** Lowers an inherited pre-constructor by preserving its setup code and rewriting the final `super(...)` into
     * `Parent_init(this, ...)`.
@@ -660,7 +629,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   private def compilePreCtor(
       clsLikeDefn: ClsLikeDefn,
       thisVar: LocalIdx,
-  )(using Ctx, Raise, Scope, SessionExportCtx): (Expr, Seq[Local]) =
+  )(using Ctx, FunctionCtx, Raise, Scope, SessionExportCtx): Expr =
     def withRest(block: NonBlockTail, rest: Block): Block = block match
       case Scoped(syms, _) => Scoped(syms, rest)
       case Begin(sub, _) => Begin(sub, rest)
@@ -684,11 +653,11 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       case _ => N
 
     clsLikeDefn.preCtor match
-      case End(_) => (nop, Nil)
+      case End(_) => nop
       case _ =>
         splitSuperTail(clsLikeDefn.preCtor) match
           case S((prefixBlock, args)) =>
-            val (prefixWat, prefixLocals) = block(prefixBlock)
+            val prefixWat = block(prefixBlock)
             resolveParentSym(clsLikeDefn) match
               case S(parentSym) =>
                 val parentInitFunc = initFuncSym(parentSym)
@@ -697,16 +666,13 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                   operands = local.get(thisVar, RefType.anyref) +: args.map(argument),
                   returnTypes = Seq(Result(RefType.anyref)),
                 )
-                (
-                  blockInstr(
-                    label = N,
-                    children = Seq(asStatement(prefixWat), drop(superCall)),
-                    resultTypes = Seq.empty,
-                  ),
-                  prefixLocals,
+                blockInstr(
+                  label = N,
+                  children = Seq(asStatement(prefixWat), drop(superCall)),
+                  resultTypes = Seq.empty,
                 )
               case N =>
-                (nop, Nil)
+                nop
           case N =>
             raise(ErrorReport(
               msg"Wasm preCtor lowering only supports lowered super(...) shapes." ->
@@ -714,13 +680,9 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
               extraInfo = S(clsLikeDefn.preCtor.showAsTree),
               source = Diagnostic.Source.Compilation,
             ))
-            (nop, Nil)
+            nop
     end match
   end compilePreCtor
-
-  /** Returns locals allocated during codegen (e.g., temp locals). */
-  private def getExtraLocals(using Ctx): Seq[Local] =
-    ctx.getWasmLocals._2.getOrElse(Seq.empty)
 
   /** Converts expression result types to WAT result clauses, dropping unreachable types. */
   private def resultClauses(expr: Expr): Seq[Result] =
@@ -731,7 +693,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   private def normalizeEntryExpr(
       expr: Expr,
       isAbortive: Bool,
-  )(using Ctx, Raise, Scope, SessionExportCtx): Expr =
+  )(using Ctx, FunctionCtx, Raise, Scope, SessionExportCtx): Expr =
     if expr.resultTypes.isEmpty && !isAbortive then
       blockInstr(
         label = N,
@@ -756,7 +718,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
   /** Emits a tuple element load that works for both mutable and immutable tuple arrays.
     */
-  private def tupleArrayGet(tupleExpr: Expr, idxBuilder: Expr => Expr)(using Ctx, Raise, Scope): Expr =
+  private def tupleArrayGet(tupleExpr: Expr, idxBuilder: Expr => Expr)(using Ctx, FunctionCtx, Raise, Scope): Expr =
     val elemType = RefType.anyref
     val mutArrayType = tupleArrayType(true)
     val immArrayType = tupleArrayType(false)
@@ -783,7 +745,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       loc: Opt[Loc],
       errCtx: Str,
       errExtra: => Str,
-  )(using Ctx, Raise, Scope, SessionExportCtx): Expr => Expr =
+  )(using Ctx, FunctionCtx, Raise, Scope, SessionExportCtx): Expr => Expr =
     fld match
       case Value.Lit(IntLit(value)) if value.isValidInt =>
         val idx = value.toInt
@@ -842,7 +804,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     raise(ErrorReport(errMsgs, source = Diagnostic.Source.Compilation, extraInfo = extraInfo))
     unreachable
 
-  def getVar(l: Local, loc: Opt[Loc])(using Ctx, Raise, Scope): Expr =
+  def getVar(l: Local, loc: Opt[Loc])(using Ctx, FunctionCtx, Raise, Scope): Expr =
     singletonInfoFor(l) match
       case S(info) => singletonGlobalGet(info)
       case N => l match
@@ -859,20 +821,21 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
               extraInfo = S(ts.toString),
             )
           case ts: semantics.InnerSymbol =>
-            if !ctx.containsLocal(l) then
-              return errExpr(
-                Ls(
-                  msg"WatBuilder::getVar for InnerSymbol (symbol not in top-level scope) not implemented yet" ->
-                    ts.toLoc,
-                ),
-                extraInfo = S(
-                  s"Block IR: `${ts.toString}`\nScope: ${scope.toString}\nWasm Locals: ${ctx.getAllWasmLocals.toString}",
-                ),
-              )
-            local.get(LocalIdx(SymIdx(scope.lookup_!(ts, ts.toLoc))), RefType.anyref)
+            funcCtx.lookupLocal(ts) match
+              case S(localIdx) => local.get(localIdx, RefType.anyref)
+              case N =>
+                errExpr(
+                  Ls(
+                    msg"WatBuilder::getVar for InnerSymbol (symbol not in top-level scope) not implemented yet" ->
+                      ts.toLoc,
+                  ),
+                  extraInfo = S(
+                    s"Block IR: `${l.toString}`\nLocals${(funcCtx.params ++ funcCtx.locals).toString}\nGlobals: ${ctx.getGlobals.toString}",
+                  ),
+                )
           case l =>
-            if ctx.containsLocal(l) then
-              local.get(LocalIdx(SymIdx(scope.lookup_!(l, l.toLoc))), RefType.anyref)
+            if funcCtx.containsLocal(l) then
+              local.get(funcCtx.lookupLocal_!(l, l.toLoc), RefType.anyref)
             else if ctx.containsGlobal(l) then
               global.get(GlobalIdx(SymIdx(scope.lookup_!(l, l.toLoc))), ctx.getGlobalType_!(l).globalType.valType)
             else
@@ -884,12 +847,12 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                     l.toLoc,
                 ),
                 extraInfo = S(
-                  s"Block IR: `${l.toString}`\nScope: ${scope.toString}\nWasm Locals: ${ctx.getAllWasmLocals.toString}",
+                  s"Block IR: `${l.toString}`\nLocals${(funcCtx.params ++ funcCtx.locals).toString}\nGlobals: ${ctx.getGlobals.toString}",
                 ),
               )
   end getVar
 
-  def argument(a: Arg)(using Ctx, Raise, Scope, SessionExportCtx): Expr =
+  def argument(a: Arg)(using Ctx, FunctionCtx, Raise, Scope, SessionExportCtx): Expr =
     if a.spread.nonEmpty then
       errExpr(
         Ls(msg"WatBackend::argument for spread expression not implemented yet" -> a.value.toLoc),
@@ -897,10 +860,10 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       )
     else result(a.value)
 
-  def operand(a: Arg)(using Ctx, Raise, Scope, SessionExportCtx): Expr =
+  def operand(a: Arg)(using Ctx, FunctionCtx, Raise, Scope, SessionExportCtx): Expr =
     if a.spread.nonEmpty then die else subexpression(a.value)
 
-  def subexpression(r: codegen.Result)(using Ctx, Raise, Scope, SessionExportCtx): Expr = r match
+  def subexpression(r: codegen.Result)(using Ctx, FunctionCtx, Raise, Scope, SessionExportCtx): Expr = r match
     case r: Lambda =>
       errExpr(
         Ls(msg"WatBuilder::subexpression for Lambda not implemented yet" -> r.toLoc),
@@ -934,11 +897,11 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     ))
   end fieldSelect
 
-  def result(r: codegen.Result)(using Ctx, Raise, Scope, SessionExportCtx): Expr = r match
+  def result(r: codegen.Result)(using Ctx, FunctionCtx, Raise, Scope, SessionExportCtx): Expr = r match
     case Value.This(sym) =>
       // TODO(Derppening): Add type tracking and refinement for locals, remove the `ref.cast`
       ref.cast(
-        local.get(LocalIdx(SymIdx(scope.lookup_!(sym, sym.toLoc))), RefType.anyref),
+        local.get(funcCtx.lookupLocal_!(sym, sym.toLoc), RefType.anyref),
         RefType(
           sym.asBlkMember.fold(baseObjectTypeIdx)(ctx.getType_!(_)),
           nullable = false,
@@ -1323,7 +1286,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
         case S(_) => drop(expr)
         case N => expr
 
-  def returningTerm(t: Block)(using Ctx, Raise, Scope, SessionExportCtx): Expr =
+  def returningTerm(t: Block)(using Ctx, FunctionCtx, Raise, Scope, SessionExportCtx): Expr =
     t match
       case _: HandleBlock =>
         errExpr(Ls(msg"This code requires effect handler instrumentation but was compiled without it." -> N))
@@ -1490,14 +1453,14 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                     val result = pss.foldRight(bod):
                       case (ps, block) =>
                         Return(Lambda(ps, block), false)
-                    val (params, bodyWat, locals) = setupFunction(ps, result)
+                    val (bodyWat, fnCtx) = setupFunction(ps, result)
                     if sym.nameIsMeaningful then
                       val funcTy = ctx.addType(
                         sym = N,
                         TypeInfo(
                           id = SymIdx(scope.allocateName(TempSymbol(N, sym.nme))),
                           FunctionType(
-                            params = params.map(_._1),
+                            params = fnCtx.params.map(p => WasmParam(p._2.id, RefType.anyref)),
                             results = Seq.fill(bodyWat.resultTypes.length)(Result(RefType.anyref)),
                           ),
                           objectTag = N,
@@ -1508,9 +1471,9 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                         FuncInfo(
                           sym,
                           typeUse = TypeUse(funcTy),
-                          params = ps.params.zip(params.map(_._2)).map((p, nme) => p.sym -> nme),
+                          params = ps.params.zip(fnCtx.params.map(_._2.id)).map((p, nme) => p.sym -> nme),
                           nResults = bodyWat.resultTypes.length,
-                          locals = locals,
+                          locals = fnCtx.locals.map((local, idx) => local -> idx.id),
                           body = bodyWat,
                         )
                       ctx.addFunc(S(defn.sym), funcInfo)
@@ -1559,49 +1522,51 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
                     val ctorAuxParams = clsLikeDefn.auxParams.map: ps =>
                       ps.params.map: p =>
-                        p -> scope.allocateName(p.sym)
+                        p -> errUnimplExpr("auxParams.nonEmpty")
 
                     // Use the symbolic type reference (e.g. `$Foo`) in emitted WAT for readability.
                     // Numeric indices are only needed for `$tag` values.
                     val typeref = ctx.getType_!(clsLikeDefn.sym)
                     val typeinfo = ctx.getTypeInfo_!(typeref)
 
-                    val (ctorParams, thisVar, ctorLocals) = setupCtorWrapperLocals(clsLikeDefn)
-                    val (initParams, initWat, initLocals) = setupInitLocals(clsLikeDefn)
+                    val (initWat, initFnCtx) = setupInitLocals(clsLikeDefn)
 
                     // * If there are no ctor params, pop one param list off the aux params
-                    val (newCtorAuxParams, initialCtorParams) = clsLikeDefn.paramsOpt match
+                    val newCtorAuxParams = clsLikeDefn.paramsOpt match
                       case None => ctorAuxParams match
-                          case head :: next => (next, head)
-                          case Nil => (ctorAuxParams, Nil)
-                      case Some(_) => (ctorAuxParams, ctorParams)
+                          case head :: next => next
+                          case Nil => ctorAuxParams
+                      case Some(_) => ctorAuxParams
 
                     val tagValue = typeinfo.objectTag.getOrElse:
                       lastWords(s"Expected class ${clsLikeDefn.sym} to have an object tag")
 
                     val initFuncRef = initFuncSym(clsLikeDefn.sym)
-                    val initCall = call(
-                      funcidx = ctx.getFunc_!(initFuncRef),
-                      operands = local.get(thisVar, RefType.anyref) +: ctorParams.map((_, nme) => getLocalAnyref(nme)),
-                      returnTypes = Seq(Result(RefType.anyref)),
-                    )
-                    val ctorCode = blockInstr(
-                      label = N,
-                      Seq(
-                        local.set(thisVar, struct.new_default(typeref)),
-                        struct.set(
-                          FieldIdx(SymIdx(typeinfo.compType.asInstanceOf[StructType].fields(0)._2.id)),
-                          ref.cast(
-                            local.get(thisVar, RefType.anyref),
-                            RefType(typeref, nullable = false),
+                    val (ctorCode, ctorFnCtx) = genFuncBody(clsLikeDefn.paramsOpt.fold(Nil)(_.paramSyms)):
+                      val thisVar = bindCtorThis(clsLikeDefn.isym)
+                      val initCall = call(
+                        funcidx = ctx.getFunc_!(initFuncRef),
+                        operands = local.get(thisVar, RefType.anyref) +:
+                          funcCtx.params.map((_, nme) => getLocalAnyref(nme.id)),
+                        returnTypes = Seq(Result(RefType.anyref)),
+                      )
+                      blockInstr(
+                        label = N,
+                        Seq(
+                          local.set(thisVar, struct.new_default(typeref)),
+                          struct.set(
+                            FieldIdx(SymIdx(typeinfo.compType.asInstanceOf[StructType].fields(0)._2.id)),
+                            ref.cast(
+                              local.get(thisVar, RefType.anyref),
+                              RefType(typeref, nullable = false),
+                            ),
+                            i32.const(tagValue),
                           ),
-                          i32.const(tagValue),
+                          drop(initCall),
+                          `return`(S(local.get(thisVar, RefType(typeref, nullable = false)))),
                         ),
-                        drop(initCall),
-                        `return`(S(local.get(thisVar, RefType(typeref, nullable = false)))),
-                      ),
-                      resultTypes = Seq(Result(RefType.anyref)),
-                    )
+                        resultTypes = Seq(Result(RefType.anyref)),
+                      )
 
                     val ctorAux =
                       if newCtorAuxParams.isEmpty then ctorCode
@@ -1613,9 +1578,9 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                       FuncInfo(
                         id = predeclaredInit.id,
                         typeUse = predeclaredInit.typeUse,
-                        params = initParams,
+                        params = initFnCtx.params.map((local, idx) => local -> idx.id),
                         resultTypes = initWat.resultTypes.map(ty => Result(ty.asValType_!)),
-                        locals = initLocals,
+                        locals = initFnCtx.locals.map((local, idx) => local -> idx.id),
                         body = initWat,
                         exportName = predeclaredInit.exportName,
                       ),
@@ -1627,9 +1592,9 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                       FuncInfo(
                         id = predeclaredCtor.id,
                         typeUse = predeclaredCtor.typeUse,
-                        params = ctorParams,
+                        params = ctorFnCtx.params.map((local, idx) => local -> idx.id),
                         resultTypes = ctorAux.resultTypes.map(ty => Result(ty.asValType_!)),
-                        locals = ctorLocals,
+                        locals = ctorFnCtx.locals.map((local, idx) => local -> idx.id),
                         body = ctorAux,
                         exportName = predeclaredCtor.exportName,
                       ),
@@ -1651,7 +1616,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                           exportName = clsLikeDefn.sym.nme,
                           funcType = FunctionType(
                             SignatureType(
-                              params = ctorParams.map(p => WasmParam(p._2, RefType.anyref)),
+                              params = ctorFnCtx.params.map(p => WasmParam(p._2.id, RefType.anyref)),
                               results = Seq(Result(RefType.anyref)),
                             ),
                           ),
@@ -2075,11 +2040,9 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
       // Compile the entry function under a dedicated local scope so that any temp locals introduced
       // during codegen (e.g., via `local.tee`) are declared in the entry function.
-      ctx.pushLocal()
-      val (rawEntryFnExpr, entryFnLocals) =
-        block(p.main)
-      val entryFnExpr = normalizeEntryExpr(rawEntryFnExpr, p.main.isAbortive)
-      val entryExtraLocals = getExtraLocals.filterNot(entryFnLocals.toSet.contains)
+      val (entryFnExpr, entryFnCtx) = genFuncBody(Seq.empty):
+        val rawEntryFnExpr = block(p.main)
+        normalizeEntryExpr(rawEntryFnExpr, p.main.isAbortive)
 
       val entrySym = BlockMemberSymbol("entry", Nil)
       val entryNme = scope.allocateName(entrySym)
@@ -2097,13 +2060,11 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
         typeUse = TypeUse(entryFnTy),
         params = Seq.empty,
         resultTypes = Seq(Result(RefType.anyref)),
-        // TODO(Derppening): Should we place top-level scope variables in the global section?
-        locals = (entryFnLocals ++ entryExtraLocals).map(l => l -> scope.allocateOrGetName(l)),
+        locals = entryFnCtx.locals.map((local, idx) => local -> idx.id),
         body = entryFnExpr,
         exportName = S(entryNme),
       )
 
-      ctx.popLocal()
       if stringLits.nonEmpty then
         stringLits.foreach: (s, lit) =>
           if lit.byteLen > 0 then
@@ -2149,15 +2110,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       compiledModule(entryNme)
   end program
 
-  /** Captures the local symbols introduced while compiling `expr`.
-    */
-  private def withLocalDelta(expr: => Expr)(using Ctx): (Expr, Seq[Local]) =
-    val before = ctx.getWasmLocals._2.getOrElse(Seq.empty).toSet
-    val compiled = expr
-    val after = ctx.getWasmLocals._2.getOrElse(Seq.empty)
-    (compiled, after.filterNot(before.contains))
-
-  def blockPreamble(ss: Iterable[Symbol])(using Ctx, Raise, Scope): Seq[Local] =
+  def blockPreamble(ss: Iterable[Symbol])(using Ctx, FunctionCtx, Raise, Scope): Seq[Local] =
     val vars = ss.filter(sym =>
       scope.lookup(sym).toSeq.isEmpty
         && !ctx.containsGlobal(sym)
@@ -2170,44 +2123,26 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
         scope.allocateName(l)
         l
       .toSeq
-    ctx.addLocals(vars)
+    vars.foreach: v =>
+      funcCtx.addLocal(v)
     vars
 
   def nonNestedScoped(
       blk: Block,
-  )(k: Block => Expr)(using Ctx, Raise, Scope, SessionExportCtx): Expr = blk match
+  )(k: Block => Expr)(using Ctx, FunctionCtx, Raise, Scope, SessionExportCtx): Expr = blk match
     case Scoped(syms, body) =>
       blockPreamble(syms.view.filter(body.freeVars))
       k(body)
     case _ => k(blk)
 
-  def block(t: Block)(using Ctx, Raise, Scope, SessionExportCtx): (Expr, Seq[Local]) =
-    withLocalDelta:
-      nonNestedScoped(t)(returningTerm)
+  def block(t: Block)(using Ctx, FunctionCtx, Raise, Scope, SessionExportCtx): Expr =
+    nonNestedScoped(t)(returningTerm)
 
   def setupFunction(
       params: ParamList,
       body: Block,
-  )(using Ctx, Raise, Scope, SessionExportCtx): (Seq[WasmParam -> Str], Expr, Seq[(Local, Str)]) =
-    // Add a frame for `ctx.locals`
-    ctx.pushLocal()
-
-    val result = scope.nest givenIn:
-      val wasmParams = params.params.map: p =>
-        val paramNme = scope.allocateName(p.sym)
-        val param = WasmParam(paramNme, RefType.anyref)
-        ctx.addLocal(p.sym)
-        param -> paramNme
-      val (wasmBody, locals) = block(body)
-      val paramSyms: Set[Local] = params.params.map(p => (p.sym: Local)).toSet
-      val extraLocals = getExtraLocals.filterNot((locals.toSet ++ paramSyms).contains)
-      val localsWithNames = (locals ++ extraLocals).map(l => l -> scope.allocateOrGetName(l))
-      (wasmParams.toSeq, wasmBody, localsWithNames)
-
-    // Restore `ctx.locals`
-    ctx.popLocal()
-
-    result
-  end setupFunction
+  )(using Ctx, Raise, Scope, SessionExportCtx): (Expr, FunctionCtx) =
+    genFuncBody(params.params.map(_.sym).toSeq):
+      block(body)
 
 end WatBuilder


### PR DESCRIPTION
This PR introduces `FunctionCtx` used to track state that is only valid within a function. `FunctionCtx` currently only stores the set of local variables present in the function, but will also store control flow labels in a future PR.

As a result, all functions in `Ctx` related to local creation and tracking are removed.

Partially supersedes #454.