### PR TITLE
Fix missing configs for `Resolver` in compile test

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
@@ -90,7 +90,8 @@ class MLsCompiler
       val elab = Elaborator(etl, wd, newCtx)
       val parsed = mainParse.resultBlk
       val (blk0, _) = elab.importFrom(parsed)
-      val resolver = Resolver(rtl)
+      val effectiveConfig = Config.extractConfigFromStats(blk0)
+      val resolver = Resolver(rtl)(using summon[Raise], summon[State], summon[Ctx], effectiveConfig)
       resolver.traverseBlock(blk0)(using Resolver.ICtx.empty)
       def findQuote(t: semantics.Statement): Bool = t match
         case Term.Quoted(_) | Term.Unquoted(_) => true
@@ -106,7 +107,6 @@ class MLsCompiler
             blk0.stats),
         blk0.res
       )
-      val effectiveConfig = Config.extractConfigFromStats(blk)
       val low = ltl.givenIn:
         new codegen.Lowering()(using effectiveConfig)
           with codegen.LoweringSelSanityChecks

--- a/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
@@ -90,46 +90,46 @@ class MLsCompiler
       val elab = Elaborator(etl, wd, newCtx)
       val parsed = mainParse.resultBlk
       val (blk0, _) = elab.importFrom(parsed)
-      val effectiveConfig = Config.extractConfigFromStats(blk0)
-      val resolver = Resolver(rtl)(using summon[Raise], summon[State], summon[Ctx], effectiveConfig)
-      resolver.traverseBlock(blk0)(using Resolver.ICtx.empty)
-      def findQuote(t: semantics.Statement): Bool = t match
-        case Term.Quoted(_) | Term.Unquoted(_) => true
-        case Term.Ref(sym) => sym === State.termSymbol
-        case _ => t.subTerms.exists(findQuote)
-      val hasQuote = findQuote(blk0)
-      val blk = new Term.Blk(
-        Import(State.runtimeSymbol, runtimeFile.toString, runtimeFile) ::
-          // Only import `Term.mls` when necessary.
-          (if hasQuote then
-            Import(State.termSymbol, termFile.toString, termFile) :: blk0.stats
-          else
-            blk0.stats),
-        blk0.res
-      )
-      val low = ltl.givenIn:
-        new codegen.Lowering()(using effectiveConfig)
-          with codegen.LoweringSelSanityChecks
-      val jsb = ltl.givenIn:
-        codegen.js.JSBuilder(using effectiveConfig)
-      val le_0 = low.program(blk)
-      val nme = file.baseName
-      val exportedSymbol = parsed.definedSymbols.find(_._1 === nme).map(_._2)
-      val le_1 = ltl.givenIn:
-        codegen.BlockSimplifier(exportedSymbol.toSet)(le_0)
-      val le_2 = ltl.givenIn:
-        codegen.DeadParamElim(le_1)
-      val baseScp: utils.Scope =
-        utils.Scope.empty(utils.Scope.Cfg.default)
-      // * This line serves for `import.meta.url`, which retrieves directory and file names of mjs files.
-      // * Having `module id"import" with ...` in `prelude.mls` will generate `globalThis.import` that is undefined.
-      baseScp.addToBindings(Elaborator.State.importSymbol, "import", shadow = false)
-      val nestedScp = baseScp.nest
-      val je = nestedScp.givenIn:
-        jsb.program(le_2, exportedSymbol, wd)
-      val jsStr = je.stripBreaks.mkString(100)
-      val out = file.up / io.RelPath(file.baseName + ".mjs")
-      cctx.fs.write(out, jsStr)
+      Config.extractConfigFromStats(blk0).givenIn:
+        val resolver = Resolver(rtl)
+        resolver.traverseBlock(blk0)(using Resolver.ICtx.empty)
+        def findQuote(t: semantics.Statement): Bool = t match
+          case Term.Quoted(_) | Term.Unquoted(_) => true
+          case Term.Ref(sym) => sym === State.termSymbol
+          case _ => t.subTerms.exists(findQuote)
+        val hasQuote = findQuote(blk0)
+        val blk = new Term.Blk(
+          Import(State.runtimeSymbol, runtimeFile.toString, runtimeFile) ::
+            // Only import `Term.mls` when necessary.
+            (if hasQuote then
+              Import(State.termSymbol, termFile.toString, termFile) :: blk0.stats
+            else
+              blk0.stats),
+          blk0.res
+        )
+        val low = ltl.givenIn:
+          new codegen.Lowering()
+            with codegen.LoweringSelSanityChecks
+        val jsb = ltl.givenIn:
+          codegen.js.JSBuilder()
+        val le_0 = low.program(blk)
+        val nme = file.baseName
+        val exportedSymbol = parsed.definedSymbols.find(_._1 === nme).map(_._2)
+        val le_1 = ltl.givenIn:
+          codegen.BlockSimplifier(exportedSymbol.toSet)(le_0)
+        val le_2 = ltl.givenIn:
+          codegen.DeadParamElim(le_1)
+        val baseScp: utils.Scope =
+          utils.Scope.empty(utils.Scope.Cfg.default)
+        // * This line serves for `import.meta.url`, which retrieves directory and file names of mjs files.
+        // * Having `module id"import" with ...` in `prelude.mls` will generate `globalThis.import` that is undefined.
+        baseScp.addToBindings(Elaborator.State.importSymbol, "import", shadow = false)
+        val nestedScp = baseScp.nest
+        val je = nestedScp.givenIn:
+          jsb.program(le_2, exportedSymbol, wd)
+        val jsStr = je.stripBreaks.mkString(100)
+        val out = file.up / io.RelPath(file.baseName + ".mjs")
+        cctx.fs.write(out, jsStr)
   
   
 end MLsCompiler

--- a/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/MLsCompiler.scala
@@ -90,46 +90,47 @@ class MLsCompiler
       val elab = Elaborator(etl, wd, newCtx)
       val parsed = mainParse.resultBlk
       val (blk0, _) = elab.importFrom(parsed)
-      Config.extractConfigFromStats(blk0).givenIn:
-        val resolver = Resolver(rtl)
-        resolver.traverseBlock(blk0)(using Resolver.ICtx.empty)
-        def findQuote(t: semantics.Statement): Bool = t match
-          case Term.Quoted(_) | Term.Unquoted(_) => true
-          case Term.Ref(sym) => sym === State.termSymbol
-          case _ => t.subTerms.exists(findQuote)
-        val hasQuote = findQuote(blk0)
-        val blk = new Term.Blk(
-          Import(State.runtimeSymbol, runtimeFile.toString, runtimeFile) ::
-            // Only import `Term.mls` when necessary.
-            (if hasQuote then
-              Import(State.termSymbol, termFile.toString, termFile) :: blk0.stats
-            else
-              blk0.stats),
-          blk0.res
-        )
-        val low = ltl.givenIn:
-          new codegen.Lowering()
-            with codegen.LoweringSelSanityChecks
-        val jsb = ltl.givenIn:
-          codegen.js.JSBuilder()
-        val le_0 = low.program(blk)
-        val nme = file.baseName
-        val exportedSymbol = parsed.definedSymbols.find(_._1 === nme).map(_._2)
-        val le_1 = ltl.givenIn:
-          codegen.BlockSimplifier(exportedSymbol.toSet)(le_0)
-        val le_2 = ltl.givenIn:
-          codegen.DeadParamElim(le_1)
-        val baseScp: utils.Scope =
-          utils.Scope.empty(utils.Scope.Cfg.default)
-        // * This line serves for `import.meta.url`, which retrieves directory and file names of mjs files.
-        // * Having `module id"import" with ...` in `prelude.mls` will generate `globalThis.import` that is undefined.
-        baseScp.addToBindings(Elaborator.State.importSymbol, "import", shadow = false)
-        val nestedScp = baseScp.nest
-        val je = nestedScp.givenIn:
-          jsb.program(le_2, exportedSymbol, wd)
-        val jsStr = je.stripBreaks.mkString(100)
-        val out = file.up / io.RelPath(file.baseName + ".mjs")
-        cctx.fs.write(out, jsStr)
+      Config.extractConfigFromStats(blk0).givenIn {
+      val resolver = Resolver(rtl)
+      resolver.traverseBlock(blk0)(using Resolver.ICtx.empty)
+      def findQuote(t: semantics.Statement): Bool = t match
+        case Term.Quoted(_) | Term.Unquoted(_) => true
+        case Term.Ref(sym) => sym === State.termSymbol
+        case _ => t.subTerms.exists(findQuote)
+      val hasQuote = findQuote(blk0)
+      val blk = new Term.Blk(
+        Import(State.runtimeSymbol, runtimeFile.toString, runtimeFile) ::
+          // Only import `Term.mls` when necessary.
+          (if hasQuote then
+            Import(State.termSymbol, termFile.toString, termFile) :: blk0.stats
+          else
+            blk0.stats),
+        blk0.res
+      )
+      val low = ltl.givenIn:
+        new codegen.Lowering()
+          with codegen.LoweringSelSanityChecks
+      val jsb = ltl.givenIn:
+        codegen.js.JSBuilder()
+      val le_0 = low.program(blk)
+      val nme = file.baseName
+      val exportedSymbol = parsed.definedSymbols.find(_._1 === nme).map(_._2)
+      val le_1 = ltl.givenIn:
+        codegen.BlockSimplifier(exportedSymbol.toSet)(le_0)
+      val le_2 = ltl.givenIn:
+        codegen.DeadParamElim(le_1)
+      val baseScp: utils.Scope =
+        utils.Scope.empty(utils.Scope.Cfg.default)
+      // * This line serves for `import.meta.url`, which retrieves directory and file names of mjs files.
+      // * Having `module id"import" with ...` in `prelude.mls` will generate `globalThis.import` that is undefined.
+      baseScp.addToBindings(Elaborator.State.importSymbol, "import", shadow = false)
+      val nestedScp = baseScp.nest
+      val je = nestedScp.givenIn:
+        jsb.program(le_2, exportedSymbol, wd)
+      val jsStr = je.stripBreaks.mkString(100)
+      val out = file.up / io.RelPath(file.baseName + ".mjs")
+      cctx.fs.write(out, jsStr)
+      }
   
   
 end MLsCompiler

--- a/hkmc2/shared/src/test/mlscript-compile/NoFreeze.mjs
+++ b/hkmc2/shared/src/test/mlscript-compile/NoFreeze.mjs
@@ -23,6 +23,9 @@ let NoFreeze1;
   }
   static foo() {
     return (new NoFreeze.Foo.class(0))
+  } 
+  static bar() {
+    return runtime.safeCall(NoFreeze1["foo"]())
   }
   toString() { return runtime.render(this); }
   static [definitionMetadata] = ["class", "NoFreeze"]; 

--- a/hkmc2/shared/src/test/mlscript-compile/NoFreeze.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/NoFreeze.mls
@@ -1,7 +1,9 @@
 #config(noFreeze: true)
+#config(noModuleCheck: true)
 
 module NoFreeze with
   class Foo(val x)
 
   fun foo() = new Foo(0)
+  fun bar() = NoFreeze."foo"()
 

--- a/hkmc2DiffTests/src/test/scala/hkmc2/MLsDiffMaker.scala
+++ b/hkmc2DiffTests/src/test/scala/hkmc2/MLsDiffMaker.scala
@@ -7,7 +7,7 @@ import utils.*
 
 import hkmc2.semantics.{Elaborator, Resolver, Resolvable, Symbol, SymbolPrinter}
 
-import semantics.Elaborator.Ctx
+import semantics.Elaborator.{Ctx, State}
 
 abstract class MLsDiffMaker extends DiffMaker:
   
@@ -370,7 +370,8 @@ abstract class MLsDiffMaker extends DiffMaker:
   
   def processTerm(trm: semantics.Term.Blk, inImport: Bool)(using Config, Raise): Unit =
     given Ctx = curCtx
-    val resolver = Resolver(rtl)
+    val effectiveConfig = Config.extractConfigFromStats(trm)
+    val resolver = Resolver(rtl)(using summon[Raise], summon[State], summon[Ctx], effectiveConfig)
     curICtx = resolver.traverseBlock(trm)(using curICtx)
     
     if showResolve.isSet then

--- a/hkmc2DiffTests/src/test/scala/hkmc2/MLsDiffMaker.scala
+++ b/hkmc2DiffTests/src/test/scala/hkmc2/MLsDiffMaker.scala
@@ -370,8 +370,8 @@ abstract class MLsDiffMaker extends DiffMaker:
   
   def processTerm(trm: semantics.Term.Blk, inImport: Bool)(using Config, Raise): Unit =
     given Ctx = curCtx
-    val effectiveConfig = Config.extractConfigFromStats(trm)
-    val resolver = Resolver(rtl)(using summon[Raise], summon[State], summon[Ctx], effectiveConfig)
+    given Config = Config.extractConfigFromStats(trm)
+    val resolver = Resolver(rtl)
     curICtx = resolver.traverseBlock(trm)(using curICtx)
     
     if showResolve.isSet then


### PR DESCRIPTION
Continuation of #473 