### PR TITLE
wasm: Move label generation and tracking into `FunctionCtx`

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -351,9 +351,31 @@ end TagInfo
 enum WasmIntrinsicType:
   case TupleArray(mutable: Bool)
 
+/** Class containing identifiers of labels to jump to when breaking or continuing from a control flow structure.
+  *
+  * @param breakLabel
+  *   The identifier of the label to jump to for exiting the control flow structure, e.g. for `break` statements.
+  * @param continueLabel
+  *   The identifier of the label to jump to for continuing the control flow structure, e.g. for `continue` statements
+  *   in loops. This is `None` for non-loop control flow structures.
+  */
+case class LabelTarget(breakLabel: Str, continueLabel: Opt[Str])
+
 object FunctionCtx:
 
   def funcCtx(using funcCtx: FunctionCtx): FunctionCtx = funcCtx
+
+  /** Context for tracking control flow jump targets.
+    *
+    * @param scp
+    *   [[Scope]] for generating WAT identifiers of labels in this control flow context.
+    * @param breakLabel
+    *   The label to jump to for exiting this control flow context, e.g. for `break` statements.
+    * @param continueLabel
+    *   The label to jump to for continuing this control flow context, e.g. for `continue` statements in loops. This is
+    *   `None` for non-loop contexts.
+    */
+  private case class ControlFlowCtx(scp: Scope, breakLabel: LabelSymbol, continueLabel: Opt[LabelSymbol])
 
 /** Context associated with codegen for a Wasm function.
   *
@@ -377,6 +399,7 @@ class FunctionCtx(_params: Ls[ParamList], thisSym: Opt[InnerSymbol])(using Raise
       dis -> SymIdx(localScp.addToBindings(dis, "this", shadow = false))
     thisParam.toSeq ++ _params.flatMap(_.paramSyms).map(p => p -> SymIdx(localScp.allocateName(p)))
   private val _locals = ArrayBuf.empty[Local]
+  private var labels = ListMap.empty[LabelSymbol, FunctionCtx.ControlFlowCtx]
 
   /** Adds a Wasm local into this context.
     *
@@ -403,6 +426,41 @@ class FunctionCtx(_params: Ls[ParamList], thisSym: Opt[InnerSymbol])(using Raise
     * identifier.
     */
   def locals: Seq[Local -> SymIdx] = _locals.map(l => l -> SymIdx(localScp.lookup_!(l, N))).toSeq
+
+  /** Pushes a label target for the dynamic extent of `body` and pops it afterwards.
+    *
+    * The `body` function is given a [[LabelTarget]] containing the `break` and `continue` labels corresponding to
+    * `label`.
+    *
+    * @param hasContinueLabel
+    *   Indicates whether a `continue` label should be generated for this control flow context, e.g. for loops.
+    */
+  def withLabel[T](label: LabelSymbol, hasContinueLabel: Bool)(body: LabelTarget => T): T =
+    import Scope.scope
+
+    val ctrlFlowCtx = FunctionCtx.ControlFlowCtx(
+      scp = labels.lastOption.fold(Scope.empty(Scope.Cfg.default))(_._2.scp.nest),
+      breakLabel = label,
+      continueLabel = if hasContinueLabel then S(LabelSymbol(N, s"${label.nme}_cont")) else N,
+    )
+    labels = labels + (label -> ctrlFlowCtx)
+    val res = body(
+      LabelTarget(
+        breakLabel = ctrlFlowCtx.scp.allocateName(label),
+        continueLabel = ctrlFlowCtx.continueLabel.map(cl => ctrlFlowCtx.scp.allocateName(cl)),
+      ),
+    )
+    labels = labels.init
+    res
+
+  /** Looks up the nearest in-scope target for `label`. */
+  def lookupLabel(label: LabelSymbol): Opt[LabelTarget] =
+    labels.last._2.scp.lookup(label)
+      .map: labelId =>
+        LabelTarget(
+          breakLabel = labelId,
+          continueLabel = labels(label).continueLabel.map(cl => labels.last._2.scp.lookup_!(cl, N)),
+        )
 end FunctionCtx
   
 /** Generates a function body, providing an instance of [[FunctionCtx]] for parameter and locals tracking.
@@ -421,11 +479,6 @@ object Ctx:
   case class SingletonInfo(
       globalName: Str,
       globalTy: RefType,
-  )
-
-  case class LabelTarget(
-      breakLabel: Str,
-      continueLabel: Opt[Str],
   )
 
   val binaryOps: Map[Str, (Expr, Expr) => Expr] = Map(
@@ -507,7 +560,6 @@ class Ctx extends ToWat:
   private val cachedFunctionImports = MutMap.empty[(Str, Str), FuncIdx]
   private val cachedGlobalImports = MutMap.empty[(Str, Str), GlobalIdx]
 
-  private var labelTargets = Nil: List[(LabelSymbol, Ctx.LabelTarget)]
   private val singletonByBms = MutMap.empty[BlockMemberSymbol, Ctx.SingletonInfo]
   private val singletonByIsym = MutMap.empty[ModuleOrObjectSymbol, Ctx.SingletonInfo]
   private val singletonInitActions = ArrayBuf.empty[Expr]
@@ -526,18 +578,6 @@ class Ctx extends ToWat:
     globalEntry match
       case globalInfo: GlobalInfo => ExternType.Global(globalInfo.id, globalInfo.globalType)
       case globalImport: Import[ExternType.Global] => globalImport.externType
-
-  /** Pushes a label target for the dynamic extent of `body` and pops it afterwards. */
-  def withLabel[T](label: LabelSymbol, target: Ctx.LabelTarget)(body: => T): T =
-    labelTargets = (label, target) :: labelTargets
-    val res = body
-    labelTargets = labelTargets.tail
-    res
-
-  /** Looks up the nearest in-scope target for `label`. */
-  def lookupLabel(label: LabelSymbol): Opt[Ctx.LabelTarget] =
-    labelTargets.collectFirst:
-      case (sym, target) if sym eq label => target
 
   /** Returns a new number to be used as an object tag. */
   def getFreshObjectTag(): Int =

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -436,8 +436,6 @@ class FunctionCtx(_params: Ls[ParamList], thisSym: Opt[InnerSymbol])(using Raise
     *   Indicates whether a `continue` label should be generated for this control flow context, e.g. for loops.
     */
   def withLabel[T](label: LabelSymbol, hasContinueLabel: Bool)(body: LabelTarget => T): T =
-    import Scope.scope
-
     val ctrlFlowCtx = FunctionCtx.ControlFlowCtx(
       scp = labels.lastOption.fold(Scope.empty(Scope.Cfg.default))(_._2.scp.nest),
       breakLabel = label,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -444,12 +444,11 @@ class FunctionCtx(_params: Ls[ParamList], thisSym: Opt[InnerSymbol])(using Raise
       continueLabel = if hasContinueLabel then S(LabelSymbol(N, s"${label.nme}_cont")) else N,
     )
     labels += label -> ctrlFlowCtx
-    val res = body(
+    val res = body:
       LabelTarget(
         breakLabel = ctrlFlowCtx.scp.allocateName(label),
         continueLabel = ctrlFlowCtx.continueLabel.map(cl => ctrlFlowCtx.scp.allocateName(cl)),
-      ),
-    )
+      )
     labels = labels.init
     res
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -452,8 +452,8 @@ class FunctionCtx(_params: Ls[ParamList], thisSym: Opt[InnerSymbol])(using Raise
 
   /** Looks up the nearest in-scope target for `label`. */
   def lookupLabel(label: LabelSymbol): Opt[LabelTarget] =
-    labels.last._2.scp.lookup(label)
-      .map: labelId =>
+    labels.lastOption.flatMap: (_, ctrlFlowCtx) =>
+      ctrlFlowCtx.scp.lookup(label).map: labelId =>
         LabelTarget(
           breakLabel = labelId,
           continueLabel = labels(label).continueLabel.map(cl => labels.last._2.scp.lookup_!(cl, N)),

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -443,7 +443,7 @@ class FunctionCtx(_params: Ls[ParamList], thisSym: Opt[InnerSymbol])(using Raise
       breakLabel = label,
       continueLabel = if hasContinueLabel then S(LabelSymbol(N, s"${label.nme}_cont")) else N,
     )
-    labels = labels + (label -> ctrlFlowCtx)
+    labels += label -> ctrlFlowCtx
     val res = body(
       LabelTarget(
         breakLabel = ctrlFlowCtx.scp.allocateName(label),

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -1763,7 +1763,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
         blockPreamble(syms)
         returningTerm(body)
       case Break(label) =>
-        ctx.lookupLabel(label) match
+        funcCtx.lookupLabel(label) match
           case S(target) => br(target.breakLabel)
           case N =>
             errExpr(
@@ -1773,7 +1773,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
               extraInfo = S(t.showAsTree),
             )
       case Continue(label) =>
-        ctx.lookupLabel(label) match
+        funcCtx.lookupLabel(label) match
           case S(target) =>
             target.continueLabel match
               case S(continueLabel) => br(continueLabel)
@@ -1792,37 +1792,29 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
               extraInfo = S(t.showAsTree),
             )
       case Label(label, loop, body, rst) =>
-        val breakLabel = scope.allocateName(label)
-        val continueLabel =
-          if loop then S(scope.allocateName(TempSymbol(N, s"${label.nme}_cont")))
-          else N
-
-        val bodyExpr = ctx.withLabel(
-          label,
-          Ctx.LabelTarget(breakLabel, continueLabel),
-        ):
-          returningTerm(body)
-        val bodyStmt = asStatement(bodyExpr)
-
-        val labeledRegion =
-          if loop then
-            Instructions.block(
-              label = S(breakLabel),
-              children = Seq(
-                Instructions.loop(
-                  label = continueLabel,
-                  children = Seq(bodyStmt),
-                  resultTypes = Seq.empty,
+        val labeledRegion = funcCtx.withLabel(label, hasContinueLabel = loop):
+          case LabelTarget(breakLabel, continueLabel) =>
+            val bodyExpr = returningTerm(body)
+            val bodyStmt = asStatement(bodyExpr)
+    
+            if loop then
+              Instructions.block(
+                label = S(breakLabel),
+                children = Seq(
+                  Instructions.loop(
+                    label = continueLabel,
+                    children = Seq(bodyStmt),
+                    resultTypes = Seq.empty,
+                  ),
                 ),
-              ),
-              resultTypes = Seq.empty,
-            )
-          else
-            Instructions.block(
-              label = S(breakLabel),
-              children = Seq(bodyStmt),
-              resultTypes = Seq.empty,
-            )
+                resultTypes = Seq.empty,
+              )
+            else
+              Instructions.block(
+                label = S(breakLabel),
+                children = Seq(bodyStmt),
+                resultTypes = Seq.empty,
+              )
 
         val rstExpr = returningTerm(rst)
         val rstResultTypes = rstExpr.resultTypes.flatMap(ty => ty.asValType.map(Result(_)))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -1824,8 +1824,6 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
           resultTypes = rstResultTypes,
         )
       case Match(scrut, arms, dflt, rst) =>
-        val matchLabelSym = TempSymbol(N, "match")
-        val matchLabel = scope.allocateName(matchLabelSym)
         val tailMode = rst.isInstanceOf[End]
         val matchResLocal =
           if tailMode then S(mkTempLocal("matchRes"))
@@ -1856,157 +1854,161 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
           local.set(localIdx, ref.`null`(HeapType.Any))
 
         // Compile each match arm
-        boundary:
-          val armExprs = arms.zipWithIndex.flatMap: (caseAndBody, armIdx) =>
-            val (cse, body) = caseAndBody
-            cse match
-              case Case.Lit(lit) =>
-                val testExpr: FoldedInstr = lit match
-                  case BoolLit(value) =>
-                    val scrutAsI31 = ref.cast(getScrutExpr, RefType.i31ref)
-                    val scrutValue = i31.get(scrutAsI31, signed = true)
-                    i32.eq(scrutValue, i32.const(if value then 1 else 0))
-                  case IntLit(value) =>
-                    val scrutAsI31 = ref.cast(getScrutExpr, RefType.i31ref)
-                    val scrutValue = i31.get(scrutAsI31, signed = true)
-                    i32.eq(scrutValue, withValidIntLit(value, lit.toLoc)(i32.const))
+        val matchBlock = funcCtx.withLabel(LabelSymbol(N, "match"), hasContinueLabel = false):
+          case LabelTarget(matchLabel, _) =>
+            boundary:
+              val armExprs = arms.zipWithIndex.flatMap: (caseAndBody, armIdx) =>
+                val (cse, body) = caseAndBody
+                cse match
+                  case Case.Lit(lit) =>
+                    val testExpr: FoldedInstr = lit match
+                      case BoolLit(value) =>
+                        val scrutAsI31 = ref.cast(getScrutExpr, RefType.i31ref)
+                        val scrutValue = i31.get(scrutAsI31, signed = true)
+                        i32.eq(scrutValue, i32.const(if value then 1 else 0))
+                      case IntLit(value) =>
+                        val scrutAsI31 = ref.cast(getScrutExpr, RefType.i31ref)
+                        val scrutValue = i31.get(scrutAsI31, signed = true)
+                        i32.eq(scrutValue, withValidIntLit(value, lit.toLoc)(i32.const))
+                      case _ =>
+                        break(errExpr(Ls(msg"Pattern matching for unit literals not implemented yet" -> lit.toLoc)))
+
+                    val bodyExpr = returningTerm(body)
+                    val armBodyExpr = lowerMatchBody(bodyExpr)
+                    funcCtx.withLabel(LabelSymbol(N, "arm"), hasContinueLabel = false):
+                      case LabelTarget(armLabel, _) =>
+                        S(`if`(
+                          condition = testExpr,
+                          ifTrue = blockInstr(
+                            label = S(armLabel),
+                            children = Seq(armBodyExpr, br(matchLabel)),
+                            resultTypes = Seq.empty,
+                          ),
+                          ifFalse = N,
+                          resultTypes = Seq.empty,
+                        ))
+
+                  case Case.Cls(cls, _) =>
+                    val clsBlkMemberSym = cls.asBlkMember.getOrElse:
+                      break(errExpr(
+                        Ls(msg"Could not resolve BlockMemberSymbol for class pattern" -> cls.toLoc),
+                        extraInfo = S(s"ClassLikeSymbol: ${cls.toString}"),
+                      ))
+                    val clsTypeIdx = ctx.getType_!(clsBlkMemberSym)
+                    val typeinfo = ctx.getTypeInfo_!(clsTypeIdx)
+
+                    val expectedTag = typeinfo.objectTag.getOrElse:
+                      lastWords(s"Expected class $clsBlkMemberSym to have an object tag")
+
+                    // TODO (https://github.com/orgs/hkust-taco/projects/14/views/1?pane=issue&itemId=174476970):
+                    // replace with RTTI ancestry checks once each object carries runtime type information.
+                    val matchTags = ctx.getAllRuntimeTags(clsBlkMemberSym)
+                      .getOrElse(LinkedHashSet(expectedTag))
+
+                    val scrutExpr = getScrutExpr
+                    val isStructCompatible = ref.test(scrutExpr, baseObjectRefType(nullable = true))
+
+                    val bodyExpr = returningTerm(body)
+                    val armBodyExpr = lowerMatchBody(bodyExpr)
+
+                    // Safe to cast and extract tag since ref.test passed
+                    val scrutAsObject = ref.cast(scrutExpr, baseObjectRefType(nullable = false))
+                    val scrutTag = struct.get(
+                      FieldIdx(SymIdx(typeinfo.compType.asInstanceOf[StructType].fields(0)._2.id)),
+                      scrutAsObject,
+                      I32Type,
+                    )
+                    val tagMatches = matchTags.toList match
+                      case tag :: Nil => i32.eq(scrutTag, i32.const(tag))
+                      case tag :: rest =>
+                        rest.foldLeft[Expr](i32.eq(scrutTag, i32.const(tag))): (acc, candidateTag) =>
+                          i32.or(acc, i32.eq(scrutTag, i32.const(candidateTag)))
+                      case Nil =>
+                        lastWords(s"Expected class $clsBlkMemberSym to have at least one accepted runtime tag")
+
+                    funcCtx.withLabel(LabelSymbol(N, "arm"), hasContinueLabel = false):
+                      case LabelTarget(armLabel, _) =>
+                        S(`if`(
+                          condition = isStructCompatible,
+                          ifTrue = `if`(
+                            condition = tagMatches,
+                            ifTrue = blockInstr(
+                              label = S(armLabel),
+                              children = Seq(armBodyExpr, br(matchLabel)),
+                              resultTypes = Seq.empty,
+                            ),
+                            ifFalse = N,
+                            resultTypes = Seq.empty,
+                          ),
+                          ifFalse = N,
+                          resultTypes = Seq.empty,
+                        ))
+                  case Case.Tup(len, inf) =>
+                    val arrayRefType = RefType(HeapType.Array, nullable = true)
+                    val isArrayTest = ref.test(getScrutExpr, arrayRefType)
+
+                    // Length check
+                    val scrutArray = ref.cast(getScrutExpr, arrayRefType)
+                    val arrayLength = array.len(scrutArray)
+                    val lengthTest = if inf then
+                      i32.ge_u(arrayLength, i32.const(len))
+                    else
+                      i32.eq(arrayLength, i32.const(len))
+
+                    val testExpr = i32.and(isArrayTest, lengthTest)
+                    val bodyExpr = returningTerm(body)
+                    val armBodyExpr = lowerMatchBody(bodyExpr)
+                    funcCtx.withLabel(LabelSymbol(N, "arm"), hasContinueLabel = false):
+                      case LabelTarget(armLabel, _) =>
+                        S(`if`(
+                          condition = testExpr,
+                          ifTrue = blockInstr(
+                            label = S(armLabel),
+                            children = Seq(armBodyExpr, br(matchLabel)),
+                            resultTypes = Seq.empty,
+                          ),
+                          ifFalse = N,
+                          resultTypes = Seq.empty,
+                        ))
                   case _ =>
-                    break(errExpr(Ls(msg"Pattern matching for unit literals not implemented yet" -> lit.toLoc)))
+                    break(errExpr(
+                      Ls(
+                        msg"WatBuilder::returningTerm for Match(...) with case `${cse.toString}` not implemented yet" ->
+                          N,
+                      ),
+                      extraInfo = S(cse.toString),
+                    ))
+                end match
 
-                val bodyExpr = returningTerm(body)
-                val armBodyExpr = lowerMatchBody(bodyExpr)
-                val armLabelSym = TempSymbol(N, "arm")
-                val armLabel = scope.allocateName(armLabelSym)
-                S(`if`(
-                  condition = testExpr,
-                  ifTrue = blockInstr(
-                    label = S(armLabel),
-                    children = Seq(armBodyExpr, br(matchLabel)),
-                    resultTypes = Seq.empty,
-                  ),
-                  ifFalse = N,
-                  resultTypes = Seq.empty,
-                ))
+              val defaultExpr =
+                val rawDefaultExpr = dflt match
+                  case S(defaultBody) => returningTerm(defaultBody)
+                  case N => nop
+                lowerMatchBody(rawDefaultExpr)
 
-              case Case.Cls(cls, _) =>
-                val clsBlkMemberSym = cls.asBlkMember.getOrElse:
-                  break(errExpr(
-                    Ls(msg"Could not resolve BlockMemberSymbol for class pattern" -> cls.toLoc),
-                    extraInfo = S(s"ClassLikeSymbol: ${cls.toString}"),
-                  ))
-                val clsTypeIdx = ctx.getType_!(clsBlkMemberSym)
-                val typeinfo = ctx.getTypeInfo_!(clsTypeIdx)
+              // Generate the match block
+              blockInstr(
+                label = S(matchLabel),
+                children = matchResInitExpr.toSeq ++ armExprs :+ defaultExpr,
+                resultTypes = Seq.empty,
+              )
 
-                val expectedTag = typeinfo.objectTag.getOrElse:
-                  lastWords(s"Expected class $clsBlkMemberSym to have an object tag")
-
-                // TODO (https://github.com/orgs/hkust-taco/projects/14/views/1?pane=issue&itemId=174476970):
-                // replace with RTTI ancestry checks once each object carries runtime type information.
-                val matchTags = ctx.getAllRuntimeTags(clsBlkMemberSym)
-                  .getOrElse(LinkedHashSet(expectedTag))
-
-                val scrutExpr = getScrutExpr
-                val isStructCompatible = ref.test(scrutExpr, baseObjectRefType(nullable = true))
-
-                val bodyExpr = returningTerm(body)
-                val armBodyExpr = lowerMatchBody(bodyExpr)
-                val armLabelSym = TempSymbol(N, "arm")
-                val armLabel = scope.allocateName(armLabelSym)
-
-                // Safe to cast and extract tag since ref.test passed
-                val scrutAsObject = ref.cast(scrutExpr, baseObjectRefType(nullable = false))
-                val scrutTag = struct.get(
-                  FieldIdx(SymIdx(typeinfo.compType.asInstanceOf[StructType].fields(0)._2.id)),
-                  scrutAsObject,
-                  I32Type,
-                )
-                val tagMatches = matchTags.toList match
-                  case tag :: Nil => i32.eq(scrutTag, i32.const(tag))
-                  case tag :: rest =>
-                    rest.foldLeft[Expr](i32.eq(scrutTag, i32.const(tag))): (acc, candidateTag) =>
-                      i32.or(acc, i32.eq(scrutTag, i32.const(candidateTag)))
-                  case Nil =>
-                    lastWords(s"Expected class $clsBlkMemberSym to have at least one accepted runtime tag")
-
-                S(`if`(
-                  condition = isStructCompatible,
-                  ifTrue = `if`(
-                    condition = tagMatches,
-                    ifTrue = blockInstr(
-                      label = S(armLabel),
-                      children = Seq(armBodyExpr, br(matchLabel)),
-                      resultTypes = Seq.empty,
-                    ),
-                    ifFalse = N,
-                    resultTypes = Seq.empty,
-                  ),
-                  ifFalse = N,
-                  resultTypes = Seq.empty,
-                ))
-              case Case.Tup(len, inf) =>
-                val arrayRefType = RefType(HeapType.Array, nullable = true)
-                val isArrayTest = ref.test(getScrutExpr, arrayRefType)
-
-                // Length check
-                val scrutArray = ref.cast(getScrutExpr, arrayRefType)
-                val arrayLength = array.len(scrutArray)
-                val lengthTest = if inf then
-                  i32.ge_u(arrayLength, i32.const(len))
-                else
-                  i32.eq(arrayLength, i32.const(len))
-
-                val testExpr = i32.and(isArrayTest, lengthTest)
-                val bodyExpr = returningTerm(body)
-                val armBodyExpr = lowerMatchBody(bodyExpr)
-                val armLabelSym = TempSymbol(N, "arm")
-                val armLabel = scope.allocateName(armLabelSym)
-                S(`if`(
-                  condition = testExpr,
-                  ifTrue = blockInstr(
-                    label = S(armLabel),
-                    children = Seq(armBodyExpr, br(matchLabel)),
-                    resultTypes = Seq.empty,
-                  ),
-                  ifFalse = N,
-                  resultTypes = Seq.empty,
-                ))
-              case _ =>
-                break(errExpr(
-                  Ls(msg"WatBuilder::returningTerm for Match(...) with case `${cse.toString}` not implemented yet" ->
-                    N),
-                  extraInfo = S(cse.toString),
-                ))
-            end match
-
-          val defaultExpr =
-            val rawDefaultExpr = dflt match
-              case S(defaultBody) => returningTerm(defaultBody)
-              case N => nop
-            lowerMatchBody(rawDefaultExpr)
-
-          // Generate the match block
-          val matchBlock = blockInstr(
-            label = S(matchLabel),
-            children = matchResInitExpr.toSeq ++ armExprs :+ defaultExpr,
-            resultTypes = Seq.empty,
+        if tailMode then
+          Instructions.block(
+            label = N,
+            children = Seq(
+              matchBlock,
+              local.get(matchResLocal.get, RefType.anyref),
+            ),
+            resultTypes = Seq(Result(RefType.anyref)),
           )
-
-          if tailMode then
-            Instructions.block(
-              label = N,
-              children = Seq(
-                matchBlock,
-                local.get(matchResLocal.get, RefType.anyref),
-              ),
-              resultTypes = Seq(Result(RefType.anyref)),
-            )
-          else
-            val rstExpr = returningTerm(rst)
-            Instructions.block(
-              label = N,
-              children = Seq(matchBlock, rstExpr),
-              resultTypes = rstExpr.resultTypes.flatMap(ty => ty.asValType.map(Result(_))),
-            )
+        else
+          val rstExpr = returningTerm(rst)
+          Instructions.block(
+            label = N,
+            children = Seq(matchBlock, rstExpr),
+            resultTypes = rstExpr.resultTypes.flatMap(ty => ty.asValType.map(Result(_))),
+          )
 
       // * Try/finally lowering is intentionally rejected for now: the previous implementation required `exnref` support
       // * which can only be enabled with the `--experimental-wasm-exnref` flag.

--- a/hkmc2/shared/src/test/mlscript/wasm/ControlFlow.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/ControlFlow.mls
@@ -214,7 +214,7 @@ tailMatchAllValue(1)
 //│                 (local.get $x)))
 //│             (i32.const 1))
 //│           (then
-//│             (block $arm1
+//│             (block $arm
 //│               (return
 //│                 (ref.i31
 //│                   (i32.const 20)))

--- a/hkmc2/shared/src/test/mlscript/wasm/Matching.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/Matching.mls
@@ -135,7 +135,7 @@ if Bar(true) is
 //│                           (local.get $scrut)))
 //│                       (i32.const 1))
 //│                     (then
-//│                       (block $arm1
+//│                       (block $arm
 //│                         (local.set $matchRes
 //│                           (block (result (ref null any))
 //│                             (local.set $arg$Bar$0$
@@ -177,7 +177,7 @@ if Bar(true) is
 //│                           (local.get $scrut)))
 //│                       (i32.const 2))
 //│                     (then
-//│                       (block $arm2
+//│                       (block $arm
 //│                         (local.set $matchRes
 //│                           (block (result (ref null any))
 //│                             (local.set $arg$Baz$0$


### PR DESCRIPTION
This PR moves the generation and tracking of labels into `FunctionCtx`. Previously, label generation is done in `WatBuilder`, whereas label tracking is done in `Ctx`.

The benefit of merging into `FunctionCtx` is

- Label generation is now consolidated into `withLabel`
- Label names are now scoped, allowing labels to be reused if their identifier scope do not intersect
- Labels inside function context reflects a better structure, since labels cannot exist outside of functions