### PR TITLE
Handler IR changes

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -44,8 +44,6 @@ sealed abstract class Block extends Product:
       // * Note: the body may be abortive for the reason of breaking to the rest!
       // * So we can't really use the result of bod.isAbortive even when `loop` is false.
       rst.isAbortive
-    case Suspend(_, _, _, rst) => rst.isAbortive
-    case HandleSuspension(_, _, _, rst) => rst.isAbortive
     case Scoped(_, body) => body.isAbortive
   
   // * Note: it seems most historical uses of `definedVars` would be better removed,
@@ -66,8 +64,6 @@ sealed abstract class Block extends Product:
     case Define(defn, rst) =>
       val rest = rst.definedVars
       if defn.isOwned then rest else rest + defn.sym
-    case Suspend(lhs, _, _, rst) => rst.definedVars + lhs
-    case HandleSuspension(lhs, _, _, rst) => rst.definedVars + lhs
     case TryBlock(sub, fin, rst) => sub.definedVars ++ fin.definedVars ++ rst.definedVars
     case Label(lbl, _, bod, rst) => bod.definedVars ++ rst.definedVars
     case Scoped(syms, body) => body.definedVars ++ syms
@@ -83,8 +79,6 @@ sealed abstract class Block extends Product:
     case Define(_, rst) => 1 + rst.size
     case TryBlock(sub, fin, rst) => 1 + sub.size + fin.size + rst.size
     case Label(_, _, bod, rst) => 1 + bod.size + rst.size
-    case Suspend(_, _, _, rst) => 1 + rst.size
-    case HandleSuspension(_, _, _, rst) => 1 + rst.size
     case Scoped(_, body) => body.size
   
   
@@ -113,8 +107,6 @@ sealed abstract class Block extends Product:
     case AssignField(lhs, nme, rhs, rest) => lhs.freeVars ++ rhs.freeVars ++ rest.freeVars
     case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => lhs.freeVars ++ fld.freeVars ++ rhs.freeVars ++ rest.freeVars
     case Define(defn, rest) => defn.freeVars ++ rest.freeVars
-    case Suspend(lhs, tag, handlerFun, rest) => Set.single(lhs) ++ tag.freeVars ++ handlerFun.freeVars ++ rest.freeVars
-    case HandleSuspension(lhs, tag, bodyFun, rest) => Set.single(lhs) ++ tag.freeVars ++ bodyFun.freeVars ++ rest.freeVars
     case Scoped(syms, body) => body.freeVars
     case End(msg) => Set.empty
     case Unreachable(msg) => Set.empty
@@ -135,8 +127,6 @@ sealed abstract class Block extends Product:
     case AssignField(lhs, nme, rhs, rest) => lhs.freeVarsLLIR ++ rhs.freeVarsLLIR ++ rest.freeVarsLLIR
     case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => lhs.freeVarsLLIR ++ fld.freeVarsLLIR ++ rhs.freeVarsLLIR ++ rest.freeVarsLLIR
     case Define(defn, rest) => defn.freeVarsLLIR ++ (rest.freeVarsLLIR - defn.sym)
-    case Suspend(lhs, tag, handlerFun, rest) => tag.freeVarsLLIR ++ handlerFun.freeVarsLLIR ++ rest.freeVarsLLIR
-    case HandleSuspension(lhs, tag, bodyFun, rest) => tag.freeVarsLLIR ++ bodyFun.freeVarsLLIR ++ rest.freeVarsLLIR
     case Scoped(syms, body) => body.freeVarsLLIR
     case End(msg) => Set.empty
     case Unreachable(msg) => Set.empty
@@ -149,8 +139,6 @@ sealed abstract class Block extends Product:
     case AssignField(_, _, rhs, rest) => rhs.subBlocks ::: rest :: Nil
     case AssignDynField(_, _, _, rhs, rest) => rhs.subBlocks ::: rest :: Nil
     case Define(d, rest) => d.subBlocks ::: rest :: Nil
-    case Suspend(_, tag, handlerFun, rest) => tag.subBlocks ::: handlerFun.subBlocks ::: rest :: Nil
-    case HandleSuspension(_, tag, bodyFun, rest) => tag.subBlocks ::: bodyFun.subBlocks ::: rest :: Nil
     case Label(_, _, body, rest) => body :: rest :: Nil
     case Scoped(_, body) => body :: Nil
     
@@ -278,18 +266,6 @@ sealed abstract class Block extends Product:
       then this
       else Define(newDefn, newRest)
     
-    case Suspend(lhs, tag, handlerFun, rest) =>
-      val newRest = rest.flatten(k)
-      if newRest is rest
-      then this
-      else Suspend(lhs, tag, handlerFun, newRest)
-    
-    case HandleSuspension(lhs, tag, bodyFun, rest) =>
-      val newRest = rest.flatten(k)
-      if newRest is rest
-      then this
-      else HandleSuspension(lhs, tag, bodyFun, newRest)
-
     case Scoped(syms, body) =>
       val newBody = body.flatten(k)
       if newBody is body
@@ -454,34 +430,14 @@ object Begin:
       case _ => new Begin(sub, rest)
 
 
-// `shift0` operator
-case class Suspend(
-    lhs: Local,
-    tag: Path,
-    handlerFun: Path,
-    rest: Block
-) extends Block with ProductWithTail with NonBlockTail
-
-
-// `reset0` operator
-case class HandleSuspension(
-    lhs: Local,
-    tag: Path,
-    bodyFun: Path,
-    rest: Block,
-) extends Block with ProductWithTail with NonBlockTail
-
-object Suspend:
-  def apply(lhs: Local, tag: Path, handlerFun: Path, rest: Block): Block = rest match
-    case Scoped(syms, body) => Scoped(syms, Suspend(lhs, tag, handlerFun, body))
-    case _ => new Suspend(lhs, tag, handlerFun, rest)
-
-object HandleSuspension:
-  def apply(lhs: Local, tag: Path, bodyFun: Path, rest: Block): Block = rest match
-    case Scoped(syms, b) => Scoped(syms, HandleSuspension(lhs, tag, bodyFun, b))
-    case _ => new HandleSuspension(lhs, tag, bodyFun, rest)
-
 object HandleBlock:
+
+  def suspend(tag: Path, handlerFun: Path)(using Elaborator.Ctx): Result =
+    Call(Value.Ref(Elaborator.ctx.builtins.js.suspend, N), tag.asArg :: handlerFun.asArg :: Nil)(true, true, false)
+
+  def handleSuspension(tag: Path, bodyFun: Path)(using Elaborator.Ctx): Result =
+    Call(Value.Ref(Elaborator.ctx.builtins.js.handle_suspension, N), tag.asArg :: bodyFun.asArg :: Nil)(true, true, false)
+  
   private def create(
       lhs: Local,
       res: Local,
@@ -491,7 +447,7 @@ object HandleBlock:
       handlers: Ls[Handler],
       body: Block,
       rest: Block
-  )(using State) =
+  )(using Elaborator.State, Elaborator.Ctx) =
     val sym = new BlockMemberSymbol("handleBlock$", Nil, false)
 
     val bodyDefn = FunDefn.withFreshSymbol(N, sym, PlainParamList(Nil) :: Nil, body)(false, N, Visibility.Public)
@@ -509,7 +465,7 @@ object HandleBlock:
         handler.params,
         Scoped(Set(sym, rSym), Define(
           fDef,
-          Suspend(rSym, cls.asPath, Value.Ref(sym, S(fDef.dSym)), Return(Value.Ref(rSym), false)))))(false, N, Visibility.Public)
+          Return(suspend(cls.asPath, Value.Ref(sym, S(fDef.dSym))), false))))(false, N, Visibility.Public)
 
     val clsDefn = ClsLikeDefn(
       N, // no owner
@@ -531,7 +487,8 @@ object HandleBlock:
       .define(clsDefn)
       .assign(lhs, Instantiate(mut = true, Value.Ref(clsDefn.sym, S(cls)), Nil))
       .define(bodyDefn)
-      .rest(HandleSuspension(res, lhs.asPath, Value.Ref(sym, S(bodyDefn.dSym)), rest))
+      .assign(res, handleSuspension(lhs.asPath, Value.Ref(bodyDefn.sym, S(bodyDefn.dSym))))
+      .rest(rest)
   
   def apply(
       lhs: Local,
@@ -542,7 +499,7 @@ object HandleBlock:
       handlers: Ls[Handler],
       body: Block,
       rest: Block
-    )(using State) =
+    )(using Elaborator.State, Elaborator.Ctx) =
   rest match
   case Scoped(syms, rest) =>
     Scoped(syms, create(lhs, res, par, args, cls, handlers, body, rest))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -433,10 +433,10 @@ object Begin:
 object HandleBlock:
 
   def suspend(tag: Path, handlerFun: Path)(using Elaborator.Ctx): Result =
-    Call(Value.Ref(Elaborator.ctx.builtins.js.suspend, N), tag.asArg :: handlerFun.asArg :: Nil)(true, true, false)
+    Call(Value.Ref(Elaborator.ctx.builtins.runtime.suspend, N), tag.asArg :: handlerFun.asArg :: Nil)(true, true, false)
 
   def handleSuspension(tag: Path, bodyFun: Path)(using Elaborator.Ctx): Result =
-    Call(Value.Ref(Elaborator.ctx.builtins.js.handle_suspension, N), tag.asArg :: bodyFun.asArg :: Nil)(true, true, false)
+    Call(Value.Ref(Elaborator.ctx.builtins.runtime.handle_suspension, N), tag.asArg :: bodyFun.asArg :: Nil)(true, true, false)
   
   private def create(
       lhs: Local,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -44,8 +44,8 @@ sealed abstract class Block extends Product:
       // * Note: the body may be abortive for the reason of breaking to the rest!
       // * So we can't really use the result of bod.isAbortive even when `loop` is false.
       rst.isAbortive
-    case Suspend(_, _, rst) => rst.isAbortive
-    case HandleSuspension(_, _, rst) => rst.isAbortive
+    case Suspend(_, _, _, rst) => rst.isAbortive
+    case HandleSuspension(_, _, _, rst) => rst.isAbortive
     case Scoped(_, body) => body.isAbortive
   
   // * Note: it seems most historical uses of `definedVars` would be better removed,
@@ -66,8 +66,8 @@ sealed abstract class Block extends Product:
     case Define(defn, rst) =>
       val rest = rst.definedVars
       if defn.isOwned then rest else rest + defn.sym
-    case Suspend(_, _, rst) => rst.definedVars
-    case HandleSuspension(_, _, rst) => rst.definedVars
+    case Suspend(lhs, _, _, rst) => rst.definedVars + lhs
+    case HandleSuspension(lhs, _, _, rst) => rst.definedVars + lhs
     case TryBlock(sub, fin, rst) => sub.definedVars ++ fin.definedVars ++ rst.definedVars
     case Label(lbl, _, bod, rst) => bod.definedVars ++ rst.definedVars
     case Scoped(syms, body) => body.definedVars ++ syms
@@ -83,8 +83,8 @@ sealed abstract class Block extends Product:
     case Define(_, rst) => 1 + rst.size
     case TryBlock(sub, fin, rst) => 1 + sub.size + fin.size + rst.size
     case Label(_, _, bod, rst) => 1 + bod.size + rst.size
-    case Suspend(_, _, rst) => 1 + rst.size
-    case HandleSuspension(_, _, rst) => 1 + rst.size
+    case Suspend(_, _, _, rst) => 1 + rst.size
+    case HandleSuspension(_, _, _, rst) => 1 + rst.size
     case Scoped(_, body) => body.size
   
   
@@ -113,8 +113,8 @@ sealed abstract class Block extends Product:
     case AssignField(lhs, nme, rhs, rest) => lhs.freeVars ++ rhs.freeVars ++ rest.freeVars
     case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => lhs.freeVars ++ fld.freeVars ++ rhs.freeVars ++ rest.freeVars
     case Define(defn, rest) => defn.freeVars ++ rest.freeVars
-    case Suspend(tag, handlerFun, rest) => tag.freeVars ++ handlerFun.freeVars ++ rest.freeVars
-    case HandleSuspension(tag, body, rest) => tag.freeVars ++ body.freeVars ++ rest.freeVars
+    case Suspend(lhs, tag, handlerFun, rest) => Set.single(lhs) ++ tag.freeVars ++ handlerFun.freeVars ++ rest.freeVars
+    case HandleSuspension(lhs, tag, bodyFun, rest) => Set.single(lhs) ++ tag.freeVars ++ bodyFun.freeVars ++ rest.freeVars
     case Scoped(syms, body) => body.freeVars
     case End(msg) => Set.empty
     case Unreachable(msg) => Set.empty
@@ -135,8 +135,8 @@ sealed abstract class Block extends Product:
     case AssignField(lhs, nme, rhs, rest) => lhs.freeVarsLLIR ++ rhs.freeVarsLLIR ++ rest.freeVarsLLIR
     case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => lhs.freeVarsLLIR ++ fld.freeVarsLLIR ++ rhs.freeVarsLLIR ++ rest.freeVarsLLIR
     case Define(defn, rest) => defn.freeVarsLLIR ++ (rest.freeVarsLLIR - defn.sym)
-    case Suspend(tag, handlerFun, rest) => tag.freeVarsLLIR ++ handlerFun.freeVarsLLIR ++ rest.freeVarsLLIR
-    case HandleSuspension(tag, bodyFun, rest) => tag.freeVarsLLIR ++ bodyFun.freeVarsLLIR ++ rest.freeVarsLLIR
+    case Suspend(lhs, tag, handlerFun, rest) => tag.freeVarsLLIR ++ handlerFun.freeVarsLLIR ++ rest.freeVarsLLIR
+    case HandleSuspension(lhs, tag, bodyFun, rest) => tag.freeVarsLLIR ++ bodyFun.freeVarsLLIR ++ rest.freeVarsLLIR
     case Scoped(syms, body) => body.freeVarsLLIR
     case End(msg) => Set.empty
     case Unreachable(msg) => Set.empty
@@ -149,8 +149,8 @@ sealed abstract class Block extends Product:
     case AssignField(_, _, rhs, rest) => rhs.subBlocks ::: rest :: Nil
     case AssignDynField(_, _, _, rhs, rest) => rhs.subBlocks ::: rest :: Nil
     case Define(d, rest) => d.subBlocks ::: rest :: Nil
-    case Suspend(_, handlerFun, rest) => handlerFun.subBlocks ::: rest :: Nil
-    case HandleSuspension(_, bodyFun, rest) => bodyFun.subBlocks ::: rest :: Nil
+    case Suspend(_, tag, handlerFun, rest) => tag.subBlocks ::: handlerFun.subBlocks ::: rest :: Nil
+    case HandleSuspension(_, tag, bodyFun, rest) => tag.subBlocks ::: bodyFun.subBlocks ::: rest :: Nil
     case Label(_, _, body, rest) => body :: rest :: Nil
     case Scoped(_, body) => body :: Nil
     
@@ -278,17 +278,17 @@ sealed abstract class Block extends Product:
       then this
       else Define(newDefn, newRest)
     
-    case Suspend(tag, handlerFun, rest) =>
+    case Suspend(lhs, tag, handlerFun, rest) =>
       val newRest = rest.flatten(k)
       if newRest is rest
       then this
-      else Suspend(tag, handlerFun, newRest)
+      else Suspend(lhs, tag, handlerFun, newRest)
     
-    case HandleSuspension(tag, bodyFun, rest) =>
+    case HandleSuspension(lhs, tag, bodyFun, rest) =>
       val newRest = rest.flatten(k)
       if newRest is rest
       then this
-      else HandleSuspension(tag, bodyFun, newRest)
+      else HandleSuspension(lhs, tag, bodyFun, newRest)
 
     case Scoped(syms, body) =>
       val newBody = body.flatten(k)
@@ -456,6 +456,7 @@ object Begin:
 
 // `shift0` operator
 case class Suspend(
+    lhs: Local,
     tag: Path,
     handlerFun: Path,
     rest: Block
@@ -464,20 +465,21 @@ case class Suspend(
 
 // `reset0` operator
 case class HandleSuspension(
+    lhs: Local,
     tag: Path,
     bodyFun: Path,
     rest: Block,
 ) extends Block with ProductWithTail with NonBlockTail
 
 object Suspend:
-  def apply(tag: Path, handlerFun: Path, rest: Block): Block = rest match
-    case Scoped(syms, body) => Scoped(syms, Suspend(tag, handlerFun, body))
-    case _ => new Suspend(tag, handlerFun, rest)
+  def apply(lhs: Local, tag: Path, handlerFun: Path, rest: Block): Block = rest match
+    case Scoped(syms, body) => Scoped(syms, Suspend(lhs, tag, handlerFun, body))
+    case _ => new Suspend(lhs, tag, handlerFun, rest)
 
 object HandleSuspension:
-  def apply(tag: Path, bodyFun: Path, rest: Block): Block = rest match
-    case Scoped(syms, b) => Scoped(syms, HandleSuspension(tag, bodyFun, b))
-    case _ => new HandleSuspension(tag, bodyFun, rest)
+  def apply(lhs: Local, tag: Path, bodyFun: Path, rest: Block): Block = rest match
+    case Scoped(syms, b) => Scoped(syms, HandleSuspension(lhs, tag, bodyFun, b))
+    case _ => new HandleSuspension(lhs, tag, bodyFun, rest)
 
 object HandleBlock:
   private def create(
@@ -500,13 +502,14 @@ object HandleBlock:
         N, sym, PlainParamList(Param(FldFlags.empty, handler.resumeSym, N, Modulefulness.none) :: Nil) :: Nil,
         handler.body
         )(false, N, Visibility.Public)
+      val rSym = TempSymbol(N, "suspendRes")
       FunDefn.withFreshSymbol(
         S(cls),
         handler.sym,
         handler.params,
-        Scoped(Set(sym), Define(
+        Scoped(Set(sym, rSym), Define(
           fDef,
-          Suspend(cls.asPath, Value.Ref(sym, S(fDef.dSym)), Return(Value.Lit(Tree.UnitLit(true)), false)))))(false, N, Visibility.Public)
+          Suspend(rSym, cls.asPath, Value.Ref(sym, S(fDef.dSym)), Return(Value.Ref(rSym), false)))))(false, N, Visibility.Public)
 
     val clsDefn = ClsLikeDefn(
       N, // no owner
@@ -523,18 +526,12 @@ object HandleBlock:
       N,
     )(N)
 
-    val sym2 = new BlockMemberSymbol("handleBlock$$", Nil, false)
-
-    val bodyDefn2 = FunDefn.withFreshSymbol(N, sym2, PlainParamList(Nil) :: Nil,
-      Assign(res, Call(Value.Ref(sym, S(bodyDefn.dSym)), Nil)(true, true, false), Return(Value.Lit(Tree.UnitLit(false)), false)))(false, N, Visibility.Public)
-
     blockBuilder
-      .scopedVars(Set(clsDefn.sym, sym, sym2))
+      .scopedVars(Set(clsDefn.sym, sym))
       .define(clsDefn)
       .assign(lhs, Instantiate(mut = true, Value.Ref(clsDefn.sym, S(cls)), Nil))
       .define(bodyDefn)
-      .define(bodyDefn2)
-      .rest(HandleSuspension(lhs.asPath, Value.Ref(sym2, S(bodyDefn2.dSym)), rest))
+      .rest(HandleSuspension(res, lhs.asPath, Value.Ref(sym, S(bodyDefn.dSym)), rest))
   
   def apply(
       lhs: Local,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -44,7 +44,8 @@ sealed abstract class Block extends Product:
       // * Note: the body may be abortive for the reason of breaking to the rest!
       // * So we can't really use the result of bod.isAbortive even when `loop` is false.
       rst.isAbortive
-    case HandleBlock(_, _, _, _, _, handlers, body, rst) => rst.isAbortive
+    case Suspend(_, _, rst) => rst.isAbortive
+    case HandleSuspension(_, _, rst) => rst.isAbortive
     case Scoped(_, body) => body.isAbortive
   
   // * Note: it seems most historical uses of `definedVars` would be better removed,
@@ -65,8 +66,8 @@ sealed abstract class Block extends Product:
     case Define(defn, rst) =>
       val rest = rst.definedVars
       if defn.isOwned then rest else rest + defn.sym
-    // Note that the handler's LHS and body are not part of the current block, so we do not consider them here.
-    case HandleBlock(lhs, res, par, args, cls, hdr, bod, rst) => rst.definedVars + res
+    case Suspend(_, _, rst) => rst.definedVars
+    case HandleSuspension(_, _, rst) => rst.definedVars
     case TryBlock(sub, fin, rst) => sub.definedVars ++ fin.definedVars ++ rst.definedVars
     case Label(lbl, _, bod, rst) => bod.definedVars ++ rst.definedVars
     case Scoped(syms, body) => body.definedVars ++ syms
@@ -82,8 +83,8 @@ sealed abstract class Block extends Product:
     case Define(_, rst) => 1 + rst.size
     case TryBlock(sub, fin, rst) => 1 + sub.size + fin.size + rst.size
     case Label(_, _, bod, rst) => 1 + bod.size + rst.size
-    case HandleBlock(lhs, res, par, args, cls, handlers, bdy, rst) =>
-      1 + handlers.map(_.body.size).sum + bdy.size + rst.size
+    case Suspend(_, _, rst) => 1 + rst.size
+    case HandleSuspension(_, _, rst) => 1 + rst.size
     case Scoped(_, body) => body.size
   
   
@@ -112,8 +113,8 @@ sealed abstract class Block extends Product:
     case AssignField(lhs, nme, rhs, rest) => lhs.freeVars ++ rhs.freeVars ++ rest.freeVars
     case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => lhs.freeVars ++ fld.freeVars ++ rhs.freeVars ++ rest.freeVars
     case Define(defn, rest) => defn.freeVars ++ rest.freeVars
-    case HandleBlock(lhs, res, par, args, cls, hdr, bod, rst) =>
-      (bod.freeVars - lhs) ++ rst.freeVars ++ hdr.flatMap(_.freeVars)
+    case Suspend(tag, handlerFun, rest) => tag.freeVars ++ handlerFun.freeVars ++ rest.freeVars
+    case HandleSuspension(tag, body, rest) => tag.freeVars ++ body.freeVars ++ rest.freeVars
     case Scoped(syms, body) => body.freeVars
     case End(msg) => Set.empty
     case Unreachable(msg) => Set.empty
@@ -134,8 +135,8 @@ sealed abstract class Block extends Product:
     case AssignField(lhs, nme, rhs, rest) => lhs.freeVarsLLIR ++ rhs.freeVarsLLIR ++ rest.freeVarsLLIR
     case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => lhs.freeVarsLLIR ++ fld.freeVarsLLIR ++ rhs.freeVarsLLIR ++ rest.freeVarsLLIR
     case Define(defn, rest) => defn.freeVarsLLIR ++ (rest.freeVarsLLIR - defn.sym)
-    case HandleBlock(lhs, res, par, args, cls, hdr, bod, rst) =>
-      (bod.freeVarsLLIR - lhs) ++ rst.freeVarsLLIR ++ hdr.flatMap(_.freeVarsLLIR)
+    case Suspend(tag, handlerFun, rest) => tag.freeVarsLLIR ++ handlerFun.freeVarsLLIR ++ rest.freeVarsLLIR
+    case HandleSuspension(tag, bodyFun, rest) => tag.freeVarsLLIR ++ bodyFun.freeVarsLLIR ++ rest.freeVarsLLIR
     case Scoped(syms, body) => body.freeVarsLLIR
     case End(msg) => Set.empty
     case Unreachable(msg) => Set.empty
@@ -148,7 +149,8 @@ sealed abstract class Block extends Product:
     case AssignField(_, _, rhs, rest) => rhs.subBlocks ::: rest :: Nil
     case AssignDynField(_, _, _, rhs, rest) => rhs.subBlocks ::: rest :: Nil
     case Define(d, rest) => d.subBlocks ::: rest :: Nil
-    case HandleBlock(_, _, par, args, _, handlers, body, rest) => par.subBlocks ++ args.flatMap(_.subBlocks) ++ handlers.map(_.body) :+ body :+ rest
+    case Suspend(_, handlerFun, rest) => handlerFun.subBlocks ::: rest :: Nil
+    case HandleSuspension(_, bodyFun, rest) => bodyFun.subBlocks ::: rest :: Nil
     case Label(_, _, body, rest) => body :: rest :: Nil
     case Scoped(_, body) => body :: Nil
     
@@ -276,7 +278,17 @@ sealed abstract class Block extends Product:
       then this
       else Define(newDefn, newRest)
     
-    case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) => ???
+    case Suspend(tag, handlerFun, rest) =>
+      val newRest = rest.flatten(k)
+      if newRest is rest
+      then this
+      else Suspend(tag, handlerFun, newRest)
+    
+    case HandleSuspension(tag, bodyFun, rest) =>
+      val newRest = rest.flatten(k)
+      if newRest is rest
+      then this
+      else HandleSuspension(tag, bodyFun, newRest)
 
     case Scoped(syms, body) =>
       val newBody = body.flatten(k)
@@ -453,19 +465,8 @@ case class Suspend(
 // `reset0` operator
 case class HandleSuspension(
     tag: Path,
-    body: Block,
+    bodyFun: Path,
     rest: Block,
-) extends Block with ProductWithTail with NonBlockTail
-
-case class HandleBlock(
-    lhs: Local,
-    res: Local,
-    par: Path,
-    args: Ls[Path],
-    cls: ClassSymbol,
-    handlers: Ls[Handler],
-    body: Block,
-    rest: Block
 ) extends Block with ProductWithTail with NonBlockTail
 
 object Suspend:
@@ -474,9 +475,9 @@ object Suspend:
     case _ => new Suspend(tag, handlerFun, rest)
 
 object HandleSuspension:
-  def apply(tag: Path, body: Block, rest: Block): Block = rest match
-    case Scoped(syms, b) => Scoped(syms, HandleSuspension(tag, body, b))
-    case _ => new HandleSuspension(tag, body, rest)
+  def apply(tag: Path, bodyFun: Path, rest: Block): Block = rest match
+    case Scoped(syms, b) => Scoped(syms, HandleSuspension(tag, bodyFun, b))
+    case _ => new HandleSuspension(tag, bodyFun, rest)
 
 object HandleBlock:
   private def create(
@@ -522,12 +523,18 @@ object HandleBlock:
       N,
     )(N)
 
+    val sym2 = new BlockMemberSymbol("handleBlock$$", Nil, false)
+
+    val bodyDefn2 = FunDefn.withFreshSymbol(N, sym2, PlainParamList(Nil) :: Nil,
+      Assign(res, Call(Value.Ref(sym, S(bodyDefn.dSym)), Nil)(true, true, false), Return(Value.Lit(Tree.UnitLit(false)), false)))(false, N, Visibility.Public)
+
     blockBuilder
       .scopedVars(Set(clsDefn.sym, sym))
       .define(clsDefn)
       .assign(lhs, Instantiate(mut = true, Value.Ref(clsDefn.sym, S(cls)), Nil))
       .define(bodyDefn)
-      .rest(HandleSuspension(lhs.asPath, Assign(res, Call(Value.Ref(sym, S(bodyDefn.dSym)), Nil)(true, true, false), End()), rest))
+      .define(bodyDefn2)
+      .rest(HandleSuspension(lhs.asPath, Value.Ref(sym2, S(bodyDefn2.dSym)), rest))
   
   def apply(
       lhs: Local,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -529,7 +529,7 @@ object HandleBlock:
       Assign(res, Call(Value.Ref(sym, S(bodyDefn.dSym)), Nil)(true, true, false), Return(Value.Lit(Tree.UnitLit(false)), false)))(false, N, Visibility.Public)
 
     blockBuilder
-      .scopedVars(Set(clsDefn.sym, sym))
+      .scopedVars(Set(clsDefn.sym, sym, sym2))
       .define(clsDefn)
       .assign(lhs, Instantiate(mut = true, Value.Ref(clsDefn.sym, S(cls)), Nil))
       .define(bodyDefn)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -276,15 +276,7 @@ sealed abstract class Block extends Product:
       then this
       else Define(newDefn, newRest)
     
-    case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) =>
-      val newHandlers = handlers.mapConserve: h =>
-        val newBody = h.body.flattened
-        if newBody is h.body then h else h.copy(body = newBody)
-      val newBody = body.flattened
-      val newRest = rest.flatten(k)
-      if (newHandlers is handlers) && (newBody is body) && (newRest is rest)
-      then this
-      else HandleBlock(lhs, res, par, args, cls, newHandlers, newBody, newRest)
+    case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) => ???
 
     case Scoped(syms, body) =>
       val newBody = body.flatten(k)
@@ -450,6 +442,21 @@ object Begin:
       case _ => new Begin(sub, rest)
 
 
+// `shift0` operator
+case class Suspend(
+    tag: Path,
+    handlerFun: Path,
+    rest: Block
+) extends Block with ProductWithTail with NonBlockTail
+
+
+// `reset0` operator
+case class HandleSuspension(
+    tag: Path,
+    body: Block,
+    rest: Block,
+) extends Block with ProductWithTail with NonBlockTail
+
 case class HandleBlock(
     lhs: Local,
     res: Local,
@@ -461,7 +468,67 @@ case class HandleBlock(
     rest: Block
 ) extends Block with ProductWithTail with NonBlockTail
 
+object Suspend:
+  def apply(tag: Path, handlerFun: Path, rest: Block): Block = rest match
+    case Scoped(syms, body) => Scoped(syms, Suspend(tag, handlerFun, body))
+    case _ => new Suspend(tag, handlerFun, rest)
+
+object HandleSuspension:
+  def apply(tag: Path, body: Block, rest: Block): Block = rest match
+    case Scoped(syms, b) => Scoped(syms, HandleSuspension(tag, body, b))
+    case _ => new HandleSuspension(tag, body, rest)
+
 object HandleBlock:
+  private def create(
+      lhs: Local,
+      res: Local,
+      par: Path,
+      args: Ls[Path],
+      cls: ClassSymbol,
+      handlers: Ls[Handler],
+      body: Block,
+      rest: Block
+  )(using State) =
+    val sym = new BlockMemberSymbol("handleBlock$", Nil, false)
+
+    val bodyDefn = FunDefn.withFreshSymbol(N, sym, PlainParamList(Nil) :: Nil, body)(false, N, Visibility.Public)
+    
+    val handlerMtds = handlers.map: handler =>
+      val sym = BlockMemberSymbol(cls.nme + handler.sym.nme, Nil, true)
+      val fDef = FunDefn.withFreshSymbol(
+        N, sym, PlainParamList(Param(FldFlags.empty, handler.resumeSym, N, Modulefulness.none) :: Nil) :: Nil,
+        handler.body
+        )(false, N, Visibility.Public)
+      FunDefn.withFreshSymbol(
+        S(cls),
+        handler.sym,
+        handler.params,
+        Scoped(Set(sym), Define(
+          fDef,
+          Suspend(cls.asPath, Value.Ref(sym, S(fDef.dSym)), Return(Value.Lit(Tree.UnitLit(true)), false)))))(false, N, Visibility.Public)
+
+    val clsDefn = ClsLikeDefn(
+      N, // no owner
+      cls,
+      BlockMemberSymbol(cls.id.name, Nil),
+      N,
+      syntax.Cls,
+      N, Nil,
+      S(par), handlerMtds, Nil, Nil,
+      // Apparently, the lifter is not happy with any assignment in the preCtor...
+      Return(Call(Value.Ref(State.builtinOpsMap("super")), args.map(_.asArg))(true, true, false), true),
+      End(),
+      N,
+      N,
+    )(N)
+
+    blockBuilder
+      .scopedVars(Set(clsDefn.sym, sym))
+      .define(clsDefn)
+      .assign(lhs, Instantiate(mut = true, Value.Ref(clsDefn.sym, S(cls)), Nil))
+      .define(bodyDefn)
+      .rest(HandleSuspension(lhs.asPath, Assign(res, Call(Value.Ref(sym, S(bodyDefn.dSym)), Nil)(true, true, false), End()), rest))
+  
   def apply(
       lhs: Local,
       res: Local,
@@ -471,11 +538,11 @@ object HandleBlock:
       handlers: Ls[Handler],
       body: Block,
       rest: Block
-    ) =
+    )(using State) =
   rest match
   case Scoped(syms, rest) =>
-    Scoped(syms, new HandleBlock(lhs, res, par, args, cls, handlers, body, rest))
-  case _ => new HandleBlock(lhs, res, par, args, cls, handlers, body, rest)
+    Scoped(syms, create(lhs, res, par, args, cls, handlers, body, rest))
+  case _ => create(lhs, res, par, args, cls, handlers, body, rest)
 
 
 sealed abstract class Defn:

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -136,8 +136,6 @@ class BlockSimplifier(symbolsToPreserve: Set[Local])(using DebugPrinter, State, 
         case _: Throw | Return(_, false) | _: Unreachable | _: Continue | _: Break => true
         case Return(_, true) => false
         case _: End => false
-        case Suspend(_, _, _, rest) => rest.analyze
-        case HandleSuspension(_, _, _, rest) => rest.analyze
         
     end AbortiveAnalysis
     

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -136,8 +136,8 @@ class BlockSimplifier(symbolsToPreserve: Set[Local])(using DebugPrinter, State, 
         case _: Throw | Return(_, false) | _: Unreachable | _: Continue | _: Break => true
         case Return(_, true) => false
         case _: End => false
-        case Suspend(_, _, rest) => rest.analyze
-        case HandleSuspension(_, _, rest) => rest.analyze
+        case Suspend(_, _, _, rest) => rest.analyze
+        case HandleSuspension(_, _, _, rest) => rest.analyze
         
     end AbortiveAnalysis
     

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -136,8 +136,8 @@ class BlockSimplifier(symbolsToPreserve: Set[Local])(using DebugPrinter, State, 
         case _: Throw | Return(_, false) | _: Unreachable | _: Continue | _: Break => true
         case Return(_, true) => false
         case _: End => false
-        case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) =>
-          body.analyze || rest.analyze
+        case Suspend(_, _, rest) => rest.analyze
+        case HandleSuspension(_, _, rest) => rest.analyze
         
     end AbortiveAnalysis
     

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
@@ -95,20 +95,6 @@ class BlockTransformer(subst: SymbolSubst):
       applyDefn(defn): defn2 =>
         val rst2 = applySubBlock(rst)
         if (defn2 is defn) && (rst2 is rst) then b else Define(defn2, rst2)
-    case Suspend(l, tag, handlerFun, rst) =>
-      applyPath(tag): tag2 =>
-        applyPath(handlerFun): handlerFun2 =>
-          val l2 = applyLocal(l)
-          val rst2 = applySubBlock(rst)
-          if (l2 is l) && (tag2 is tag) && (handlerFun2 is handlerFun) && (rst2 is rst)
-            then b else Suspend(l2, tag2, handlerFun2, rst2)
-    case HandleSuspension(l, tag, bodyFun, rst) =>
-      applyPath(tag): tag2 =>
-        applyPath(bodyFun): bodyFun2 =>
-          val l2 = applyLocal(l)
-          val rst2 = applySubBlock(rst)
-          if (l2 is l) && (tag2 is tag) && (bodyFun2 is bodyFun) && (rst2 is rst)
-            then b else HandleSuspension(l2, tag2, bodyFun2, rst2)
     case AssignDynField(lhs, fld, arrayIdx, rhs, rest) =>
       applyResult(rhs): rhs2 =>
         applyPath(lhs): lhs2 =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
@@ -95,18 +95,18 @@ class BlockTransformer(subst: SymbolSubst):
       applyDefn(defn): defn2 =>
         val rst2 = applySubBlock(rst)
         if (defn2 is defn) && (rst2 is rst) then b else Define(defn2, rst2)
-    case HandleBlock(l, res, par, args, cls, hdr, bod, rst) =>
-      val l2 = applyLocal(l)
-      val res2 = applyLocal(res)
-      applyPath(par): par2 =>
-        applyListOf(args, applyPath(_)(_)): args2 =>
-          val cls2 = cls.subst
-          val hdr2 = hdr.mapConserve(applyHandler)
-          val bod2 = applySubBlock(bod)
+    case Suspend(tag, handlerFun, rst) =>
+      applyPath(tag): tag2 =>
+        applyPath(handlerFun): handlerFun2 =>
           val rst2 = applySubBlock(rst)
-          if (l2 is l) && (res2 is res) && (par2 is par) && (args2 is args) &&
-              (cls2 is cls) && (hdr2 is hdr) && (bod2 is bod) && (rst2 is rst)
-            then b else HandleBlock(l2, res2, par2, args2, cls2, hdr2, bod2, rst2)
+          if (tag2 is tag) && (handlerFun2 is handlerFun) && (rst2 is rst)
+            then b else Suspend(tag2, handlerFun2, rst2)
+    case HandleSuspension(tag, bodyFun, rst) =>
+      applyPath(tag): tag2 =>
+        applyPath(bodyFun): bodyFun2 =>
+          val rst2 = applySubBlock(rst)
+          if (tag2 is tag) && (bodyFun2 is bodyFun) && (rst2 is rst)
+            then b else HandleSuspension(tag2, bodyFun2, rst2)
     case AssignDynField(lhs, fld, arrayIdx, rhs, rest) =>
       applyResult(rhs): rhs2 =>
         applyPath(lhs): lhs2 =>
@@ -318,20 +318,6 @@ class BlockTransformerShallow(subst: SymbolSubst) extends BlockTransformer(subst
     case _: ValDefn => super.applyDefn(defn)(k)
   
   override def applyHandler(hdr: Handler): Handler = hdr
-  
-  override def applyBlock(b: Block): Block = b match
-    case HandleBlock(l, res, par, args, cls, hdr, bod, rst) =>
-      val l2 = applyLocal(l)
-      val res2 = applyLocal(res)
-      applyPath(par): par2 =>
-        applyListOf(args, applyPath(_)(_)): args2 =>
-          val cls2 = cls.subst
-          val hdr2 = hdr.mapConserve(applyHandler)
-          val rst2 = applySubBlock(rst)
-          if (l2 is l) && (res2 is res) && (par2 is par) && (args2 is args) &&
-              (cls2 is cls) && (hdr2 is hdr) && (rst2 is rst)
-            then b else HandleBlock(l2, res2, par2, args2, cls2, hdr2, bod, rst2)
-    case _ => super.applyBlock(b)
 
 // Does not traverse into sub-blocks or definitions. The purpose of this is is to only rewrite a block's data, i.e. 
 // paths, values, cases, etc. within a block. Can be used in tandem with `BlockTransformer` or `BlockTransformerShallow` 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
@@ -95,18 +95,20 @@ class BlockTransformer(subst: SymbolSubst):
       applyDefn(defn): defn2 =>
         val rst2 = applySubBlock(rst)
         if (defn2 is defn) && (rst2 is rst) then b else Define(defn2, rst2)
-    case Suspend(tag, handlerFun, rst) =>
+    case Suspend(l, tag, handlerFun, rst) =>
       applyPath(tag): tag2 =>
         applyPath(handlerFun): handlerFun2 =>
+          val l2 = applyLocal(l)
           val rst2 = applySubBlock(rst)
-          if (tag2 is tag) && (handlerFun2 is handlerFun) && (rst2 is rst)
-            then b else Suspend(tag2, handlerFun2, rst2)
-    case HandleSuspension(tag, bodyFun, rst) =>
+          if (l2 is l) && (tag2 is tag) && (handlerFun2 is handlerFun) && (rst2 is rst)
+            then b else Suspend(l2, tag2, handlerFun2, rst2)
+    case HandleSuspension(l, tag, bodyFun, rst) =>
       applyPath(tag): tag2 =>
         applyPath(bodyFun): bodyFun2 =>
+          val l2 = applyLocal(l)
           val rst2 = applySubBlock(rst)
-          if (tag2 is tag) && (bodyFun2 is bodyFun) && (rst2 is rst)
-            then b else HandleSuspension(tag2, bodyFun2, rst2)
+          if (l2 is l) && (tag2 is tag) && (bodyFun2 is bodyFun) && (rst2 is rst)
+            then b else HandleSuspension(l2, tag2, bodyFun2, rst2)
     case AssignDynField(lhs, fld, arrayIdx, rhs, rest) =>
       applyResult(rhs): rhs2 =>
         applyPath(lhs): lhs2 =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTraverser.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTraverser.scala
@@ -47,10 +47,6 @@ class BlockTraverser:
     case b @ AssignField(l, n, r, rst) =>
       applyPath(l); applyResult(r); applySubBlock(rst); b.symbol.foreach(_.traverse)
     case Define(defn, rst) => applyDefn(defn); applySubBlock(rst)
-    case Suspend(lhs, tag, handlerFun, rst) =>
-      applyLocal(lhs); applyPath(tag); applyPath(handlerFun); applySubBlock(rst)
-    case HandleSuspension(lhs, tag, bodyFun, rst) =>
-      applyLocal(lhs); applyPath(tag); applyPath(bodyFun); applySubBlock(rst)
     case AssignDynField(lhs, fld, arrayIdx, rhs, rest) =>
       applyPath(lhs)
       applyResult(rhs)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTraverser.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTraverser.scala
@@ -47,14 +47,10 @@ class BlockTraverser:
     case b @ AssignField(l, n, r, rst) =>
       applyPath(l); applyResult(r); applySubBlock(rst); b.symbol.foreach(_.traverse)
     case Define(defn, rst) => applyDefn(defn); applySubBlock(rst)
-    case HandleBlock(l, res, par, args, cls, hdr, bod, rst) =>
-      applyLocal(l)
-      applyLocal(res)
-      applyPath(par)
-      args.foreach(applyPath)
-      hdr.foreach(applyHandler)
-      applySubBlock(bod)
-      applySubBlock(rst)
+    case Suspend(tag, handlerFun, rst) =>
+      applyPath(tag); applyPath(handlerFun); applySubBlock(rst)
+    case HandleSuspension(tag, bodyFun, rst) =>
+      applyPath(tag); applyPath(bodyFun); applySubBlock(rst)
     case AssignDynField(lhs, fld, arrayIdx, rhs, rest) =>
       applyPath(lhs)
       applyResult(rhs)
@@ -160,17 +156,6 @@ class BlockTraverserShallow extends BlockTraverser:
     case _: ValDefn => super.applyDefn(defn)
   
   override def applyHandler(hdr: Handler): Unit = ()
-  
-  override def applyBlock(b: Block): Unit = b match
-    case HandleBlock(l, res, par, args, cls, hdr, bod, rst) =>
-      applyLocal(l)
-      applyLocal(res)
-      applyPath(par)
-      args.foreach(applyPath)
-      cls.traverse
-      hdr.foreach(applyHandler)
-      applySubBlock(rst)
-    case _ => super.applyBlock(b)
 
 class BlockDataTraverser extends BlockTraverserShallow:
   override def applySubBlock(b: Block): Unit = ()

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTraverser.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTraverser.scala
@@ -47,10 +47,10 @@ class BlockTraverser:
     case b @ AssignField(l, n, r, rst) =>
       applyPath(l); applyResult(r); applySubBlock(rst); b.symbol.foreach(_.traverse)
     case Define(defn, rst) => applyDefn(defn); applySubBlock(rst)
-    case Suspend(tag, handlerFun, rst) =>
-      applyPath(tag); applyPath(handlerFun); applySubBlock(rst)
-    case HandleSuspension(tag, bodyFun, rst) =>
-      applyPath(tag); applyPath(bodyFun); applySubBlock(rst)
+    case Suspend(lhs, tag, handlerFun, rst) =>
+      applyLocal(lhs); applyPath(tag); applyPath(handlerFun); applySubBlock(rst)
+    case HandleSuspension(lhs, tag, bodyFun, rst) =>
+      applyLocal(lhs); applyPath(tag); applyPath(bodyFun); applySubBlock(rst)
     case AssignDynField(lhs, fld, arrayIdx, rhs, rest) =>
       applyPath(lhs)
       applyResult(rhs)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -327,7 +327,6 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
           source = Diagnostic.Source.Compilation))
       case Throw(_) => blk
       case Scoped(_, body) => go(body) // PreHandlerLowering
-      case _: Suspend | _: HandleSuspension => lastWords("unexpected handleBlock") // already translated at this point
 
     val initId = allocId()
     // Note: initial part will only be resumed if stack safety is on.
@@ -556,22 +555,14 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, bod2)(fun.forceTailRec, fun.configOverride, fun.visibility)
       (debugInfoSym, debugInfo, fun2)
 
-    // transform innner function/class and Suspend/HandleSuspend to the JS runtime primitives.
+    // transform inner function/class and Suspend/HandleSuspend to the JS runtime primitives.
     val preTransform = new BlockTransformer(SymbolSubst.Id):
-      override def applyBlock(b: Block): Block = b match
-        // This is the common case
-        case Suspend(lhs, tag, handlerFun, Return(Value.Ref(lhs2, N), false)) if lhs is lhs2 =>
-          Return(Call(paths.mkEffectPath, tag.asArg :: handlerFun.asArg :: Nil)(true, true, false), false)
-        // To handle possible transformed block, we need to handle the general case
-        case Suspend(lhs, tag, handlerFun, rest) =>
-          Assign(lhs,
-            Call(paths.mkEffectPath, tag.asArg :: handlerFun.asArg :: Nil)(true, true, false),
-            applyBlock(rest))
-        case HandleSuspension(lhs, tag, bodyFun, rest) =>
-          Assign(lhs,
-            Call(paths.enterHandleBlockPath, tag.asArg :: bodyFun.asArg :: Nil)(true, true, false),
-            applyBlock(rest))
-        case _ => super.applyBlock(b)
+      override def applyResult(r: Result)(k: Result => Block): Block = r match
+        case Call(Value.Ref(sym, _), args) if sym is Elaborator.ctx.builtins.js.suspend =>
+          k(Call(paths.mkEffectPath, args)(true, true, false))
+        case Call(Value.Ref(sym, _), args) if sym is Elaborator.ctx.builtins.js.handle_suspension =>
+          k(Call(paths.enterHandleBlockPath, args)(true, true, false))
+        case _ => super.applyResult(r)(k)
       override def applyDefn(defn: Defn)(k: Defn => Block): Block = defn match
         case fun: FunDefn =>
           if !h.allowDefn then

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -555,7 +555,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, bod2)(fun.forceTailRec, fun.configOverride, fun.visibility)
       (debugInfoSym, debugInfo, fun2)
 
-    // transform inner function/class and Suspend/HandleSuspend to the JS runtime primitives.
+    // transform inner function/class and effect handler intrinsics to the JS runtime functions.
     val preTransform = new BlockTransformer(SymbolSubst.Id):
       override def applyResult(r: Result)(k: Result => Block): Block = r match
         case Call(Value.Ref(sym, _), args) if sym is Elaborator.ctx.builtins.js.suspend =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -558,9 +558,9 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
     // transform inner function/class and effect handler intrinsics to the JS runtime functions.
     val preTransform = new BlockTransformer(SymbolSubst.Id):
       override def applyResult(r: Result)(k: Result => Block): Block = r match
-        case Call(Value.Ref(sym, _), args) if sym is Elaborator.ctx.builtins.js.suspend =>
+        case Call(Value.Ref(sym, _), args) if sym is Elaborator.ctx.builtins.runtime.suspend =>
           k(Call(paths.mkEffectPath, args)(true, true, false))
-        case Call(Value.Ref(sym, _), args) if sym is Elaborator.ctx.builtins.js.handle_suspension =>
+        case Call(Value.Ref(sym, _), args) if sym is Elaborator.ctx.builtins.runtime.handle_suspension =>
           k(Call(paths.enterHandleBlockPath, args)(true, true, false))
         case _ => super.applyResult(r)(k)
       override def applyDefn(defn: Defn)(k: Defn => Block): Block = defn match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -555,7 +555,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, bod2)(fun.forceTailRec, fun.configOverride, fun.visibility)
       (debugInfoSym, debugInfo, fun2)
 
-    // transform inner function/class and effect handler intrinsics to the JS runtime functions.
+    // transform inner function/class and effect handler intrinsics to the runtime functions.
     val preTransform = new BlockTransformer(SymbolSubst.Id):
       override def applyResult(r: Result)(k: Result => Block): Block = r match
         case Call(Value.Ref(sym, _), args) if sym is Elaborator.ctx.builtins.runtime.suspend =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -528,9 +528,9 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
 
   /**
    * The actual translation:
-   * 1. rewrite handler blocks in terms of classes and functions
+   * 1. rewrite handler blocks in terms of classes and functions (directly during Lowering)
    * 2. class lifter
-   * 3. state machine transformation of all functions
+   * 3. state machine transformation of all functions (HandlerLowering, this class)
    */
 
   private def translateBlock(blk: Block, h: HandlerCtx, scopedVars: collection.Set[Local]): Block =
@@ -556,7 +556,22 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, bod2)(fun.forceTailRec, fun.configOverride, fun.visibility)
       (debugInfoSym, debugInfo, fun2)
 
-    val subblockTransform = new BlockTransformer(SymbolSubst.Id):
+    // transform innner function/class and Suspend/HandleSuspend to the JS runtime primitives.
+    val preTransform = new BlockTransformer(SymbolSubst.Id):
+      override def applyBlock(b: Block): Block = b match
+        // This is the common case
+        // case Suspend(tag, handlerFun, Return(Value.Lit(Tree.UnitLit(true)), false)) =>
+        //   Return(Call(paths.mkEffectPath, tag.asArg :: handlerFun.asArg :: Nil)(true, true, false), false)
+        // To handle possible transformed block, we need to handle the general case
+        case Suspend(tag, handlerFun, rest) =>
+          Assign(State.noSymbol,
+            Call(paths.mkEffectPath, tag.asArg :: handlerFun.asArg :: Nil)(true, true, false),
+            applyBlock(rest))
+        case HandleSuspension(tag, bodyFun, rest) =>
+          Assign(State.noSymbol,
+            Call(paths.enterHandleBlockPath, tag.asArg :: bodyFun.asArg :: Nil)(true, true, false),
+            applyBlock(rest))
+        case _ => super.applyBlock(b)
       override def applyDefn(defn: Defn)(k: Defn => Block): Block = defn match
         case fun: FunDefn =>
           if !h.allowDefn then
@@ -594,7 +609,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
               Assign(elem._1, Tuple(false, elem._2), blk))
           else k(c2)
         case _ => super.applyDefn(defn)(k)
-    val b = subblockTransform.applyBlock(blk)
+    val b = preTransform.applyBlock(blk)
     if h.inCtor then
       return translateIllegalEffectCtx(b, Call(paths.illegalEffectPath, Value.Lit(Tree.StrLit("in a constructor")).asArg :: Nil)(true, true, false))
     if h.inTopLevel then

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -327,7 +327,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
           source = Diagnostic.Source.Compilation))
       case Throw(_) => blk
       case Scoped(_, body) => go(body) // PreHandlerLowering
-      case _: HandleBlock => lastWords("unexpected handleBlock") // already translated at this point
+      case _: Suspend | _: HandleSuspension => lastWords("unexpected handleBlock") // already translated at this point
 
     val initId = allocId()
     // Note: initial part will only be resumed if stack safety is on.
@@ -741,63 +741,6 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
           Scoped(Set(l), effectCheck(l, r, k(Value.Ref(l))))
         case _ => super.applyResult(r)(k)
     topLevelTransform.applyBlock(b)
-  
-  // Handle block is rewritten into:
-  // 1. Instantiation of the handler
-  // 2. An effectful call to enterHandleBlock
-  private def translateHandleBlockShallow(h: HandleBlock): Block =
-    val sym = new BlockMemberSymbol("handleBlock$", Nil, false)
-
-    val bodyDefn = FunDefn.withFreshSymbol(N, sym, PlainParamList(Nil) :: Nil, h.body)(false, N, Visibility.Public)
-    
-    val handlerMtds = h.handlers.map: handler =>
-      val sym = BlockMemberSymbol(h.cls.nme + handler.sym.nme, Nil, true)
-      val fDef = FunDefn.withFreshSymbol(
-        N, sym, PlainParamList(Param(FldFlags.empty, handler.resumeSym, N, Modulefulness.none) :: Nil) :: Nil,
-        handler.body
-        )(false, N, Visibility.Public)
-      FunDefn.withFreshSymbol(
-        S(h.cls),
-        handler.sym,
-        handler.params,
-        Scoped(Set(sym), Define(
-          fDef,
-          Return(PureCall(paths.mkEffectPath, h.cls.asPath :: Value.Ref(sym, S(fDef.dSym)) :: Nil), false))))(false, N, Visibility.Public)
-
-    val clsDefn = ClsLikeDefn(
-      N, // no owner
-      h.cls,
-      BlockMemberSymbol(h.cls.id.name, Nil),
-      N,
-      syntax.Cls,
-      N, Nil,
-      S(h.par), handlerMtds, Nil, Nil,
-      // Apparently, the lifter is not happy with any assignment in the preCtor...
-      Return(Call(Value.Ref(State.builtinOpsMap("super")), h.args.map(_.asArg))(true, true, false), true),
-      End(),
-      N,
-      N,
-    )(N)
-
-    blockBuilder
-      .scopedVars(Set(clsDefn.sym, sym))
-      .define(clsDefn)
-      .assign(h.lhs, Instantiate(mut = true, Value.Ref(clsDefn.sym, S(h.cls)), Nil))
-      .define(bodyDefn)
-      .assign(h.res, Call(paths.enterHandleBlockPath, List(h.lhs.asPath.asArg, Value.Ref(sym, S(bodyDefn.dSym)).asArg))(true, true, false))
-      .rest(h.rest)
-  
-  def translateHandleBlocks(b: Block): Block =
-
-    val transform = new BlockTransformer(SymbolSubst.Id):
-      override def applyBlock(b: Block) = b match
-        case HandleBlock(lhs, res, par, args, cls, hdr, bod, rst) =>
-          val hdr2 = hdr.map(applyHandler)
-          val bod2 = applySubBlock(bod)
-          val rst2 = applySubBlock(rst)
-          translateHandleBlockShallow(new HandleBlock(lhs, res, par, args, cls, hdr2, bod2, rst2))
-        case _ => super.applyBlock(b)
-    transform.applyBlock(b)
 
   def translateTopLevel(b: Block): (Block, StackSafetyMap) =
     val preTransformed = new ScopeFlattener().applyBlock(b)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -560,15 +560,15 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
     val preTransform = new BlockTransformer(SymbolSubst.Id):
       override def applyBlock(b: Block): Block = b match
         // This is the common case
-        // case Suspend(tag, handlerFun, Return(Value.Lit(Tree.UnitLit(true)), false)) =>
-        //   Return(Call(paths.mkEffectPath, tag.asArg :: handlerFun.asArg :: Nil)(true, true, false), false)
+        case Suspend(lhs, tag, handlerFun, Return(Value.Ref(lhs2, N), false)) if lhs is lhs2 =>
+          Return(Call(paths.mkEffectPath, tag.asArg :: handlerFun.asArg :: Nil)(true, true, false), false)
         // To handle possible transformed block, we need to handle the general case
-        case Suspend(tag, handlerFun, rest) =>
-          Assign(State.noSymbol,
+        case Suspend(lhs, tag, handlerFun, rest) =>
+          Assign(lhs,
             Call(paths.mkEffectPath, tag.asArg :: handlerFun.asArg :: Nil)(true, true, false),
             applyBlock(rest))
-        case HandleSuspension(tag, bodyFun, rest) =>
-          Assign(State.noSymbol,
+        case HandleSuspension(lhs, tag, bodyFun, rest) =>
+          Assign(lhs,
             Call(paths.enterHandleBlockPath, tag.asArg :: bodyFun.asArg :: Nil)(true, true, false),
             applyBlock(rest))
         case _ => super.applyBlock(b)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -1104,15 +1104,12 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
             deforest.Deforest(Program(imps.map(imp => imp.sym -> imp.str), desug)).main
     
     val handlerPaths = new HandlerPaths
-
-    val withHandlers1 = effectiveConfig.effectHandlers.fold(deforested): opt =>
-      HandlerLowering(handlerPaths, opt).translateHandleBlocks(deforested)
     
     val shouldFlattenScopes = effectiveConfig.effectHandlers.isDefined
     
     val scopeFlattened =
-      if shouldFlattenScopes then ScopeFlattener().applyBlock(withHandlers1)
-      else withHandlers1
+      if shouldFlattenScopes then ScopeFlattener().applyBlock(deforested)
+      else deforested
     
     val lifted =
       if lift then Lifter(scopeFlattened).transform

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/SpecializedSwitch.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/SpecializedSwitch.scala
@@ -157,8 +157,6 @@ private object PostCondAnalysisImpl extends CachedAnalysis[Block, PostCondRes]:
       case v: ValDefn => res(S(v.sym), v.rhs, rest)
       case c: ClsLikeDefn => analyze(rest).markImpure // TODO: refine for object and module ctors
       case f: FunDefn => analyze(rest)
-    case Suspend(lhs, tag, handlerFun, rest) => analyze(rest)
-    case HandleSuspension(lhs, tag, bodyFun, rest) => analyze(rest)
     case b: BlockTail => PostCondRes.empty.copy(isAbortive = b.isAbortive)
 
 private object PostCondAnalysis extends CachedAnalysis[Block, Map[Local, Literal]]:

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/SpecializedSwitch.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/SpecializedSwitch.scala
@@ -157,7 +157,8 @@ private object PostCondAnalysisImpl extends CachedAnalysis[Block, PostCondRes]:
       case v: ValDefn => res(S(v.sym), v.rhs, rest)
       case c: ClsLikeDefn => analyze(rest).markImpure // TODO: refine for object and module ctors
       case f: FunDefn => analyze(rest)
-    case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) => analyze(body) >=> analyze(rest)
+    case Suspend(tag, handlerFun, rest) => analyze(rest)
+    case HandleSuspension(tag, bodyFun, rest) => analyze(rest)
     case b: BlockTail => PostCondRes.empty.copy(isAbortive = b.isAbortive)
 
 private object PostCondAnalysis extends CachedAnalysis[Block, Map[Local, Literal]]:

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/SpecializedSwitch.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/SpecializedSwitch.scala
@@ -157,8 +157,8 @@ private object PostCondAnalysisImpl extends CachedAnalysis[Block, PostCondRes]:
       case v: ValDefn => res(S(v.sym), v.rhs, rest)
       case c: ClsLikeDefn => analyze(rest).markImpure // TODO: refine for object and module ctors
       case f: FunDefn => analyze(rest)
-    case Suspend(tag, handlerFun, rest) => analyze(rest)
-    case HandleSuspension(tag, bodyFun, rest) => analyze(rest)
+    case Suspend(lhs, tag, handlerFun, rest) => analyze(rest)
+    case HandleSuspension(lhs, tag, bodyFun, rest) => analyze(rest)
     case b: BlockTail => PostCondRes.empty.copy(isAbortive = b.isAbortive)
 
 private object PostCondAnalysis extends CachedAnalysis[Block, Map[Local, Literal]]:

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
@@ -74,8 +74,6 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
           else
             super.applyBlock(b)
         
-        case _: Suspend | _: HandleSuspension => lastWords("Suspension in stack safe transformation")
-        
         case _ => super.applyBlock(b)
         
       override def applyHandler(hdr: Handler): Handler = lastWords("HandleBlock in stack safe transformation")

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
@@ -74,7 +74,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
           else
             super.applyBlock(b)
         
-        case HandleBlock(l, res, par, args, cls, hdr, bod, rst) => lastWords("HandleBlock in stack safe transformation")
+        case _: Suspend | _: HandleSuspension => lastWords("Suspension in stack safe transformation")
         
         case _ => super.applyBlock(b)
         

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/flowAnalysis/FlowAnalysis.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/flowAnalysis/FlowAnalysis.scala
@@ -402,14 +402,6 @@ class FlowPreAnalyzer(val pgrm: Program)(using
       applyPath(fld)
       applyResult(rhs)
       applyBlock(rest)
-    case Suspend(lhs, tag, handlerFun, rest) =>
-      applyPath(tag)
-      applyPath(handlerFun)
-      applyBlock(rest)
-    case HandleSuspension(lhs, tag, bodyFun, rest) =>
-      applyPath(tag)
-      applyPath(bodyFun)
-      applyBlock(rest)
     case End(_) => ()
     case Unreachable(_) => ()
   
@@ -739,18 +731,6 @@ class FlowConstraintsCollector(val preAnalyzer: FlowPreAnalyzer, val mono: Bool)
         constrainOpaqueResult(lhs)
         constrainOpaqueResult(fld)
         constrainOpaqueResult(rhs)
-        processBlock(rest)
-      case Suspend(lhs, tag, handlerFun, rest) =>
-        val rhsStrat = processResult(Call(eState.suspendSymbol.asPath, tag.asArg :: handlerFun.asArg :: Nil)(true, true, false))
-        lhs.match
-          case _: NoSymbol => ()
-          case _ => cc.constrain(rhsStrat, generatedProdVars(lhs).asConsStrat)
-        processBlock(rest)
-      case HandleSuspension(lhs, tag, bodyFun, rest) =>
-        val rhsStrat = processResult(Call(eState.handleSuspensionSymbol.asPath, tag.asArg :: bodyFun.asArg :: Nil)(true, true, false))
-        lhs.match
-          case _: NoSymbol => ()
-          case _ => cc.constrain(rhsStrat, generatedProdVars(lhs).asConsStrat)
         processBlock(rest)
       case Define(defn, rest) =>
         defn match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/flowAnalysis/FlowAnalysis.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/flowAnalysis/FlowAnalysis.scala
@@ -741,14 +741,16 @@ class FlowConstraintsCollector(val preAnalyzer: FlowPreAnalyzer, val mono: Bool)
         constrainOpaqueResult(rhs)
         processBlock(rest)
       case Suspend(lhs, tag, handlerFun, rest) =>
-        // TODO: do sth with lhs...
-        constrainOpaqueResult(tag)
-        constrainOpaqueResult(handlerFun)
+        val rhsStrat = processResult(Call(eState.suspendSymbol.asPath, tag.asArg :: handlerFun.asArg :: Nil)(true, true, false))
+        lhs.match
+          case _: NoSymbol => ()
+          case _ => cc.constrain(rhsStrat, generatedProdVars(lhs).asConsStrat)
         processBlock(rest)
       case HandleSuspension(lhs, tag, bodyFun, rest) =>
-        // TODO: do sth with lhs...
-        constrainOpaqueResult(tag)
-        constrainOpaqueResult(bodyFun)
+        val rhsStrat = processResult(Call(eState.handleSuspensionSymbol.asPath, tag.asArg :: bodyFun.asArg :: Nil)(true, true, false))
+        lhs.match
+          case _: NoSymbol => ()
+          case _ => cc.constrain(rhsStrat, generatedProdVars(lhs).asConsStrat)
         processBlock(rest)
       case Define(defn, rest) =>
         defn match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/flowAnalysis/FlowAnalysis.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/flowAnalysis/FlowAnalysis.scala
@@ -402,11 +402,11 @@ class FlowPreAnalyzer(val pgrm: Program)(using
       applyPath(fld)
       applyResult(rhs)
       applyBlock(rest)
-    case Suspend(tag, handlerFun, rest) =>
+    case Suspend(lhs, tag, handlerFun, rest) =>
       applyPath(tag)
       applyPath(handlerFun)
       applyBlock(rest)
-    case HandleSuspension(tag, bodyFun, rest) =>
+    case HandleSuspension(lhs, tag, bodyFun, rest) =>
       applyPath(tag)
       applyPath(bodyFun)
       applyBlock(rest)
@@ -740,11 +740,13 @@ class FlowConstraintsCollector(val preAnalyzer: FlowPreAnalyzer, val mono: Bool)
         constrainOpaqueResult(fld)
         constrainOpaqueResult(rhs)
         processBlock(rest)
-      case Suspend(tag, handlerFun, rest) =>
+      case Suspend(lhs, tag, handlerFun, rest) =>
+        // TODO: do sth with lhs...
         constrainOpaqueResult(tag)
         constrainOpaqueResult(handlerFun)
         processBlock(rest)
-      case HandleSuspension(tag, bodyFun, rest) =>
+      case HandleSuspension(lhs, tag, bodyFun, rest) =>
+        // TODO: do sth with lhs...
         constrainOpaqueResult(tag)
         constrainOpaqueResult(bodyFun)
         processBlock(rest)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/flowAnalysis/FlowAnalysis.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/flowAnalysis/FlowAnalysis.scala
@@ -402,12 +402,14 @@ class FlowPreAnalyzer(val pgrm: Program)(using
       applyPath(fld)
       applyResult(rhs)
       applyBlock(rest)
-    case HandleBlock(local, res, par, args, cls, hdr, bod, rst) =>
-      applyPath(par)
-      args.foreach(applyPath)
-      hdr.foreach(applyHandler)
-      applyBlock(bod)
-      applyBlock(rst)
+    case Suspend(tag, handlerFun, rest) =>
+      applyPath(tag)
+      applyPath(handlerFun)
+      applyBlock(rest)
+    case HandleSuspension(tag, bodyFun, rest) =>
+      applyPath(tag)
+      applyPath(bodyFun)
+      applyBlock(rest)
     case End(_) => ()
     case Unreachable(_) => ()
   
@@ -738,13 +740,13 @@ class FlowConstraintsCollector(val preAnalyzer: FlowPreAnalyzer, val mono: Bool)
         constrainOpaqueResult(fld)
         constrainOpaqueResult(rhs)
         processBlock(rest)
-      case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) =>
-        constrainOpaqueResult(par)
-        args.foreach: arg =>
-          constrainOpaqueResult(arg)
-        handlers.foreach: handler =>
-          processBlock(handler.body)(using cc, NoCons)
-        processBlock(body)
+      case Suspend(tag, handlerFun, rest) =>
+        constrainOpaqueResult(tag)
+        constrainOpaqueResult(handlerFun)
+        processBlock(rest)
+      case HandleSuspension(tag, bodyFun, rest) =>
+        constrainOpaqueResult(tag)
+        constrainOpaqueResult(bodyFun)
         processBlock(rest)
       case Define(defn, rest) =>
         defn match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -270,8 +270,6 @@ class JSBuilder(using TL, State, Ctx, Config) extends CodeBuilder:
   def returningTerm(t: Block, endSemi: Bool)(using Raise, Scope): Document =
     def mkSemi = if endSemi then ";" else ""
     t match
-    case _: Suspend | _: HandleSuspension =>
-      errStmt(msg"This code requires effect handler instrumentation but was compiled without it.")
     case Assign(l, r, rst) if l is State.noSymbol =>
       doc" # ${result(r)};${returningTerm(rst, endSemi)}"
     case Assign(l, r, rst) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -270,7 +270,7 @@ class JSBuilder(using TL, State, Ctx, Config) extends CodeBuilder:
   def returningTerm(t: Block, endSemi: Bool)(using Raise, Scope): Document =
     def mkSemi = if endSemi then ";" else ""
     t match
-    case _: HandleBlock =>
+    case _: Suspend | _: HandleSuspension =>
       errStmt(msg"This code requires effect handler instrumentation but was compiled without it.")
     case Assign(l, r, rst) if l is State.noSymbol =>
       doc" # ${result(r)};${returningTerm(rst, endSemi)}"

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Builder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Builder.scala
@@ -569,8 +569,6 @@ final class LlirBuilder(using Elaborator.State)(tl: TraceLogger, uid: FreshInt):
         case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => applyBlock(rest)
         case Define(defn, rest) => applyDefn(defn); applyBlock(rest)
         case Scoped(_, body) => applyBlock(body)
-        case Suspend(lhs, tag, handlerFun, rest) => applyBlock(rest)
-        case HandleSuspension(lhs, tag, bodyFun, rest) => applyBlock(rest)
         case End(msg) =>
       
       override def applyDefn(defn: Defn): Unit = defn match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Builder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Builder.scala
@@ -569,7 +569,8 @@ final class LlirBuilder(using Elaborator.State)(tl: TraceLogger, uid: FreshInt):
         case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => applyBlock(rest)
         case Define(defn, rest) => applyDefn(defn); applyBlock(rest)
         case Scoped(_, body) => applyBlock(body)
-        case HandleBlock(lhs, res, par, args, cls, handlers, body, rest) => applyBlock(rest)
+        case Suspend(tag, handlerFun, rest) => applyBlock(rest)
+        case HandleSuspension(tag, bodyFun, rest) => applyBlock(rest)
         case End(msg) =>
       
       override def applyDefn(defn: Defn): Unit = defn match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Builder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/llir/Builder.scala
@@ -569,8 +569,8 @@ final class LlirBuilder(using Elaborator.State)(tl: TraceLogger, uid: FreshInt):
         case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => applyBlock(rest)
         case Define(defn, rest) => applyDefn(defn); applyBlock(rest)
         case Scoped(_, body) => applyBlock(body)
-        case Suspend(tag, handlerFun, rest) => applyBlock(rest)
-        case HandleSuspension(tag, bodyFun, rest) => applyBlock(rest)
+        case Suspend(lhs, tag, handlerFun, rest) => applyBlock(rest)
+        case HandleSuspension(lhs, tag, bodyFun, rest) => applyBlock(rest)
         case End(msg) =>
       
       override def applyDefn(defn: Defn): Unit = defn match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -408,8 +408,6 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       case Match(_, _, _, rst) => S(rst)
       case TryBlock(_, _, rst) => S(rst)
       case Label(_, _, _, rst) => S(rst)
-      case Suspend(_, _, _, rst) => S(rst)
-      case HandleSuspension(_, _, _, rst) => S(rst)
       case _ => N
 
     def recur(block: Block): Set[Symbol] = block match
@@ -671,8 +669,6 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       case AssignDynField(lhs, fld, arrayIdx, rhs, _) => AssignDynField(lhs, fld, arrayIdx, rhs, rest)
       case Define(defn, _) => Define(defn, rest)
       case Match(scrut, arms, dflt, _) => Match(scrut, arms, dflt, rest)
-      case Suspend(lhs, tag, handlerFun, _) => Suspend(lhs, tag, handlerFun, rest)
-      case HandleSuspension(lhs, tag, bodyFun, _) => HandleSuspension(lhs, tag, bodyFun, rest)
       case Label(label, loop, body, _) => Label(label, loop, body, rest)
 
     def splitSuperTail(block: Block): Opt[Block -> Ls[Arg]] = block match
@@ -1326,8 +1322,6 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
   def returningTerm(t: Block)(using Ctx, Raise, Scope, SessionExportCtx): Expr =
     t match
-      case _: Suspend | _: HandleSuspension =>
-        errExpr(Ls(msg"This code requires effect handler instrumentation but was compiled without it." -> N))
       case Assign(l, r, rst) if l is State.noSymbol =>
         val rExpr = result(r)
         val evalExpr = rExpr.resultType match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -408,7 +408,8 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       case Match(_, _, _, rst) => S(rst)
       case TryBlock(_, _, rst) => S(rst)
       case Label(_, _, _, rst) => S(rst)
-      case HandleBlock(_, _, _, _, _, _, _, rst) => S(rst)
+      case Suspend(_, _, rst) => S(rst)
+      case HandleSuspension(_, _, rst) => S(rst)
       case _ => N
 
     def recur(block: Block): Set[Symbol] = block match
@@ -670,8 +671,8 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       case AssignDynField(lhs, fld, arrayIdx, rhs, _) => AssignDynField(lhs, fld, arrayIdx, rhs, rest)
       case Define(defn, _) => Define(defn, rest)
       case Match(scrut, arms, dflt, _) => Match(scrut, arms, dflt, rest)
-      case HandleBlock(lhs, res, par, args0, cls, handlers, body, _) =>
-        HandleBlock(lhs, res, par, args0, cls, handlers, body, rest)
+      case Suspend(tag, handlerFun, _) => Suspend(tag, handlerFun, rest)
+      case HandleSuspension(tag, bodyFun, _) => HandleSuspension(tag, bodyFun, rest)
       case Label(label, loop, body, _) => Label(label, loop, body, rest)
 
     def splitSuperTail(block: Block): Opt[Block -> Ls[Arg]] = block match
@@ -1325,7 +1326,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
   def returningTerm(t: Block)(using Ctx, Raise, Scope, SessionExportCtx): Expr =
     t match
-      case _: HandleBlock =>
+      case _: Suspend | _: HandleSuspension =>
         errExpr(Ls(msg"This code requires effect handler instrumentation but was compiled without it." -> N))
       case Assign(l, r, rst) if l is State.noSymbol =>
         val rExpr = result(r)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -408,8 +408,8 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       case Match(_, _, _, rst) => S(rst)
       case TryBlock(_, _, rst) => S(rst)
       case Label(_, _, _, rst) => S(rst)
-      case Suspend(_, _, rst) => S(rst)
-      case HandleSuspension(_, _, rst) => S(rst)
+      case Suspend(_, _, _, rst) => S(rst)
+      case HandleSuspension(_, _, _, rst) => S(rst)
       case _ => N
 
     def recur(block: Block): Set[Symbol] = block match
@@ -671,8 +671,8 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       case AssignDynField(lhs, fld, arrayIdx, rhs, _) => AssignDynField(lhs, fld, arrayIdx, rhs, rest)
       case Define(defn, _) => Define(defn, rest)
       case Match(scrut, arms, dflt, _) => Match(scrut, arms, dflt, rest)
-      case Suspend(tag, handlerFun, _) => Suspend(tag, handlerFun, rest)
-      case HandleSuspension(tag, bodyFun, _) => HandleSuspension(tag, bodyFun, rest)
+      case Suspend(lhs, tag, handlerFun, _) => Suspend(lhs, tag, handlerFun, rest)
+      case HandleSuspension(lhs, tag, bodyFun, _) => HandleSuspension(lhs, tag, bodyFun, rest)
       case Label(label, loop, body, _) => Label(label, loop, body, rest)
 
     def splitSuperTail(block: Block): Opt[Block -> Ls[Arg]] = block match

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
@@ -188,6 +188,8 @@ object Elaborator:
         val bitor = assumeObject("bitor")
         val shl = assumeObject("shl")
         val try_catch = assumeObject("try_catch")
+        val suspend = assumeObject("suspend")
+        val handle_suspension = assumeObject("handle_suspension")
       object wasm extends VirtualModule(assumeBuiltinMod("wasm")):
         val plus_impl = assumeObject("plus_impl")
         val minus_impl = assumeObject("minus_impl")
@@ -277,8 +279,6 @@ object Elaborator:
     val nonLocalRet =
       val id = new Ident("ret")
       BlockMemberSymbol(id.name, Nil, true)
-    val suspendSymbol = TempSymbol(N, "suspend")
-    val handleSuspensionSymbol = TempSymbol(N, "handleSuspension")
     val unreachableSymbol = TermSymbol(syntax.ImmutVal, N, new Ident("unreachable"))
     val tupleGetSymbol = createFunSymbolInMod("get", "xs" :: "i" :: Nil, tupleSymbol)
     val tupleSliceSymbol = createFunSymbolInMod("slice", "xs" :: "i" :: "j" :: Nil, tupleSymbol)

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
@@ -188,8 +188,6 @@ object Elaborator:
         val bitor = assumeObject("bitor")
         val shl = assumeObject("shl")
         val try_catch = assumeObject("try_catch")
-        val suspend = assumeObject("suspend")
-        val handle_suspension = assumeObject("handle_suspension")
       object wasm extends VirtualModule(assumeBuiltinMod("wasm")):
         val plus_impl = assumeObject("plus_impl")
         val minus_impl = assumeObject("minus_impl")
@@ -213,6 +211,9 @@ object Elaborator:
         val bufferable = assumeObject("bufferable")
       object scope extends VirtualModule(assumeBuiltinMod("scope")):
         val locally = assumeObject("locally")
+      object runtime extends VirtualModule(assumeBuiltinMod("runtime")):
+        val suspend = assumeObject("suspend")
+        val handle_suspension = assumeObject("handle_suspension")
       def getBuiltinOp(op: Str): Opt[Str] =
         if getBuiltin(op).isDefined then builtinBinOps.get(op) else N
       /** Classes that do not use `instanceof` in pattern matching. */

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
@@ -277,6 +277,8 @@ object Elaborator:
     val nonLocalRet =
       val id = new Ident("ret")
       BlockMemberSymbol(id.name, Nil, true)
+    val suspendSymbol = TempSymbol(N, "suspend")
+    val handleSuspensionSymbol = TempSymbol(N, "handleSuspension")
     val unreachableSymbol = TermSymbol(syntax.ImmutVal, N, new Ident("unreachable"))
     val tupleGetSymbol = createFunSymbolInMod("get", "xs" :: "i" :: Nil, tupleSymbol)
     val tupleSliceSymbol = createFunSymbolInMod("slice", "xs" :: "i" :: "j" :: Nil, tupleSymbol)

--- a/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
+++ b/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
@@ -233,7 +233,7 @@ id(Foo)(1)
 // ——— ——— ———
 
 data class FooSpd(...args)
-//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1315': mismatched param list lengths List() vs List(term:FooSpd/args)
+//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1316': mismatched param list lengths List() vs List(term:FooSpd/args)
 //│ ╟── The compilation result may be incorrect.
 //│ ╙── This is a compiler bug; please report it to the maintainers.
 

--- a/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
+++ b/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
@@ -233,7 +233,7 @@ id(Foo)(1)
 // ——— ——— ———
 
 data class FooSpd(...args)
-//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1313': mismatched param list lengths List() vs List(term:FooSpd/args)
+//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1315': mismatched param list lengths List() vs List(term:FooSpd/args)
 //│ ╟── The compilation result may be incorrect.
 //│ ╙── This is a compiler bug; please report it to the maintainers.
 

--- a/hkmc2/shared/src/test/mlscript/codegen/Spreads.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Spreads.mls
@@ -58,7 +58,7 @@ foo(0, ...a)
 data class A(...r)
 let x = new A(1, 2, 3)
 x.r
-//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1315': mismatched param list lengths List() vs List(term:A/r)
+//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1316': mismatched param list lengths List() vs List(term:A/r)
 //│ ╟── The compilation result may be incorrect.
 //│ ╙── This is a compiler bug; please report it to the maintainers.
 //│ ═══[RUNTIME ERROR] Error: Access to required field 'r' yielded 'undefined'
@@ -70,7 +70,7 @@ x.r
 data class A(...r) with
   fun getR = r
 new A(1, 2, 3).getR
-//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1315': mismatched param list lengths List() vs List(term:A/r)
+//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1316': mismatched param list lengths List() vs List(term:A/r)
 //│ ╟── The compilation result may be incorrect.
 //│ ╙── This is a compiler bug; please report it to the maintainers.
 //│ ═══[RUNTIME ERROR] ReferenceError: r is not defined

--- a/hkmc2/shared/src/test/mlscript/codegen/Spreads.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Spreads.mls
@@ -58,7 +58,7 @@ foo(0, ...a)
 data class A(...r)
 let x = new A(1, 2, 3)
 x.r
-//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1313': mismatched param list lengths List() vs List(term:A/r)
+//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1315': mismatched param list lengths List() vs List(term:A/r)
 //│ ╟── The compilation result may be incorrect.
 //│ ╙── This is a compiler bug; please report it to the maintainers.
 //│ ═══[RUNTIME ERROR] Error: Access to required field 'r' yielded 'undefined'
@@ -70,7 +70,7 @@ x.r
 data class A(...r) with
   fun getR = r
 new A(1, 2, 3).getR
-//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1313': mismatched param list lengths List() vs List(term:A/r)
+//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1315': mismatched param list lengths List() vs List(term:A/r)
 //│ ╟── The compilation result may be incorrect.
 //│ ╙── This is a compiler bug; please report it to the maintainers.
 //│ ═══[RUNTIME ERROR] ReferenceError: r is not defined

--- a/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
+++ b/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
@@ -245,8 +245,6 @@ declare module js with
     bitor
     shl
     try_catch
-    suspend
-    handle_suspension
 
 declare module wasm with
   fun
@@ -275,6 +273,11 @@ declare module annotations with
 
 declare module scope with
   fun locally
+
+declare module runtime with
+  fun
+    suspend
+    handle_suspension
 
 
 // HTML DOM API definitions.

--- a/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
+++ b/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
@@ -245,6 +245,8 @@ declare module js with
     bitor
     shl
     try_catch
+    suspend
+    handle_suspension
 
 declare module wasm with
   fun

--- a/hkmc2/shared/src/test/mlscript/handlers/BadHandlers.mls
+++ b/hkmc2/shared/src/test/mlscript/handlers/BadHandlers.mls
@@ -33,10 +33,11 @@ h.lol
 //│ ╔══[COMPILATION ERROR] Handler function cannot be a getter
 //│ ║  l.31: 	  fun lol(k) = k(())
 //│ ╙──      	  ^^^^^^^^^^^^^^^^^^
+//│ ═══[RUNTIME ERROR] Error: Effect Handler$h$6 is raised in a getter
   fun lol(k) = k(1)
 h.lol + 2
 //│ ╔══[COMPILATION ERROR] Name not found: h
-//│ ║  l.37: 	h.lol + 2
+//│ ║  l.38: 	h.lol + 2
 //│ ╙──      	^
 //│ ═══[RUNTIME ERROR] This code cannot be run as its compilation yielded an error.
 
@@ -64,7 +65,7 @@ object Foo with
 :re
 Foo.x
 //│ ╔══[COMPILATION ERROR] Object 'Foo' does not contain member 'x'
-//│ ║  l.65: 	Foo.x
+//│ ║  l.66: 	Foo.x
 //│ ╙──      	   ^^
 //│ ═══[RUNTIME ERROR] Error: Access to required field 'x' yielded 'undefined'
 

--- a/hkmc2/shared/src/test/mlscript/invalml/InvalMLPrelude.mls
+++ b/hkmc2/shared/src/test/mlscript/invalml/InvalMLPrelude.mls
@@ -82,6 +82,8 @@ declare module js with
     bitor
     shl
     try_catch
+    suspend
+    handle_suspension
 
 declare module wasm with
   fun
@@ -140,10 +142,10 @@ declare fun (||): (Bool, Bool) -> Bool
 
 fun print(x) = @untyped globalThis.console.log(x)
 //│ ╔══[WARNING] This annotation has no effect.
-//│ ║  l.141: 	fun print(x) = @untyped globalThis.console.log(x)
+//│ ║  l.143: 	fun print(x) = @untyped globalThis.console.log(x)
 //│ ║         	               ^^^^^^^^
 //│ ╟── This annotation is not supported on application terms.
-//│ ║  l.141: 	fun print(x) = @untyped globalThis.console.log(x)
+//│ ║  l.143: 	fun print(x) = @untyped globalThis.console.log(x)
 //│ ╙──       	                        ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 

--- a/hkmc2/shared/src/test/mlscript/invalml/InvalMLPrelude.mls
+++ b/hkmc2/shared/src/test/mlscript/invalml/InvalMLPrelude.mls
@@ -82,8 +82,6 @@ declare module js with
     bitor
     shl
     try_catch
-    suspend
-    handle_suspension
 
 declare module wasm with
   fun
@@ -112,6 +110,11 @@ declare module annotations with
 
 declare module scope with
   fun locally
+
+declare module runtime with
+  fun
+    suspend
+    handle_suspension
 
 
 declare fun run: [T] -> CodeBase[out T, out Nothing, out Any] -> T
@@ -142,10 +145,10 @@ declare fun (||): (Bool, Bool) -> Bool
 
 fun print(x) = @untyped globalThis.console.log(x)
 //│ ╔══[WARNING] This annotation has no effect.
-//│ ║  l.143: 	fun print(x) = @untyped globalThis.console.log(x)
+//│ ║  l.146: 	fun print(x) = @untyped globalThis.console.log(x)
 //│ ║         	               ^^^^^^^^
 //│ ╟── This annotation is not supported on application terms.
-//│ ║  l.143: 	fun print(x) = @untyped globalThis.console.log(x)
+//│ ║  l.146: 	fun print(x) = @untyped globalThis.console.log(x)
 //│ ╙──       	                        ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 

--- a/hkmc2/shared/src/test/mlscript/lifter/ClassInFun.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/ClassInFun.mls
@@ -246,7 +246,7 @@ fun f(x) =
 let res = f(0)
 res.a
 res.b
-//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1315': mismatched param list lengths List() vs List(term:A/r)
+//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1316': mismatched param list lengths List() vs List(term:A/r)
 //│ ╟── The compilation result may be incorrect.
 //│ ╙── This is a compiler bug; please report it to the maintainers.
 //│ ═══[RUNTIME ERROR] ReferenceError: r is not defined

--- a/hkmc2/shared/src/test/mlscript/lifter/ClassInFun.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/ClassInFun.mls
@@ -288,7 +288,7 @@ fun f(x) =
 let res = f(0)
 res.a
 res.b
-//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1313': mismatched param list lengths List() vs List(term:A/r)
+//│ ╔══[INTERNAL ERROR] Compiler reached an unexpected state at 'Elaborator.scala:1315': mismatched param list lengths List() vs List(term:A/r)
 //│ ╟── The compilation result may be incorrect.
 //│ ╙── This is a compiler bug; please report it to the maintainers.
 //│ ═══[RUNTIME ERROR] ReferenceError: r is not defined


### PR DESCRIPTION
Remove `HandleBlock` from the IR, as it create extra complexity that is not inherent to effect handlers.