### PR TITLE
wasm: Refactor more `Str` to `SymIdx`, miscellaneous cleanup

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -188,9 +188,9 @@ object SessionExportCtx:
 class FuncInfo(
     val id: SymIdx,
     val typeUse: TypeUse,
-    params: Seq[Local -> Str],
+    params: Seq[Local -> SymIdx],
     val resultTypes: Seq[Result],
-    locals: Seq[Local -> Str],
+    locals: Seq[Local -> SymIdx],
     val body: Expr,
     val exportName: Opt[Str],
 ) extends ToWat:
@@ -211,9 +211,9 @@ class FuncInfo(
   def this(
       sym: BlockMemberSymbol,
       typeUse: TypeUse,
-      params: Seq[Local -> Str],
+      params: Seq[Local -> SymIdx],
       nResults: Int,
-      locals: Seq[Local -> Str],
+      locals: Seq[Local -> SymIdx],
       body: Expr,
   )(using Raise, Scope) = this(
     SymIdx(sym.optionIf(_.nameIsMeaningful).fold(summon[Scope].allocateName(sym))(_.nme)),
@@ -228,9 +228,9 @@ class FuncInfo(
   def this(
       id: Opt[SymIdx],
       typeUse: TypeUse,
-      params: Seq[Local -> Str],
+      params: Seq[Local -> SymIdx],
       nResults: Int,
-      locals: Seq[Local -> Str],
+      locals: Seq[Local -> SymIdx],
       body: Expr,
       `export`: Opt[Str],
   )(using Raise, Scope, State) = this(
@@ -245,7 +245,7 @@ class FuncInfo(
 
   /** Returns the type of this function as a [[SignatureType]]. */
   def getSignatureType: SignatureType = SignatureType(
-    params = params.map((_, varNme) => WasmParam(varNme, RefType.anyref)),
+    params = params.map((_, paramIdx) => WasmParam(paramIdx, RefType.anyref)),
     results = resultTypes,
   )
 
@@ -257,7 +257,7 @@ class FuncInfo(
         getSignatureType.toWat.surroundUnlessEmpty(doc" ")
       } #{ ${
         locals.map: p =>
-          doc"(local $$${p._2} ${RefType.anyref.toWat})"
+          doc"(local ${p._2.toWat} ${RefType.anyref.toWat})"
         .mkDocument(doc" # ").surroundUnlessEmpty(doc" # ")
       } # ${body.toWat} #} )"""
 end FuncInfo

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -15,7 +15,6 @@ import semantics.{
 import text.Param as WasmParam
 import Instructions.*
 
-import scala.annotation.{nowarn, targetName}
 import scala.collection.immutable.ListMap
 import scala.collection.mutable.{ArrayBuffer as ArrayBuf, Map as MutMap, LinkedHashSet}
 import scala.reflect.ClassTag
@@ -590,30 +589,11 @@ class Ctx extends ToWat:
       namedTypes(_) = typeInfo
     TypeIdx(id)
 
-  @deprecated("Use the overload without `resolveSymIdx` instead.")
-  def getType(typeref: TypeIdx | BlockMemberSymbol, resolveSymIdx: Bool): Opt[TypeIdx] =
-    if resolveSymIdx then
-      typeref match
-        case TypeIdx(idx @ SymIdx(_)) =>
-          types.zipWithIndex.collectFirst:
-            case ((symIdx, _), i) if symIdx == idx => TypeIdx(NumIdx(i))
-        case typeidx: TypeIdx => S(typeidx)
-        case sym: BlockMemberSymbol =>
-          namedTypes.get(sym).flatMap: typeInfo =>
-            types.zipWithIndex.collectFirst:
-              case ((_, ti), i) if ti === typeInfo => TypeIdx(NumIdx(i))
-    else getType(typeref)
-
   /** Returns the [[TypeIdx]] of the given `typeref`.
     */
   def getType(typeref: TypeIdx | BlockMemberSymbol): Opt[TypeIdx] = typeref match
     case typeidx: TypeIdx => S(typeidx)
     case sym: BlockMemberSymbol => getTypeInfo(typeref).map(ti => TypeIdx(ti.id))
-
-  @deprecated("Use the overload without `resolveSymIdx` instead.")
-  def getType_!(typeref: TypeIdx | BlockMemberSymbol, resolveSymIdx: Bool): TypeIdx =
-    getType(typeref, resolveSymIdx).getOrElse:
-      lastWords(s"Missing type definition for ${typeref.prettyString}")
 
   /** Same as [[getType]] but throws an exception when the `typeref` is not found. */
   def getType_!(typeref: TypeIdx | BlockMemberSymbol): TypeIdx =
@@ -621,9 +601,7 @@ class Ctx extends ToWat:
       lastWords(s"Missing type definition for ${typeref.prettyString}")
 
   /** Returns the [[TypeInfo]] instance associated with the given `typeref`. */
-  @nowarn("cat=deprecation")
   def getTypeInfo(typeref: TypeIdx | BlockMemberSymbol): Opt[TypeInfo] = typeref match
-    case TypeIdx(NumIdx(idx)) => types.drop(idx).headOption.map(_._2)
     case TypeIdx(idx @ SymIdx(nme)) => types.get(idx)
     case sym: BlockMemberSymbol => namedTypes.get(sym)
 
@@ -640,13 +618,6 @@ class Ctx extends ToWat:
   def getAllRuntimeTags(sym: BlockMemberSymbol): Opt[LinkedHashSet[Int]] =
     runtimeClassTags.get(sym)
 
-  @deprecated("Use the `Import[ExternType.Func]` overload instead.")
-  def addFunctionImport(sym: Opt[Symbol], funcImport: FuncImport): FuncIdx =
-    addFunctionImport(
-      sym,
-      Import(funcImport.module, funcImport.name, ExternType.Func(funcImport.id, TypeUse(funcImport.typeIdx))),
-    )
-
   /** Adds a function import into this context.
     *
     * Returns the function index in the global function index space.
@@ -657,14 +628,6 @@ class Ctx extends ToWat:
     sym.foreach:
       namedFuncs(_) = funcImport
     FuncIdx(id)
-
-  @deprecated("Use the `Import[ExternType.Func]` overload instead.")
-  @targetName("getOrCreateFuncImport")
-  def getOrCreateFunctionImport(
-      module: Str,
-      name: Str,
-  )(createImport: => FuncImport): FuncIdx =
-    cachedFunctionImports.getOrElseUpdate((module, name), addFunctionImport(N, createImport))
 
   /** Returns the cached function import for (`module`, `name`), creating it with `createImport` if needed.
     */
@@ -719,11 +682,6 @@ class Ctx extends ToWat:
         cachedMemoryImport(key) = SymIdx(name)
   end ensureMemoryImport
 
-  /** Returns the minimum page requirement of memory import (`module`, `name`) if present. */
-  @deprecated("Use `getMemoryImport` instead to get the full memory import information.")
-  def getMemoryImportMinPages(module: Str, name: Str): Opt[Int] =
-    getMemoryImport(module, name).map(_.memType.lim.min)
-
   /** Returns the memory import information for the given (`module`, `name`) tuple if present. */
   def getMemoryImport(module: Str, name: Str): Opt[ExternType.Mem] =
     memories.collectFirst:
@@ -751,20 +709,6 @@ class Ctx extends ToWat:
       (id -> ElemSegment.Declare(id, refType -> Seq(ref.func(idx, refType))))
     idx
 
-  @deprecated("Use the overload without `resolveSymIdx` instead.")
-  def getFunc(funcref: FuncIdx | Symbol, resolveSymIdx: Bool): Opt[FuncIdx] =
-    if resolveSymIdx then
-      funcref match
-        case FuncIdx(idx @ SymIdx(_)) =>
-          funcs.zipWithIndex.collectFirst:
-            case ((symIdx, _), i) if symIdx == idx => FuncIdx(NumIdx(i))
-        case funcidx: FuncIdx => S(funcidx)
-        case sym: Symbol =>
-          namedFuncs.get(sym).flatMap: funcInfo =>
-            funcs.zipWithIndex.collectFirst:
-              case ((_, fi), i) if fi === funcInfo => FuncIdx(NumIdx(i))
-    else getFunc(funcref)
-
   /** Returns the [[FuncIdx]] of the given `funcref`.
     */
   def getFunc(funcref: FuncIdx | Symbol): Opt[FuncIdx] = funcref match
@@ -775,19 +719,12 @@ class Ctx extends ToWat:
           case fi: FuncInfo => FuncIdx(fi.id)
           case imp: Import[ExternType.Func] => FuncIdx(imp.externType.id)
 
-  @deprecated("Use the overload without `resolveSymIdx` instead.")
-  def getFunc_!(funcref: FuncIdx | Symbol, resolveSymIdx: Bool): FuncIdx =
-    getFunc(funcref, resolveSymIdx).getOrElse:
-      lastWords(s"Missing function definition for ${funcref.prettyString}")
-
   /** Same as [[getFunc]] but throws an exception when the `funcref` is not found. */
   def getFunc_!(funcref: FuncIdx | Symbol): FuncIdx =
     getFunc(funcref).getOrElse:
       lastWords(s"Missing function definition for ${funcref.prettyString}")
 
-  @nowarn("cat=deprecation")
   private def getFuncEntry(funcref: FuncIdx | Symbol): Opt[FuncInfo | Import[ExternType.Func]] = funcref match
-    case FuncIdx(NumIdx(idx)) => funcs.drop(idx).headOption.map(_._2)
     case FuncIdx(idx @ SymIdx(_)) => funcs.get(idx)
     case funcref: Symbol => namedFuncs.get(funcref)
 
@@ -824,10 +761,8 @@ class Ctx extends ToWat:
     getGlobal(globalref).getOrElse:
       lastWords(s"Missing global definition for ${globalref.prettyString}")
 
-  @nowarn("cat=deprecation")
   private def getGlobalEntry(globalref: GlobalIdx | Symbol): Opt[GlobalInfo | Import[ExternType.Global]] =
     globalref match
-      case GlobalIdx(NumIdx(idx)) => globals.drop(idx.toInt).headOption.map(_._2)
       case GlobalIdx(idx @ SymIdx(_)) => globals.get(idx)
       case sym: Symbol => namedGlobals.get(sym)
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
@@ -165,13 +165,6 @@ case class TypeUse(typeIdx: TypeIdx) extends ToWat:
 
 sealed abstract class Index extends ToWat
 
-/** A numeric index. */
-@deprecated(
-  "NumIdx is only used for internal bookkeeping and should not be used in WAT generation; Use SymIdx instead.",
-)
-case class NumIdx(val index: Int) extends Index:
-  def toWat: Document = doc"${index.toString}"
-
 /** A symbolic identifier. */
 case class SymIdx(val id: Str) extends Index:
   def toWat: Document = doc"$$$id"

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
@@ -89,9 +89,9 @@ end HeapType
 type ValType = NumType | VecType | RefType
 
 /** A Wasm parameter clause. Appears in function signatures. */
-case class Param(id: Str, valtype: ValType) extends ToWat:
+case class Param(id: SymIdx, valtype: ValType) extends ToWat:
   def toWat: Document =
-    doc"(param $$$id ${valtype.toWat})"
+    doc"(param ${id.toWat} ${valtype.toWat})"
 
 /** A Wasm result clause. Appears in function signatures and some instructions. */
 case class Result(valtype: ValType) extends ToWat:

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -118,14 +118,15 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     returningTerm(Define(unitDefn, End("")))
 
     val typeInfo = ctx.getTypeInfo_!(unitDefn.sym)
-    val singletonInfo = ctx.getSingletonInfo(unitDefn.sym).getOrElse:
+    val singletonInfo = ctx.getSingletonInfo(unitDefn.sym) getOrElse:
       lastWords("Missing singleton metadata for synthetic Unit object")
     // Record session metadata for the synthetic Unit singleton.
     summon[SessionExportCtx].emit(SessionClass(
       sym = unitDefn.sym,
       typeInfo = typeInfo,
-      runtimeTags = ctx.getAllRuntimeTags(unitDefn.sym)
-        .getOrElse(LinkedHashSet(ctx.getRuntimeClassTag_!(unitDefn.sym))),
+      runtimeTags = ctx.getAllRuntimeTags(unitDefn.sym) getOrElse:
+        LinkedHashSet(ctx.getRuntimeClassTag_!(unitDefn.sym))
+      ,
       aliasSyms = singletonOwner.toSeq,
     ))
     summon[SessionExportCtx].emit(SessionSingleton(
@@ -265,8 +266,10 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     val parentTypeIdx =
       if defn.parentPath.isEmpty then baseObjectTypeIdx
       else
-        ctx.getType_!(resolveParentSym(defn).getOrElse:
-          lastWords(s"Expected resolved parent class symbol when predeclaring ${defn.sym.nme}"))
+        ctx.getType_!(
+          resolveParentSym(defn) getOrElse:
+            lastWords(s"Expected resolved parent class symbol when predeclaring ${defn.sym.nme}"),
+        )
     val inheritedFields = ctx.getTypeInfo_!(parentTypeIdx).compType match
       case struct: StructType => struct.fields
       case other => lastWords(s"Parent type must be a struct, found ${other.toWat.mkString()}")
@@ -300,7 +303,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       resolveParentSym(defn).foreach: parentSym =>
         childrenBySym(parentSym) += defn.sym
     orderedDefns.reverseIterator.foreach: defn =>
-      val ownTag = ctx.getTypeInfo_!(defn.sym).objectTag.getOrElse:
+      val ownTag = ctx.getTypeInfo_!(defn.sym).objectTag getOrElse:
         lastWords(s"Expected class ${defn.sym} to have an object tag")
       val childTags = childrenBySym(defn.sym).flatMap: childSym =>
         ctx.getAllRuntimeTags(childSym).getOrElse(lastWords("unreachable"))
@@ -316,10 +319,8 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     val funcTyId = defn.sym
       .optionIf: sym =>
         !isSingletonObj && sym.nameIsMeaningful
-      .map: sym =>
+      .fold(scope.allocateName(TempSymbol(N, s"${defn.sym.nme}_$suffix"))): sym =>
         s"${sym.nme}_$suffix"
-      .getOrElse:
-        scope.allocateName(TempSymbol(N, s"${defn.sym.nme}_$suffix"))
     ctx.addType(
       sym = N,
       TypeInfo(
@@ -514,7 +515,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       .optionIf: sym =>
         !(ownerCls.k is syntax.Obj) && sym.nameIsMeaningful
       .map: sym =>
-        s"${sym.nme}_${methodDefn.sym.nme}"
+        SymIdx(s"${sym.nme}_${methodDefn.sym.nme}")
     predeclareClassFunc(ownerCls, methodDefn.sym.nme, methodParams, S(methodDefn.sym), methodId, N)
 
   /** Declares placeholders for all methods on one top-level class. */
@@ -905,10 +906,10 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     val symToField = structInfo.compType match
       case ty: StructType => ty.fieldsBySym
       case _ => lastWords(s"Cannot select field from non-struct type: ${structInfo.compType.toWat.mkString()}")
-    val fieldIdx = symToField.get(sym).map(_.id).getOrElse:
-      lastWords(
-        s"Missing field `${sym.toString}` in struct `${thisSym.toString}` with type `${structInfo.toWat.mkString()}`",
-      )
+    val fieldIdx = symToField.get(sym).fold(lastWords(
+      s"Missing field `${sym.toString}` in struct `${thisSym.toString}` with type `${structInfo.toWat.mkString()}`",
+    )): field =>
+      field.id
     FieldIdx(SymIdx(fieldIdx))
   end fieldSelect
 
@@ -1584,7 +1585,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                           case Nil => ctorAuxParams
                       case Some(_) => ctorAuxParams
 
-                    val tagValue = typeinfo.objectTag.getOrElse:
+                    val tagValue = typeinfo.objectTag getOrElse:
                       lastWords(s"Expected class ${clsLikeDefn.sym} to have an object tag")
 
                     val initFuncRef = initFuncSym(clsLikeDefn.sym)
@@ -1679,8 +1680,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                       summon[SessionExportCtx].emit(SessionClass(
                         sym = clsLikeDefn.sym,
                         typeInfo = typeinfo,
-                        runtimeTags = ctx.getAllRuntimeTags(clsLikeDefn.sym)
-                          .getOrElse(LinkedHashSet(tagValue)),
+                        runtimeTags = ctx.getAllRuntimeTags(clsLikeDefn.sym).getOrElse(LinkedHashSet(tagValue)),
                         aliasSyms = clsLikeDefn.isym match
                           case mos: ModuleOrObjectSymbol => mos :: Nil
                           case _ => Nil,
@@ -1794,7 +1794,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
           case LabelTarget(breakLabel, continueLabel) =>
             val bodyExpr = returningTerm(body)
             val bodyStmt = asStatement(bodyExpr)
-    
+
             if loop then
               blockInstr(
                 label = S(breakLabel),
@@ -1887,7 +1887,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                         ))
 
                   case Case.Cls(cls, _) =>
-                    val clsBlkMemberSym = cls.asBlkMember.getOrElse:
+                    val clsBlkMemberSym = cls.asBlkMember getOrElse:
                       break(errExpr(
                         Ls(msg"Could not resolve BlockMemberSymbol for class pattern" -> cls.toLoc),
                         extraInfo = S(s"ClassLikeSymbol: ${cls.toString}"),
@@ -1895,13 +1895,12 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                     val clsTypeIdx = ctx.getType_!(clsBlkMemberSym)
                     val typeinfo = ctx.getTypeInfo_!(clsTypeIdx)
 
-                    val expectedTag = typeinfo.objectTag.getOrElse:
+                    val expectedTag = typeinfo.objectTag getOrElse:
                       lastWords(s"Expected class $clsBlkMemberSym to have an object tag")
 
                     // TODO (https://github.com/orgs/hkust-taco/projects/14/views/1?pane=issue&itemId=174476970):
                     // replace with RTTI ancestry checks once each object carries runtime type information.
-                    val matchTags = ctx.getAllRuntimeTags(clsBlkMemberSym)
-                      .getOrElse(LinkedHashSet(expectedTag))
+                    val matchTags = ctx.getAllRuntimeTags(clsBlkMemberSym).getOrElse(LinkedHashSet(expectedTag))
 
                     val scrutExpr = getScrutExpr
                     val isStructCompatible = ref.test(scrutExpr, baseObjectRefType(nullable = true))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -310,7 +310,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   private def declareClassFuncType(
       defn: ClsLikeDefn,
       suffix: Str,
-      params: Seq[Local -> Str],
+      params: Seq[Local -> SymIdx],
   )(using Ctx, Raise, Scope): TypeIdx =
     val isSingletonObj = defn.k is syntax.Obj
     val funcTyId = defn.sym
@@ -341,7 +341,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   private def predeclareClassFunc(
       defn: ClsLikeDefn,
       suffix: Str,
-      params: Seq[Local -> Str],
+      params: Seq[Local -> SymIdx],
       sym: Opt[Symbol],
       id: Opt[Str],
       exportName: Opt[Str],
@@ -363,10 +363,10 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
   /** Declares one top-level class init function. */
   private def predeclareClassInit(defn: ClsLikeDefn)(using Ctx, Raise, Scope): Unit =
-    val initParams = (defn.isym -> "this") +:
+    val initParams = (defn.isym -> SymIdx("this")) +:
       defn.paramsOpt.fold(Nil): ps =>
         ps.params.map: p =>
-          p.sym -> p.sym.nme
+          p.sym -> SymIdx(p.sym.nme)
     val initId = defn.sym
       .optionIf: sym =>
         !(defn.k is syntax.Obj) && sym.nameIsMeaningful
@@ -378,7 +378,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   private def predeclareClassConstructor(defn: ClsLikeDefn)(using Ctx, Raise, Scope): Unit =
     val ctorParams = defn.paramsOpt.fold(Nil): ps =>
       ps.params.map: p =>
-        p.sym -> p.sym.nme
+        p.sym -> SymIdx(p.sym.nme)
     val ctorId = defn.sym
       .optionIf: sym =>
         !(defn.k is syntax.Obj) && sym.nameIsMeaningful
@@ -503,10 +503,10 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
   /** Declares one top-level class method. */
   private def predeclareMethod(methodDefn: FunDefn, ownerCls: ClsLikeDefn)(using Ctx, Raise, Scope): Unit =
-    val methodParams = (ownerCls.isym -> "this") +:
+    val methodParams = (ownerCls.isym -> SymIdx("this")) +:
       methodDefn.params.headOption.fold(Nil): ps =>
         ps.params.map: p =>
-          p.sym -> p.sym.nme
+          p.sym -> SymIdx(p.sym.nme)
     val methodId = ownerCls.sym
       .optionIf: sym =>
         !(ownerCls.k is syntax.Obj) && sym.nameIsMeaningful
@@ -538,7 +538,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
           sym = N,
           TypeInfo(
             id = SymIdx(symNme),
-            FunctionType(params = Seq(WasmParam("ex", RefType.anyref)), results = Seq.empty),
+            FunctionType(params = Seq(WasmParam(SymIdx("ex"), RefType.anyref)), results = Seq.empty),
             objectTag = S(ctx.getFreshObjectTag()),
           ),
         )),
@@ -588,7 +588,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
         TypeInfo(
           id = SymIdx(importTyNme),
           FunctionType(
-            params = Seq(WasmParam("glob_offset", RefType.anyref), WasmParam("len", RefType.anyref)),
+            params = Seq(WasmParam(SymIdx("glob_offset"), RefType.anyref), WasmParam(SymIdx("len"), RefType.anyref)),
             results = Seq(Result(RefType.anyref)),
           ),
           objectTag = N,
@@ -1210,7 +1210,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       TypeInfo(
         id = SymIdx(scope.allocateName(TempSymbol(N, name))),
         FunctionType(
-          params = intrinsicParamSuffixes(name).map(nme => WasmParam(nme, RefType.anyref)),
+          params = intrinsicParamSuffixes(name).map(nme => WasmParam(SymIdx(nme), RefType.anyref)),
           results = Seq(Result(RefType.anyref)),
         ),
         objectTag = N,
@@ -1227,7 +1227,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     val params = mkIntrinsicParams(name, Seq("lhs", "rhs"))
     val lhsName = params.head._2
     val rhsName = params(1)._2
-    val body = binaryInt31Body(lhsName, rhsName, op)
+    val body = binaryInt31Body(LocalIdx(lhsName), LocalIdx(rhsName), op)
     createIntrinsicFunc(name, params, body, exportName)
 
   /** Creates a unary Int31 intrinsic with a single parameter and body built from `op`.
@@ -1239,14 +1239,14 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   )(using Ctx, Raise, Scope): FuncIdx =
     val params = mkIntrinsicParams(name, Seq("arg"))
     val argName = params.head._2
-    val body = unaryInt31Body(argName, op)
+    val body = unaryInt31Body(LocalIdx(argName), op)
     createIntrinsicFunc(name, params, body, exportName)
 
   /** Allocates the Wasm type and function definition for an intrinsic with the given signature.
     */
   private def createIntrinsicFunc(
       name: Str,
-      params: Seq[(TempSymbol, Str)],
+      params: Seq[TempSymbol -> SymIdx],
       body: Expr,
       exportName: Opt[Str],
   )(using Ctx, Raise, Scope): FuncIdx =
@@ -1273,15 +1273,15 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   /** Builds the body for an Int31 binary operator.
     */
   private def binaryInt31Body(
-      lhsName: Str,
-      rhsName: Str,
+      lhsIdx: LocalIdx,
+      rhsIdx: LocalIdx,
       op: (Expr, Expr) => Expr,
   )(using Ctx, Scope): Expr =
     val cond = i32.and(
-      ref.test(getLocalAnyref(lhsName), RefType.i31ref),
-      ref.test(getLocalAnyref(rhsName), RefType.i31ref),
+      ref.test(getLocalAnyref(lhsIdx), RefType.i31ref),
+      ref.test(getLocalAnyref(rhsIdx), RefType.i31ref),
     )
-    val i31Op = ref.i31(op(getI32FromAnyref(lhsName), getI32FromAnyref(rhsName)))
+    val i31Op = ref.i31(op(getI32FromAnyref(lhsIdx), getI32FromAnyref(rhsIdx)))
     `if`(
       condition = cond,
       ifTrue = i31Op,
@@ -1291,9 +1291,9 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
   /** Builds the body for an Int31 unary operator.
     */
-  private def unaryInt31Body(paramName: Str, op: Expr => Expr)(using Ctx, Scope): Expr =
-    val cond = ref.test(getLocalAnyref(paramName), RefType.i31ref)
-    val i31Op = ref.i31(op(getI32FromAnyref(paramName)))
+  private def unaryInt31Body(paramIdx: LocalIdx, op: Expr => Expr)(using Ctx, Scope): Expr =
+    val cond = ref.test(getLocalAnyref(paramIdx), RefType.i31ref)
+    val i31Op = ref.i31(op(getI32FromAnyref(paramIdx)))
     `if`(
       condition = cond,
       ifTrue = i31Op,
@@ -1303,20 +1303,20 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
   /** Creates parameters for an intrinsic.
     */
-  private def mkIntrinsicParams(name: Str, suffixes: Seq[Str]): Seq[(TempSymbol, Str)] =
+  private def mkIntrinsicParams(name: Str, suffixes: Seq[Str]): Seq[TempSymbol -> SymIdx] =
     suffixes.map: suffix =>
       val sym = TempSymbol(N, suffix)
-      sym -> suffix
+      sym -> SymIdx(suffix)
 
   /** Loads the local `name` as an `anyref`.
     */
-  private def getLocalAnyref(name: Str): Expr =
-    local.get(LocalIdx(SymIdx(name)), RefType.anyref)
+  private def getLocalAnyref(idx: LocalIdx): Expr =
+    local.get(idx, RefType.anyref)
 
   /** Extracts the signed i32 value from the Int31 stored in the local `name`.
     */
-  private def getI32FromAnyref(name: Str): Expr =
-    i31.get(ref.cast(getLocalAnyref(name), RefType.i31ref), true)
+  private def getI32FromAnyref(idx: LocalIdx): Expr =
+    i31.get(ref.cast(getLocalAnyref(idx), RefType.i31ref), true)
 
   extension (expr: Expr)
     private def isControlTransfer: Bool =
@@ -1503,7 +1503,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                         TypeInfo(
                           id = SymIdx(scope.allocateName(TempSymbol(N, sym.nme))),
                           FunctionType(
-                            params = fnCtx.params.map(p => WasmParam(p._2.id, RefType.anyref)),
+                            params = fnCtx.params.map(p => WasmParam(p._2, RefType.anyref)),
                             results = Seq.fill(bodyWat.resultTypes.length)(Result(RefType.anyref)),
                           ),
                           objectTag = N,
@@ -1514,9 +1514,9 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                         FuncInfo(
                           sym,
                           typeUse = TypeUse(funcTy),
-                          params = ps.params.zip(fnCtx.params.map(_._2.id)).map((p, nme) => p.sym -> nme),
+                          params = ps.params.zip(fnCtx.params.map(_._2)).map((p, idx) => p.sym -> idx),
                           nResults = bodyWat.resultTypes.length,
-                          locals = fnCtx.locals.map((local, idx) => local -> idx.id),
+                          locals = fnCtx.locals,
                           body = bodyWat,
                         )
                       ctx.addFunc(S(defn.sym), funcInfo)
@@ -1590,7 +1590,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                       val initCall = call(
                         funcidx = ctx.getFunc_!(initFuncRef),
                         operands = local.get(thisVar, RefType.anyref) +:
-                          funcCtx.params.map((_, nme) => getLocalAnyref(nme.id)),
+                          funcCtx.params.map((_, nme) => getLocalAnyref(LocalIdx(nme))),
                         returnTypes = Seq(Result(RefType.anyref)),
                       )
                       blockInstr(
@@ -1621,9 +1621,9 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                       FuncInfo(
                         id = predeclaredInit.id,
                         typeUse = predeclaredInit.typeUse,
-                        params = initFnCtx.params.map((local, idx) => local -> idx.id),
+                        params = initFnCtx.params,
                         resultTypes = initWat.resultTypes.map(ty => Result(ty.asValType_!)),
-                        locals = initFnCtx.locals.map((local, idx) => local -> idx.id),
+                        locals = initFnCtx.locals,
                         body = initWat,
                         exportName = predeclaredInit.exportName,
                       ),
@@ -1635,9 +1635,9 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                       FuncInfo(
                         id = predeclaredCtor.id,
                         typeUse = predeclaredCtor.typeUse,
-                        params = ctorFnCtx.params.map((local, idx) => local -> idx.id),
+                        params = ctorFnCtx.params,
                         resultTypes = ctorAux.resultTypes.map(ty => Result(ty.asValType_!)),
-                        locals = ctorFnCtx.locals.map((local, idx) => local -> idx.id),
+                        locals = ctorFnCtx.locals,
                         body = ctorAux,
                         exportName = predeclaredCtor.exportName,
                       ),
@@ -1655,9 +1655,9 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                         FuncInfo(
                           id = predeclaredMethod.id,
                           typeUse = predeclaredMethod.typeUse,
-                          params = fnCtx.params.map((local, idx) => local -> idx.id),
+                          params = fnCtx.params,
                           resultTypes = Seq.fill(bodyWat.resultTypes.length)(Result(RefType.anyref)),
-                          locals = fnCtx.locals.map((local, idx) => local -> idx.id),
+                          locals = fnCtx.locals,
                           body = bodyWat,
                           exportName = predeclaredMethod.exportName,
                         ),
@@ -1689,7 +1689,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                           exportName = clsLikeDefn.sym.nme,
                           funcType = FunctionType(
                             SignatureType(
-                              params = ctorFnCtx.params.map(p => WasmParam(p._2.id, RefType.anyref)),
+                              params = ctorFnCtx.params.map(p => WasmParam(p._2, RefType.anyref)),
                               results = Seq(Result(RefType.anyref)),
                             ),
                           ),
@@ -2128,7 +2128,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
         typeUse = TypeUse(entryFnTy),
         params = Seq.empty,
         resultTypes = Seq(Result(RefType.anyref)),
-        locals = entryFnCtx.locals.map((local, idx) => local -> idx.id),
+        locals = entryFnCtx.locals,
         body = entryFnExpr,
         exportName = S(entryNme),
       )

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -343,14 +343,17 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       suffix: Str,
       params: Seq[Local -> SymIdx],
       sym: Opt[Symbol],
-      id: Opt[Str],
+      id: Opt[SymIdx],
       exportName: Opt[Str],
   )(using Ctx, Raise, Scope): Unit =
     val funcTy = declareClassFuncType(defn, suffix, params)
     ctx.addFunc(
       sym,
       FuncInfo(
-        id = SymIdx(id.orElse(exportName).getOrElse(scope.allocateName(TempSymbol(N, s"${defn.sym.nme}_$suffix")))),
+        id = id getOrElse:
+          SymIdx(exportName getOrElse:
+            scope.allocateName(TempSymbol(N, s"${defn.sym.nme}_$suffix")))
+        ,
         typeUse = TypeUse(funcTy),
         params = params,
         resultTypes = Seq(Result(RefType.anyref)),
@@ -371,7 +374,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       .optionIf: sym =>
         !(defn.k is syntax.Obj) && sym.nameIsMeaningful
       .map: sym =>
-        s"${sym.nme}_init"
+        SymIdx(s"${sym.nme}_init")
     predeclareClassFunc(defn, "init", initParams, S(initFuncSym(defn.sym)), initId, N)
 
   /** Declares one top-level class constructor. */
@@ -383,7 +386,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       .optionIf: sym =>
         !(defn.k is syntax.Obj) && sym.nameIsMeaningful
       .map: sym =>
-        s"${sym.nme}_ctor"
+        SymIdx(s"${sym.nme}_ctor")
     val ctorExportName = defn.sym
       .optionIf: sym =>
         !(defn.k is syntax.Obj) && sym.nameIsMeaningful

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -41,7 +41,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   import Ctx.ctx
   import Ctx.{SingletonInfo, binaryOps, unaryOps, wasmIntrinsicArities, wasmIntrinsicNameSet}
   import FunctionCtx.funcCtx
-  import Instructions.{block as blockInstr, *}
+  import Instructions.{block as blockInstr, loop as loopInstr, *}
   import WatBuilder.ExternIntrinsics
 
   type Context = Ctx
@@ -1453,7 +1453,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                       s"Expected `global.*` or `local.*` when compiling definition for `$sym`, but got ${symExpr.mnemonic}",
                     )
                 val rstWat = returningTerm(rst)
-                Instructions.block(
+                blockInstr(
                   label = N,
                   children = Seq(
                     defineExpr,
@@ -1793,10 +1793,10 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
             val bodyStmt = asStatement(bodyExpr)
     
             if loop then
-              Instructions.block(
+              blockInstr(
                 label = S(breakLabel),
                 children = Seq(
-                  Instructions.loop(
+                  loopInstr(
                     label = continueLabel,
                     children = Seq(bodyStmt),
                     resultTypes = Seq.empty,
@@ -1805,7 +1805,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                 resultTypes = Seq.empty,
               )
             else
-              Instructions.block(
+              blockInstr(
                 label = S(breakLabel),
                 children = Seq(bodyStmt),
                 resultTypes = Seq.empty,
@@ -1813,7 +1813,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
         val rstExpr = returningTerm(rst)
         val rstResultTypes = rstExpr.resultTypes.flatMap(ty => ty.asValType.map(Result(_)))
-        Instructions.block(
+        blockInstr(
           label = N,
           children = Seq(labeledRegion, rstExpr),
           resultTypes = rstResultTypes,
@@ -1831,7 +1831,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
           else
             expr.resultType match
               case S(_) => local.set(target, expr)
-              case N => Instructions.block(
+              case N => blockInstr(
                   label = N,
                   children = Seq(
                     expr,
@@ -1989,7 +1989,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
               )
 
         if tailMode then
-          Instructions.block(
+          blockInstr(
             label = N,
             children = Seq(
               matchBlock,
@@ -1999,7 +1999,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
           )
         else
           val rstExpr = returningTerm(rst)
-          Instructions.block(
+          blockInstr(
             label = N,
             children = Seq(matchBlock, rstExpr),
             resultTypes = rstExpr.resultTypes.flatMap(ty => ty.asValType.map(Result(_))),


### PR DESCRIPTION
- Refactor `Str` to `SymIdx` where it makes sense(TM)
- Remove deprecated functions in `Ctx`
- Refactor usages of `Instructions.*` (due to conflict with Scala builtins or `Elaborator.*`) to `*Instr`
- Refactor `.map(...).getOrElse(...)` to `fold`
- Use postfix syntax for `getOrElse` where applicable