### PR TITLE
Track annotations in block IR and stage definitions lifted from staged modules

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -234,7 +234,7 @@ sealed abstract class Block extends Product:
           val newBody = d.body.flattened
           if newBody is d.body
           then d
-          else d.copy(body = newBody)(forceTailRec = d.forceTailRec, configOverride = d.configOverride, annotations = d.annotations)
+          else d.copy(body = newBody)(configOverride = d.configOverride, annotations = d.annotations)
         case v: ValDefn => v
         case c: ClsLikeDefn =>
           val newPreCtor = c.preCtor.flattened
@@ -242,7 +242,7 @@ sealed abstract class Block extends Product:
           def flattenMethods(ms: List[FunDefn]) = ms.mapConserve:
             case f@FunDefn(owner, sym, dSym, params, body) =>
               val newBody = body.flattened
-              if newBody is body then f else f.copy(body = newBody)(forceTailRec = f.forceTailRec, configOverride = f.configOverride, annotations = f.annotations)
+              if newBody is body then f else f.copy(body = newBody)(configOverride = f.configOverride, annotations = f.annotations)
           val newMethods = flattenMethods(c.methods)
           val newCompanion = c.companion.mapConserve: c =>
             val newCtor = c.ctor.flattened
@@ -450,14 +450,14 @@ object HandleBlock:
   )(using Elaborator.State, Elaborator.Ctx) =
     val sym = new BlockMemberSymbol("handleBlock$", Nil, false)
 
-    val bodyDefn = FunDefn.withFreshSymbol(N, sym, PlainParamList(Nil) :: Nil, body)(false, N, annotations = Nil)
+    val bodyDefn = FunDefn.withFreshSymbol(N, sym, PlainParamList(Nil) :: Nil, body)(N, annotations = Nil)
     
     val handlerMtds = handlers.map: handler =>
       val sym = BlockMemberSymbol(cls.nme + handler.sym.nme, Nil, true)
       val fDef = FunDefn.withFreshSymbol(
         N, sym, PlainParamList(Param(FldFlags.empty, handler.resumeSym, N, Modulefulness.none) :: Nil) :: Nil,
         handler.body
-        )(false, N, annotations = Nil)
+        )(N, annotations = Nil)
       val rSym = TempSymbol(N, "suspendRes")
       FunDefn.withFreshSymbol(
         S(cls),
@@ -465,7 +465,7 @@ object HandleBlock:
         handler.params,
         Scoped(Set(sym, rSym), Define(
           fDef,
-          Return(suspend(cls.asPath, Value.Ref(sym, S(fDef.dSym))), false))))(false, N, annotations = Nil)
+          Return(suspend(cls.asPath, Value.Ref(sym, S(fDef.dSym))), false))))(N, annotations = Nil)
 
     val clsDefn = ClsLikeDefn(
       N, // no owner
@@ -566,21 +566,21 @@ final case class FunDefn(
     params: Ls[ParamList],
     body: Block,
   )(
-    val forceTailRec: Bool,
     val configOverride: Opt[Config],
     val annotations: Ls[Annot],
 ) extends Defn:
   val innerSym = N
   val asPath = Value.Ref(sym, S(dSym))
+  def forceTailRec: Bool = annotations.contains(Annot.TailRec)
   def visibility: Visibility = annotations.collectFirst:
     case Annot.Modifier(Keyword.`private`) => Visibility.Private
     case Annot.Modifier(Keyword.`public`) => Visibility.Public
   .getOrElse(Visibility.Public)
 object FunDefn:
-  def withFreshSymbol(owner: Opt[InnerSymbol], sym: BlockMemberSymbol, params: Ls[ParamList], body: Block)(forceTailRec: Bool, configOverride: Opt[Config], annotations: Ls[Annot])(using State) =
+  def withFreshSymbol(owner: Opt[InnerSymbol], sym: BlockMemberSymbol, params: Ls[ParamList], body: Block)(configOverride: Opt[Config], annotations: Ls[Annot])(using State) =
     val tSym = TermSymbol(syntax.Fun, owner, Tree.Ident(sym.nme))
     sym.tsym = S(tSym)
-    FunDefn(owner, sym, tSym, params, body)(forceTailRec, configOverride, annotations)
+    FunDefn(owner, sym, tSym, params, body)(configOverride, annotations)
 
 final case class ValDefn(
     tsym: TermSymbol,
@@ -895,5 +895,4 @@ def blockBuilder: Block => Block = identity
 
 extension (l: Local)
   def asPath: Path = Value.Ref(l, N)
-
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -234,7 +234,7 @@ sealed abstract class Block extends Product:
           val newBody = d.body.flattened
           if newBody is d.body
           then d
-          else d.copy(body = newBody)(forceTailRec = d.forceTailRec, configOverride = d.configOverride, visibility = d.visibility)
+          else d.copy(body = newBody)(forceTailRec = d.forceTailRec, configOverride = d.configOverride, visibility = d.visibility, isStaged = d.isStaged)
         case v: ValDefn => v
         case c: ClsLikeDefn =>
           val newPreCtor = c.preCtor.flattened
@@ -242,7 +242,7 @@ sealed abstract class Block extends Product:
           def flattenMethods(ms: List[FunDefn]) = ms.mapConserve:
             case f@FunDefn(owner, sym, dSym, params, body) =>
               val newBody = body.flattened
-              if newBody is body then f else f.copy(body = newBody)(forceTailRec = f.forceTailRec, configOverride = f.configOverride, visibility = f.visibility)
+              if newBody is body then f else f.copy(body = newBody)(forceTailRec = f.forceTailRec, configOverride = f.configOverride, visibility = f.visibility, isStaged = f.isStaged)
           val newMethods = flattenMethods(c.methods)
           val newCompanion = c.companion.mapConserve: c =>
             val newCtor = c.ctor.flattened
@@ -259,7 +259,7 @@ sealed abstract class Block extends Product:
             ctor = newCtor,
             methods = newMethods,
             companion = newCompanion,
-          )(c.configOverride)
+          )(c.configOverride, c.isStaged)
       
       val newRest = rest.flatten(k)
       if (newDefn is defn) && (newRest is rest)
@@ -450,14 +450,14 @@ object HandleBlock:
   )(using Elaborator.State, Elaborator.Ctx) =
     val sym = new BlockMemberSymbol("handleBlock$", Nil, false)
 
-    val bodyDefn = FunDefn.withFreshSymbol(N, sym, PlainParamList(Nil) :: Nil, body)(false, N, Visibility.Public)
+    val bodyDefn = FunDefn.withFreshSymbol(N, sym, PlainParamList(Nil) :: Nil, body)(false, N, Visibility.Public, isStaged = false)
     
     val handlerMtds = handlers.map: handler =>
       val sym = BlockMemberSymbol(cls.nme + handler.sym.nme, Nil, true)
       val fDef = FunDefn.withFreshSymbol(
         N, sym, PlainParamList(Param(FldFlags.empty, handler.resumeSym, N, Modulefulness.none) :: Nil) :: Nil,
         handler.body
-        )(false, N, Visibility.Public)
+        )(false, N, Visibility.Public, isStaged = false)
       val rSym = TempSymbol(N, "suspendRes")
       FunDefn.withFreshSymbol(
         S(cls),
@@ -465,7 +465,7 @@ object HandleBlock:
         handler.params,
         Scoped(Set(sym, rSym), Define(
           fDef,
-          Return(suspend(cls.asPath, Value.Ref(sym, S(fDef.dSym))), false))))(false, N, Visibility.Public)
+          Return(suspend(cls.asPath, Value.Ref(sym, S(fDef.dSym))), false))))(false, N, Visibility.Public, isStaged = false)
 
     val clsDefn = ClsLikeDefn(
       N, // no owner
@@ -480,7 +480,7 @@ object HandleBlock:
       End(),
       N,
       N,
-    )(N)
+    )(N, isStaged = false)
 
     blockBuilder
       .scopedVars(Set(clsDefn.sym, sym))
@@ -509,6 +509,7 @@ object HandleBlock:
 sealed abstract class Defn:
   val innerSym: Opt[MemberSymbol]
   val sym: BlockMemberSymbol
+  val isStaged: Bool
   def isOwned: Bool = owner.isDefined
   def owner: Opt[InnerSymbol]
   
@@ -565,14 +566,15 @@ final case class FunDefn(
     val forceTailRec: Bool,
     val configOverride: Opt[Config],
     val visibility: Visibility,
+    val isStaged: Bool,
 ) extends Defn:
   val innerSym = N
   val asPath = Value.Ref(sym, S(dSym))
 object FunDefn:
-  def withFreshSymbol(owner: Opt[InnerSymbol], sym: BlockMemberSymbol, params: Ls[ParamList], body: Block)(forceTailRec: Bool, configOverride: Opt[Config], visibility: Visibility)(using State) =
+  def withFreshSymbol(owner: Opt[InnerSymbol], sym: BlockMemberSymbol, params: Ls[ParamList], body: Block)(forceTailRec: Bool, configOverride: Opt[Config], visibility: Visibility, isStaged: Bool)(using State) =
     val tSym = TermSymbol(syntax.Fun, owner, Tree.Ident(sym.nme))
     sym.tsym = S(tSym)
-    FunDefn(owner, sym, tSym, params, body)(forceTailRec, configOverride, visibility)
+    FunDefn(owner, sym, tSym, params, body)(forceTailRec, configOverride, visibility, isStaged)
 
 final case class ValDefn(
     tsym: TermSymbol,
@@ -583,6 +585,7 @@ final case class ValDefn(
 ) extends Defn:
   val innerSym = S(tsym)
   val owner: Opt[InnerSymbol] = tsym.owner
+  val isStaged: Bool = false
 
 
 object ValDefn:
@@ -649,6 +652,7 @@ final case class ClsLikeDefn(
     bufferable: Option[Bool],
 )(
     val configOverride: Opt[Config],
+    val isStaged: Bool,
 ) extends Defn:
   require(k isnt syntax.Mod)
   val innerSym = S(isym.asMemSym)
@@ -661,6 +665,7 @@ final case class ClsLikeBody(
     privateFields: Ls[TermSymbol],
     publicFields: Ls[BlockMemberSymbol -> TermSymbol],
     ctor: Block,
+    isStaged: Bool,
 ):
   def subBlocks: Ls[Block] =
     ctor :: methods.flatMap(_.subBlocks)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -9,7 +9,7 @@ import hkmc2.Message.MessageContext
 import hkmc2.{semantics => sem}
 import hkmc2.semantics.{Term => st}
 
-import syntax.{Literal, Tree, SpreadKind}
+import syntax.{Literal, Tree, SpreadKind, Keyword}
 import semantics.*
 import semantics.Term.*
 import sem.Elaborator.State
@@ -234,7 +234,7 @@ sealed abstract class Block extends Product:
           val newBody = d.body.flattened
           if newBody is d.body
           then d
-          else d.copy(body = newBody)(forceTailRec = d.forceTailRec, configOverride = d.configOverride, visibility = d.visibility, isStaged = d.isStaged)
+          else d.copy(body = newBody)(forceTailRec = d.forceTailRec, configOverride = d.configOverride, annotations = d.annotations)
         case v: ValDefn => v
         case c: ClsLikeDefn =>
           val newPreCtor = c.preCtor.flattened
@@ -242,7 +242,7 @@ sealed abstract class Block extends Product:
           def flattenMethods(ms: List[FunDefn]) = ms.mapConserve:
             case f@FunDefn(owner, sym, dSym, params, body) =>
               val newBody = body.flattened
-              if newBody is body then f else f.copy(body = newBody)(forceTailRec = f.forceTailRec, configOverride = f.configOverride, visibility = f.visibility, isStaged = f.isStaged)
+              if newBody is body then f else f.copy(body = newBody)(forceTailRec = f.forceTailRec, configOverride = f.configOverride, annotations = f.annotations)
           val newMethods = flattenMethods(c.methods)
           val newCompanion = c.companion.mapConserve: c =>
             val newCtor = c.ctor.flattened
@@ -259,7 +259,7 @@ sealed abstract class Block extends Product:
             ctor = newCtor,
             methods = newMethods,
             companion = newCompanion,
-          )(c.configOverride, c.isStaged)
+          )(c.configOverride, c.annotations)
       
       val newRest = rest.flatten(k)
       if (newDefn is defn) && (newRest is rest)
@@ -450,14 +450,14 @@ object HandleBlock:
   )(using Elaborator.State, Elaborator.Ctx) =
     val sym = new BlockMemberSymbol("handleBlock$", Nil, false)
 
-    val bodyDefn = FunDefn.withFreshSymbol(N, sym, PlainParamList(Nil) :: Nil, body)(false, N, Visibility.Public, isStaged = false)
+    val bodyDefn = FunDefn.withFreshSymbol(N, sym, PlainParamList(Nil) :: Nil, body)(false, N, annotations = Nil)
     
     val handlerMtds = handlers.map: handler =>
       val sym = BlockMemberSymbol(cls.nme + handler.sym.nme, Nil, true)
       val fDef = FunDefn.withFreshSymbol(
         N, sym, PlainParamList(Param(FldFlags.empty, handler.resumeSym, N, Modulefulness.none) :: Nil) :: Nil,
         handler.body
-        )(false, N, Visibility.Public, isStaged = false)
+        )(false, N, annotations = Nil)
       val rSym = TempSymbol(N, "suspendRes")
       FunDefn.withFreshSymbol(
         S(cls),
@@ -465,7 +465,7 @@ object HandleBlock:
         handler.params,
         Scoped(Set(sym, rSym), Define(
           fDef,
-          Return(suspend(cls.asPath, Value.Ref(sym, S(fDef.dSym))), false))))(false, N, Visibility.Public, isStaged = false)
+          Return(suspend(cls.asPath, Value.Ref(sym, S(fDef.dSym))), false))))(false, N, annotations = Nil)
 
     val clsDefn = ClsLikeDefn(
       N, // no owner
@@ -480,7 +480,7 @@ object HandleBlock:
       End(),
       N,
       N,
-    )(N, isStaged = false)
+    )(N, Nil)
 
     blockBuilder
       .scopedVars(Set(clsDefn.sym, sym))
@@ -509,7 +509,10 @@ object HandleBlock:
 sealed abstract class Defn:
   val innerSym: Opt[MemberSymbol]
   val sym: BlockMemberSymbol
-  val isStaged: Bool
+  val annotations: Ls[Annot]
+  def isStaged: Bool = annotations.exists:
+    case Annot.Modifier(Keyword.`staged`) => true
+    case _ => false
   def isOwned: Bool = owner.isDefined
   def owner: Opt[InnerSymbol]
   
@@ -565,16 +568,19 @@ final case class FunDefn(
   )(
     val forceTailRec: Bool,
     val configOverride: Opt[Config],
-    val visibility: Visibility,
-    val isStaged: Bool,
+    val annotations: Ls[Annot],
 ) extends Defn:
   val innerSym = N
   val asPath = Value.Ref(sym, S(dSym))
+  def visibility: Visibility = annotations.collectFirst:
+    case Annot.Modifier(Keyword.`private`) => Visibility.Private
+    case Annot.Modifier(Keyword.`public`) => Visibility.Public
+  .getOrElse(Visibility.Public)
 object FunDefn:
-  def withFreshSymbol(owner: Opt[InnerSymbol], sym: BlockMemberSymbol, params: Ls[ParamList], body: Block)(forceTailRec: Bool, configOverride: Opt[Config], visibility: Visibility, isStaged: Bool)(using State) =
+  def withFreshSymbol(owner: Opt[InnerSymbol], sym: BlockMemberSymbol, params: Ls[ParamList], body: Block)(forceTailRec: Bool, configOverride: Opt[Config], annotations: Ls[Annot])(using State) =
     val tSym = TermSymbol(syntax.Fun, owner, Tree.Ident(sym.nme))
     sym.tsym = S(tSym)
-    FunDefn(owner, sym, tSym, params, body)(forceTailRec, configOverride, visibility, isStaged)
+    FunDefn(owner, sym, tSym, params, body)(forceTailRec, configOverride, annotations)
 
 final case class ValDefn(
     tsym: TermSymbol,
@@ -582,10 +588,10 @@ final case class ValDefn(
     rhs: Path,
 )(
     val configOverride: Opt[Config],
+    val annotations: Ls[Annot],
 ) extends Defn:
   val innerSym = S(tsym)
   val owner: Opt[InnerSymbol] = tsym.owner
-  val isStaged: Bool = false
 
 
 object ValDefn:
@@ -595,9 +601,10 @@ object ValDefn:
       sym: BlockMemberSymbol,
       rhs: Path,
       configOverride: Opt[Config],
+      annotations: Ls[Annot],
     )(using State)
     : ValDefn =
-      ValDefn(tsym = TermSymbol(k, owner, Tree.Ident(sym.nme)), sym = sym, rhs = rhs)(configOverride)
+      ValDefn(tsym = TermSymbol(k, owner, Tree.Ident(sym.nme)), sym = sym, rhs = rhs)(configOverride, annotations)
 
 
 /*
@@ -652,7 +659,7 @@ final case class ClsLikeDefn(
     bufferable: Option[Bool],
 )(
     val configOverride: Opt[Config],
-    val isStaged: Bool,
+    val annotations: Ls[Annot],
 ) extends Defn:
   require(k isnt syntax.Mod)
   val innerSym = S(isym.asMemSym)
@@ -665,8 +672,11 @@ final case class ClsLikeBody(
     privateFields: Ls[TermSymbol],
     publicFields: Ls[BlockMemberSymbol -> TermSymbol],
     ctor: Block,
-    isStaged: Bool,
+    annotations: Ls[Annot],
 ):
+  def isStaged: Bool = annotations.exists:
+    case Annot.Modifier(Keyword.`staged`) => true
+    case _ => false
   def subBlocks: Ls[Block] =
     ctor :: methods.flatMap(_.subBlocks)
   lazy val freeVars: Set[Local] =

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -571,8 +571,8 @@ final case class FunDefn(
 ) extends Defn:
   val innerSym = N
   val asPath = Value.Ref(sym, S(dSym))
-  def forceTailRec: Bool = annotations.contains(Annot.TailRec)
-  def visibility: Visibility = annotations.collectFirst:
+  lazy val forceTailRec: Bool = annotations.contains(Annot.TailRec)
+  lazy val visibility: Visibility = annotations.collectFirst:
     case Annot.Modifier(Keyword.`private`) => Visibility.Private
     case Annot.Modifier(Keyword.`public`) => Visibility.Public
   .getOrElse(Visibility.Public)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -430,13 +430,13 @@ class BlockSimplifier(symbolsToPreserve: Set[Local])(using DebugPrinter, State, 
               val newBdy = applyBlock(fun.body)
               newFunctionBody(fun.dSym) = S(newBdy)
               if newBdy is fun.body then fun else
-              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, newBdy)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)
+              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, newBdy)(fun.forceTailRec, fun.configOverride, fun.annotations)
             case S(N) =>
               // The expansion of the function body itself reaches its own definition, which is impossible
               lastWords("Function body contains its own definition.")
             case S(S(blk)) =>
               if blk is fun.body then fun else
-              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, blk)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)
+              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, blk)(fun.forceTailRec, fun.configOverride, fun.annotations)
         
         override def applyResult(r: Result)(k: Result => Block): Block = r match
           case Call(TermSymbolPath(ts), args) if m.contains(ts) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -430,13 +430,13 @@ class BlockSimplifier(symbolsToPreserve: Set[Local])(using DebugPrinter, State, 
               val newBdy = applyBlock(fun.body)
               newFunctionBody(fun.dSym) = S(newBdy)
               if newBdy is fun.body then fun else
-              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, newBdy)(fun.forceTailRec, fun.configOverride, fun.visibility)
+              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, newBdy)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)
             case S(N) =>
               // The expansion of the function body itself reaches its own definition, which is impossible
               lastWords("Function body contains its own definition.")
             case S(S(blk)) =>
               if blk is fun.body then fun else
-              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, blk)(fun.forceTailRec, fun.configOverride, fun.visibility)
+              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, blk)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)
         
         override def applyResult(r: Result)(k: Result => Block): Block = r match
           case Call(TermSymbolPath(ts), args) if m.contains(ts) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -430,13 +430,13 @@ class BlockSimplifier(symbolsToPreserve: Set[Local])(using DebugPrinter, State, 
               val newBdy = applyBlock(fun.body)
               newFunctionBody(fun.dSym) = S(newBdy)
               if newBdy is fun.body then fun else
-              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, newBdy)(fun.forceTailRec, fun.configOverride, fun.annotations)
+              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, newBdy)(fun.configOverride, fun.annotations)
             case S(N) =>
               // The expansion of the function body itself reaches its own definition, which is impossible
               lastWords("Function body contains its own definition.")
             case S(S(blk)) =>
               if blk is fun.body then fun else
-              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, blk)(fun.forceTailRec, fun.configOverride, fun.annotations)
+              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, blk)(fun.configOverride, fun.annotations)
         
         override def applyResult(r: Result)(k: Result => Block): Block = r match
           case Call(TermSymbolPath(ts), args) if m.contains(ts) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
@@ -188,7 +188,7 @@ class BlockTransformer(subst: SymbolSubst):
     val params2 = fun.params.mapConserve(applyParamList)
     val body2 = applyFunBodyLikeBlock(fun.body)
     if (own2 is fun.owner) && (sym2 is fun.sym) && (dSym2 is fun.dSym) && (params2 is fun.params) && (body2 is fun.body)
-      then fun else FunDefn(own2, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)
+      then fun else FunDefn(own2, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.annotations)
   
   def applyValDefn(defn: ValDefn)(k: ValDefn => Block): Block =
     val ValDefn(tsym, sym, rhs) = defn
@@ -196,7 +196,7 @@ class BlockTransformer(subst: SymbolSubst):
     val sym2 = sym.subst
     applyPath(rhs): rhs2 =>
       if (tsym2 is tsym) && (sym2 is sym) && (rhs2 is rhs)
-        then k(defn) else k(ValDefn(tsym2, sym2, rhs2)(defn.configOverride))
+        then k(defn) else k(ValDefn(tsym2, sym2, rhs2)(defn.configOverride, defn.annotations))
   
   def applyPublicField(f: BlockMemberSymbol -> TermSymbol): BlockMemberSymbol -> TermSymbol =
     val f_1_2 = f._1.subst
@@ -213,7 +213,7 @@ class BlockTransformer(subst: SymbolSubst):
         (privateFields2 is defn.privateFields) &&
         (publicFields2 is defn.publicFields) &&
         (ctor2 is defn.ctor)
-      then defn else ClsLikeBody(isym2, methods2, privateFields2, publicFields2, ctor2, defn.isStaged)
+      then defn else ClsLikeBody(isym2, methods2, privateFields2, publicFields2, ctor2, defn.annotations)
     
   def applyDefn(defn: Defn)(k: Defn => Block): Block = defn match
     case defn: FunDefn => k(applyFunDefn(defn))
@@ -245,7 +245,7 @@ class BlockTransformer(subst: SymbolSubst):
               (preCtor2 is preCtor) && (ctor2 is ctor) &&
               (mod2 is mod)
             then defn else ClsLikeDefn(own2, isym2, sym2, ctorSym2, kind, paramsOpt2, 
-              auxParams2, parentPath2, methods2, privateFields2, publicFields2, preCtor2, ctor2, mod2, bufferable)(defn.configOverride, defn.isStaged)
+              auxParams2, parentPath2, methods2, privateFields2, publicFields2, preCtor2, ctor2, mod2, bufferable)(defn.configOverride, defn.annotations)
       parentPath match
       case Some(pp) => applyPath(pp): pp2 =>
         helper:

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
@@ -188,7 +188,7 @@ class BlockTransformer(subst: SymbolSubst):
     val params2 = fun.params.mapConserve(applyParamList)
     val body2 = applyFunBodyLikeBlock(fun.body)
     if (own2 is fun.owner) && (sym2 is fun.sym) && (dSym2 is fun.dSym) && (params2 is fun.params) && (body2 is fun.body)
-      then fun else FunDefn(own2, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.annotations)
+      then fun else FunDefn(own2, sym2, dSym2, params2, body2)(fun.configOverride, fun.annotations)
   
   def applyValDefn(defn: ValDefn)(k: ValDefn => Block): Block =
     val ValDefn(tsym, sym, rhs) = defn
@@ -312,5 +312,4 @@ class BlockTransformerShallow(subst: SymbolSubst) extends BlockTransformer(subst
 // to traverse sub-blocks while using this class to perform more complicated transformations on the blocks themselves.
 class BlockDataTransformer(subst: SymbolSubst) extends BlockTransformerShallow(subst):
   override def applySubBlock(b: Block): Block = b
-
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
@@ -188,7 +188,7 @@ class BlockTransformer(subst: SymbolSubst):
     val params2 = fun.params.mapConserve(applyParamList)
     val body2 = applyFunBodyLikeBlock(fun.body)
     if (own2 is fun.owner) && (sym2 is fun.sym) && (dSym2 is fun.dSym) && (params2 is fun.params) && (body2 is fun.body)
-      then fun else FunDefn(own2, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.visibility)
+      then fun else FunDefn(own2, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)
   
   def applyValDefn(defn: ValDefn)(k: ValDefn => Block): Block =
     val ValDefn(tsym, sym, rhs) = defn
@@ -213,7 +213,7 @@ class BlockTransformer(subst: SymbolSubst):
         (privateFields2 is defn.privateFields) &&
         (publicFields2 is defn.publicFields) &&
         (ctor2 is defn.ctor)
-      then defn else ClsLikeBody(isym2, methods2, privateFields2, publicFields2, ctor2)
+      then defn else ClsLikeBody(isym2, methods2, privateFields2, publicFields2, ctor2, defn.isStaged)
     
   def applyDefn(defn: Defn)(k: Defn => Block): Block = defn match
     case defn: FunDefn => k(applyFunDefn(defn))
@@ -245,7 +245,7 @@ class BlockTransformer(subst: SymbolSubst):
               (preCtor2 is preCtor) && (ctor2 is ctor) &&
               (mod2 is mod)
             then defn else ClsLikeDefn(own2, isym2, sym2, ctorSym2, kind, paramsOpt2, 
-              auxParams2, parentPath2, methods2, privateFields2, publicFields2, preCtor2, ctor2, mod2, bufferable)(defn.configOverride)
+              auxParams2, parentPath2, methods2, privateFields2, publicFields2, preCtor2, ctor2, mod2, bufferable)(defn.configOverride, defn.isStaged)
       parentPath match
       case Some(pp) => applyPath(pp): pp2 =>
         helper:

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BufferableTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BufferableTransform.scala
@@ -79,20 +79,20 @@ class BufferableTransform()(using Ctx, State, Raise):
               val blk = mkFieldReplacer(buf, idx, symMap).applyBlock(f.body)
               FunDefn(f.owner, f.sym, TermSymbol(f.dSym.k, f.dSym.owner, f.dSym.id), PlainParamList(
                 Param(FldFlags.empty, buf, N, Modulefulness.none) :: Param(FldFlags.empty, idx, N, Modulefulness.none) :: Nil) :: newParams,
-                if isCtor then Begin(blk, Return(idx.asPath, false)) else blk)(forceTailRec = f.forceTailRec, configOverride = f.configOverride, visibility = f.visibility, isStaged = f.isStaged)
+                if isCtor then Begin(blk, Return(idx.asPath, false)) else blk)(forceTailRec = f.forceTailRec, configOverride = f.configOverride, annotations = f.annotations)
             val fakeCtor = transformFunDefn(FunDefn.withFreshSymbol(
                 S(companionSym), 
                 BlockMemberSymbol("ctor", Nil, false), 
                 cls.paramsOpt.toList,
                 Begin(cls.preCtor, cls.ctor),
-              )(false, N, Visibility.Public, isStaged = false), true)
+              )(false, N, annotations = Nil), true)
             val fakeCompanion = ClsLikeBody(
               companionSym,
               fakeCtor :: cls.methods.map(transformFunDefn(_, false)),
               Nil,
               clsSizeSym -> clsSizeTermSym :: Nil,
-              Define(ValDefn(clsSizeTermSym, clsSizeSym, Value.Lit(Tree.IntLit(fields.size)))(N), End()),
-              isStaged = false,
+              Define(ValDefn(clsSizeTermSym, clsSizeSym, Value.Lit(Tree.IntLit(fields.size)))(N, Nil), End()),
+              annotations = Nil,
             )
             k:
               ClsLikeDefn(
@@ -111,6 +111,6 @@ class BufferableTransform()(using Ctx, State, Raise):
                 if bufferable then cls.ctor else End(),
                 S(fakeCompanion),
                 cls.bufferable,
-              )(cls.configOverride, cls.isStaged)
+              )(cls.configOverride, cls.annotations)
         case _ => super.applyDefn(defn)(k)
     transformer.applyBlock(blk)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BufferableTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BufferableTransform.scala
@@ -79,19 +79,20 @@ class BufferableTransform()(using Ctx, State, Raise):
               val blk = mkFieldReplacer(buf, idx, symMap).applyBlock(f.body)
               FunDefn(f.owner, f.sym, TermSymbol(f.dSym.k, f.dSym.owner, f.dSym.id), PlainParamList(
                 Param(FldFlags.empty, buf, N, Modulefulness.none) :: Param(FldFlags.empty, idx, N, Modulefulness.none) :: Nil) :: newParams,
-                if isCtor then Begin(blk, Return(idx.asPath, false)) else blk)(forceTailRec = f.forceTailRec, configOverride = f.configOverride, visibility = f.visibility)
+                if isCtor then Begin(blk, Return(idx.asPath, false)) else blk)(forceTailRec = f.forceTailRec, configOverride = f.configOverride, visibility = f.visibility, isStaged = f.isStaged)
             val fakeCtor = transformFunDefn(FunDefn.withFreshSymbol(
                 S(companionSym), 
                 BlockMemberSymbol("ctor", Nil, false), 
                 cls.paramsOpt.toList,
                 Begin(cls.preCtor, cls.ctor),
-              )(false, N, Visibility.Public), true)
+              )(false, N, Visibility.Public, isStaged = false), true)
             val fakeCompanion = ClsLikeBody(
               companionSym,
               fakeCtor :: cls.methods.map(transformFunDefn(_, false)),
               Nil,
               clsSizeSym -> clsSizeTermSym :: Nil,
               Define(ValDefn(clsSizeTermSym, clsSizeSym, Value.Lit(Tree.IntLit(fields.size)))(N), End()),
+              isStaged = false,
             )
             k:
               ClsLikeDefn(
@@ -110,6 +111,6 @@ class BufferableTransform()(using Ctx, State, Raise):
                 if bufferable then cls.ctor else End(),
                 S(fakeCompanion),
                 cls.bufferable,
-              )(cls.configOverride)
+              )(cls.configOverride, cls.isStaged)
         case _ => super.applyDefn(defn)(k)
     transformer.applyBlock(blk)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BufferableTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BufferableTransform.scala
@@ -79,13 +79,13 @@ class BufferableTransform()(using Ctx, State, Raise):
               val blk = mkFieldReplacer(buf, idx, symMap).applyBlock(f.body)
               FunDefn(f.owner, f.sym, TermSymbol(f.dSym.k, f.dSym.owner, f.dSym.id), PlainParamList(
                 Param(FldFlags.empty, buf, N, Modulefulness.none) :: Param(FldFlags.empty, idx, N, Modulefulness.none) :: Nil) :: newParams,
-                if isCtor then Begin(blk, Return(idx.asPath, false)) else blk)(forceTailRec = f.forceTailRec, configOverride = f.configOverride, annotations = f.annotations)
+                if isCtor then Begin(blk, Return(idx.asPath, false)) else blk)(configOverride = f.configOverride, annotations = f.annotations)
             val fakeCtor = transformFunDefn(FunDefn.withFreshSymbol(
                 S(companionSym), 
                 BlockMemberSymbol("ctor", Nil, false), 
                 cls.paramsOpt.toList,
                 Begin(cls.preCtor, cls.ctor),
-              )(false, N, annotations = Nil), true)
+              )(N, annotations = Nil), true)
             val fakeCompanion = ClsLikeBody(
               companionSym,
               fakeCtor :: cls.methods.map(transformFunDefn(_, false)),

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/DeadParamElim.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/DeadParamElim.scala
@@ -301,7 +301,7 @@ class Rewrite(val deadParamElimSolver: DeadParamElimSolver)(using Raise):
         applyFunBodyLikeBlock(fun.body)
       if (own2 is fun.owner) && (sym2 is fun.sym) && (dSym2 is fun.dSym) &&
           (params2 is fun.params) && (body2 is fun.body)
-      then fun else FunDefn(own2, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)
+      then fun else FunDefn(own2, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.annotations)
   end Rewriter
   
   val newBody =
@@ -363,7 +363,7 @@ class Rewrite(val deadParamElimSolver: DeadParamElimSolver)(using Raise):
         val bodyWithCorrectSymbols = new RefreshSymbol(refreshParamMap).applyBlock(transformedBody)
         FunDefn(
           N, bms, tSym, refreshedParams,
-          bodyWithCorrectSymbols)(fDefn.forceTailRec, fDefn.configOverride, fDefn.visibility, fDefn.isStaged)
+          bodyWithCorrectSymbols)(fDefn.forceTailRec, fDefn.configOverride, fDefn.annotations)
     
     val inplaceRewrittenFunBodies = Map.from[TermSymbol, Block]:
       for (selfInstId, funSym) <- collector.synthesizedInstIdToFunSym yield
@@ -375,7 +375,7 @@ class Rewrite(val deadParamElimSolver: DeadParamElimSolver)(using Raise):
         override def applyFunDefn(fun: FunDefn): FunDefn =
           inplaceRewrittenFunBodies.get(fun.dSym) match
             case Some(rewrittenBody) =>
-              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, rewrittenBody)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)
+              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, rewrittenBody)(fun.forceTailRec, fun.configOverride, fun.annotations)
             case None => super.applyFunDefn(fun)
       Scoped(
         Set.from(newPolyFuns.map(_.sym)),

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/DeadParamElim.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/DeadParamElim.scala
@@ -301,7 +301,7 @@ class Rewrite(val deadParamElimSolver: DeadParamElimSolver)(using Raise):
         applyFunBodyLikeBlock(fun.body)
       if (own2 is fun.owner) && (sym2 is fun.sym) && (dSym2 is fun.dSym) &&
           (params2 is fun.params) && (body2 is fun.body)
-      then fun else FunDefn(own2, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.visibility)
+      then fun else FunDefn(own2, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)
   end Rewriter
   
   val newBody =
@@ -363,7 +363,7 @@ class Rewrite(val deadParamElimSolver: DeadParamElimSolver)(using Raise):
         val bodyWithCorrectSymbols = new RefreshSymbol(refreshParamMap).applyBlock(transformedBody)
         FunDefn(
           N, bms, tSym, refreshedParams,
-          bodyWithCorrectSymbols)(fDefn.forceTailRec, fDefn.configOverride, fDefn.visibility)
+          bodyWithCorrectSymbols)(fDefn.forceTailRec, fDefn.configOverride, fDefn.visibility, fDefn.isStaged)
     
     val inplaceRewrittenFunBodies = Map.from[TermSymbol, Block]:
       for (selfInstId, funSym) <- collector.synthesizedInstIdToFunSym yield
@@ -375,7 +375,7 @@ class Rewrite(val deadParamElimSolver: DeadParamElimSolver)(using Raise):
         override def applyFunDefn(fun: FunDefn): FunDefn =
           inplaceRewrittenFunBodies.get(fun.dSym) match
             case Some(rewrittenBody) =>
-              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, rewrittenBody)(fun.forceTailRec, fun.configOverride, fun.visibility)
+              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, rewrittenBody)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)
             case None => super.applyFunDefn(fun)
       Scoped(
         Set.from(newPolyFuns.map(_.sym)),

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/DeadParamElim.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/DeadParamElim.scala
@@ -301,7 +301,7 @@ class Rewrite(val deadParamElimSolver: DeadParamElimSolver)(using Raise):
         applyFunBodyLikeBlock(fun.body)
       if (own2 is fun.owner) && (sym2 is fun.sym) && (dSym2 is fun.dSym) &&
           (params2 is fun.params) && (body2 is fun.body)
-      then fun else FunDefn(own2, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.annotations)
+      then fun else FunDefn(own2, sym2, dSym2, params2, body2)(fun.configOverride, fun.annotations)
   end Rewriter
   
   val newBody =
@@ -363,7 +363,7 @@ class Rewrite(val deadParamElimSolver: DeadParamElimSolver)(using Raise):
         val bodyWithCorrectSymbols = new RefreshSymbol(refreshParamMap).applyBlock(transformedBody)
         FunDefn(
           N, bms, tSym, refreshedParams,
-          bodyWithCorrectSymbols)(fDefn.forceTailRec, fDefn.configOverride, fDefn.annotations)
+          bodyWithCorrectSymbols)(fDefn.configOverride, fDefn.annotations)
     
     val inplaceRewrittenFunBodies = Map.from[TermSymbol, Block]:
       for (selfInstId, funSym) <- collector.synthesizedInstIdToFunSym yield
@@ -375,7 +375,7 @@ class Rewrite(val deadParamElimSolver: DeadParamElimSolver)(using Raise):
         override def applyFunDefn(fun: FunDefn): FunDefn =
           inplaceRewrittenFunBodies.get(fun.dSym) match
             case Some(rewrittenBody) =>
-              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, rewrittenBody)(fun.forceTailRec, fun.configOverride, fun.annotations)
+              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, rewrittenBody)(fun.configOverride, fun.annotations)
             case None => super.applyFunDefn(fun)
       Scoped(
         Set.from(newPolyFuns.map(_.sym)),

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/FirstClassFunctionTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/FirstClassFunctionTransformer.scala
@@ -26,10 +26,10 @@ class FirstClassFunctionTransformer(using Elaborator.State, Elaborator.Ctx, Rais
     )
     val defSym = new BlockMemberSymbol("Function$", Nil, false)
     val callDef = FunDefn.withFreshSymbol(Some(clsSym), new BlockMemberSymbol("call", Nil, true), params :: Nil,
-      Return(Call(p, params.params.map(_.sym.asPath.asArg))(true, false, false), false))(false, N, Visibility.Public, isStaged = false)
+      Return(Call(p, params.params.map(_.sym.asPath.asArg))(true, false, false), false))(false, N, annotations = Nil)
     ClsLikeDefn(None, clsSym, defSym, None, syntax.Cls, None, Nil,
       Some(Select(Value.Ref(State.globalThisSymbol, Some(State.globalThisSymbol)), Tree.Ident("Function"))(Some(ctx.builtins.Function))),
-      callDef :: Nil, Nil, Nil, Return(Call(Value.Ref(State.builtinOpsMap("super")), Nil)(false, false, false), true), End(), None, None)(N, isStaged = false)
+      callDef :: Nil, Nil, Nil, Return(Call(Value.Ref(State.builtinOpsMap("super")), Nil)(false, false, false), true), End(), None, None)(N, Nil)
 
   private def getParamList(l: BlockMemberSymbol): Option[ParamList] = funDefns.get(l) match
     case Some(fd) => fd.params.headOption
@@ -99,10 +99,10 @@ class FirstClassFunctionTransformer(using Elaborator.State, Elaborator.Ctx, Rais
           case head :: rest =>
             val newBody = rec(rest)
             val funSym = new BlockMemberSymbol("lambda$", Nil, false)
-            val funDef = FunDefn.withFreshSymbol(None, funSym, head :: Nil, newBody)(false, N, Visibility.Public, isStaged = false)
+            val funDef = FunDefn.withFreshSymbol(None, funSym, head :: Nil, newBody)(false, N, annotations = Nil)
             Scoped(Set(funSym), Define(funDef, Return(Value.Ref(funDef.sym, Some(funDef.dSym)), false)))
           case Nil => fd.body
-        FunDefn.withFreshSymbol(fd.owner, fd.sym, head :: Nil, rec(tail))(fd.forceTailRec, fd.configOverride, fd.visibility, fd.isStaged)
+        FunDefn.withFreshSymbol(fd.owner, fd.sym, head :: Nil, rec(tail))(fd.forceTailRec, fd.configOverride, fd.annotations)
 
   def transform(b: Block): Block =
     val desugared = new DesugarMultipleParamList().applyBlock(b)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/FirstClassFunctionTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/FirstClassFunctionTransformer.scala
@@ -26,7 +26,7 @@ class FirstClassFunctionTransformer(using Elaborator.State, Elaborator.Ctx, Rais
     )
     val defSym = new BlockMemberSymbol("Function$", Nil, false)
     val callDef = FunDefn.withFreshSymbol(Some(clsSym), new BlockMemberSymbol("call", Nil, true), params :: Nil,
-      Return(Call(p, params.params.map(_.sym.asPath.asArg))(true, false, false), false))(false, N, annotations = Nil)
+      Return(Call(p, params.params.map(_.sym.asPath.asArg))(true, false, false), false))(N, annotations = Nil)
     ClsLikeDefn(None, clsSym, defSym, None, syntax.Cls, None, Nil,
       Some(Select(Value.Ref(State.globalThisSymbol, Some(State.globalThisSymbol)), Tree.Ident("Function"))(Some(ctx.builtins.Function))),
       callDef :: Nil, Nil, Nil, Return(Call(Value.Ref(State.builtinOpsMap("super")), Nil)(false, false, false), true), End(), None, None)(N, Nil)
@@ -99,10 +99,10 @@ class FirstClassFunctionTransformer(using Elaborator.State, Elaborator.Ctx, Rais
           case head :: rest =>
             val newBody = rec(rest)
             val funSym = new BlockMemberSymbol("lambda$", Nil, false)
-            val funDef = FunDefn.withFreshSymbol(None, funSym, head :: Nil, newBody)(false, N, annotations = Nil)
+            val funDef = FunDefn.withFreshSymbol(None, funSym, head :: Nil, newBody)(N, annotations = Nil)
             Scoped(Set(funSym), Define(funDef, Return(Value.Ref(funDef.sym, Some(funDef.dSym)), false)))
           case Nil => fd.body
-        FunDefn.withFreshSymbol(fd.owner, fd.sym, head :: Nil, rec(tail))(fd.forceTailRec, fd.configOverride, fd.annotations)
+        FunDefn.withFreshSymbol(fd.owner, fd.sym, head :: Nil, rec(tail))(fd.configOverride, fd.annotations)
 
   def transform(b: Block): Block =
     val desugared = new DesugarMultipleParamList().applyBlock(b)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/FirstClassFunctionTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/FirstClassFunctionTransformer.scala
@@ -26,10 +26,10 @@ class FirstClassFunctionTransformer(using Elaborator.State, Elaborator.Ctx, Rais
     )
     val defSym = new BlockMemberSymbol("Function$", Nil, false)
     val callDef = FunDefn.withFreshSymbol(Some(clsSym), new BlockMemberSymbol("call", Nil, true), params :: Nil,
-      Return(Call(p, params.params.map(_.sym.asPath.asArg))(true, false, false), false))(false, N, Visibility.Public)
+      Return(Call(p, params.params.map(_.sym.asPath.asArg))(true, false, false), false))(false, N, Visibility.Public, isStaged = false)
     ClsLikeDefn(None, clsSym, defSym, None, syntax.Cls, None, Nil,
       Some(Select(Value.Ref(State.globalThisSymbol, Some(State.globalThisSymbol)), Tree.Ident("Function"))(Some(ctx.builtins.Function))),
-      callDef :: Nil, Nil, Nil, Return(Call(Value.Ref(State.builtinOpsMap("super")), Nil)(false, false, false), true), End(), None, None)(N)
+      callDef :: Nil, Nil, Nil, Return(Call(Value.Ref(State.builtinOpsMap("super")), Nil)(false, false, false), true), End(), None, None)(N, isStaged = false)
 
   private def getParamList(l: BlockMemberSymbol): Option[ParamList] = funDefns.get(l) match
     case Some(fd) => fd.params.headOption
@@ -99,10 +99,10 @@ class FirstClassFunctionTransformer(using Elaborator.State, Elaborator.Ctx, Rais
           case head :: rest =>
             val newBody = rec(rest)
             val funSym = new BlockMemberSymbol("lambda$", Nil, false)
-            val funDef = FunDefn.withFreshSymbol(None, funSym, head :: Nil, newBody)(false, N, Visibility.Public)
+            val funDef = FunDefn.withFreshSymbol(None, funSym, head :: Nil, newBody)(false, N, Visibility.Public, isStaged = false)
             Scoped(Set(funSym), Define(funDef, Return(Value.Ref(funDef.sym, Some(funDef.dSym)), false)))
           case Nil => fd.body
-        FunDefn.withFreshSymbol(fd.owner, fd.sym, head :: Nil, rec(tail))(fd.forceTailRec, fd.configOverride, fd.visibility)
+        FunDefn.withFreshSymbol(fd.owner, fd.sym, head :: Nil, rec(tail))(fd.forceTailRec, fd.configOverride, fd.visibility, fd.isStaged)
 
   def transform(b: Block): Block =
     val desugared = new DesugarMultipleParamList().applyBlock(b)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -552,7 +552,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         DebugInfo(debugNme, if opt.debug then debugInfoSym.asPath else unit), thisPath.isDefined && fun.params.isEmpty))
       val bod2 = translateBlock(fun.body, newCtx, scopedVars)
       val fun2 = if fun.body is bod2 then fun else
-        FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, bod2)(fun.forceTailRec, fun.configOverride, fun.visibility)
+        FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, bod2)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)
       (debugInfoSym, debugInfo, fun2)
 
     // transform inner function/class and effect handler intrinsics to the runtime functions.
@@ -592,9 +592,9 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
             val newCtor = if opt.doNotInstrumentTopLevelModCtor && !h.innerDefIsTrulyNested then bod.ctor else
               translateCtorLike(bod.ctor, bod.isym.asPath, true)
             tl.log(s"companion name: ${bod.isym.nme}")
-            ClsLikeBody(bod.isym, newMtds, bod.privateFields, bod.publicFields, newCtor)
+            ClsLikeBody(bod.isym, newMtds, bod.privateFields, bod.publicFields, newCtor, bod.isStaged)
           val c2 = ClsLikeDefn(owner, isym, sym, ctorSym, kind, paramsOpt, auxParams, parentPath, newMtds, privateFields, publicFields,
-            translateCtorLike(preCtor, isym.asPath, false), translateCtorLike(ctor, isym.asPath, false), companion2, bufferable)(defn.configOverride)
+            translateCtorLike(preCtor, isym.asPath, false), translateCtorLike(ctor, isym.asPath, false), companion2, bufferable)(defn.configOverride, defn.isStaged)
           if opt.debug then
             Scoped(debugInfos.map(_._1).toSet, debugInfos.foldRight(k(c2)): (elem, blk) =>
               Assign(elem._1, Tuple(false, elem._2), blk))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -552,7 +552,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         DebugInfo(debugNme, if opt.debug then debugInfoSym.asPath else unit), thisPath.isDefined && fun.params.isEmpty))
       val bod2 = translateBlock(fun.body, newCtx, scopedVars)
       val fun2 = if fun.body is bod2 then fun else
-        FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, bod2)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)
+        FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, bod2)(fun.forceTailRec, fun.configOverride, fun.annotations)
       (debugInfoSym, debugInfo, fun2)
 
     // transform inner function/class and effect handler intrinsics to the runtime functions.
@@ -592,9 +592,9 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
             val newCtor = if opt.doNotInstrumentTopLevelModCtor && !h.innerDefIsTrulyNested then bod.ctor else
               translateCtorLike(bod.ctor, bod.isym.asPath, true)
             tl.log(s"companion name: ${bod.isym.nme}")
-            ClsLikeBody(bod.isym, newMtds, bod.privateFields, bod.publicFields, newCtor, bod.isStaged)
+            ClsLikeBody(bod.isym, newMtds, bod.privateFields, bod.publicFields, newCtor, bod.annotations)
           val c2 = ClsLikeDefn(owner, isym, sym, ctorSym, kind, paramsOpt, auxParams, parentPath, newMtds, privateFields, publicFields,
-            translateCtorLike(preCtor, isym.asPath, false), translateCtorLike(ctor, isym.asPath, false), companion2, bufferable)(defn.configOverride, defn.isStaged)
+            translateCtorLike(preCtor, isym.asPath, false), translateCtorLike(ctor, isym.asPath, false), companion2, bufferable)(defn.configOverride, defn.annotations)
           if opt.debug then
             Scoped(debugInfos.map(_._1).toSet, debugInfos.foldRight(k(c2)): (elem, blk) =>
               Assign(elem._1, Tuple(false, elem._2), blk))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -552,7 +552,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         DebugInfo(debugNme, if opt.debug then debugInfoSym.asPath else unit), thisPath.isDefined && fun.params.isEmpty))
       val bod2 = translateBlock(fun.body, newCtx, scopedVars)
       val fun2 = if fun.body is bod2 then fun else
-        FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, bod2)(fun.forceTailRec, fun.configOverride, fun.annotations)
+        FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, bod2)(fun.configOverride, fun.annotations)
       (debugInfoSym, debugInfo, fun2)
 
     // transform inner function/class and effect handler intrinsics to the runtime functions.

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/LambdaRewriter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/LambdaRewriter.scala
@@ -16,7 +16,7 @@ object LambdaRewriter:
         case lam: Lambda =>
           val sym = BlockMemberSymbol("lambda", Nil, nameIsMeaningful = false)
           val Lambda(params, body) = super.applyLam(lam)
-          val lamDefn = FunDefn.withFreshSymbol(N, sym, params :: Nil, body)(false, N, annotations = Nil)
+          val lamDefn = FunDefn.withFreshSymbol(N, sym, params :: Nil, body)(N, annotations = Nil)
           Scoped(Set.single(sym), Define(lamDefn, k(lamDefn.asPath)))
         case _ => super.applyResult(r)(k)
       
@@ -25,7 +25,7 @@ object LambdaRewriter:
           val newSym = BlockMemberSymbol(lhs.nme, Nil,
             nameIsMeaningful = true // TODO: lhs.nme is not always meaningful
           )
-          val defn = FunDefn.withFreshSymbol(N, newSym, params :: Nil, applyBlock(body))(false, N, annotations = Nil)
+          val defn = FunDefn.withFreshSymbol(N, newSym, params :: Nil, applyBlock(body))(N, annotations = Nil)
           val blk = blockBuilder
             .define(defn)
             .assign(lhs, defn.asPath)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/LambdaRewriter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/LambdaRewriter.scala
@@ -16,7 +16,7 @@ object LambdaRewriter:
         case lam: Lambda =>
           val sym = BlockMemberSymbol("lambda", Nil, nameIsMeaningful = false)
           val Lambda(params, body) = super.applyLam(lam)
-          val lamDefn = FunDefn.withFreshSymbol(N, sym, params :: Nil, body)(false, N, Visibility.Public, isStaged = false)
+          val lamDefn = FunDefn.withFreshSymbol(N, sym, params :: Nil, body)(false, N, annotations = Nil)
           Scoped(Set.single(sym), Define(lamDefn, k(lamDefn.asPath)))
         case _ => super.applyResult(r)(k)
       
@@ -25,7 +25,7 @@ object LambdaRewriter:
           val newSym = BlockMemberSymbol(lhs.nme, Nil,
             nameIsMeaningful = true // TODO: lhs.nme is not always meaningful
           )
-          val defn = FunDefn.withFreshSymbol(N, newSym, params :: Nil, applyBlock(body))(false, N, Visibility.Public, isStaged = false)
+          val defn = FunDefn.withFreshSymbol(N, newSym, params :: Nil, applyBlock(body))(false, N, annotations = Nil)
           val blk = blockBuilder
             .define(defn)
             .assign(lhs, defn.asPath)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/LambdaRewriter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/LambdaRewriter.scala
@@ -16,7 +16,7 @@ object LambdaRewriter:
         case lam: Lambda =>
           val sym = BlockMemberSymbol("lambda", Nil, nameIsMeaningful = false)
           val Lambda(params, body) = super.applyLam(lam)
-          val lamDefn = FunDefn.withFreshSymbol(N, sym, params :: Nil, body)(false, N, Visibility.Public)
+          val lamDefn = FunDefn.withFreshSymbol(N, sym, params :: Nil, body)(false, N, Visibility.Public, isStaged = false)
           Scoped(Set.single(sym), Define(lamDefn, k(lamDefn.asPath)))
         case _ => super.applyResult(r)(k)
       
@@ -25,7 +25,7 @@ object LambdaRewriter:
           val newSym = BlockMemberSymbol(lhs.nme, Nil,
             nameIsMeaningful = true // TODO: lhs.nme is not always meaningful
           )
-          val defn = FunDefn.withFreshSymbol(N, newSym, params :: Nil, applyBlock(body))(false, N, Visibility.Public)
+          val defn = FunDefn.withFreshSymbol(N, newSym, params :: Nil, applyBlock(body))(false, N, Visibility.Public, isStaged = false)
           val blk = blockBuilder
             .define(defn)
             .assign(lhs, defn.asPath)
@@ -35,4 +35,4 @@ object LambdaRewriter:
     
     transformer.applyBlock(b)
   
-
+  

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -886,7 +886,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
       
       val rewritten = rewriter.rewrite(obj.fun.body)
       val withCapture = addExtraSyms(rewritten)
-      LifterResult(obj.fun.copy(body = withCapture)(obj.fun.forceTailRec, obj.fun.configOverride, obj.fun.annotations), rewriter.extraDefns.toList)
+      LifterResult(obj.fun.copy(body = withCapture)(obj.fun.configOverride, obj.fun.annotations), rewriter.extraDefns.toList)
   
   class RewrittenClassCtor(override val obj: ScopedObject.ClassCtor)(using ctx: LifterCtxNew) extends RewrittenScope[Unit](obj):
     override lazy val capturePath: Path = lastWords("tried to create a capture class for a class ctor")
@@ -980,7 +980,6 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
       val newBod = rewriter.rewrite(fun.body)
       val withCapture = addExtraSyms(newBod)
       val newDefn = fun.copy(owner = N, sym = mainSym, dSym = mainDsym, params = newPlists, body = withCapture)(
-        fun.forceTailRec,
         fun.configOverride,
         if liftedFromStagedModule && !fun.isStaged then Annot.Modifier(Keyword.`staged`) :: fun.annotations
         else fun.annotations)
@@ -1013,7 +1012,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         auxDsym,
         newPlists,
         bod
-      )(false, N,
+      )(N,
         if fun.visibility is Visibility.Private then Annot.Modifier(Keyword.`private`) :: Nil
         else Nil)
     
@@ -1141,7 +1140,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         if clsIsParamless then auxParamList :: Nil
         else auxParamList :: main :: Nil
       
-      FunDefn(N, flattenedSym, flattenedDSym, paramLists, bod)(false, N, annotations = Nil)
+      FunDefn(N, flattenedSym, flattenedDSym, paramLists, bod)(N, annotations = Nil)
     
     private val flat = Lazy[Defn](mkFlattenedDefn)
     

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -3,7 +3,7 @@ package hkmc2
 import mlscript.utils.*, shorthands.*
 import utils.*
 
-import syntax.{SpreadKind}
+import syntax.{Keyword, SpreadKind}
 import hkmc2.codegen.*
 import hkmc2.semantics.*
 import hkmc2.Message.*
@@ -544,7 +544,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
           tSym,
           fldSym,
           Value.Ref(varSym)
-        )(N)
+        )(N, Nil)
         
         (sym -> varSym, p, vd)
     
@@ -560,7 +560,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         case (acc, (_, _, vd)) => Define(vd, acc),
       N,
       N,
-    )(N, isStaged = false)
+    )(N, Nil)
     
     (defn, sortedVars.iterator.map(x => (x.ctorSyms.local, x.valDefn.tsym)).toList)
   
@@ -609,7 +609,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
           case Some(_) => die 
           case None => N
         
-        k(newCls.copy(companion = newComp)(newCls.configOverride, newCls.isStaged))
+        k(newCls.copy(companion = newComp)(newCls.configOverride, newCls.annotations))
       case _ => super.applyDefn(defn)(k)
 
   /**
@@ -886,7 +886,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
       
       val rewritten = rewriter.rewrite(obj.fun.body)
       val withCapture = addExtraSyms(rewritten)
-      LifterResult(obj.fun.copy(body = withCapture)(obj.fun.forceTailRec, obj.fun.configOverride, obj.fun.visibility, obj.fun.isStaged), rewriter.extraDefns.toList)
+      LifterResult(obj.fun.copy(body = withCapture)(obj.fun.forceTailRec, obj.fun.configOverride, obj.fun.annotations), rewriter.extraDefns.toList)
   
   class RewrittenClassCtor(override val obj: ScopedObject.ClassCtor)(using ctx: LifterCtxNew) extends RewrittenScope[Unit](obj):
     override lazy val capturePath: Path = lastWords("tried to create a capture class for a class ctor")
@@ -916,7 +916,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         preCtor = rewrittenPrector,
         privateFields = appendCaptureField(liftedObjsOrdered.map(liftedObjsSyms) ::: obj.cls.privateFields),
         methods = newMtds,
-      )(obj.cls.configOverride, obj.cls.isStaged)
+      )(obj.cls.configOverride, obj.cls.annotations)
       LifterResult(newCls, rewriterCtor.extraDefns.toList ::: rewriterPreCtor.extraDefns.toList ::: extras)
 
   class RewrittenCompanion(override val obj: ScopedObject.Companion)(using ctx: LifterCtxNew)
@@ -982,8 +982,8 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
       val newDefn = fun.copy(owner = N, sym = mainSym, dSym = mainDsym, params = newPlists, body = withCapture)(
         fun.forceTailRec,
         fun.configOverride,
-        fun.visibility,
-        fun.isStaged || liftedFromStagedModule)
+        if liftedFromStagedModule && !fun.isStaged then Annot.Modifier(Keyword.`staged`) :: fun.annotations
+        else fun.annotations)
       LifterResult(newDefn, rewriter.extraDefns.toList)
     
     // Definition with the auxiliary parameters merged into the second parameter list.
@@ -1013,7 +1013,9 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         auxDsym,
         newPlists,
         bod
-      )(false, N, fun.visibility, isStaged = false)
+      )(false, N,
+        if fun.visibility is Visibility.Private then Annot.Modifier(Keyword.`private`) :: Nil
+        else Nil)
     
     private val aux = Lazy[Defn](mkAuxDefn)
     
@@ -1139,7 +1141,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         if clsIsParamless then auxParamList :: Nil
         else auxParamList :: main :: Nil
       
-      FunDefn(N, flattenedSym, flattenedDSym, paramLists, bod)(false, N, Visibility.Public, isStaged = false)
+      FunDefn(N, flattenedSym, flattenedDSym, paramLists, bod)(false, N, annotations = Nil)
     
     private val flat = Lazy[Defn](mkFlattenedDefn)
     
@@ -1227,7 +1229,9 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         privateFields = appendCaptureField(extraPrivSyms ::: obj.cls.privateFields),
         methods = newMtds,
         auxParams = newAuxList
-      )(obj.cls.configOverride, obj.cls.isStaged || liftedFromStagedModule)
+      )(obj.cls.configOverride,
+        if liftedFromStagedModule && !obj.cls.isStaged then Annot.Modifier(Keyword.`staged`) :: obj.cls.annotations
+        else obj.cls.annotations)
       val extrasDefns = rewriterCtor.extraDefns.toList ::: rewriterPreCtor.extraDefns.toList ::: extras
       LifterResult(newCls, flat :: extrasDefns)
   

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -1012,9 +1012,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         auxDsym,
         newPlists,
         bod
-      )(N,
-        if fun.visibility is Visibility.Private then Annot.Modifier(Keyword.`private`) :: Nil
-        else Nil)
+      )(N, fun.annotations)
     
     private val aux = Lazy[Defn](mkAuxDefn)
     

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -33,7 +33,7 @@ object Lifter:
     def gatherUsed: List[Defn] = l.collect:
       case l: Lazy[?] if !l.isEmpty => l.force_!
       case d: Defn => d
-    
+
   /**
     * Describes previously defined locals and definitions which could possibly be accessed or mutated by particular definition.
     * Here, a "previously defined" local or definition means it is accessible to the particular definition (which we call `d`), 
@@ -560,7 +560,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         case (acc, (_, _, vd)) => Define(vd, acc),
       N,
       N,
-    )(N)
+    )(N, isStaged = false)
     
     (defn, sortedVars.iterator.map(x => (x.ctorSyms.local, x.valDefn.tsym)).toList)
   
@@ -609,7 +609,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
           case Some(_) => die 
           case None => N
         
-        k(newCls.copy(companion = newComp)(newCls.configOverride))
+        k(newCls.copy(companion = newComp)(newCls.configOverride, newCls.isStaged))
       case _ => super.applyDefn(defn)(k)
 
   /**
@@ -806,6 +806,11 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
       val captureArgs = capturesOrdered.map(c => ctx.capturesMap(c).asArg)
       val localArgs = passedSymsOrdered.map(l => ctx.symbolsMap(l).asArg)
       defnsArgs ::: captureArgs ::: localArgs
+
+    final lazy val liftedFromStagedModule: Bool =
+      node.allAncestors.exists:
+        case ScopeNode(ScopedObject.Companion(comp, _), _, _) => comp.isStaged
+        case _ => false
   
   /* MIXINS */
   
@@ -881,7 +886,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
       
       val rewritten = rewriter.rewrite(obj.fun.body)
       val withCapture = addExtraSyms(rewritten)
-      LifterResult(obj.fun.copy(body = withCapture)(obj.fun.forceTailRec, obj.fun.configOverride, obj.fun.visibility), rewriter.extraDefns.toList)
+      LifterResult(obj.fun.copy(body = withCapture)(obj.fun.forceTailRec, obj.fun.configOverride, obj.fun.visibility, obj.fun.isStaged), rewriter.extraDefns.toList)
   
   class RewrittenClassCtor(override val obj: ScopedObject.ClassCtor)(using ctx: LifterCtxNew) extends RewrittenScope[Unit](obj):
     override lazy val capturePath: Path = lastWords("tried to create a capture class for a class ctor")
@@ -911,7 +916,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         preCtor = rewrittenPrector,
         privateFields = appendCaptureField(liftedObjsOrdered.map(liftedObjsSyms) ::: obj.cls.privateFields),
         methods = newMtds,
-      )(obj.cls.configOverride)
+      )(obj.cls.configOverride, obj.cls.isStaged)
       LifterResult(newCls, rewriterCtor.extraDefns.toList ::: rewriterPreCtor.extraDefns.toList ::: extras)
 
   class RewrittenCompanion(override val obj: ScopedObject.Companion)(using ctx: LifterCtxNew)
@@ -974,7 +979,11 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
       val rewriter = new BlockRewriter
       val newBod = rewriter.rewrite(fun.body)
       val withCapture = addExtraSyms(newBod)
-      val newDefn = fun.copy(owner = N, sym = mainSym, dSym = mainDsym, params = newPlists, body = withCapture)(fun.forceTailRec, fun.configOverride, fun.visibility)
+      val newDefn = fun.copy(owner = N, sym = mainSym, dSym = mainDsym, params = newPlists, body = withCapture)(
+        fun.forceTailRec,
+        fun.configOverride,
+        fun.visibility,
+        fun.isStaged || liftedFromStagedModule)
       LifterResult(newDefn, rewriter.extraDefns.toList)
     
     // Definition with the auxiliary parameters merged into the second parameter list.
@@ -1004,7 +1013,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         auxDsym,
         newPlists,
         bod
-      )(false, N, fun.visibility)
+      )(false, N, fun.visibility, isStaged = false)
     
     private val aux = Lazy[Defn](mkAuxDefn)
     
@@ -1130,7 +1139,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         if clsIsParamless then auxParamList :: Nil
         else auxParamList :: main :: Nil
       
-      FunDefn(N, flattenedSym, flattenedDSym, paramLists, bod)(false, N, Visibility.Public)
+      FunDefn(N, flattenedSym, flattenedDSym, paramLists, bod)(false, N, Visibility.Public, isStaged = false)
     
     private val flat = Lazy[Defn](mkFlattenedDefn)
     
@@ -1218,7 +1227,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         privateFields = appendCaptureField(extraPrivSyms ::: obj.cls.privateFields),
         methods = newMtds,
         auxParams = newAuxList
-      )(obj.cls.configOverride)
+      )(obj.cls.configOverride, obj.cls.isStaged || liftedFromStagedModule)
       val extrasDefns = rewriterCtor.extraDefns.toList ::: rewriterPreCtor.extraDefns.toList ::: extras
       LifterResult(newCls, flat :: extrasDefns)
   

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -806,7 +806,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
       val captureArgs = capturesOrdered.map(c => ctx.capturesMap(c).asArg)
       val localArgs = passedSymsOrdered.map(l => ctx.symbolsMap(l).asArg)
       defnsArgs ::: captureArgs ::: localArgs
-
+    
     final lazy val liftedFromStagedModule: Bool =
       node.allAncestors.exists:
         case ScopeNode(ScopedObject.Companion(comp, _), _, _) => comp.isStaged

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -248,7 +248,8 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
               val (paramLists, bodyBlock) = setupFunctionOrByNameDef(td.params, bod, S(td.sym.nme))
               val cfgOverride = td.extraAnnotations.collectFirst:
                 case Annot.Config(modify) => modify(config)
-              Define(FunDefn(td.owner, td.sym, td.tsym, paramLists, bodyBlock)(td.extraAnnotations.contains(Annot.TailRec), cfgOverride, td.visibility),
+              val isStaged = td.hasStagedModifier.isDefined
+              Define(FunDefn(td.owner, td.sym, td.tsym, paramLists, bodyBlock)(td.extraAnnotations.contains(Annot.TailRec), cfgOverride, td.visibility, isStaged),
                 blockImpl(stats, res))
             case syntax.Ins =>
               // Implicit instances are not parameterized for now.
@@ -326,7 +327,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
                 case (sym, params, split) =>
                   val paramLists = params :: Nil
                   val bodyBlock = inScopedBlock(ucs.Normalization(this)(split)(Ret))
-                  FunDefn.withFreshSymbol(N, sym, paramLists, bodyBlock)(forceTailRec = false, configOverride = N, visibility = Visibility.Public)
+                  FunDefn.withFreshSymbol(N, sym, paramLists, bodyBlock)(forceTailRec = false, configOverride = N, visibility = Visibility.Public, isStaged = false)
               // The return type is intended to be consistent with `gatherMembers`
               (mtds, Nil, Nil, End())
             case _ => gatherMembers(defn.body)
@@ -344,7 +345,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
                 case N =>
                 val (mtds, publicFlds, privateFlds, ctor) =
                   gatherMembers(mod.body)
-                S(ClsLikeBody(mod.sym, mtds, privateFlds, publicFlds, ctor))
+                S(ClsLikeBody(mod.sym, mtds, privateFlds, publicFlds, ctor, mod.hasStagedModifier.isDefined))
               case _ => N
             case _ => N
           defn.ext match
@@ -360,7 +361,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
                 ctor,
                 mod,
                 bufferable,
-              )(cfgOverride),
+              )(cfgOverride, defn.hasStagedModifier.isDefined),
               blockImpl(stats, res))
           case S(ext) =>
             assert(k isnt syntax.Mod) // modules can't extend things and can't have super calls
@@ -372,7 +373,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
                 ClsLikeDefn(
                   defn.owner, defn.sym, defn.bsym, defn.ctorSym, defn.kind, defn.paramsOpt, defn.auxParams, S(clsp),
                   mtds, privateFlds, publicFlds, pctor, ctor, mod, bufferable,
-                )(cfgOverride),
+                )(cfgOverride, defn.hasStagedModifier.isDefined),
                 blockImpl(stats, res)
               )
         case td: TypeDef => // * Type definitions are erased
@@ -705,7 +706,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
       else
         val lamSym = new BlockMemberSymbol("lambda", Nil, false)
         loweringCtx.collectScopedSym(lamSym)
-        val lamDef = FunDefn.withFreshSymbol(N, lamSym, paramLists, bodyBlock)(forceTailRec = false, configOverride = N, visibility = Visibility.Public)
+        val lamDef = FunDefn.withFreshSymbol(N, lamSym, paramLists, bodyBlock)(forceTailRec = false, configOverride = N, visibility = Visibility.Public, isStaged = false)
         Define(
           lamDef,
           k(lamDef.asPath))
@@ -766,7 +767,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
           val (mtds, publicFlds, privateFlds, ctor) = gatherMembers(rft)
           val pctor = parentConstructor(cls, as)
           val clsDef = ClsLikeDefn(N, isym, sym, N, syntax.Cls, N, Nil, S(sr),
-            mtds, privateFlds, publicFlds, pctor, ctor, N, N)(N)
+            mtds, privateFlds, publicFlds, pctor, ctor, N, N)(N, isStaged = false)
           val inner = new New(sym.ref().resolved(isym), Nil, N)(N)
           Define(clsDef, term_nonTail(if mut then Mut(inner) else inner)(k))
       
@@ -983,7 +984,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
           reportAnnotations(td, td.extraAnnotations)
           val cfgOverride = td.extraAnnotations.collectFirst:
             case Annot.Config(modify) => modify(config)
-          FunDefn(td.owner, td.sym, td.tsym, paramLists, bodyBlock)(td.extraAnnotations.contains(Annot.TailRec), cfgOverride, td.visibility)
+          FunDefn(td.owner, td.sym, td.tsym, paramLists, bodyBlock)(td.extraAnnotations.contains(Annot.TailRec), cfgOverride, td.visibility, td.hasStagedModifier.isDefined)
     val publicFlds = clsBody.publicFlds.map(f => f.sym -> f.tsym)
     val privateFlds = clsBody.nonMethods.collect:
       case decl @ LetDecl(sym: TermSymbol, annotations) =>
@@ -1061,7 +1062,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
       case Lambda(params, body) =>
         val lamSym = BlockMemberSymbol("lambda", Nil, false)
         loweringCtx.collectScopedSym(lamSym)
-        val lamDef = FunDefn.withFreshSymbol(N, lamSym, params :: Nil, body)(forceTailRec = false, configOverride = N, visibility = Visibility.Public)
+        val lamDef = FunDefn.withFreshSymbol(N, lamSym, params :: Nil, body)(forceTailRec = false, configOverride = N, visibility = Visibility.Public, isStaged = false)
         Define(lamDef, k(lamDef.asPath))
       case r =>
         val l = loweringCtx.registerTempSymbol(N)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -242,14 +242,13 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
               subTerm_nonTail(bod)(r =>
                 // Assign(td.sym, r,
                 //   term(st.Blk(stats, res))(k)))
-                Define(ValDefn(td.tsym, td.sym, r)(cfgOverride),
+                Define(ValDefn(td.tsym, td.sym, r)(cfgOverride, td.annotations),
                   blockImpl(stats, res)))(using LoweringCtx.nestFunc)
             case syntax.Fun =>
               val (paramLists, bodyBlock) = setupFunctionOrByNameDef(td.params, bod, S(td.sym.nme))
               val cfgOverride = td.extraAnnotations.collectFirst:
                 case Annot.Config(modify) => modify(config)
-              val isStaged = td.hasStagedModifier.isDefined
-              Define(FunDefn(td.owner, td.sym, td.tsym, paramLists, bodyBlock)(td.extraAnnotations.contains(Annot.TailRec), cfgOverride, td.visibility, isStaged),
+              Define(FunDefn(td.owner, td.sym, td.tsym, paramLists, bodyBlock)(td.extraAnnotations.contains(Annot.TailRec), cfgOverride, td.annotations),
                 blockImpl(stats, res))
             case syntax.Ins =>
               // Implicit instances are not parameterized for now.
@@ -257,7 +256,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
               val cfgOverride = td.extraAnnotations.collectFirst:
                 case Annot.Config(modify) => modify(config)
               subTerm(bod)(r =>
-                Define(ValDefn(td.tsym, td.sym, r)(cfgOverride),
+                Define(ValDefn(td.tsym, td.sym, r)(cfgOverride, td.annotations),
                   blockImpl(stats, res)))
             case syntax.LetBind | syntax.HandlerBind => fail:
               ErrorReport(
@@ -327,7 +326,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
                 case (sym, params, split) =>
                   val paramLists = params :: Nil
                   val bodyBlock = inScopedBlock(ucs.Normalization(this)(split)(Ret))
-                  FunDefn.withFreshSymbol(N, sym, paramLists, bodyBlock)(forceTailRec = false, configOverride = N, visibility = Visibility.Public, isStaged = false)
+                  FunDefn.withFreshSymbol(N, sym, paramLists, bodyBlock)(forceTailRec = false, configOverride = N, annotations = Nil)
               // The return type is intended to be consistent with `gatherMembers`
               (mtds, Nil, Nil, End())
             case _ => gatherMembers(defn.body)
@@ -345,7 +344,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
                 case N =>
                 val (mtds, publicFlds, privateFlds, ctor) =
                   gatherMembers(mod.body)
-                S(ClsLikeBody(mod.sym, mtds, privateFlds, publicFlds, ctor, mod.hasStagedModifier.isDefined))
+                S(ClsLikeBody(mod.sym, mtds, privateFlds, publicFlds, ctor, mod.annotations))
               case _ => N
             case _ => N
           defn.ext match
@@ -361,7 +360,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
                 ctor,
                 mod,
                 bufferable,
-              )(cfgOverride, defn.hasStagedModifier.isDefined),
+              )(cfgOverride, defn.annotations),
               blockImpl(stats, res))
           case S(ext) =>
             assert(k isnt syntax.Mod) // modules can't extend things and can't have super calls
@@ -373,7 +372,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
                 ClsLikeDefn(
                   defn.owner, defn.sym, defn.bsym, defn.ctorSym, defn.kind, defn.paramsOpt, defn.auxParams, S(clsp),
                   mtds, privateFlds, publicFlds, pctor, ctor, mod, bufferable,
-                )(cfgOverride, defn.hasStagedModifier.isDefined),
+                )(cfgOverride, defn.annotations),
                 blockImpl(stats, res)
               )
         case td: TypeDef => // * Type definitions are erased
@@ -706,7 +705,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
       else
         val lamSym = new BlockMemberSymbol("lambda", Nil, false)
         loweringCtx.collectScopedSym(lamSym)
-        val lamDef = FunDefn.withFreshSymbol(N, lamSym, paramLists, bodyBlock)(forceTailRec = false, configOverride = N, visibility = Visibility.Public, isStaged = false)
+        val lamDef = FunDefn.withFreshSymbol(N, lamSym, paramLists, bodyBlock)(forceTailRec = false, configOverride = N, annotations = Nil)
         Define(
           lamDef,
           k(lamDef.asPath))
@@ -767,7 +766,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
           val (mtds, publicFlds, privateFlds, ctor) = gatherMembers(rft)
           val pctor = parentConstructor(cls, as)
           val clsDef = ClsLikeDefn(N, isym, sym, N, syntax.Cls, N, Nil, S(sr),
-            mtds, privateFlds, publicFlds, pctor, ctor, N, N)(N, isStaged = false)
+            mtds, privateFlds, publicFlds, pctor, ctor, N, N)(N, Nil)
           val inner = new New(sym.ref().resolved(isym), Nil, N)(N)
           Define(clsDef, term_nonTail(if mut then Mut(inner) else inner)(k))
       
@@ -984,7 +983,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
           reportAnnotations(td, td.extraAnnotations)
           val cfgOverride = td.extraAnnotations.collectFirst:
             case Annot.Config(modify) => modify(config)
-          FunDefn(td.owner, td.sym, td.tsym, paramLists, bodyBlock)(td.extraAnnotations.contains(Annot.TailRec), cfgOverride, td.visibility, td.hasStagedModifier.isDefined)
+          FunDefn(td.owner, td.sym, td.tsym, paramLists, bodyBlock)(td.extraAnnotations.contains(Annot.TailRec), cfgOverride, td.annotations)
     val publicFlds = clsBody.publicFlds.map(f => f.sym -> f.tsym)
     val privateFlds = clsBody.nonMethods.collect:
       case decl @ LetDecl(sym: TermSymbol, annotations) =>
@@ -1062,7 +1061,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
       case Lambda(params, body) =>
         val lamSym = BlockMemberSymbol("lambda", Nil, false)
         loweringCtx.collectScopedSym(lamSym)
-        val lamDef = FunDefn.withFreshSymbol(N, lamSym, params :: Nil, body)(forceTailRec = false, configOverride = N, visibility = Visibility.Public, isStaged = false)
+        val lamDef = FunDefn.withFreshSymbol(N, lamSym, params :: Nil, body)(forceTailRec = false, configOverride = N, annotations = Nil)
         Define(lamDef, k(lamDef.asPath))
       case r =>
         val l = loweringCtx.registerTempSymbol(N)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -248,7 +248,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
               val (paramLists, bodyBlock) = setupFunctionOrByNameDef(td.params, bod, S(td.sym.nme))
               val cfgOverride = td.extraAnnotations.collectFirst:
                 case Annot.Config(modify) => modify(config)
-              Define(FunDefn(td.owner, td.sym, td.tsym, paramLists, bodyBlock)(td.extraAnnotations.contains(Annot.TailRec), cfgOverride, td.annotations),
+              Define(FunDefn(td.owner, td.sym, td.tsym, paramLists, bodyBlock)(cfgOverride, td.annotations),
                 blockImpl(stats, res))
             case syntax.Ins =>
               // Implicit instances are not parameterized for now.
@@ -326,7 +326,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
                 case (sym, params, split) =>
                   val paramLists = params :: Nil
                   val bodyBlock = inScopedBlock(ucs.Normalization(this)(split)(Ret))
-                  FunDefn.withFreshSymbol(N, sym, paramLists, bodyBlock)(forceTailRec = false, configOverride = N, annotations = Nil)
+                  FunDefn.withFreshSymbol(N, sym, paramLists, bodyBlock)(configOverride = N, annotations = Nil)
               // The return type is intended to be consistent with `gatherMembers`
               (mtds, Nil, Nil, End())
             case _ => gatherMembers(defn.body)
@@ -705,7 +705,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
       else
         val lamSym = new BlockMemberSymbol("lambda", Nil, false)
         loweringCtx.collectScopedSym(lamSym)
-        val lamDef = FunDefn.withFreshSymbol(N, lamSym, paramLists, bodyBlock)(forceTailRec = false, configOverride = N, annotations = Nil)
+        val lamDef = FunDefn.withFreshSymbol(N, lamSym, paramLists, bodyBlock)(configOverride = N, annotations = Nil)
         Define(
           lamDef,
           k(lamDef.asPath))
@@ -983,7 +983,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
           reportAnnotations(td, td.extraAnnotations)
           val cfgOverride = td.extraAnnotations.collectFirst:
             case Annot.Config(modify) => modify(config)
-          FunDefn(td.owner, td.sym, td.tsym, paramLists, bodyBlock)(td.extraAnnotations.contains(Annot.TailRec), cfgOverride, td.annotations)
+          FunDefn(td.owner, td.sym, td.tsym, paramLists, bodyBlock)(cfgOverride, td.annotations)
     val publicFlds = clsBody.publicFlds.map(f => f.sym -> f.tsym)
     val privateFlds = clsBody.nonMethods.collect:
       case decl @ LetDecl(sym: TermSymbol, annotations) =>
@@ -1061,7 +1061,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx):
       case Lambda(params, body) =>
         val lamSym = BlockMemberSymbol("lambda", Nil, false)
         loweringCtx.collectScopedSym(lamSym)
-        val lamDef = FunDefn.withFreshSymbol(N, lamSym, params :: Nil, body)(forceTailRec = false, configOverride = N, annotations = Nil)
+        val lamDef = FunDefn.withFreshSymbol(N, lamSym, params :: Nil, body)(configOverride = N, annotations = Nil)
         Define(lamDef, k(lamDef.asPath))
       case r =>
         val l = loweringCtx.registerTempSymbol(N)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
@@ -117,24 +117,25 @@ class Printer(using Raise, ShowCfg, SymbolPrinter, Config):
       .mkDocument("")
   
   def print(defn: Defn)(using Scope): Document = defn match
-    case FunDefn(own, sym, dSym, paramss, body) =>
+    case fun @ FunDefn(own, sym, dSym, paramss, body) =>
       scope.nest.givenIn:
         val docParams = printParamLists(paramss)
         val docBody = print(body)
-        doc"fun ${print(dSym)}${docParams} ${bracedbk(docBody)}"
+        val docStaged = if fun.isStaged then doc"staged " else doc""
+        doc"${docStaged}fun ${print(dSym)}${docParams} ${bracedbk(docBody)}"
     case ValDefn(tsym, sym, rhs) =>
       doc"val ${print(tsym)} = ${print(rhs)}"
-    case ClsLikeDefn(own, isym, sym, ctorSym, k, paramsOpt, auxParams, parentSym, methods,
+    case cls @ ClsLikeDefn(own, isym, sym, ctorSym, k, paramsOpt, auxParams, parentSym, methods,
         privateFields, publicFields, preCtor, ctor, mod, bufferable)
     => scope.nest.givenIn:
       val ctorParams = printParamLists(paramsOpt.toList)
-      val docStaged = if isym.defn.forall(_.hasStagedModifier.isEmpty) then doc"" else doc"staged "
+      val docStaged = if cls.isStaged then doc"staged " else doc""
       val docBody = print(privateFields, publicFields, methods, auxParams, S(preCtor), ctor, ctorSym)
       val clsType = k.str
       val docCls = doc"${docStaged}${clsType} ${print(isym)}${ctorParams}${docBody}"
       val docModule = mod match
         case Some(mod) =>
-          val docStaged = if mod.isym.defn.forall(_.hasStagedModifier.isEmpty) then doc"" else doc"staged "
+          val docStaged = if mod.isStaged then doc"staged " else doc""
           val docBody = print(mod.privateFields, mod.publicFields, mod.methods, Nil, N, mod.ctor, N)
           doc" # ${docStaged}module ${print(mod.isym)}${docBody}"
         case None => doc""

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
@@ -368,7 +368,9 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
             val (stagedMethods, debugPrintCode) = c.methods
               .map(applyFunDefnInner)
               .unzip
-            val newModule = c.copy(methods = c.methods ++ stagedMethods)(c.configOverride, Nil)
+            val newModule = c.copy(methods = c.methods ++ stagedMethods)(c.configOverride, c.annotations.filter:
+              case Annot.Modifier(Keyword.`staged`) => false
+              case _ => true)
             Define(newModule, rest)
           case b => b
       val newCtor = genCls.applyBlock(companion.ctor)
@@ -376,7 +378,9 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
         methods = stagedCtor :: companion.methods ++ stagedMethods,
         ctor = Begin(newCtor, debugCont(End())),
       )
-      val newModule = c.copy(sym = sym, companion = S(newCompanion))(c.configOverride, Nil)
+      val newModule = c.copy(sym = sym, companion = S(newCompanion))(c.configOverride, c.annotations.filter:
+        case Annot.Modifier(Keyword.`staged`) => false
+        case _ => true)
       Define(newModule, rest)
     case b => b
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
@@ -343,18 +343,18 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
 
     // TODO: remove it. only for test
     val debug = (k: Block) => call(sym, Nil)(fnPrintCode(_)(k))
-    val newFun = f.copy(sym = genSym, dSym = dSym, params = Ls(PlainParamList(Nil)), body = newBody)(false, f.configOverride, f.visibility)
+    val newFun = f.copy(sym = genSym, dSym = dSym, params = Ls(PlainParamList(Nil)), body = newBody)(false, f.configOverride, f.visibility, false)
     (newFun, debug)
 
   override def applyBlock(b: Block): Block = super.applyBlock(b) match
     // find modules with staged annotation
-    case Define(c: ClsLikeDefn, rest) if c.companion.exists(_.isym.defn.exists(_.hasStagedModifier.isDefined)) =>
+    case Define(c: ClsLikeDefn, rest) if c.companion.exists(_.isStaged) =>
       val sym = c.sym.subst
       val companion = c.companion.get
       val (stagedMethods, debugPrintCode) = companion.methods
         .map(applyFunDefnInner)
         .unzip
-      val ctor = FunDefn.withFreshSymbol(S(companion.isym), BlockMemberSymbol("ctor$", Nil), Ls(PlainParamList(Nil)), companion.ctor)(false, N, Visibility.Public)
+      val ctor = FunDefn.withFreshSymbol(S(companion.isym), BlockMemberSymbol("ctor$", Nil), Ls(PlainParamList(Nil)), companion.ctor)(false, N, Visibility.Public, false)
       val (stagedCtor, ctorPrint) = applyFunDefnInner(ctor)
 
       val unit = State.runtimeSymbol.asPath.selSN("Unit")
@@ -368,7 +368,7 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
             val (stagedMethods, debugPrintCode) = c.methods
               .map(applyFunDefnInner)
               .unzip
-            val newModule = c.copy(methods = c.methods ++ stagedMethods)(c.configOverride)
+            val newModule = c.copy(methods = c.methods ++ stagedMethods)(c.configOverride, false)
             Define(newModule, rest)
           case b => b
       val newCtor = genCls.applyBlock(companion.ctor)
@@ -376,7 +376,7 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
         methods = stagedCtor :: companion.methods ++ stagedMethods,
         ctor = Begin(newCtor, debugCont(End())),
       )
-      val newModule = c.copy(sym = sym, companion = S(newCompanion))(c.configOverride)
+      val newModule = c.copy(sym = sym, companion = S(newCompanion))(c.configOverride, false)
       Define(newModule, rest)
     case b => b
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
@@ -12,7 +12,7 @@ import mlscript.utils.*, shorthands.*
 import semantics.*
 import semantics.Elaborator.{State, Ctx, ctx}
 
-import syntax.{Literal, Tree}
+import syntax.{Keyword, Literal, Tree}
 
 // it should be possible to cache some common constructions (End, Option) into the context
 // this avoids having to rebuild the same shapes everytime they are needed
@@ -343,7 +343,7 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
 
     // TODO: remove it. only for test
     val debug = (k: Block) => call(sym, Nil)(fnPrintCode(_)(k))
-    val newFun = f.copy(sym = genSym, dSym = dSym, params = Ls(PlainParamList(Nil)), body = newBody)(false, f.configOverride, f.visibility, false)
+    val newFun = f.copy(sym = genSym, dSym = dSym, params = Ls(PlainParamList(Nil)), body = newBody)(false, f.configOverride, f.annotations)
     (newFun, debug)
 
   override def applyBlock(b: Block): Block = super.applyBlock(b) match
@@ -354,7 +354,7 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
       val (stagedMethods, debugPrintCode) = companion.methods
         .map(applyFunDefnInner)
         .unzip
-      val ctor = FunDefn.withFreshSymbol(S(companion.isym), BlockMemberSymbol("ctor$", Nil), Ls(PlainParamList(Nil)), companion.ctor)(false, N, Visibility.Public, false)
+      val ctor = FunDefn.withFreshSymbol(S(companion.isym), BlockMemberSymbol("ctor$", Nil), Ls(PlainParamList(Nil)), companion.ctor)(false, N, Nil)
       val (stagedCtor, ctorPrint) = applyFunDefnInner(ctor)
 
       val unit = State.runtimeSymbol.asPath.selSN("Unit")
@@ -368,7 +368,7 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
             val (stagedMethods, debugPrintCode) = c.methods
               .map(applyFunDefnInner)
               .unzip
-            val newModule = c.copy(methods = c.methods ++ stagedMethods)(c.configOverride, false)
+            val newModule = c.copy(methods = c.methods ++ stagedMethods)(c.configOverride, Nil)
             Define(newModule, rest)
           case b => b
       val newCtor = genCls.applyBlock(companion.ctor)
@@ -376,7 +376,7 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
         methods = stagedCtor :: companion.methods ++ stagedMethods,
         ctor = Begin(newCtor, debugCont(End())),
       )
-      val newModule = c.copy(sym = sym, companion = S(newCompanion))(c.configOverride, false)
+      val newModule = c.copy(sym = sym, companion = S(newCompanion))(c.configOverride, Nil)
       Define(newModule, rest)
     case b => b
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
@@ -343,7 +343,7 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
 
     // TODO: remove it. only for test
     val debug = (k: Block) => call(sym, Nil)(fnPrintCode(_)(k))
-    val newFun = f.copy(sym = genSym, dSym = dSym, params = Ls(PlainParamList(Nil)), body = newBody)(false, f.configOverride, f.annotations)
+    val newFun = f.copy(sym = genSym, dSym = dSym, params = Ls(PlainParamList(Nil)), body = newBody)(f.configOverride, f.annotations)
     (newFun, debug)
 
   override def applyBlock(b: Block): Block = super.applyBlock(b) match
@@ -354,7 +354,7 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
       val (stagedMethods, debugPrintCode) = companion.methods
         .map(applyFunDefnInner)
         .unzip
-      val ctor = FunDefn.withFreshSymbol(S(companion.isym), BlockMemberSymbol("ctor$", Nil), Ls(PlainParamList(Nil)), companion.ctor)(false, N, Nil)
+      val ctor = FunDefn.withFreshSymbol(S(companion.isym), BlockMemberSymbol("ctor$", Nil), Ls(PlainParamList(Nil)), companion.ctor)(N, Nil)
       val (stagedCtor, ctorPrint) = applyFunDefnInner(ctor)
 
       val unit = State.runtimeSymbol.asPath.selSN("Unit")

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
@@ -34,7 +34,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
   
   def wrapStackSafe(body: Block, resSym: Local, rest: Block) =
     val bodSym = BlockMemberSymbol("‹stack safe body›", Nil, false)
-    val bodFun = FunDefn.withFreshSymbol(N, bodSym, ParamList(ParamListFlags.empty, Nil, N) :: Nil, body)(forceTailRec = false, configOverride = N, annotations = Nil)
+    val bodFun = FunDefn.withFreshSymbol(N, bodSym, ParamList(ParamListFlags.empty, Nil, N) :: Nil, body)(configOverride = N, annotations = Nil)
     Scoped(Set.single(bodSym),
       Define(bodFun, Assign(resSym, Call(runStackSafePath, intLit(depthLimit).asArg :: bodSym.asPath.asArg :: Nil)(true, true, false), rest))
     )
@@ -154,6 +154,6 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
 
 
   def rewriteFn(defn: FunDefn) = 
-    FunDefn(defn.owner, defn.sym, defn.dSym, defn.params, rewriteBlk(defn.body, L(defn.sym)))(defn.forceTailRec, defn.configOverride, defn.annotations)
+    FunDefn(defn.owner, defn.sym, defn.dSym, defn.params, rewriteBlk(defn.body, L(defn.sym)))(defn.configOverride, defn.annotations)
 
   def transformTopLevel(b: Block) = transform(b, TempSymbol(N), true)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
@@ -34,7 +34,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
   
   def wrapStackSafe(body: Block, resSym: Local, rest: Block) =
     val bodSym = BlockMemberSymbol("‹stack safe body›", Nil, false)
-    val bodFun = FunDefn.withFreshSymbol(N, bodSym, ParamList(ParamListFlags.empty, Nil, N) :: Nil, body)(forceTailRec = false, configOverride = N, visibility = Visibility.Public, isStaged = false)
+    val bodFun = FunDefn.withFreshSymbol(N, bodSym, ParamList(ParamListFlags.empty, Nil, N) :: Nil, body)(forceTailRec = false, configOverride = N, annotations = Nil)
     Scoped(Set.single(bodSym),
       Define(bodFun, Assign(resSym, Call(runStackSafePath, intLit(depthLimit).asArg :: bodSym.asPath.asArg :: Nil)(true, true, false), rest))
     )
@@ -113,7 +113,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
         ctor,
         mod.map(rewriteObjBody(_, isTopLevel)),
         bufferable,
-      )(defn.configOverride, defn.isStaged)
+      )(defn.configOverride, defn.annotations)
   
   def rewriteObjBody(defn: ClsLikeBody, isTopLevel: Bool): ClsLikeBody =
     ClsLikeBody(
@@ -124,7 +124,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
       if isTopLevel then
         if config.effectHandlers.exists(_.doNotInstrumentTopLevelModCtor) then defn.ctor else transformTopLevel(defn.ctor)
       else rewriteBlk(defn.ctor, R(defn.isym)),
-      defn.isStaged,
+      defn.annotations,
     )
 
   // fnOrCls points us to the doUnwind function
@@ -154,6 +154,6 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
 
 
   def rewriteFn(defn: FunDefn) = 
-    FunDefn(defn.owner, defn.sym, defn.dSym, defn.params, rewriteBlk(defn.body, L(defn.sym)))(defn.forceTailRec, defn.configOverride, defn.visibility, defn.isStaged)
+    FunDefn(defn.owner, defn.sym, defn.dSym, defn.params, rewriteBlk(defn.body, L(defn.sym)))(defn.forceTailRec, defn.configOverride, defn.annotations)
 
   def transformTopLevel(b: Block) = transform(b, TempSymbol(N), true)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
@@ -34,7 +34,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
   
   def wrapStackSafe(body: Block, resSym: Local, rest: Block) =
     val bodSym = BlockMemberSymbol("‹stack safe body›", Nil, false)
-    val bodFun = FunDefn.withFreshSymbol(N, bodSym, ParamList(ParamListFlags.empty, Nil, N) :: Nil, body)(forceTailRec = false, configOverride = N, visibility = Visibility.Public)
+    val bodFun = FunDefn.withFreshSymbol(N, bodSym, ParamList(ParamListFlags.empty, Nil, N) :: Nil, body)(forceTailRec = false, configOverride = N, visibility = Visibility.Public, isStaged = false)
     Scoped(Set.single(bodSym),
       Define(bodFun, Assign(resSym, Call(runStackSafePath, intLit(depthLimit).asArg :: bodSym.asPath.asArg :: Nil)(true, true, false), rest))
     )
@@ -113,7 +113,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
         ctor,
         mod.map(rewriteObjBody(_, isTopLevel)),
         bufferable,
-      )(defn.configOverride)
+      )(defn.configOverride, defn.isStaged)
   
   def rewriteObjBody(defn: ClsLikeBody, isTopLevel: Bool): ClsLikeBody =
     ClsLikeBody(
@@ -124,6 +124,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
       if isTopLevel then
         if config.effectHandlers.exists(_.doNotInstrumentTopLevelModCtor) then defn.ctor else transformTopLevel(defn.ctor)
       else rewriteBlk(defn.ctor, R(defn.isym)),
+      defn.isStaged,
     )
 
   // fnOrCls points us to the doUnwind function
@@ -153,6 +154,6 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
 
 
   def rewriteFn(defn: FunDefn) = 
-    FunDefn(defn.owner, defn.sym, defn.dSym, defn.params, rewriteBlk(defn.body, L(defn.sym)))(defn.forceTailRec, defn.configOverride, defn.visibility)
+    FunDefn(defn.owner, defn.sym, defn.dSym, defn.params, rewriteBlk(defn.body, L(defn.sym)))(defn.forceTailRec, defn.configOverride, defn.visibility, defn.isStaged)
 
   def transformTopLevel(b: Block) = transform(b, TempSymbol(N), true)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/SymbolRefresher.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/SymbolRefresher.scala
@@ -106,9 +106,9 @@ class SymbolRefresher(existingMapping: Map[Symbol, Symbol])(using State) extends
       val body2 = applyFunBodyLikeBlock(fun.body)
       for s <- oldParamSyms do mapping.remove(s)
       if newlyCreated then
-        Scoped(Set.single(sym2), k(FunDefn(N, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.visibility)))
+        Scoped(Set.single(sym2), k(FunDefn(N, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)))
       else
-        k(FunDefn(N, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.visibility))
+        k(FunDefn(N, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged))
     case defn @ ValDefn(tsym, sym, rhs) =>
       val (tsym2, sym2) = mapping.get(sym) match
         case None =>
@@ -177,7 +177,7 @@ class SymbolRefresher(existingMapping: Map[Symbol, Symbol])(using State) extends
       def buildResult(newParentPath: Opt[Path]): Block =
         val newDefn = ClsLikeDefn(newOwn, newIsym, newSym, newCtorSym, defn.k,
           newParamsOpt, newAuxParams, newParentPath, newMethods,
-          newPrivateFields, newPublicFields, newPreCtor, newCtor, newMod, defn.bufferable)(defn.configOverride)
+          newPrivateFields, newPublicFields, newPreCtor, newCtor, newMod, defn.bufferable)(defn.configOverride, defn.isStaged)
         if newlyCreatedSym then
           Scoped(Set.single(newSym), k(newDefn))
         else
@@ -266,7 +266,7 @@ class SymbolRefresher(existingMapping: Map[Symbol, Symbol])(using State) extends
         ParamList(pl.flags, pl.params.map(handleParam), pl.restParam.map(handleParam))
       val newBody = applyFunBodyLikeBlock(m.body)
       methodParamOlds.foreach(mapping.remove)
-      FunDefn(S(newIsym), newMsym, newDsym, newParams, newBody)(m.forceTailRec, m.configOverride, m.visibility)
+      FunDefn(S(newIsym), newMsym, newDsym, newParams, newBody)(m.forceTailRec, m.configOverride, m.visibility, m.isStaged)
   
   override def applyObjBody(defn: ClsLikeBody): ClsLikeBody =
     val hd = toRemoveSymbols.head
@@ -283,4 +283,4 @@ class SymbolRefresher(existingMapping: Map[Symbol, Symbol])(using State) extends
     val newMethods = freshenMethods(defn.methods, oldIsym, newIsym)
     val newCtor = applyFunBodyLikeBlock(defn.ctor)
 
-    ClsLikeBody(newIsym, newMethods, newPrivateFields, newPublicFields, newCtor)
+    ClsLikeBody(newIsym, newMethods, newPrivateFields, newPublicFields, newCtor, defn.isStaged)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/SymbolRefresher.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/SymbolRefresher.scala
@@ -106,9 +106,9 @@ class SymbolRefresher(existingMapping: Map[Symbol, Symbol])(using State) extends
       val body2 = applyFunBodyLikeBlock(fun.body)
       for s <- oldParamSyms do mapping.remove(s)
       if newlyCreated then
-        Scoped(Set.single(sym2), k(FunDefn(N, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.annotations)))
+        Scoped(Set.single(sym2), k(FunDefn(N, sym2, dSym2, params2, body2)(fun.configOverride, fun.annotations)))
       else
-        k(FunDefn(N, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.annotations))
+        k(FunDefn(N, sym2, dSym2, params2, body2)(fun.configOverride, fun.annotations))
     case defn @ ValDefn(tsym, sym, rhs) =>
       val (tsym2, sym2) = mapping.get(sym) match
         case None =>
@@ -266,7 +266,7 @@ class SymbolRefresher(existingMapping: Map[Symbol, Symbol])(using State) extends
         ParamList(pl.flags, pl.params.map(handleParam), pl.restParam.map(handleParam))
       val newBody = applyFunBodyLikeBlock(m.body)
       methodParamOlds.foreach(mapping.remove)
-      FunDefn(S(newIsym), newMsym, newDsym, newParams, newBody)(m.forceTailRec, m.configOverride, m.annotations)
+      FunDefn(S(newIsym), newMsym, newDsym, newParams, newBody)(m.configOverride, m.annotations)
   
   override def applyObjBody(defn: ClsLikeBody): ClsLikeBody =
     val hd = toRemoveSymbols.head

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/SymbolRefresher.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/SymbolRefresher.scala
@@ -106,9 +106,9 @@ class SymbolRefresher(existingMapping: Map[Symbol, Symbol])(using State) extends
       val body2 = applyFunBodyLikeBlock(fun.body)
       for s <- oldParamSyms do mapping.remove(s)
       if newlyCreated then
-        Scoped(Set.single(sym2), k(FunDefn(N, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)))
+        Scoped(Set.single(sym2), k(FunDefn(N, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.annotations)))
       else
-        k(FunDefn(N, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged))
+        k(FunDefn(N, sym2, dSym2, params2, body2)(fun.forceTailRec, fun.configOverride, fun.annotations))
     case defn @ ValDefn(tsym, sym, rhs) =>
       val (tsym2, sym2) = mapping.get(sym) match
         case None =>
@@ -120,7 +120,7 @@ class SymbolRefresher(existingMapping: Map[Symbol, Symbol])(using State) extends
           (bms.tsym.get, bms)
         case _ => die
       applyPath(rhs): rhs2 =>
-        k(ValDefn(tsym2, sym2, rhs2)(defn.configOverride))
+        k(ValDefn(tsym2, sym2, rhs2)(defn.configOverride, defn.annotations))
     case defn: ClsLikeDefn =>
       val hd = toRemoveSymbols.head
       val oldIsym = defn.isym
@@ -177,7 +177,7 @@ class SymbolRefresher(existingMapping: Map[Symbol, Symbol])(using State) extends
       def buildResult(newParentPath: Opt[Path]): Block =
         val newDefn = ClsLikeDefn(newOwn, newIsym, newSym, newCtorSym, defn.k,
           newParamsOpt, newAuxParams, newParentPath, newMethods,
-          newPrivateFields, newPublicFields, newPreCtor, newCtor, newMod, defn.bufferable)(defn.configOverride, defn.isStaged)
+          newPrivateFields, newPublicFields, newPreCtor, newCtor, newMod, defn.bufferable)(defn.configOverride, defn.annotations)
         if newlyCreatedSym then
           Scoped(Set.single(newSym), k(newDefn))
         else
@@ -266,7 +266,7 @@ class SymbolRefresher(existingMapping: Map[Symbol, Symbol])(using State) extends
         ParamList(pl.flags, pl.params.map(handleParam), pl.restParam.map(handleParam))
       val newBody = applyFunBodyLikeBlock(m.body)
       methodParamOlds.foreach(mapping.remove)
-      FunDefn(S(newIsym), newMsym, newDsym, newParams, newBody)(m.forceTailRec, m.configOverride, m.visibility, m.isStaged)
+      FunDefn(S(newIsym), newMsym, newDsym, newParams, newBody)(m.forceTailRec, m.configOverride, m.annotations)
   
   override def applyObjBody(defn: ClsLikeBody): ClsLikeBody =
     val hd = toRemoveSymbols.head
@@ -283,4 +283,4 @@ class SymbolRefresher(existingMapping: Map[Symbol, Symbol])(using State) extends
     val newMethods = freshenMethods(defn.methods, oldIsym, newIsym)
     val newCtor = applyFunBodyLikeBlock(defn.ctor)
 
-    ClsLikeBody(newIsym, newMethods, newPrivateFields, newPublicFields, newCtor, defn.isStaged)
+    ClsLikeBody(newIsym, newMethods, newPrivateFields, newPublicFields, newCtor, defn.annotations)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
@@ -447,7 +447,7 @@ class TailRecOpt(using State, TL, Raise):
           Call(sel, args)(true, false, false),
           false
         )
-        FunDefn(f.owner, f.sym, f.dSym, f.params, newBod)(false, N, f.annotations)
+        FunDefn(f.owner, f.sym, f.dSym, f.params, newBod)(N, f.annotations)
     
     val params =
       val initial = paramSyms.map(Param.simple(_))
@@ -457,7 +457,7 @@ class TailRecOpt(using State, TL, Raise):
     val loopDefn = FunDefn(
       owner, bms, dSym,
       PlainParamList(params) :: Nil,
-      loop)(false, N, annotations = Nil) // Q: maybe should be Private?
+      loop)(N, annotations = Nil) // Q: maybe should be Private?
     
     if funs.size === 1 then (N, loopDefn :: Nil)
     else (S(loopDefn), rewrittenFuns)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
@@ -447,7 +447,7 @@ class TailRecOpt(using State, TL, Raise):
           Call(sel, args)(true, false, false),
           false
         )
-        FunDefn(f.owner, f.sym, f.dSym, f.params, newBod)(false, N, f.visibility, f.isStaged)
+        FunDefn(f.owner, f.sym, f.dSym, f.params, newBod)(false, N, f.annotations)
     
     val params =
       val initial = paramSyms.map(Param.simple(_))
@@ -457,7 +457,7 @@ class TailRecOpt(using State, TL, Raise):
     val loopDefn = FunDefn(
       owner, bms, dSym,
       PlainParamList(params) :: Nil,
-      loop)(false, N, Visibility.Public, isStaged = false) // Q: maybe should be Private?
+      loop)(false, N, annotations = Nil) // Q: maybe should be Private?
     
     if funs.size === 1 then (N, loopDefn :: Nil)
     else (S(loopDefn), rewrittenFuns)
@@ -495,13 +495,13 @@ class TailRecOpt(using State, TL, Raise):
       val companion = c.companion.map: comp =>
         val cMtds = optFunctionsFlat(comp.methods, S(comp.isym))
         comp.copy(methods = cMtds)
-      c.copy(companion = companion)(c.configOverride, c.isStaged)
+      c.copy(companion = companion)(c.configOverride, c.annotations)
     else
       val mtds = optFunctionsFlat(c.methods, S(c.isym))
       val companion = c.companion.map: comp =>
         val cMtds = optFunctionsFlat(comp.methods, S(comp.isym))
         comp.copy(methods = cMtds)
-      c.copy(methods = mtds, companion = companion)(c.configOverride, c.isStaged)
+      c.copy(methods = mtds, companion = companion)(c.configOverride, c.annotations)
   
   def transform(b: Block) =
     /* To avoid `x` being overridden in the following when the lifter is not run:

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
@@ -447,7 +447,7 @@ class TailRecOpt(using State, TL, Raise):
           Call(sel, args)(true, false, false),
           false
         )
-        FunDefn(f.owner, f.sym, f.dSym, f.params, newBod)(false, N, f.visibility)
+        FunDefn(f.owner, f.sym, f.dSym, f.params, newBod)(false, N, f.visibility, f.isStaged)
     
     val params =
       val initial = paramSyms.map(Param.simple(_))
@@ -457,7 +457,7 @@ class TailRecOpt(using State, TL, Raise):
     val loopDefn = FunDefn(
       owner, bms, dSym,
       PlainParamList(params) :: Nil,
-      loop)(false, N, Visibility.Public) // Q: maybe should be Private?
+      loop)(false, N, Visibility.Public, isStaged = false) // Q: maybe should be Private?
     
     if funs.size === 1 then (N, loopDefn :: Nil)
     else (S(loopDefn), rewrittenFuns)
@@ -495,13 +495,13 @@ class TailRecOpt(using State, TL, Raise):
       val companion = c.companion.map: comp =>
         val cMtds = optFunctionsFlat(comp.methods, S(comp.isym))
         comp.copy(methods = cMtds)
-      c.copy(companion = companion)(c.configOverride)
+      c.copy(companion = companion)(c.configOverride, c.isStaged)
     else
       val mtds = optFunctionsFlat(c.methods, S(c.isym))
       val companion = c.companion.map: comp =>
         val cMtds = optFunctionsFlat(comp.methods, S(comp.isym))
         comp.copy(methods = cMtds)
-      c.copy(methods = mtds, companion = companion)(c.configOverride)
+      c.copy(methods = mtds, companion = companion)(c.configOverride, c.isStaged)
   
   def transform(b: Block) =
     /* To avoid `x` being overridden in the following when the lifter is not run:

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/deforest/Rewrite.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/deforest/Rewrite.scala
@@ -517,7 +517,7 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
         val bodyWithCorrectSymbols = new RefreshSymbol(refreshParamMap.toMap).applyBlock(transformedBody)
         FunDefn(
           N, bms, tSym, refreshedParams,
-          bodyWithCorrectSymbols)(false, N, fDefn.annotations)
+          bodyWithCorrectSymbols)(N, fDefn.annotations)
     end newPolyFuns
     
     val newBranchFuns =
@@ -534,7 +534,7 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
         FunDefn(N, bms, tSym,
           (refreshedFvSymbols.unzip._2 ++ branchFunParamFieldSyms(branchId)).asParamList :: Nil,
           bodyWithCorrectSymbols
-        )(false, N, annotations = Nil)
+        )(N, annotations = Nil)
     end newBranchFuns
     
     val newRestFuns =
@@ -554,7 +554,7 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
             Begin(transformedOgBody, Return(Value.Lit(Tree.UnitLit(true)), false))
         val refreshedFvSymbols = restFnFvs(restFunId).map(s => s -> new VarSymbol(Tree.Ident(s"fv_${s.nme}")))
         val bodyWithCorrectSymbols = new RefreshSymbol(refreshedFvSymbols.toMap).applyBlock(actualBody)
-        FunDefn(N, bms, tsym, refreshedFvSymbols.unzip._2.asParamList :: Nil, bodyWithCorrectSymbols)(false, N, annotations = Nil)
+        FunDefn(N, bms, tsym, refreshedFvSymbols.unzip._2.asParamList :: Nil, bodyWithCorrectSymbols)(N, annotations = Nil)
     end newRestFuns
 
     val inplaceRewrittenFunBodies = Map.from[TermSymbol, Block]:
@@ -567,7 +567,7 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
         override def applyFunDefn(fun: FunDefn): FunDefn =
           inplaceRewrittenFunBodies.get(fun.dSym) match
             case Some(rewrittenBody) =>
-              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, rewrittenBody)(fun.forceTailRec, fun.configOverride, fun.annotations)
+              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, rewrittenBody)(fun.configOverride, fun.annotations)
             case None => super.applyFunDefn(fun)
       object implicitRetPass extends BlockTransformerShallow(_symSubst):
         override def applyBlock(b: Block): Block = b match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/deforest/Rewrite.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/deforest/Rewrite.scala
@@ -517,7 +517,7 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
         val bodyWithCorrectSymbols = new RefreshSymbol(refreshParamMap.toMap).applyBlock(transformedBody)
         FunDefn(
           N, bms, tSym, refreshedParams,
-          bodyWithCorrectSymbols)(false, N, fDefn.visibility)
+          bodyWithCorrectSymbols)(false, N, fDefn.visibility, fDefn.isStaged)
     end newPolyFuns
     
     val newBranchFuns =
@@ -534,7 +534,7 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
         FunDefn(N, bms, tSym,
           (refreshedFvSymbols.unzip._2 ++ branchFunParamFieldSyms(branchId)).asParamList :: Nil,
           bodyWithCorrectSymbols
-        )(false, N, Visibility.Public)
+        )(false, N, Visibility.Public, isStaged = false)
     end newBranchFuns
     
     val newRestFuns =
@@ -554,7 +554,7 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
             Begin(transformedOgBody, Return(Value.Lit(Tree.UnitLit(true)), false))
         val refreshedFvSymbols = restFnFvs(restFunId).map(s => s -> new VarSymbol(Tree.Ident(s"fv_${s.nme}")))
         val bodyWithCorrectSymbols = new RefreshSymbol(refreshedFvSymbols.toMap).applyBlock(actualBody)
-        FunDefn(N, bms, tsym, refreshedFvSymbols.unzip._2.asParamList :: Nil, bodyWithCorrectSymbols)(false, N, Visibility.Public)
+        FunDefn(N, bms, tsym, refreshedFvSymbols.unzip._2.asParamList :: Nil, bodyWithCorrectSymbols)(false, N, Visibility.Public, isStaged = false)
     end newRestFuns
 
     val inplaceRewrittenFunBodies = Map.from[TermSymbol, Block]:
@@ -567,7 +567,7 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
         override def applyFunDefn(fun: FunDefn): FunDefn =
           inplaceRewrittenFunBodies.get(fun.dSym) match
             case Some(rewrittenBody) =>
-              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, rewrittenBody)(fun.forceTailRec, fun.configOverride, fun.visibility)
+              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, rewrittenBody)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)
             case None => super.applyFunDefn(fun)
       object implicitRetPass extends BlockTransformerShallow(_symSubst):
         override def applyBlock(b: Block): Block = b match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/deforest/Rewrite.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/deforest/Rewrite.scala
@@ -517,7 +517,7 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
         val bodyWithCorrectSymbols = new RefreshSymbol(refreshParamMap.toMap).applyBlock(transformedBody)
         FunDefn(
           N, bms, tSym, refreshedParams,
-          bodyWithCorrectSymbols)(false, N, fDefn.visibility, fDefn.isStaged)
+          bodyWithCorrectSymbols)(false, N, fDefn.annotations)
     end newPolyFuns
     
     val newBranchFuns =
@@ -534,7 +534,7 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
         FunDefn(N, bms, tSym,
           (refreshedFvSymbols.unzip._2 ++ branchFunParamFieldSyms(branchId)).asParamList :: Nil,
           bodyWithCorrectSymbols
-        )(false, N, Visibility.Public, isStaged = false)
+        )(false, N, annotations = Nil)
     end newBranchFuns
     
     val newRestFuns =
@@ -554,7 +554,7 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
             Begin(transformedOgBody, Return(Value.Lit(Tree.UnitLit(true)), false))
         val refreshedFvSymbols = restFnFvs(restFunId).map(s => s -> new VarSymbol(Tree.Ident(s"fv_${s.nme}")))
         val bodyWithCorrectSymbols = new RefreshSymbol(refreshedFvSymbols.toMap).applyBlock(actualBody)
-        FunDefn(N, bms, tsym, refreshedFvSymbols.unzip._2.asParamList :: Nil, bodyWithCorrectSymbols)(false, N, Visibility.Public, isStaged = false)
+        FunDefn(N, bms, tsym, refreshedFvSymbols.unzip._2.asParamList :: Nil, bodyWithCorrectSymbols)(false, N, annotations = Nil)
     end newRestFuns
 
     val inplaceRewrittenFunBodies = Map.from[TermSymbol, Block]:
@@ -567,7 +567,7 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
         override def applyFunDefn(fun: FunDefn): FunDefn =
           inplaceRewrittenFunBodies.get(fun.dSym) match
             case Some(rewrittenBody) =>
-              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, rewrittenBody)(fun.forceTailRec, fun.configOverride, fun.visibility, fun.isStaged)
+              FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, rewrittenBody)(fun.forceTailRec, fun.configOverride, fun.annotations)
             case None => super.applyFunDefn(fun)
       object implicitRetPass extends BlockTransformerShallow(_symSubst):
         override def applyBlock(b: Block): Block = b match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -100,7 +100,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       ctor = End(""),
       companion = N,
       bufferable = N,
-    )(N)
+    )(N, isStaged = false)
 
   /** Registers the synthetic `Unit` singleton. */
   private def RegisterUnitSingleton()(using Ctx, FunctionCtx, Raise, Scope, SessionExportCtx): Unit =

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -100,7 +100,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       ctor = End(""),
       companion = N,
       bufferable = N,
-    )(N, isStaged = false)
+    )(N, Nil)
 
   /** Registers the synthetic `Unit` singleton. */
   private def RegisterUnitSingleton()(using Ctx, FunctionCtx, Raise, Scope, SessionExportCtx): Unit =

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -461,7 +461,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State) e
             val loopEnd: Path =
               Select(Value.Ref(State.runtimeSymbol), Tree.Ident("LoopEnd"))(S(State.loopEndSymbol))
             val blk = blockBuilder
-              .define(FunDefn(N, f, tSym, PlainParamList(Nil) :: Nil, Begin(body, Return(loopEnd, false)))(forceTailRec = false, configOverride = N, visibility = Visibility.Public, isStaged = false))
+              .define(FunDefn(N, f, tSym, PlainParamList(Nil) :: Nil, Begin(body, Return(loopEnd, false)))(forceTailRec = false, configOverride = N, annotations = Nil))
               .assign(loopResult, Call(Value.Ref(f, S(tSym)), Nil)(true, true, false))
             if summon[LoweringCtx].mayRet then
               blk

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -461,7 +461,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State) e
             val loopEnd: Path =
               Select(Value.Ref(State.runtimeSymbol), Tree.Ident("LoopEnd"))(S(State.loopEndSymbol))
             val blk = blockBuilder
-              .define(FunDefn(N, f, tSym, PlainParamList(Nil) :: Nil, Begin(body, Return(loopEnd, false)))(forceTailRec = false, configOverride = N, visibility = Visibility.Public))
+              .define(FunDefn(N, f, tSym, PlainParamList(Nil) :: Nil, Begin(body, Return(loopEnd, false)))(forceTailRec = false, configOverride = N, visibility = Visibility.Public, isStaged = false))
               .assign(loopResult, Call(Value.Ref(f, S(tSym)), Nil)(true, true, false))
             if summon[LoweringCtx].mayRet then
               blk

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -461,7 +461,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State) e
             val loopEnd: Path =
               Select(Value.Ref(State.runtimeSymbol), Tree.Ident("LoopEnd"))(S(State.loopEndSymbol))
             val blk = blockBuilder
-              .define(FunDefn(N, f, tSym, PlainParamList(Nil) :: Nil, Begin(body, Return(loopEnd, false)))(forceTailRec = false, configOverride = N, annotations = Nil))
+              .define(FunDefn(N, f, tSym, PlainParamList(Nil) :: Nil, Begin(body, Return(loopEnd, false)))(configOverride = N, annotations = Nil))
               .assign(loopResult, Call(Value.Ref(f, S(tSym)), Nil)(true, true, false))
             if summon[LoweringCtx].mayRet then
               blk

--- a/hkmc2/shared/src/test/mlscript/block-staging/Nested.mls
+++ b/hkmc2/shared/src/test/mlscript/block-staging/Nested.mls
@@ -1,0 +1,223 @@
+:js
+:ftc
+:sir
+:staging
+
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ import Predef; end
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+staged fun direct() = 1
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ let direct⁰; define direct⁰ as staged fun direct¹() { return 1 }; end
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+
+
+staged module LiftedNested with
+  fun f() =
+    fun g() = 1
+    g()
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ let g⁰, LiftedNested⁰;
+//│ define g⁰ as staged fun g¹() {
+//│   return 1
+//│ };
+//│ define LiftedNested⁰ as class LiftedNested¹
+//│ staged module LiftedNested² {
+//│   constructor {
+//│     let tmp, tmp1, tmp2, tmp3;
+//│     set tmp2 = LiftedNested².this.ctor$_instr﹖();
+//│     set tmp3 = Block⁰.printCode﹖(tmp2);
+//│     set tmp = LiftedNested².this.f_instr﹖();
+//│     set tmp1 = Block⁰.printCode﹖(tmp);
+//│     runtime⁰.Unit﹖
+//│   }
+//│   method ctor$_instr⁰ = fun ctor$_instr¹() {
+//│     let end, tmp, tmp1, tmp2, tmp3;
+//│     set end = Block⁰.End﹖();
+//│     set tmp = Block⁰.Symbol﹖("ctor$");
+//│     set tmp1 = [];
+//│     set tmp2 = [tmp1];
+//│     set tmp3 = Block⁰.FunDefn﹖(tmp, tmp2, end, true);
+//│     return tmp3
+//│   }
+//│   method f⁰ = fun f¹() {
+//│     return g¹()
+//│   }
+//│   method f_instr⁰ = fun f_instr¹() {
+//│     let sym, var1, tmp, app, return1, tmp1, tmp2, tmp3, tmp4;
+//│     set sym = Block⁰.Symbol﹖("g");
+//│     set var1 = Block⁰.ValueRef﹖(sym);
+//│     set tmp = [];
+//│     set app = Block⁰.Call﹖(var1, tmp);
+//│     set return1 = Block⁰.Return﹖(app, false);
+//│     set tmp1 = Block⁰.Symbol﹖("f");
+//│     set tmp2 = [];
+//│     set tmp3 = [tmp2];
+//│     set tmp4 = Block⁰.FunDefn﹖(tmp1, tmp3, return1, true);
+//│     return tmp4
+//│   }
+//│ };
+//│ end
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+//│ > fun ctor_() = ()
+//│ > fun f() = g()
+
+
+staged module LiftedLambda with
+  fun foo(x) = y => x + y
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ let LiftedLambda⁰, lambda⁰, Function$⁰;
+//│ define lambda⁰ as staged fun lambda¹(x, y) {
+//│   return +⁰(x, y)
+//│ };
+//│ define Function$⁰ as staged class Function$¹ {
+//│   private val x⁰;
+//│   constructor(x) {
+//│     super⁰();
+//│     set x⁰ = x;
+//│     end
+//│   }
+//│   method call⁰ = fun call¹(y) {
+//│     return lambda¹(x⁰, y)
+//│   }
+//│ };
+//│ define LiftedLambda⁰ as class LiftedLambda¹
+//│ staged module LiftedLambda² {
+//│   constructor {
+//│     let tmp, tmp1, tmp2, tmp3;
+//│     set tmp2 = LiftedLambda².this.ctor$_instr﹖();
+//│     set tmp3 = Block⁰.printCode﹖(tmp2);
+//│     set tmp = LiftedLambda².this.foo_instr﹖();
+//│     set tmp1 = Block⁰.printCode﹖(tmp);
+//│     runtime⁰.Unit﹖
+//│   }
+//│   method ctor$_instr² = fun ctor$_instr³() {
+//│     let end, tmp, tmp1, tmp2, tmp3;
+//│     set end = Block⁰.End﹖();
+//│     set tmp = Block⁰.Symbol﹖("ctor$");
+//│     set tmp1 = [];
+//│     set tmp2 = [tmp1];
+//│     set tmp3 = Block⁰.FunDefn﹖(tmp, tmp2, end, true);
+//│     return tmp3
+//│   }
+//│   method foo⁰ = fun foo¹(x) {
+//│     let tmp;
+//│     set tmp = new Function$¹(x);
+//│     return tmp
+//│   }
+//│   method foo_instr⁰ = fun foo_instr¹() {
+//│     let x, tmp, sym, tmp1, sym1, var1, tmp2, tmp3, sym2, tmp4, tmp5, sym3, var2, tmp6, inst, sym4, tmp7, return1, assign, tmp8, tmp9, tmp10, tmp11, tmp12, tmp13;
+//│     set sym = Block⁰.Symbol﹖("tmp");
+//│     set tmp1 = [sym];
+//│     set sym1 = Block⁰.Symbol﹖("x");
+//│     set var1 = Block⁰.ValueRef﹖(sym1);
+//│     set tmp2 = Block⁰.Arg﹖(var1);
+//│     set tmp3 = option⁰.None﹖;
+//│     set sym2 = Block⁰.Symbol﹖("x1");
+//│     set tmp4 = [sym2];
+//│     set tmp5 = [tmp4];
+//│     set sym3 = Block⁰.ConcreteClassSymbol﹖("Function$", Function$⁰, tmp3, tmp5);
+//│     set var2 = Block⁰.ValueRef﹖(sym3);
+//│     set tmp6 = [tmp2];
+//│     set inst = Block⁰.Instantiate﹖(var2, tmp6);
+//│     set sym4 = Block⁰.Symbol﹖("tmp");
+//│     set tmp7 = Block⁰.ValueRef﹖(sym4);
+//│     set tmp = tmp7;
+//│     set return1 = Block⁰.Return﹖(tmp7, false);
+//│     set assign = Block⁰.Assign﹖(sym4, inst, return1);
+//│     set tmp8 = Block⁰.Scoped﹖(tmp1, assign);
+//│     set tmp9 = Block⁰.Symbol﹖("x");
+//│     set tmp10 = Block⁰.Symbol﹖("foo");
+//│     set tmp11 = [tmp9];
+//│     set tmp12 = [tmp11];
+//│     set tmp13 = Block⁰.FunDefn﹖(tmp10, tmp12, tmp8, true);
+//│     return tmp13
+//│   }
+//│ };
+//│ end
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+//│ > fun ctor_() = ()
+//│ > fun foo(x) =
+//│ >   let {tmp}
+//│ >   tmp = new Function_(x)
+//│ >   tmp
+
+
+staged module LiftedMultParams with
+  fun foo(x)(y) = x + y
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ let LiftedMultParams⁰, lambda$⁰, Function$²;
+//│ define lambda$⁰ as staged fun lambda$¹(x, y) {
+//│   return +⁰(x, y)
+//│ };
+//│ define Function$² as staged class Function$³ {
+//│   private val x¹;
+//│   constructor(x) {
+//│     super⁰();
+//│     set x¹ = x;
+//│     end
+//│   }
+//│   method call² = fun call³(y) {
+//│     return lambda$¹(x¹, y)
+//│   }
+//│ };
+//│ define LiftedMultParams⁰ as class LiftedMultParams¹
+//│ staged module LiftedMultParams² {
+//│   constructor {
+//│     let tmp, tmp1, tmp2, tmp3;
+//│     set tmp2 = LiftedMultParams².this.ctor$_instr﹖();
+//│     set tmp3 = Block⁰.printCode﹖(tmp2);
+//│     set tmp = LiftedMultParams².this.foo_instr﹖();
+//│     set tmp1 = Block⁰.printCode﹖(tmp);
+//│     runtime⁰.Unit﹖
+//│   }
+//│   method ctor$_instr⁴ = fun ctor$_instr⁵() {
+//│     let end, tmp, tmp1, tmp2, tmp3;
+//│     set end = Block⁰.End﹖();
+//│     set tmp = Block⁰.Symbol﹖("ctor$");
+//│     set tmp1 = [];
+//│     set tmp2 = [tmp1];
+//│     set tmp3 = Block⁰.FunDefn﹖(tmp, tmp2, end, true);
+//│     return tmp3
+//│   }
+//│   method foo² = fun foo³(x) {
+//│     let tmp;
+//│     set tmp = new Function$³(x);
+//│     return tmp
+//│   }
+//│   method foo_instr² = fun foo_instr³() {
+//│     let x, tmp, sym, tmp1, sym1, var1, tmp2, tmp3, sym2, tmp4, tmp5, sym3, var2, tmp6, inst, sym4, tmp7, return1, assign, tmp8, tmp9, tmp10, tmp11, tmp12, tmp13;
+//│     set sym = Block⁰.Symbol﹖("tmp");
+//│     set tmp1 = [sym];
+//│     set sym1 = Block⁰.Symbol﹖("x");
+//│     set var1 = Block⁰.ValueRef﹖(sym1);
+//│     set tmp2 = Block⁰.Arg﹖(var1);
+//│     set tmp3 = option⁰.None﹖;
+//│     set sym2 = Block⁰.Symbol﹖("x1");
+//│     set tmp4 = [sym2];
+//│     set tmp5 = [tmp4];
+//│     set sym3 = Block⁰.ConcreteClassSymbol﹖("Function$", Function$², tmp3, tmp5);
+//│     set var2 = Block⁰.ValueRef﹖(sym3);
+//│     set tmp6 = [tmp2];
+//│     set inst = Block⁰.Instantiate﹖(var2, tmp6);
+//│     set sym4 = Block⁰.Symbol﹖("tmp");
+//│     set tmp7 = Block⁰.ValueRef﹖(sym4);
+//│     set tmp = tmp7;
+//│     set return1 = Block⁰.Return﹖(tmp7, false);
+//│     set assign = Block⁰.Assign﹖(sym4, inst, return1);
+//│     set tmp8 = Block⁰.Scoped﹖(tmp1, assign);
+//│     set tmp9 = Block⁰.Symbol﹖("x");
+//│     set tmp10 = Block⁰.Symbol﹖("foo");
+//│     set tmp11 = [tmp9];
+//│     set tmp12 = [tmp11];
+//│     set tmp13 = Block⁰.FunDefn﹖(tmp10, tmp12, tmp8, true);
+//│     return tmp13
+//│   }
+//│ };
+//│ end
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+//│ > fun ctor_() = ()
+//│ > fun foo(x) =
+//│ >   let {tmp}
+//│ >   tmp = new Function_(x)
+//│ >   tmp


### PR DESCRIPTION
Related: #355 
- <del>Add `isStaged` field for `Defn`</del>Track `annotations`  for `Defn`
- Show `staged` keyword for staged definitions when printing the block IR
- If a definition is in a staged module and lifted, mark the definition staged as well.
