### PR TITLE
wasm: `binaryen` dependency update, add `WebAssembly.Instance` to `Prelude`

### DIFF
--- a/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
+++ b/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
@@ -216,6 +216,7 @@ declare val Infinity
 declare class Promise
 declare val Promise
 declare object WebAssembly with
+  declare object Instance
   declare class Memory
   declare object Module with
     fun

--- a/hkmc2/shared/src/test/mlscript/wasm/Binaryen.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/Binaryen.mls
@@ -1,0 +1,99 @@
+:js
+:silent
+
+
+// Helper functions
+import "binaryen"
+fun compileWatToWasm(wat) = 
+  let mod = binaryen.parseText of wat
+  mod.setFeatures(binaryen.Features.All)
+  Predef.js_assert of mod.validate()
+  val modBuf = mod.emitBinary()
+  mod.dispose()
+  modBuf
+fun instantiateWasm(wasm, importObj) = 
+  assert WebAssembly.validate of wasm
+  let mod = new! WebAssembly.Module of wasm
+  let inst = new! WebAssembly.Instance of mod, importObj
+  inst
+
+
+// Parsing a WAT, compiling it to a Wasm bianry, and executing it
+let wasmMod = compileWatToWasm of 
+    """
+    (module
+        (type $Foo (struct (field $i i32) (field $r i31ref)))
+        (func (export "main") (result i32)
+            (local $tmp (ref $Foo))
+            (block (result i32)
+                (local.set $tmp 
+                    (struct.new $Foo
+                        (i32.const 1)
+                        (ref.i31 (i32.const 2))))
+                (i32.add
+                    (struct.get $Foo $i
+                        (local.get $tmp))
+                    (i31.get_s
+                        (struct.get $Foo $r 
+                            (local.get $tmp)))))))
+    """
+let inst = instantiateWasm of wasmMod, {}
+inst.exports.main() |> print
+//│ > 3
+
+
+// Building a module using Binaryen APIs, and executing it
+let mod = new! binaryen.Module()
+mod.setFeatures(binaryen.Features.All)
+let fooTb = new! binaryen.TypeBuilder(1)
+fooTb.setStructType(0, [
+    (
+        "type": binaryen.i32
+        packedType: binaryen.notPacked
+        mutable: false
+    ),
+    (
+        "type": binaryen.i31ref
+        packedType: binaryen.notPacked
+        mutable: false
+    ),
+])
+let foo = fooTb.buildAndDispose().[0]
+mod.addFunction of
+  "main",
+  binaryen.none,
+  binaryen.i32,
+  [foo], 
+  mod.block of
+    null,
+    [
+      mod.local.set of
+        0,
+        mod.struct.new of
+          [
+            mod.i32.const(1),
+            mod.ref.i31 of
+              mod.i32.const of 2,
+          ],
+          foo,
+      mod.i32.add of
+        mod.struct.get of 
+          0,
+          mod.local.get(0, foo),
+          foo,
+          false,
+        mod.i31.get_s of
+          mod.struct.get of
+            1,
+            mod.local.get(0, foo),
+            foo,
+            false,
+    ],
+    binaryen.i32,
+mod.addFunctionExport of "main", "main"
+Predef.js_assert of mod.validate()
+let wasmMod = mod.emitBinary()
+mod.dispose()
+let inst = instantiateWasm of wasmMod, {}
+inst.exports.main() |> print
+//│ > 3

--- a/hkmc2/shared/src/test/mlscript/wasm/Binaryen.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/Binaryen.mls
@@ -5,16 +5,16 @@
 // Helper functions
 import "binaryen"
 fun compileWatToWasm(wat) = 
-  let mod = binaryen.parseText of wat
+  let mod = binaryen.parseText(wat)
   mod.setFeatures(binaryen.Features.All)
-  Predef.js_assert of mod.validate()
+  assert mod.validate() != false
   val modBuf = mod.emitBinary()
   mod.dispose()
   modBuf
 fun instantiateWasm(wasm, importObj) = 
-  assert WebAssembly.validate of wasm
-  let mod = new! WebAssembly.Module of wasm
-  let inst = new! WebAssembly.Instance of mod, importObj
+  assert WebAssembly.validate(wasm)
+  let mod = new! WebAssembly.Module(wasm)
+  let inst = new! WebAssembly.Instance(mod, importObj)
   inst
 
 
@@ -46,50 +46,44 @@ inst.exports.main() |> print
 let mod = new! binaryen.Module()
 mod.setFeatures(binaryen.Features.All)
 let fooTb = new! binaryen.TypeBuilder(1)
-fooTb.setStructType(0, [
+fooTb.setStructType of 0, tuple of
     (
-        "type": binaryen.i32
-        packedType: binaryen.notPacked
-        mutable: false
-    ),
+      "type": binaryen.i32
+      packedType: binaryen.notPacked
+      mutable: false
+    )
     (
-        "type": binaryen.i31ref
-        packedType: binaryen.notPacked
-        mutable: false
-    ),
-])
-let foo = fooTb.buildAndDispose().[0]
+      "type": binaryen.i31ref
+      packedType: binaryen.notPacked
+      mutable: false
+    )
+let foo = fooTb.buildAndDispose().0
 mod.addFunction of
-  "main",
-  binaryen.none,
-  binaryen.i32,
-  [foo], 
+  "main"
+  binaryen.none
+  binaryen.i32
+  [foo]
   mod.block of
-    null,
-    [
-      mod.local.set of
-        0,
+    null
+    tuple of
+      mod.local.set of 0,
         mod.struct.new of
-          [
-            mod.i32.const(1),
+          tuple of
+            mod.i32.const(1)
             mod.ref.i31 of
-              mod.i32.const of 2,
-          ],
-          foo,
+              mod.i32.const of 2
+          foo
       mod.i32.add of
-        mod.struct.get of 
-          0,
-          mod.local.get(0, foo),
-          foo,
-          false,
+        mod.struct.get of 0,
+          mod.local.get(0, foo)
+          foo
+          false
         mod.i31.get_s of
-          mod.struct.get of
-            1,
-            mod.local.get(0, foo),
-            foo,
-            false,
-    ],
-    binaryen.i32,
+          mod.struct.get of 1,
+            mod.local.get(0, foo)
+            foo
+            false
+    binaryen.i32
 mod.addFunctionExport of "main", "main"
 Predef.js_assert of mod.validate()
 let wasmMod = mod.emitBinary()

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "mlscript",
       "dependencies": {
         "benchmark": "^2.1.4",
-        "binaryen": "^125.0.0",
+        "binaryen": "^129.0.0",
         "typescript": "^4.7.4"
       }
     },
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/binaryen": {
-      "version": "125.0.0",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-125.0.0.tgz",
-      "integrity": "sha512-X7CUM9ZnwL/Ow++JH5AJKiemc82J7JyeryuPvXQdXBLcL/rqrC5KMUB1mHiORSolietH9sotvaOZlr6HSwPAlw==",
+      "version": "129.0.0",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-129.0.0.tgz",
+      "integrity": "sha512-NyF5J0SfRoLDthpPh36FGTycOEv3Eqnkq3+mP5Cqt6iD9BLGGJMEVuPzu81nhLy2MMpPKmRTM9VLZihfyRQv8A==",
       "license": "Apache-2.0",
       "bin": {
         "wasm-as": "bin/wasm-as",
@@ -75,9 +75,9 @@
       }
     },
     "binaryen": {
-      "version": "125.0.0",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-125.0.0.tgz",
-      "integrity": "sha512-X7CUM9ZnwL/Ow++JH5AJKiemc82J7JyeryuPvXQdXBLcL/rqrC5KMUB1mHiORSolietH9sotvaOZlr6HSwPAlw=="
+      "version": "129.0.0",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-129.0.0.tgz",
+      "integrity": "sha512-NyF5J0SfRoLDthpPh36FGTycOEv3Eqnkq3+mP5Cqt6iD9BLGGJMEVuPzu81nhLy2MMpPKmRTM9VLZihfyRQv8A=="
     },
     "lodash": {
       "version": "4.18.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mlscript",
   "dependencies": {
     "benchmark": "^2.1.4",
-    "binaryen": "^125.0.0",
+    "binaryen": "^129.0.0",
     "typescript": "^4.7.4"
   }
 }


### PR DESCRIPTION
The change to add `WebAssembly.Instance` to `Prelude.mls` is for synchronous instantiation of Wasm modules, which is necessary if we want to test loading and executing arbitrary Wasm modules in `HkScratch.mls`.

Example:

```
:silent
fun compileWatToWasm(wat) = 
    let mod = binaryen.parseText of wat
    mod.setFeatures(binaryen.Features.All)
    Predef.js_assert of mod.validate()
    val modBuf = mod.emitBinary()
    mod.dispose()
    modBuf
fun instantiateWasm(wasm, importObj) = 
    assert WebAssembly.validate of wasm
    let mod = new! WebAssembly.Module of wasm
    // Note: `WebAssembly.Instance` needed here
    let inst = new! WebAssembly.Instance of mod, importObj
    inst
let mod = compileWatToWasm of 
    """
    (module
        (func (export "main") (result i32)
            (i32.const 42)))
    """
let inst = instantiateWasm of mod, {}
inst.exports.main() |> print
//│ > 42
```

No functional changes.