### PR TITLE
Generate accessors for external private fields

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -107,6 +107,9 @@ class BlockSimplifier
     val definedVars = MutSet.empty[Local]
     val localVars = MutSet.empty[Local]
     val usedVars = MutSet.empty[Local]
+    val privateVars = MutSet.empty[TermSymbol]
+    val usedPrivateVars = MutSet.empty[TermSymbol]
+    var unusedPrivateVars = Set.empty[TermSymbol]
     var tailLabels = MutSet.empty[LabelSymbol]
     
     def apply(prog: Program): Program =
@@ -117,11 +120,25 @@ class BlockSimplifier
         
         override def applyPath(p: Path): Unit =
           p match
+            case sel: Select =>
+              sel.symbol.foreach:
+                case ts: TermSymbol =>
+                  usedPrivateVars += ts
+                case _ =>
             case Value.Ref(loc, _) =>
               usedVars += loc
+              loc match
+              case ts: TermSymbol =>
+                usedPrivateVars += ts
+              case _ =>
             case _ =>
           super.applyPath(p)
-        
+
+        override def applyClsLikeDefn(defn: ClsLikeDefn): Unit =
+          privateVars ++= defn.privateFields
+          defn.companion.foreach(body => privateVars ++= body.privateFields)
+          super.applyClsLikeDefn(defn)
+
         override def applyBlock(b: Block): Unit =
           b match
             case Define(defn, rst) =>
@@ -134,7 +151,10 @@ class BlockSimplifier
               definedVars += lhs
             case _ =>
           super.applyBlock(b)
-      
+
+      unusedPrivateVars =
+        privateVars.iterator.filterNot(usedPrivateVars).filterNot(symbolsToPreserve).toSet
+
       applyProgram(prog)
     
     // Evaluate `thunk` with a new tail label set. This is used for evaluating any sub blocks that is not in the tail position.
@@ -213,7 +233,22 @@ class BlockSimplifier
         registerChange(s"rm ${lhs.showDbg} = ${rhs.showDbg}")
         removedLocals += lhs
         applyResult(rhs)(r => Assign.discard(r, applyBlock(rst)))
-      
+
+      // * Discard writes to private fields that are still represented as local assignments
+      case Assign(lhs: TermSymbol, rhs, rst) if unusedPrivateVars(lhs) =>
+        registerChange(s"rm unused private field write ${lhs.showDbg} = ${rhs.showDbg}")
+        applyResult(rhs)(r => Assign.discard(r, applyBlock(rst)))
+
+      // * Discard writes to private fields that are never read
+      case assign @ AssignField(lhs, _, rhs, rst) =>
+        assign.symbol match
+        case S(ts: TermSymbol) if unusedPrivateVars(ts) =>
+          registerChange(s"rm unused private field write ${ts.showDbg} = ${rhs.showDbg}")
+          applyPath(lhs): lhs2 =>
+            applyResult(rhs): rhs2 =>
+              Assign.discard(lhs2, Assign.discard(rhs2, applyBlock(rst)))
+        case _ => super.applyBlock(b)
+
       // * Remove local pure definitions that are never read (and are not preserved)
       case Define(defn, rest) =>
         if !defn.isPure
@@ -254,7 +289,31 @@ class BlockSimplifier
         End()
       
       case x => super.applyBlock(x)
-    
+
+    private def removeUnusedPrivateFields(fields: Ls[TermSymbol]): Ls[TermSymbol] =
+      fields.filterConserve: fld =>
+        val keep = !unusedPrivateVars(fld)
+        if !keep then registerChange(s"rm unused private field ${fld.showDbg}")
+        keep
+
+    override def applyObjBody(defn: ClsLikeBody): ClsLikeBody =
+      val defn2 = super.applyObjBody(defn)
+      val privateFields2 = removeUnusedPrivateFields(defn2.privateFields)
+      if privateFields2 is defn2.privateFields
+      then defn2
+      else defn2.copy(privateFields = privateFields2)
+
+    override def applyClsLikeDefn(defn: ClsLikeDefn)(k: Defn => Block): Block =
+      super.applyClsLikeDefn(defn):
+        case cls: ClsLikeDefn =>
+          val privateFields2 = removeUnusedPrivateFields(cls.privateFields)
+          val cls2 =
+            if privateFields2 is cls.privateFields
+            then cls
+            else cls.copy(privateFields = privateFields2)(cls.configOverride, cls.annotations)
+          k(cls2)
+        case other => k(other)
+
     
     // FIXME: refactor transformers so this is not so error-prone (adding this case to `applyBlock` doesn't work)
     override def applyScopedBlock(b: Block): Block = b match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -127,10 +127,6 @@ class BlockSimplifier
                 case _ =>
             case Value.Ref(loc, _) =>
               usedVars += loc
-              loc match
-              case ts: TermSymbol =>
-                usedPrivateVars += ts
-              case _ =>
             case _ =>
           super.applyPath(p)
 
@@ -232,11 +228,6 @@ class BlockSimplifier
       case Assign(lhs, rhs, rst) if localVars(lhs) && !usedVars(lhs) && !symbolsToPreserve(lhs) =>
         registerChange(s"rm ${lhs.showDbg} = ${rhs.showDbg}")
         removedLocals += lhs
-        applyResult(rhs)(r => Assign.discard(r, applyBlock(rst)))
-
-      // * Discard writes to private fields that are still represented as local assignments
-      case Assign(lhs: TermSymbol, rhs, rst) if unusedPrivateVars(lhs) =>
-        registerChange(s"rm unused private field write ${lhs.showDbg} = ${rhs.showDbg}")
         applyResult(rhs)(r => Assign.discard(r, applyBlock(rst)))
 
       // * Discard writes to private fields that are never read

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -485,17 +485,6 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
           case Some(path) => applyResult(rhs): rhs2 =>
             path.assign(rhs2, applySubBlock(rest))
           case _ => super.applyBlock(rewritten)
-        case assign @ AssignField(_, _, rhs, rest) =>
-          assign.symbol match
-            case S(ts: TermSymbol) if ts.isPrivate =>
-              ctx.symbolsMap.get(ts) match
-                case S(LocalPath.Sym(l)) if l is ts => super.applyBlock(rewritten)
-                case S(path) =>
-                  applyResult(rhs): rhs2 =>
-                    path.assign(rhs2, applySubBlock(rest))
-                case N => super.applyBlock(rewritten)
-            case _ => super.applyBlock(rewritten)
-        
         // rewrite object definitions, assigning to the saved symbol
         case Define(d @ ClsLikeDefn(k = syntax.Obj), rest: Block) => ctx.liftedScopes.get(d.isym) match
           case Some(l: LiftedClass) if l.obj.isObj =>
@@ -506,14 +495,6 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
       pre.rest(remaining)
     
     override def applyPath(p: Path)(k: Path => Block): Block = p match
-      case sel: Select =>
-        sel.symbol match
-          case S(ts: TermSymbol) if ts.isPrivate =>
-            ctx.symbolsMap.get(ts) match
-              case S(LocalPath.Sym(l)) if l is ts => super.applyPath(p)(k)
-              case S(value) => k(value.read)
-              case N => super.applyPath(p)(k)
-          case _ => super.applyPath(p)(k)
       // This rewrites naked references to locals,
       case Value.Ref(l, _) => ctx.symbolsMap.get(l) match
         case Some(value) => k(value.read)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -98,32 +98,42 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
   enum LocalPath:
     case Sym(l: Local)
     case BmsRef(l: BlockMemberSymbol, d: DefinitionSymbol[?])
-    case InCapture(capturePath: Path, field: TermSymbol)
+    case Field(lhs: Path, field: TermSymbol)
     
     def read(using ctx: LifterCtxNew): Path = this match
-      case Sym(l: TermSymbol) =>
-        l.owner match
-        case S(owner) if l.isPrivate =>
-          Select(Value.Ref(owner, N), l.id)(S(l))
-        case _ => l.asPath
       case Sym(l) => l.asPath
       case BmsRef(l, d) => Value.Ref(l, S(d))
-      case InCapture(path, field) => Select(path, field.id)(S(field))
+      case Field(path, field) => Select(path, field.id)(S(field))
       
     def asArg(using ctx: LifterCtxNew) = read.asArg
     
     def assign(value: Result, rest: Block)(using ctx: LifterCtxNew): Block = this match
       case Sym(l) => Assign(l, value, rest)
       case BmsRef(l, d) => lastWords("Tried to assign to a BlockMemberSymbol")
-      case InCapture(path, field) => AssignField(path, field.id, value, rest)(S(field))
+      case Field(path, field) => AssignField(path, field.id, value, rest)(S(field))
+  object LocalPath:
+    /** Use when the lifter deliberately stores a captured value, passed local,
+      * or neighbouring lifted object in a private field of the class it is
+      * currently rewriting. The map still has to be keyed by the original
+      * local symbol because the lifted body mentions that original symbol;
+      * the value says that reads and writes are now field selections on self.
+      * Source private members should already have been lowered to selections,
+      * so this is not a recovery path for arbitrary private `Value.Ref`s.
+      */
+    def privateSelfField(field: TermSymbol): LocalPath =
+      field.owner match
+      case S(owner) => Field(Value.Ref(owner, N), field)
+      case N => lastWords(s"tried to build a private field path for ownerless symbol ${field.nme}")
 
   enum DefnRef:
     case Sym(l: Local)
+    case PathRef(path: Path)
     case InScope(l: BlockMemberSymbol, d: DefinitionSymbol[?])
     case Field(isym: InnerSymbol, l: BlockMemberSymbol, d: DefinitionSymbol[?])
   
     def read(using ctx: LifterCtxNew): Path = this match
       case Sym(l) => l.asPath
+      case PathRef(path) => path
       case InScope(l, d) => Value.Ref(l, S(d))
       case Field(isym, l, d) => Select(ctx.symbolsMap(isym).read, Tree.Ident(l.nme))(S(d))
     
@@ -681,7 +691,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
       val fromCap = thisCapturedLocals
         .map: s =>
           val tSym = captureMap(s)
-          s -> LocalPath.InCapture(capturePath, tSym)
+          s -> LocalPath.Field(capturePath, tSym)
         .toMap
       // Inner symbols of nested modules and objects
       val isyms = node.children
@@ -794,7 +804,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
               val fromScope = capturesOrigin(s)
               val capSym = capSymsMap(fromScope)
               val tSym = ctx.rewrittenScopes(fromScope).captureMap(s)
-              s -> LocalPath.InCapture(capSym, tSym)
+              s -> LocalPath.Field(capSym, tSym)
         .toMap
       fromParents ++ pathsFromThisObj
     
@@ -844,7 +854,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         s -> TermSymbol(syntax.ImmutVal, S(sym), Tree.Ident(s.nme + "$"))
       .toMap
     override lazy val liftedObjsMap: Map[InnerSymbol, LocalPath] = liftedObjsSyms.map:
-      case k -> v => k -> v.asLocalPath
+      case k -> v => k -> LocalPath.privateSelfField(v)
     protected def appendCaptureField(privFields: List[TermSymbol]) =
       if hasCapture then captureSym :: privFields else privFields
     protected def rewriteMethods(node: ScopeNode, methods: List[FunDefn])(using ctx: LifterCtxNew) =
@@ -1086,9 +1096,9 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
       ::: capturesOrdered.map(capSymsMap_(_).ts)
       ::: passedSymsOrdered.map(passedSymsMap_(_).ts)
     
-    override protected val passedSymsMap = passedSymsMap_.view.mapValues(_.ts.asLocalPath).toMap
-    override protected val capSymsMap = capSymsMap_.view.mapValues(_.ts.asPath).toMap
-    override protected val passedDefnsMap = defnSymsMap_.view.mapValues(_.ts.asDefnRef).toMap
+    override protected val passedSymsMap = passedSymsMap_.view.mapValues(x => LocalPath.privateSelfField(x.ts)).toMap
+    override protected val capSymsMap = capSymsMap_.view.mapValues(x => LocalPath.privateSelfField(x.ts).read).toMap
+    override protected val passedDefnsMap = defnSymsMap_.view.mapValues(x => DefnRef.PathRef(LocalPath.privateSelfField(x.ts).read)).toMap
     
     val auxParams: List[Param] =
       (reqDefnsOrdered.map(x => defnSymsMap_(x).vs)
@@ -1199,15 +1209,15 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
       val ctorWithPassed = passedSymsOrdered.foldRight(ctorWithCap):
         case (sym, acc) =>
           val (vs, ts) = passedSymsMap_(sym)
-          Assign(ts, vs.asPath, acc)
+          LocalPath.privateSelfField(ts).assign(vs.asPath, acc)
       val ctorWithCaps = capturesOrdered.foldRight(ctorWithPassed):
         case (sym, acc) =>
           val (vs, ts) = capSymsMap_(sym)
-          Assign(ts, vs.asPath, acc)
+          LocalPath.privateSelfField(ts).assign(vs.asPath, acc)
       val ctorWithDefns = reqDefnsOrdered.foldRight(ctorWithCaps):
         case (sym, acc) =>
           val (vs, ts) = defnSymsMap_(sym)
-          Assign(ts, vs.asPath, acc)
+          LocalPath.privateSelfField(ts).assign(vs.asPath, acc)
       
       val newAuxList = 
         if isTrivial then cls.auxParams

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/UsedVarAnalyzer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/UsedVarAnalyzer.scala
@@ -42,13 +42,6 @@ class UsedVarAnalyzer(b: Block, scopeData: ScopeData)(using State):
   object SDSym:
     def unapply(v: DefinitionSymbol[?] | Option[DefinitionSymbol[?]]) = dSymUnapply(scopeData, v)
   
-  object PrivateFieldSelect:
-    def unapply(p: Path): Opt[TermSymbol] = p match
-      case sel: Select =>
-        sel.symbol.collect:
-          case ts: TermSymbol if ts.isPrivate => ts
-      case _ => N
-
   private def isObj(s: ScopeNode) = s.obj match
     case c: ScopedObject.Class if c.isObj => true
     case _ => false
@@ -67,12 +60,7 @@ class UsedVarAnalyzer(b: Block, scopeData: ScopeData)(using State):
           accessed.mutated.add(lhs)
           applyResult(rhs)
           applyBlock(rest)
-        case assign @ AssignField(lhs, _, rhs, rest) =>
-          assign.symbol.foreach:
-            case ts: TermSymbol if ts.isPrivate =>
-              accessed.accessed.add(ts)
-              accessed.mutated.add(ts)
-            case _ =>
+        case AssignField(lhs, _, rhs, rest) =>
           applyPath(lhs)
           applyResult(rhs)
           applyBlock(rest)
@@ -90,8 +78,6 @@ class UsedVarAnalyzer(b: Block, scopeData: ScopeData)(using State):
       
       override def applyPath(p: Path): Unit = p match
         case Value.Ref(_: BuiltinSymbol, _) => super.applyPath(p)
-        case PrivateFieldSelect(ts) =>
-          accessed.accessed.add(ts)
         case RefOfBms(_, SDSym(dSym), _) =>
           val node = scopeData.getNode(dSym)
           node.obj match
@@ -474,8 +460,6 @@ class UsedVarAnalyzer(b: Block, scopeData: ScopeData)(using State):
         
         override def applyPath(p: Path): Unit = p match
           case RefOfBms(_, SDSym(d), _) => handleScopeRef(d)          
-          case PrivateFieldSelect(ts) =>
-            if hasMutator.contains(ts) then reqCapture += ts
           case Value.Ref(l, _) =>
             if hasMutator.contains(l) then reqCapture += (l)
           case _ => super.applyPath(p)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/deforest/Rewrite.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/deforest/Rewrite.scala
@@ -49,12 +49,6 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
     case tSym: TermSymbol => tSym.nme
     case n: Int => n.toString
 
-  private def privateFieldSelect(p: Path): Opt[TermSymbol] = p match
-    case sel: Select =>
-      sel.symbol.collect:
-        case ts: TermSymbol if ts.isPrivate => ts
-    case _ => N
-
   private def getParentLabelOrMatchesAndRestBefore(
     matchOrLabelId: MatchOrLabelId
   ): (Iterator[Label | Match], Block) =
@@ -284,10 +278,7 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
         p match
         case s@TrackableSelect(_, _, _) if branchSelSyms.isDefinedAt(s.uid.concreteId) =>
           handleTrackableSel(s)
-        case _ =>
-          privateFieldSelect(p) match
-          case S(ts) if !inCtx(ts) => freeVars.add(ts)
-          case _ => super.applyPath(p)
+        case _ => super.applyPath(p)
       
       override def applyBlock(b: Block): Unit =
         b match
@@ -479,10 +470,6 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
     end Rewriter
     
     class RefreshSymbol(existingMapping: Map[Symbol, Symbol]) extends SymbolRefresher(existingMapping):
-      override def applyPath(p: Path)(k: Path => Block): Block =
-        privateFieldSelect(p).flatMap(existingMapping.get) match
-        case S(sym) => k(Value.Ref(sym, N))
-        case N => super.applyPath(p)(k)
       override def applyScopedBlock(b: Block): Block =
         b match
         case Scoped(syms, body) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -18,6 +18,7 @@ import hkmc2.syntax.Tree.UnitLit
 import hkmc2.semantics.Elaborator.ctx
 import hkmc2.syntax.Tree.{IntLit, StrLit}
 import scala.annotation.tailrec
+import scala.collection.mutable.LinkedHashMap
 
 
 // TODO factor some logic for other codegen backends
@@ -46,6 +47,7 @@ class JSBuilder(using Config, TL, State, Ctx) extends CodeBuilder:
   
   val freeze = if !config.noFreeze then "globalThis.Object.freeze" else ""
   lazy val freezeDefns = if freezeDefinitions && !config.noFreeze then "globalThis.Object.freeze" else ""
+  private val privateAccessorSymbols = LinkedHashMap.empty[semantics.TermSymbol, semantics.TempSymbol]
   
   // TODO use this to avoid parens when we generate recomposed expressions later
   enum Context:
@@ -67,6 +69,88 @@ class JSBuilder(using Config, TL, State, Ctx) extends CodeBuilder:
       source = Diagnostic.Source.Compilation))
     doc" # ${mkErr(errMsg)};"
   
+  private def isLexicallyInside(owner: InnerSymbol)(using Scope): Bool =
+    @tailrec
+    def go(scope: Scope): Bool =
+      scope.curThis match
+      case S(S(sym)) if sym is owner => true
+      case _ =>
+        scope.parent match
+        case S(parent) => go(parent)
+        case N => false
+    go(scope)
+
+  private def privateAccessorSymbol(ts: semantics.TermSymbol): semantics.TempSymbol =
+    privateAccessorSymbols.getOrElseUpdate(ts, semantics.TempSymbol(N, "accessorSymbol$"))
+
+  private def privateAccessorName(ts: semantics.TermSymbol, loc: Opt[Loc])(using Raise, Scope): Document =
+    doc"${scope.lookup_!(privateAccessorSymbol(ts), loc)}"
+
+  private def privateFieldSelect(ts: semantics.TermSymbol, loc: Opt[Loc])(using Raise, Scope): Opt[Document] =
+    ts.owner.collect:
+      case owner if ts.isPrivate =>
+        if isLexicallyInside(owner)
+        then doc".#${owner.privatesScope.lookup_!(ts, loc)}"
+        else doc"[${privateAccessorName(ts, loc)}]"
+
+  private def privateAccessorDecls(using Raise, Scope): Document =
+    privateAccessorSymbols.iterator.toList.sortBy(_._1.uid).map: (ts, sym) =>
+      val name = scope.allocateOrGetName(sym)
+      doc"""const $name = globalThis.Symbol(${makeStringLiteral(ts.nme)});"""
+    .mkDocument(doc" # ")
+
+  private def withPrivateAccessorDecls(doc: Document)(using Raise, Scope): Document =
+    val accessors = privateAccessorDecls
+    if accessors.isEmpty then doc else doc :/: accessors
+
+  private def collectExternalPrivateAccessors(p: Program)(using State): Unit =
+    privateAccessorSymbols.clear()
+    var owners: List[InnerSymbol] = Nil
+    def withOwner(owner: InnerSymbol)(body: => Unit): Unit =
+      val oldOwners = owners
+      owners = owner :: owners
+      body
+      owners = oldOwners
+    def needsAccessor(ts: semantics.TermSymbol): Bool =
+      ts.isPrivate && ts.owner.exists(owner => !owners.exists(_ is owner))
+    def note(sym: Opt[DefinitionSymbol[?]]): Unit =
+      sym match
+      case S(ts: semantics.TermSymbol) if needsAccessor(ts) =>
+        privateAccessorSymbol(ts)
+      case _ =>
+    def noteAssign(sym: Opt[MemberSymbol]): Unit =
+      sym match
+      case S(ts: semantics.TermSymbol) if needsAccessor(ts) =>
+        privateAccessorSymbol(ts)
+      case _ =>
+    object collector extends BlockTraverser:
+      override def applyPath(p: Path): Unit = p match
+        case sel @ Select(qual, _) =>
+          applyPath(qual)
+          note(sel.symbol)
+        case _ => super.applyPath(p)
+      override def applyBlock(b: Block): Unit = b match
+        case assign @ AssignField(lhs, _, rhs, rest) =>
+          applyPath(lhs)
+          applyResult(rhs)
+          noteAssign(assign.symbol)
+          applyBlock(rest)
+        case _ => super.applyBlock(b)
+      override def applyDefn(defn: Defn): Unit = defn match
+        case cls: ClsLikeDefn =>
+          withOwner(cls.isym):
+            cls.parentPath.foreach(applyPath)
+            applyBlock(cls.preCtor)
+            applyBlock(cls.ctor)
+            cls.methods.foreach(applyDefn)
+            cls.companion.foreach(applyClsLikeBody)
+        case _ => super.applyDefn(defn)
+      def applyClsLikeBody(body: ClsLikeBody): Unit =
+        withOwner(body.isym):
+          applyBlock(body.ctor)
+          body.methods.foreach(applyDefn)
+    collector.applyBlock(p.main)
+
   def getVar(l: Local, loc: Opt[Loc])(using Raise, Scope): Document = l match
     case ts: semantics.TermSymbol =>
       ts.owner match
@@ -84,11 +168,6 @@ class JSBuilder(using Config, TL, State, Ctx) extends CodeBuilder:
       scope.findThis_!(ts)
     case _ => scope.lookup_!(l, loc)
   
-  private def privateFieldSelect(ts: semantics.TermSymbol, loc: Opt[Loc])(using Raise): Opt[Document] =
-    ts.owner.collect:
-      case owner if ts.isPrivate =>
-        doc".#${owner.privatesScope.lookup_!(ts, loc)}"
-
   def runtimeVar(using Raise, Scope): Document = getVar(State.runtimeSymbol, N)
   
   def argument(a: Arg)(using Raise, Scope): Document =
@@ -378,7 +457,7 @@ class JSBuilder(using Config, TL, State, Ctx) extends CodeBuilder:
                   doc" # $mtdPrefix${td.sym.nme}($params) ${ braced(bodyDoc) }"
                 case td @ FunDefn(params = Nil, body = bod) =>
                   doc" # ${mtdPrefix}get ${td.sym.nme}() ${ braced(body(bod, endSemi = true)) }"
-              .mkDocument(" ")
+              .mkDocument(doc"")
             
             def mkPrivs(pubFlds: Ls[BlockMemberSymbol -> TermSymbol], privFlds: Ls[TermSymbol],
                   mtdPrefix: Str, isym: InnerSymbol)(using Scope): Document =
@@ -398,7 +477,15 @@ class JSBuilder(using Config, TL, State, Ctx) extends CodeBuilder:
                 :: doc" # ${mtdPrefix}set ${escapeField(valSym.name, "")
                   }(value) { ${getVar(letSym, letSym.toLoc)} = value; }"
                 :: Nil
-              (privDecls ::: accessors).mkDocument(doc"")
+              val privateAccessors = allPrivFlds.filter(privateAccessorSymbols.contains).flatMap: fld =>
+                doc" # ${mtdPrefix}get [${privateAccessorName(fld, fld.toLoc)}]() { return ${
+                    getVar(fld, fld.toLoc)
+                  }; }"
+                :: doc" # ${mtdPrefix}set [${privateAccessorName(fld, fld.toLoc)}](value) { ${
+                    getVar(fld, fld.toLoc)
+                  } = value; }"
+                :: Nil
+              (privDecls ::: accessors ::: privateAccessors).mkDocument(doc"")
             
             val modDoc = modo match
               case N => doc""
@@ -516,7 +603,7 @@ class JSBuilder(using Config, TL, State, Ctx) extends CodeBuilder:
                         case S(_) | N => doc"null"
                       }.mkDocument(", ")}]"
                     else doc""
-                  }]; """
+                  }];"""
               }
             
             if isSingleton then
@@ -729,6 +816,7 @@ class JSBuilder(using Config, TL, State, Ctx) extends CodeBuilder:
       :/: programBody(p, exprt, wd)
   
   def programBody(p: Program, exprt: Opt[BlockMemberSymbol], wd: io.Path)(using Raise, Scope): Document =
+    collectExternalPrivateAccessors(p)
     reserveNames(p)
     // Allocate names for imported modules.
     p.imports.foreach: i =>
@@ -740,7 +828,7 @@ class JSBuilder(using Config, TL, State, Ctx) extends CodeBuilder:
         then "./" + io.Path(path).relativeTo(wd).map(_.toString).getOrElse(path)
         else path
       doc"""import ${getVar(i._1, N)} from "${relPath}";"""
-    imps.mkDocument(doc" # ")
+    withPrivateAccessorDecls(imps.mkDocument(doc" # "))
     :/: nonNestedScoped(p.main)(block(_, endSemi = false)).stripBreaks
     :: locally:
       exprt match
@@ -748,6 +836,7 @@ class JSBuilder(using Config, TL, State, Ctx) extends CodeBuilder:
       case N => doc""
   
   def worksheet(p: Program)(using Raise, Scope): (Document, Document) =
+    collectExternalPrivateAccessors(p)
     reserveNames(p)
     lazy val imps = p.imports.map: i =>
       doc"""${getVar(i._1, N)} = await import("${i._2.toString}").then(m => m.default ?? m);"""
@@ -758,10 +847,10 @@ class JSBuilder(using Config, TL, State, Ctx) extends CodeBuilder:
           !s.isInstanceOf[TempSymbol]
           // ^ VarSymbols and TermSymbols should be kept as their value will be acessed and printed by the worksheet
           || fvs(s))) ->
-        (imps.mkDocument(doc" # ") :/: block(body, endSemi = false).stripBreaks)
+        (withPrivateAccessorDecls(imps.mkDocument(doc" # ")) :/: block(body, endSemi = false).stripBreaks)
     case body =>
       blockPreamble(p.imports.map(_._1)) ->
-        (imps.mkDocument(doc" # ") :/: returningTerm(body, endSemi = false).stripBreaks)
+        (withPrivateAccessorDecls(imps.mkDocument(doc" # ")) :/: returningTerm(body, endSemi = false).stripBreaks)
   
   def genLetDecls(vars: Iterator[(Symbol, Str)]): Document =
     if vars.isEmpty then doc"" else

--- a/hkmc2/shared/src/test/mlscript-compile/NoFreeze.mjs
+++ b/hkmc2/shared/src/test/mlscript-compile/NoFreeze.mjs
@@ -18,16 +18,16 @@ let NoFreeze1;
         this.x = x;
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "Foo", ["x"]]; 
+      static [definitionMetadata] = ["class", "Foo", ["x"]];
     });
   }
   static foo() {
     return (new NoFreeze.Foo.class(0))
-  } 
+  }
   static bar() {
     return runtime.safeCall(NoFreeze1["foo"]())
   }
   toString() { return runtime.render(this); }
-  static [definitionMetadata] = ["class", "NoFreeze"]; 
+  static [definitionMetadata] = ["class", "NoFreeze"];
 });
 let NoFreeze = NoFreeze1; export default NoFreeze;

--- a/hkmc2/shared/src/test/mlscript-compile/Predef.mjs
+++ b/hkmc2/shared/src/test/mlscript-compile/Predef.mjs
@@ -25,14 +25,14 @@ let Predef1;
         globalThis.Object.freeze(this);
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["object", "Symbols"]; 
+      static [definitionMetadata] = ["object", "Symbols"];
     });
     (class Sub {
       static {
         Predef.Sub = this
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "Sub"]; 
+      static [definitionMetadata] = ["class", "Sub"];
     });
     (class Eq extends Predef.Sub {
       static {
@@ -42,7 +42,7 @@ let Predef1;
         super();
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "Eq"]; 
+      static [definitionMetadata] = ["class", "Eq"];
     });
     (class Refl extends Predef.Eq {
       static {
@@ -60,7 +60,7 @@ let Predef1;
         return x
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["object", "Refl"]; 
+      static [definitionMetadata] = ["object", "Refl"];
     });
     this.pass1 = Rendering.pass1;
     this.pass2 = Rendering.pass2;
@@ -78,78 +78,78 @@ let Predef1;
       }
       static codegen(t, file) {
         return runtime.safeCall(Term.codegen(t, file))
-      } 
+      }
       static print(t) {
         return runtime.safeCall(Term.print(t))
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "meta"]; 
+      static [definitionMetadata] = ["class", "meta"];
     });
   }
   static id(x) {
     return x
-  } 
+  }
   static hide(x) {
     return x
-  } 
+  }
   static get maybe() {
     return Predef.hide(true);
-  } 
+  }
   static apply(f, ...args) {
     return runtime.safeCall(f(...args))
-  } 
+  }
   static pipeInto(x, f) {
     return runtime.safeCall(f(x))
-  } 
+  }
   static pipeFrom(f, x) {
     return runtime.safeCall(f(x))
-  } 
+  }
   static pipeIntoHi(x, f) {
     return runtime.safeCall(f(x))
-  } 
+  }
   static pipeFromHi(f, x) {
     return runtime.safeCall(f(x))
-  } 
+  }
   static tap(x, f) {
     runtime.safeCall(f(x));
     return x
-  } 
+  }
   static pat(f, x) {
     runtime.safeCall(f(x));
     return x
-  } 
+  }
   static alsoDo(x, eff) {
     return x
-  } 
+  }
   static andThen(f, g) {
     return (x) => {
       let tmp;
       tmp = runtime.safeCall(f(x));
       return runtime.safeCall(g(tmp))
     }
-  } 
+  }
   static compose(f, g) {
     return (x) => {
       let tmp;
       tmp = runtime.safeCall(g(x));
       return runtime.safeCall(f(tmp))
     }
-  } 
+  }
   static passTo(receiver, f) {
     return (...args) => {
       return runtime.safeCall(f(receiver, ...args))
     }
-  } 
+  }
   static passToLo(receiver, f) {
     return (...args) => {
       return runtime.safeCall(f(receiver, ...args))
     }
-  } 
+  }
   static call(receiver, f) {
     return (...args) => {
       return runtime.safeCall(f.call(receiver, ...args))
     }
-  } 
+  }
   static equals(a, b) {
     let scrut, scrut1, scrut2, ac, scrut3, md, scrut4, scrut5, scrut6, scrut7, scrut8, scrut9, lambda, lambda1, tmp, tmp1;
     scrut = a === b;
@@ -229,41 +229,41 @@ let Predef1;
       return false;
     }
     return false;
-  } 
+  }
   static nequals(a, b) {
     let tmp;
     tmp = Predef.equals(a, b);
     return ! tmp
-  } 
+  }
   static print(...xs) {
     let callPrefix, tmp;
     callPrefix = runtime.safeCall(Predef.map(Predef.renderAsStr));
     tmp = runtime.safeCall(callPrefix(...xs));
     return runtime.safeCall(globalThis.console.log(...tmp))
-  } 
+  }
   static renderAsStr(arg) {
     if (typeof arg === 'string') {
       return arg
     }
     return runtime.safeCall(Predef.render(arg));
-  } 
+  }
   static check(...args) {
     return runtime.safeCall(Predef.js_assert(...args))
-  } 
+  }
   static notImplemented(msg) {
     let tmp;
     tmp = "Not implemented: " + msg;
     throw runtime.safeCall(globalThis.Error(tmp))
-  } 
+  }
   static get notImplementedError() {
     throw runtime.safeCall(globalThis.Error("Not implemented"));
-  } 
+  }
   static tuple(...xs) {
     return xs
-  } 
+  }
   static mkSet(...xs) {
     return globalThis.Object.freeze(new globalThis.Set(xs))
-  } 
+  }
   static foldr(f) {
     return (first, ...rest) => {
       let len, scrut, i, init;
@@ -289,7 +289,7 @@ let Predef1;
       }
       return runtime.safeCall(f(first, init));
     }
-  } 
+  }
   static mkStr(...xs) {
     let lambda, callPrefix;
     lambda = (undefined, function (acc, x) {
@@ -305,17 +305,17 @@ let Predef1;
     });
     callPrefix = runtime.safeCall(Predef.fold(lambda));
     return runtime.safeCall(callPrefix(...xs))
-  } 
+  }
   static use(instance) {
     return instance
-  } 
+  }
   static enterHandleBlock(handler, body) {
     return runtime.safeCall(Runtime.enterHandleBlock(handler, body))
-  } 
+  }
   static raiseUnhandledEffect() {
     return runtime.safeCall(Runtime.mkEffect(Runtime.FatalEffect, null))
   }
   toString() { return runtime.render(this); }
-  static [definitionMetadata] = ["class", "Predef"]; 
+  static [definitionMetadata] = ["class", "Predef"];
 });
 let Predef = Predef1; export default Predef;

--- a/hkmc2/shared/src/test/mlscript-compile/Runtime.mjs
+++ b/hkmc2/shared/src/test/mlscript-compile/Runtime.mjs
@@ -53,7 +53,7 @@ let Runtime1;
         return "()"
       }
       [prettyPrint]() { return this.toString(); }
-      static [definitionMetadata] = ["object", "Unit"]; 
+      static [definitionMetadata] = ["object", "Unit"];
     });
     (class Continue {
       static {
@@ -67,7 +67,7 @@ let Runtime1;
         globalThis.Object.freeze(this);
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["object", "Continue"]; 
+      static [definitionMetadata] = ["object", "Continue"];
     });
     (class LoopEnd {
       static {
@@ -81,7 +81,7 @@ let Runtime1;
         globalThis.Object.freeze(this);
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["object", "LoopEnd"]; 
+      static [definitionMetadata] = ["object", "LoopEnd"];
     });
     this.short_and = RuntimeJS.short_and;
     this.short_or = RuntimeJS.short_or;
@@ -109,13 +109,13 @@ let Runtime1;
           return Runtime.resume(this$EffectHandle.reified.contTrace)(value)
         });
         return Runtime1.try(lambda)
-      } 
+      }
       raise() {
         Runtime.curEffect = this.reified;
         return runtime.Unit
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "EffectHandle", [null]]; 
+      static [definitionMetadata] = ["class", "EffectHandle", [null]];
     });
     this.MatchSuccess = function MatchSuccess(output, bindings) {
       return globalThis.Object.freeze(new MatchSuccess.class(output, bindings));
@@ -129,7 +129,7 @@ let Runtime1;
         this.bindings = bindings;
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "MatchSuccess", ["output", "bindings"]]; 
+      static [definitionMetadata] = ["class", "MatchSuccess", ["output", "bindings"]];
     });
     this.MatchFailure = function MatchFailure(errors) {
       return globalThis.Object.freeze(new MatchFailure.class(errors));
@@ -142,7 +142,7 @@ let Runtime1;
         this.errors = errors;
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "MatchFailure", ["errors"]]; 
+      static [definitionMetadata] = ["class", "MatchFailure", ["errors"]];
     });
     (class Tuple {
       static {
@@ -155,15 +155,15 @@ let Runtime1;
         let tmp;
         tmp = xs.length - j;
         return runtime.safeCall(xs.slice(i, tmp))
-      } 
+      }
       static lazySlice(xs, i, j) {
         let callPrefix;
         callPrefix = runtime.safeCall(LazyArray.dropLeftRight(i, j));
         return runtime.safeCall(callPrefix(xs))
-      } 
+      }
       static lazyConcat(...args) {
         return runtime.safeCall(LazyArray.__concat(...args))
-      } 
+      }
       static get(xs, i) {
         let scrut, scrut1, tmp;
         scrut = i >= xs.length;
@@ -176,12 +176,12 @@ let Runtime1;
           throw runtime.safeCall(globalThis.RangeError("Tuple.get: negative index out of bounds"))
         }
         return xs.at(i);
-      } 
+      }
       static isArrayLike(xs) {
         return runtime.safeCall(Iter.isArrayLike(xs))
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "Tuple"]; 
+      static [definitionMetadata] = ["class", "Tuple"];
     });
     (class Str {
       static {
@@ -189,7 +189,7 @@ let Runtime1;
       }
       static startsWith(string, prefix) {
         return runtime.safeCall(string.startsWith(prefix))
-      } 
+      }
       static get(string, i) {
         let scrut;
         scrut = i >= string.length;
@@ -197,15 +197,15 @@ let Runtime1;
           throw runtime.safeCall(globalThis.RangeError("Str.get: index out of bounds"))
         }
         return runtime.safeCall(string.at(i));
-      } 
+      }
       static take(string, n) {
         return runtime.safeCall(string.slice(0, n))
-      } 
+      }
       static leave(string, n) {
         return runtime.safeCall(string.slice(n))
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "Str"]; 
+      static [definitionMetadata] = ["class", "Str"];
     });
     this.render = Rendering.render;
     (class TraceLogger {
@@ -232,7 +232,7 @@ let Runtime1;
           return prev
         }
         return runtime.Unit;
-      } 
+      }
       static resetIndent(n) {
         let scrut;
         scrut = TraceLogger.enabled;
@@ -241,7 +241,7 @@ let Runtime1;
           return runtime.Unit
         }
         return runtime.Unit;
-      } 
+      }
       static log(msg) {
         let scrut, tmp, tmp1, tmp2, tmp3, tmp4;
         scrut = TraceLogger.enabled;
@@ -256,7 +256,7 @@ let Runtime1;
         return runtime.Unit;
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "TraceLogger"]; 
+      static [definitionMetadata] = ["class", "TraceLogger"];
     });
     this.curEffect = null;
     this.resumeValue = null;
@@ -275,7 +275,7 @@ let Runtime1;
         globalThis.Object.freeze(this);
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["object", "FatalEffect"]; 
+      static [definitionMetadata] = ["object", "FatalEffect"];
     });
     (class PrintStackEffect {
       static {
@@ -289,7 +289,7 @@ let Runtime1;
         globalThis.Object.freeze(this);
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["object", "PrintStackEffect"]; 
+      static [definitionMetadata] = ["object", "PrintStackEffect"];
     });
     this.FunctionContFrame = function FunctionContFrame(next, saved) {
       return globalThis.Object.freeze(new FunctionContFrame.class(next, saved));
@@ -345,7 +345,7 @@ let Runtime1;
         tmp4 = tmp3 + argListLength;
         tmp5 = runtime.safeCall(this.saved.slice(tmp2, tmp4));
         return runtime.safeCall(f.apply(this.saved.at(4), tmp5))
-      } 
+      }
       get getLocals() {
         let debugInfo, i, cur, res, i1;
         debugInfo = this.saved.at(3);
@@ -382,10 +382,10 @@ let Runtime1;
           break;
         }
         return res;
-      } 
+      }
       get getNme() {
         return this.saved.at(3).at(0);
-      } 
+      }
       get getLoc() {
         let loc;
         loc = this.saved.at(2);
@@ -395,7 +395,7 @@ let Runtime1;
         return loc;
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "FunctionContFrame", ["next", "saved"]]; 
+      static [definitionMetadata] = ["class", "FunctionContFrame", ["next", "saved"]];
     });
     this.HandlerContFrame = function HandlerContFrame(next, nextHandler, handler) {
       return globalThis.Object.freeze(new HandlerContFrame.class(next, nextHandler, handler));
@@ -410,7 +410,7 @@ let Runtime1;
         this.handler = handler;
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "HandlerContFrame", ["next", "nextHandler", "handler"]]; 
+      static [definitionMetadata] = ["class", "HandlerContFrame", ["next", "nextHandler", "handler"]];
     });
     this.ContTrace = function ContTrace(next, last, nextHandler, lastHandler, resumed) {
       return globalThis.Object.freeze(new ContTrace.class(next, last, nextHandler, lastHandler, resumed));
@@ -427,7 +427,7 @@ let Runtime1;
         this.resumed = resumed;
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "ContTrace", ["next", "last", "nextHandler", "lastHandler", "resumed"]]; 
+      static [definitionMetadata] = ["class", "ContTrace", ["next", "last", "nextHandler", "lastHandler", "resumed"]];
     });
     this.EffectSig = function EffectSig(contTrace, handler, handlerFun) {
       return globalThis.Object.freeze(new EffectSig.class(contTrace, handler, handlerFun));
@@ -442,14 +442,14 @@ let Runtime1;
         this.handlerFun = handlerFun;
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "EffectSig", ["contTrace", "handler", "handlerFun"]]; 
+      static [definitionMetadata] = ["class", "EffectSig", ["contTrace", "handler", "handlerFun"]];
     });
     (class NonLocalReturn {
       static {
         Runtime.NonLocalReturn = this
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "NonLocalReturn"]; 
+      static [definitionMetadata] = ["class", "NonLocalReturn"];
     });
     this.FnLocalsInfo = function FnLocalsInfo(fnName, locals) {
       return globalThis.Object.freeze(new FnLocalsInfo.class(fnName, locals));
@@ -463,7 +463,7 @@ let Runtime1;
         this.locals = locals;
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "FnLocalsInfo", ["fnName", "locals"]]; 
+      static [definitionMetadata] = ["class", "FnLocalsInfo", ["fnName", "locals"]];
     });
     this.LocalVarInfo = function LocalVarInfo(localName, value) {
       return globalThis.Object.freeze(new LocalVarInfo.class(localName, value));
@@ -477,7 +477,7 @@ let Runtime1;
         this.value = value;
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "LocalVarInfo", ["localName", "value"]]; 
+      static [definitionMetadata] = ["class", "LocalVarInfo", ["localName", "value"]];
     });
     this.CustomStackError = function CustomStackError(stack) {
       return globalThis.Object.freeze(new CustomStackError.class(stack));
@@ -493,7 +493,7 @@ let Runtime1;
         return this.stack
       }
       [prettyPrint]() { return this.toString(); }
-      static [definitionMetadata] = ["class", "CustomStackError", ["stack"]]; 
+      static [definitionMetadata] = ["class", "CustomStackError", ["stack"]];
     });
     this.stackLimit = 0;
     this.stackDepth = 0;
@@ -519,7 +519,7 @@ let Runtime1;
         return Runtime.mkEffect(this, lambda)
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["object", "StackDelayHandler"]; 
+      static [definitionMetadata] = ["object", "StackDelayHandler"];
     });
     this.Int31 = function Int31(v) {
       return globalThis.Object.freeze(new Int31.class(v));
@@ -537,14 +537,14 @@ let Runtime1;
         tmp = runtime.safeCall(Runtime.shl(1, 31));
         tmp1 = runtime.safeCall(Runtime.bitnot(tmp));
         return runtime.safeCall(Runtime.bitand(this.#v, tmp1))
-      } 
+      }
       sext() {
         let tmp;
         tmp = runtime.safeCall(Runtime.shl(1, 31));
         return runtime.safeCall(Runtime.bitor(this.#v, tmp))
       }
       toString() { return runtime.render(this); }
-      static [definitionMetadata] = ["class", "Int31", [null]]; 
+      static [definitionMetadata] = ["class", "Int31", [null]];
     });
   }
   static handleEffects_handleEffect_resume(id, param0, param1) {
@@ -636,10 +636,10 @@ let Runtime1;
       }
       break;
     }
-  } 
+  }
   static get unreachable() {
     throw runtime.safeCall(globalThis.Error("unreachable"));
-  } 
+  }
   static assertFail(file, line) {
     let tmp, tmp1, tmp2, tmp3;
     tmp = "Assertion failed (" + file;
@@ -647,7 +647,7 @@ let Runtime1;
     tmp2 = tmp1 + line;
     tmp3 = tmp2 + ")";
     throw runtime.safeCall(globalThis.Error(tmp3))
-  } 
+  }
   static checkArgs(functionName, expected, isUB, got) {
     let scrut, scrut1, tmp, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8, tmp9, tmp10, tmp11, tmp12, tmp13, tmp14;
     tmp = got < expected;
@@ -691,19 +691,19 @@ let Runtime1;
       throw runtime.safeCall(globalThis.Error(tmp14))
     }
     return runtime.Unit;
-  } 
+  }
   static safeCall(x) {
     if (x === undefined) {
       return runtime.Unit
     }
     return x;
-  } 
+  }
   static checkCall(x) {
     if (x === undefined) {
       throw runtime.safeCall(globalThis.Error("MLscript call unexpectedly returned `undefined`, the forbidden value."))
     }
     return x;
-  } 
+  }
   static deboundMethod(mtdName, clsName) {
     let tmp, tmp1, tmp2, tmp3;
     tmp = "[debinding error] Method '" + mtdName;
@@ -711,7 +711,7 @@ let Runtime1;
     tmp2 = tmp1 + clsName;
     tmp3 = tmp2 + "' was accessed without being called.";
     throw runtime.safeCall(globalThis.Error(tmp3))
-  } 
+  }
   static try(f) {
     let res, scrut, tmp;
     res = runtime.safeCall(f());
@@ -722,7 +722,7 @@ let Runtime1;
       return Runtime.EffectHandle(tmp)
     }
     return res;
-  } 
+  }
   static printRaw(x) {
     let rcd, tmp;
     rcd = globalThis.Object.freeze({
@@ -731,15 +731,15 @@ let Runtime1;
     });
     tmp = runtime.safeCall(Runtime.render(x, rcd));
     return runtime.safeCall(globalThis.console.log(tmp))
-  } 
+  }
   static resetEffects() {
     Runtime.curEffect = null;
     Runtime.resumePc = -1;
     return runtime.Unit
-  } 
+  }
   static raisePrintStackEffect(showLocals) {
     return Runtime.mkEffect(Runtime.PrintStackEffect, showLocals)
-  } 
+  }
   static topLevelEffect(debug) {
     let tr, v, tmp, tmp1;
     tr = Runtime.curEffect;
@@ -767,7 +767,7 @@ let Runtime1;
       throw Runtime.CustomStackError(tmp1)
     }
     return v;
-  } 
+  }
   static illegalEffect(position) {
     let tmp, tmp1, tmp2, tmp3, tmp4;
     tmp = Runtime.curEffect;
@@ -777,7 +777,7 @@ let Runtime1;
     tmp3 = tmp2 + position;
     tmp4 = Runtime.showStackTrace(tmp3, tmp, false, false);
     throw Runtime.CustomStackError(tmp4)
-  } 
+  }
   static showStackTrace(header, tr, debug, showLocals) {
     let msg, curHandler, atTail, tmp;
     msg = header;
@@ -848,7 +848,7 @@ let Runtime1;
       return msg;
     }
     return header;
-  } 
+  }
   static showFunctionContChain(cont, hl, vis, reps) {
     let result, scrut, scrut1, scrut2, tmp, lambda, tmp1, tmp2, tmp3, tmp4;
     if (cont instanceof Runtime.FunctionContFrame.class) {
@@ -888,7 +888,7 @@ let Runtime1;
       return "(null)"
     }
     return "(NOT CONT)";
-  } 
+  }
   static showHandlerContChain(cont, hl, vis, reps) {
     let result, scrut, scrut1, scrut2, lambda, tmp, tmp1, tmp2, tmp3;
     if (cont instanceof Runtime.HandlerContFrame.class) {
@@ -927,21 +927,21 @@ let Runtime1;
       return "(null)"
     }
     return "(NOT HANDLER CONT)";
-  } 
+  }
   static debugCont(cont) {
     let tmp, tmp1, tmp2;
     tmp = globalThis.Object.freeze(new globalThis.Map());
     tmp1 = globalThis.Object.freeze(new globalThis.Set());
     tmp2 = Runtime.showFunctionContChain(cont, tmp, tmp1, 0);
     return runtime.safeCall(globalThis.console.log(tmp2))
-  } 
+  }
   static debugHandler(cont) {
     let tmp, tmp1, tmp2;
     tmp = globalThis.Object.freeze(new globalThis.Map());
     tmp1 = globalThis.Object.freeze(new globalThis.Set());
     tmp2 = Runtime.showHandlerContChain(cont, tmp, tmp1, 0);
     return runtime.safeCall(globalThis.console.log(tmp2))
-  } 
+  }
   static debugContTrace(contTrace) {
     let scrut, scrut1, vis, hl, cur, tmp, tmp1, tmp2, tmp3, tmp4;
     if (contTrace instanceof Runtime.ContTrace.class) {
@@ -984,7 +984,7 @@ let Runtime1;
     }
     runtime.safeCall(globalThis.console.log("Not a cont trace:"));
     return runtime.safeCall(globalThis.console.log(contTrace));
-  } 
+  }
   static debugEff(eff) {
     if (eff instanceof Runtime.EffectSig.class) {
       runtime.safeCall(globalThis.console.log("Debug EffectSig:"));
@@ -994,14 +994,14 @@ let Runtime1;
     }
     runtime.safeCall(globalThis.console.log("Not an effect:"));
     return runtime.safeCall(globalThis.console.log(eff));
-  } 
+  }
   static unwind(...saved) {
     let tmp;
     tmp = new Runtime.FunctionContFrame.class(null, saved);
     Runtime.curEffect.contTrace.last.next = tmp;
     Runtime.curEffect.contTrace.last = Runtime.curEffect.contTrace.last.next;
     return runtime.Unit
-  } 
+  }
   static mkEffect(handler, handlerFun) {
     let res, tmp;
     tmp = new Runtime.ContTrace.class(null, null, null, null, false);
@@ -1010,7 +1010,7 @@ let Runtime1;
     res.contTrace.lastHandler = res.contTrace;
     Runtime.curEffect = res;
     return runtime.Unit
-  } 
+  }
   static handleBlockImpl(cur, handler) {
     let handlerFrame;
     handlerFrame = new Runtime.HandlerContFrame.class(null, null, handler);
@@ -1018,7 +1018,7 @@ let Runtime1;
     cur.contTrace.lastHandler = handlerFrame;
     cur.contTrace.last = handlerFrame;
     return Runtime.handleEffects(cur)
-  } 
+  }
   static enterHandleBlock(handler, body) {
     let tmp, scrut;
     tmp = runtime.safeCall(body());
@@ -1027,18 +1027,18 @@ let Runtime1;
       return tmp
     }
     return Runtime.handleBlockImpl(Runtime.curEffect, handler);
-  } 
+  }
   static handleEffects(cur) {
     return Runtime.handleEffects_handleEffect_resume(0, cur, undefined)
-  } 
+  }
   static handleEffect(cur) {
     return Runtime.handleEffects_handleEffect_resume(1, cur, undefined)
-  } 
+  }
   static resume(contTrace) {
     return (value) => {
       return Runtime.handleEffects_handleEffect_resume(2, contTrace, value)
     }
-  } 
+  }
   static resumeContTrace(contTrace, value) {
     let cont, handlerCont;
     cont = contTrace.next;
@@ -1085,7 +1085,7 @@ let Runtime1;
       }
       return value;
     }
-  } 
+  }
   static checkDepth() {
     let tmp, tmp1;
     tmp = Runtime.stackDepth >= Runtime.stackLimit;
@@ -1098,7 +1098,7 @@ let Runtime1;
       return runtime.safeCall(Runtime.stackHandler.delay())
     }
     return runtime.Unit;
-  } 
+  }
   static runStackSafe(limit, f) {
     let old, old1, old2, result, scrut, tmp, tmp1, tmp2;
     old = Runtime.stackLimit;
@@ -1145,7 +1145,7 @@ let Runtime1;
       Runtime.stackLimit = old;
     }
     return tmp
-  } 
+  }
   static plus_impl(lhs, rhs) {
     if (lhs instanceof Runtime.Int31.class) {
       if (rhs instanceof Runtime.Int31.class) {
@@ -1156,6 +1156,6 @@ let Runtime1;
     return runtime.safeCall(Runtime.unreachable());
   }
   toString() { return runtime.render(this); }
-  static [definitionMetadata] = ["class", "Runtime"]; 
+  static [definitionMetadata] = ["class", "Runtime"];
 });
 let Runtime = Runtime1; export default Runtime;

--- a/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
+++ b/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
@@ -282,10 +282,6 @@ fun foo() =
 
 :breakme
 module Foo(x)
-//│ ╔══[COMPILATION ERROR] No definition found in scope for member 'x'
-//│ ╟── which references the symbol introduced here
-//│ ║  l.284: 	module Foo(x)
-//│ ╙──       	           ^
 
 :fixme // proper compilation error
 :sjs
@@ -293,7 +289,7 @@ module Foo(x) with
   print(x)
 //│ ╔══[COMPILATION ERROR] No definition found in scope for member 'x'
 //│ ╟── which references the symbol introduced here
-//│ ║  l.292: 	module Foo(x) with
+//│ ║  l.288: 	module Foo(x) with
 //│ ╙──       	           ^
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
 //│ let Foo5;
@@ -317,7 +313,7 @@ module Foo(x) with
 module Foo(val x)
 //│ ╔══[COMPILATION ERROR] No definition found in scope for member 'x'
 //│ ╟── which references the symbol introduced here
-//│ ║  l.317: 	module Foo(val x)
+//│ ║  l.313: 	module Foo(val x)
 //│ ╙──       	               ^
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
 //│ let Foo7;
@@ -338,7 +334,7 @@ module Foo(val x)
 // TODO support syntax?
 data class Foo(mut x)
 //│ ╔══[COMPILATION ERROR] Expected a valid parameter, found 'mut'-modified identifier
-//│ ║  l.339: 	data class Foo(mut x)
+//│ ║  l.335: 	data class Foo(mut x)
 //│ ╙──       	                   ^
 
 // ——— ——— ———
@@ -353,7 +349,7 @@ class Foo
 :e
 class Id(name: UnboundName)
 //│ ╔══[COMPILATION ERROR] Name not found: UnboundName
-//│ ║  l.354: 	class Id(name: UnboundName)
+//│ ║  l.350: 	class Id(name: UnboundName)
 //│ ╙──       	               ^^^^^^^^^^^
 //│ ═══[COMPILATION ERROR] Expected a type, got a non-type ‹error›
 //│ ═══[COMPILATION ERROR] Expected a type, got ‹error›

--- a/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
+++ b/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
@@ -100,7 +100,7 @@ object Cls(val x) with
 //│     return this.x;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["object", "Cls"]; 
+//│   static [definitionMetadata] = ["object", "Cls"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -157,7 +157,7 @@ class D extends id(C)
 //│     super(C1);
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "D"]; 
+//│   static [definitionMetadata] = ["class", "D"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ ═══[RUNTIME ERROR] TypeError: Class extends value id(x) {
@@ -307,7 +307,7 @@ module Foo(x) with
 //│     Predef.print(Foo4.#x);
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo"]; 
+//│   static [definitionMetadata] = ["class", "Foo"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ > 1
@@ -329,7 +329,7 @@ module Foo(val x)
 //│     this.x = x;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo"]; 
+//│   static [definitionMetadata] = ["class", "Foo"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/basics/BadModuleUses.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/BadModuleUses.mls
@@ -47,14 +47,14 @@ Example.foo() + 1
 //│ ╔══[COMPILATION ERROR] Unexpected moduleful application of type M.
 //│ ║  l.46: 	Example.foo() + 1
 //│ ╙──      	^^^^^^^^^^^^^
-//│ = "class M {   static {     M1 = this   }   static mtd() {     runtime.checkArgs(\"mtd\", 0, true, arguments.length);     return 42   }   toString() { return runtime.render(this); }   static [definitionMetadata] = [\"class\", \"M\"];  }1"
+//│ = "class M {   static {     M1 = this   }   static mtd() {     runtime.checkArgs(\"mtd\", 0, true, arguments.length);     return 42   }   toString() { return runtime.render(this); }   static [definitionMetadata] = [\"class\", \"M\"]; }1"
 
 :e
 M + 1
 //│ ╔══[COMPILATION ERROR] Unexpected moduleful reference of type M.
 //│ ║  l.53: 	M + 1
 //│ ╙──      	^
-//│ = "class M {   static {     M1 = this   }   static mtd() {     runtime.checkArgs(\"mtd\", 0, true, arguments.length);     return 42   }   toString() { return runtime.render(this); }   static [definitionMetadata] = [\"class\", \"M\"];  }1"
+//│ = "class M {   static {     M1 = this   }   static mtd() {     runtime.checkArgs(\"mtd\", 0, true, arguments.length);     return 42   }   toString() { return runtime.render(this); }   static [definitionMetadata] = [\"class\", \"M\"]; }1"
 
 :e
 M |> id

--- a/hkmc2/shared/src/test/mlscript/basics/CompanionModules_Classes.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/CompanionModules_Classes.mls
@@ -121,7 +121,7 @@ module Foo with
 //│     return state;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", []]; 
+//│   static [definitionMetadata] = ["class", "Foo", []];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/basics/Inheritance.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/Inheritance.mls
@@ -69,7 +69,7 @@ data class Baz(z) extends Bar(z * 1) with
 //│     return this.bar * 2;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Baz", ["z"]]; 
+//│   static [definitionMetadata] = ["class", "Baz", ["z"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -134,7 +134,7 @@ class B extends M.A
 //│     super();
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "B"]; 
+//│   static [definitionMetadata] = ["class", "B"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/basics/MutVal.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/MutVal.mls
@@ -36,15 +36,9 @@ class Foo(x, val y, mut val z)
 //│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
 //│ let Foo⁰;
 //│ define Foo⁰ as class Foo²(x, y, z) {
-//│   private val x⁰;
 //│   val y⁰;
 //│   val z⁰;
-//│   constructor Foo¹ {
-//│     set Foo².this.x = x;
-//│     define y⁰ as val y¹ = y;
-//│     define z⁰ as val z¹ = z;
-//│     end
-//│   }
+//│   constructor Foo¹ { define y⁰ as val y¹ = y; define z⁰ as val z¹ = z; end }
 //│ };
 //│ end
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
@@ -55,14 +49,14 @@ class Foo(x, val y, mut val z) with
 //│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
 //│ let Foo³;
 //│ define Foo³ as class Foo⁵(x, y, z) {
-//│   private val x¹;
+//│   private val x⁰;
 //│   val y²;
 //│   val z²;
 //│   constructor Foo⁴ {
 //│     set Foo⁵.this.x = x;
 //│     define y² as val y³ = y;
 //│     define z² as val z³ = z;
-//│     do Predef⁰.print⁰(Foo⁵.this.x¹);
+//│     do Predef⁰.print⁰(Foo⁵.this.x⁰);
 //│     end
 //│   }
 //│ };

--- a/hkmc2/shared/src/test/mlscript/basics/ValMemberSymbols.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/ValMemberSymbols.mls
@@ -123,7 +123,7 @@ fun foo(x, y) =
 //│   val u⁰;
 //│   val v⁰;
 //│   constructor A⁷(y) {
-//│     set y⁰ = y;
+//│     set A⁸.this.y = y;
 //│     define u⁰ as val u¹ = u;
 //│     define v⁰ as val v¹ = A⁸.this.y⁰;
 //│     end

--- a/hkmc2/shared/src/test/mlscript/block-staging/Nested.mls
+++ b/hkmc2/shared/src/test/mlscript/block-staging/Nested.mls
@@ -74,7 +74,7 @@ staged module LiftedLambda with
 //│   private val x⁰;
 //│   constructor(x) {
 //│     super⁰();
-//│     set x⁰ = x;
+//│     set Function$¹.this.x = x;
 //│     end
 //│   }
 //│   method call⁰ = fun call¹(y) {
@@ -154,7 +154,7 @@ staged module LiftedMultParams with
 //│   private val x¹;
 //│   constructor(x) {
 //│     super⁰();
-//│     set x¹ = x;
+//│     set Function$³.this.x = x;
 //│     end
 //│   }
 //│   method call² = fun call³(y) {

--- a/hkmc2/shared/src/test/mlscript/codegen/BadInit.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/BadInit.mls
@@ -30,7 +30,7 @@ object Bar with
 //│         this.a = Bar1.x;
 //│       }
 //│       toString() { return runtime.render(this); }
-//│       static [definitionMetadata] = ["class", "Baz"]; 
+//│       static [definitionMetadata] = ["class", "Baz"];
 //│     });
 //│     Object.defineProperty(this, "class", {
 //│       value: Bar
@@ -38,7 +38,7 @@ object Bar with
 //│     globalThis.Object.freeze(this);
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["object", "Bar"]; 
+//│   static [definitionMetadata] = ["object", "Bar"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -67,11 +67,11 @@ module Bar with
 //│         this.a = Bar3.x;
 //│       }
 //│       toString() { return runtime.render(this); }
-//│       static [definitionMetadata] = ["class", "Baz"]; 
+//│       static [definitionMetadata] = ["class", "Baz"];
 //│     });
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Bar"]; 
+//│   static [definitionMetadata] = ["class", "Bar"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/ClassInClass.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/ClassInClass.mls
@@ -50,7 +50,7 @@ data class Outer(a, b) with
 //│         ])
 //│       }
 //│       toString() { return runtime.render(this); }
-//│       static [definitionMetadata] = ["class", "Inner", ["c"]]; 
+//│       static [definitionMetadata] = ["class", "Inner", ["c"]];
 //│     });
 //│     tmp = this.Inner(this.a);
 //│     this.i = tmp;
@@ -60,14 +60,14 @@ data class Outer(a, b) with
 //│   }
 //│   o1(c) {
 //│     return this.Inner(c)
-//│   } 
+//│   }
 //│   o2(c, d) {
 //│     let tmp;
 //│     tmp = this.Inner(c);
 //│     return tmp.i1(d)
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Outer", ["a", "b"]]; 
+//│   static [definitionMetadata] = ["class", "Outer", ["a", "b"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/ClassInFun.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/ClassInFun.mls
@@ -17,7 +17,7 @@ fun test(a) =
 //│       this.x = a;
 //│     }
 //│     toString() { return runtime.render(this); }
-//│     static [definitionMetadata] = ["class", "C"]; 
+//│     static [definitionMetadata] = ["class", "C"];
 //│   });
 //│   return globalThis.Object.freeze(new C1())
 //│ };
@@ -53,7 +53,7 @@ fun test(x) =
 //│       this.b = b;
 //│     }
 //│     toString() { return runtime.render(this); }
-//│     static [definitionMetadata] = ["class", "Foo", ["a", "b"]]; 
+//│     static [definitionMetadata] = ["class", "Foo", ["a", "b"]];
 //│   });
 //│   tmp = x + 1;
 //│   return Foo2(x, tmp)

--- a/hkmc2/shared/src/test/mlscript/codegen/Classes.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Classes.mls
@@ -18,7 +18,7 @@ data class Foo(arguments)
 //│     this.arguments = arguments1;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["arguments"]]; 
+//│   static [definitionMetadata] = ["class", "Foo", ["arguments"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -37,7 +37,7 @@ data class Foo(eval)
 //│     this.eval = eval1;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["eval"]]; 
+//│   static [definitionMetadata] = ["class", "Foo", ["eval"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -56,7 +56,7 @@ data class Foo(static)
 //│     this.static = static1;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["static"]]; 
+//│   static [definitionMetadata] = ["class", "Foo", ["static"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -75,7 +75,7 @@ data class Foo(v')
 //│     this["v'"] = v$_;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["v'"]]; 
+//│   static [definitionMetadata] = ["class", "Foo", ["v'"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/CurriedClassInheritance.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/CurriedClassInheritance.mls
@@ -26,7 +26,7 @@ class Bar(val a)(val d) extends Foo(a)
 //│     }
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Bar", ["a"]]; 
+//│   static [definitionMetadata] = ["class", "Bar", ["a"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/CurriedClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/CurriedClasses.mls
@@ -28,7 +28,7 @@ class A(val x)(val y)
 //│     }
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "A", ["x"]]; 
+//│   static [definitionMetadata] = ["class", "A", ["x"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/FirstClassFunctionTransform.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/FirstClassFunctionTransform.mls
@@ -223,36 +223,36 @@ module Foo with
     fun bar(z) = x => x + y + z 
 //│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
 //│ let Foo¹, lambda⁸, Function$⁸;
-//│ define lambda⁸ as fun lambda⁹(y, z, x) {
+//│ define lambda⁸ as fun lambda⁹(Bar, z, x) {
 //│   let tmp;
-//│   set tmp = +⁰(x, y);
+//│   set tmp = +⁰(x, Bar.y⁰);
 //│   return +⁰(tmp, z)
 //│ };
 //│ define Function$⁸ as class Function$⁹ {
-//│   private val y⁰;
+//│   private val Bar⁰;
 //│   private val z⁰;
-//│   constructor(y, z) {
+//│   constructor(Bar, z) {
 //│     super⁰();
-//│     set y⁰ = y;
+//│     set Bar⁰ = Bar;
 //│     set z⁰ = z;
 //│     end
 //│   }
 //│   method call⁸ = fun call⁹(x) {
-//│     return lambda⁹(Function$⁹.this.y⁰, Function$⁹.this.z⁰, x)
+//│     return lambda⁹(Function$⁹.this.Bar⁰, Function$⁹.this.z⁰, x)
 //│   }
 //│ };
 //│ define Foo¹ as class Foo²
 //│ module Foo³ {
 //│   constructor {
-//│     define Bar⁰ as class Bar²(y) {
-//│       private val y¹;
-//│       constructor Bar¹ {
-//│         set Bar².this.y = y;
+//│     define Bar¹ as class Bar³(y) {
+//│       private val y⁰;
+//│       constructor Bar² {
+//│         set Bar³.this.y = y;
 //│         end
 //│       }
 //│       method bar² = fun bar³(z) {
 //│         let tmp;
-//│         set tmp = new Function$⁹(Bar².this.y¹, z);
+//│         set tmp = new Function$⁹(Bar³.this, z);
 //│         return tmp
 //│       }
 //│     };

--- a/hkmc2/shared/src/test/mlscript/codegen/FirstClassFunctionTransform.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/FirstClassFunctionTransform.mls
@@ -233,8 +233,8 @@ module Foo with
 //│   private val z⁰;
 //│   constructor(Bar, z) {
 //│     super⁰();
-//│     set Bar⁰ = Bar;
-//│     set z⁰ = z;
+//│     set Function$⁹.this.Bar = Bar;
+//│     set Function$⁹.this.z = z;
 //│     end
 //│   }
 //│   method call⁸ = fun call⁹(x) {
@@ -468,7 +468,7 @@ fun foo(x)(y) = x + y
 //│   private val x²;
 //│   constructor(x) {
 //│     super⁰();
-//│     set x² = x;
+//│     set Function$¹³.this.x = x;
 //│     end
 //│   }
 //│   method call¹² = fun call¹³(y) {

--- a/hkmc2/shared/src/test/mlscript/codegen/FunInClass.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/FunInClass.mls
@@ -39,7 +39,7 @@ fun test(a) =
 //│         this.b,
 //│         c
 //│       ])
-//│     } 
+//│     }
 //│     g(d) {
 //│       let inlinedVal;
 //│       inlinedVal = globalThis.Object.freeze([
@@ -51,7 +51,7 @@ fun test(a) =
 //│       return inlinedVal
 //│     }
 //│     toString() { return runtime.render(this); }
-//│     static [definitionMetadata] = ["class", "Inner", ["b"]]; 
+//│     static [definitionMetadata] = ["class", "Inner", ["b"]];
 //│   });
 //│   return Inner1(42)
 //│ };
@@ -96,7 +96,7 @@ fun test(a) =
 //│       Predef.print(tmp2);
 //│     }
 //│     toString() { return runtime.render(this); }
-//│     static [definitionMetadata] = ["class", "C1", ["b"]]; 
+//│     static [definitionMetadata] = ["class", "C1", ["b"]];
 //│   });
 //│   C21 = function C2(b) {
 //│     return globalThis.Object.freeze(new C2.class(b));
@@ -115,7 +115,7 @@ fun test(a) =
 //│       Predef.print(tmp2);
 //│     }
 //│     toString() { return runtime.render(this); }
-//│     static [definitionMetadata] = ["class", "C2", ["b"]]; 
+//│     static [definitionMetadata] = ["class", "C2", ["b"]];
 //│   });
 //│   tmp = C11(1);
 //│   tmp1 = C21(2);
@@ -166,7 +166,7 @@ Foo(123)
 //│     return baz()
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["a"]]; 
+//│   static [definitionMetadata] = ["class", "Foo", ["a"]];
 //│ });
 //│ Foo1(123)
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
@@ -201,7 +201,7 @@ Bar(1)
 //│     }
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Bar", ["x"]]; 
+//│   static [definitionMetadata] = ["class", "Bar", ["x"]];
 //│ });
 //│ Bar1(1)
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————

--- a/hkmc2/shared/src/test/mlscript/codegen/FunctionsThis.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/FunctionsThis.mls
@@ -25,7 +25,7 @@ class Test with
 //│     Predef.print(tmp);
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Test"]; 
+//│   static [definitionMetadata] = ["class", "Test"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/Getters.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Getters.mls
@@ -81,12 +81,12 @@ module T with
 //│   }
 //│   static t() {
 //│     return 1
-//│   } 
+//│   }
 //│   static get p() {
 //│     return 2;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "T"]; 
+//│   static [definitionMetadata] = ["class", "T"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -117,7 +117,7 @@ module M with
 //│     return 0;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "M"]; 
+//│   static [definitionMetadata] = ["class", "M"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -295,7 +295,7 @@ data class Foo(x) with
 //│     return this.x;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["x"]]; 
+//│   static [definitionMetadata] = ["class", "Foo", ["x"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/Hygiene.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Hygiene.mls
@@ -28,7 +28,7 @@ object Test with
 //│     return Test1.x
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["object", "Test"]; 
+//│   static [definitionMetadata] = ["object", "Test"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -100,7 +100,7 @@ module Test with
 //│     Test3.#x = 2;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Test"]; 
+//│   static [definitionMetadata] = ["class", "Test"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -142,12 +142,12 @@ data class Cls(x) with
 //│   #x1;
 //│   get foo() {
 //│     return this.#x;
-//│   } 
+//│   }
 //│   get bar() {
 //│     return this.#x1;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Cls", ["x"]]; 
+//│   static [definitionMetadata] = ["class", "Cls", ["x"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -207,14 +207,14 @@ module Whoops with
 //│         return Whoops.f()
 //│       }
 //│       toString() { return runtime.render(this); }
-//│       static [definitionMetadata] = ["class", "Whoops"]; 
+//│       static [definitionMetadata] = ["class", "Whoops"];
 //│     });
 //│   }
 //│   static f() {
 //│     return "Hello"
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Whoops"]; 
+//│   static [definitionMetadata] = ["class", "Whoops"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -261,11 +261,11 @@ module AA with
 //│         return BB.y;
 //│       }
 //│       toString() { return runtime.render(this); }
-//│       static [definitionMetadata] = ["class", "BB"]; 
+//│       static [definitionMetadata] = ["class", "BB"];
 //│     });
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "AA"]; 
+//│   static [definitionMetadata] = ["class", "AA"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/Hygiene.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Hygiene.mls
@@ -94,10 +94,8 @@ module Test with
 //│   static {
 //│     Test4 = this
 //│   }
-//│   static #x;
 //│   static {
 //│     this.x = 1;
-//│     Test3.#x = 2;
 //│   }
 //│   toString() { return runtime.render(this); }
 //│   static [definitionMetadata] = ["class", "Test"];
@@ -231,7 +229,7 @@ Whoops.Whoops.g()
 :e
 Runtime
 //│ ╔══[COMPILATION ERROR] Name not found: Runtime
-//│ ║  l.232: 	Runtime
+//│ ║  l.230: 	Runtime
 //│ ╙──       	^^^^^^^
 //│ ═══[RUNTIME ERROR] This code cannot be run as its compilation yielded an error.
 

--- a/hkmc2/shared/src/test/mlscript/codegen/Inliner.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Inliner.mls
@@ -214,12 +214,12 @@ module A with
 //│   }
 //│   static f() {
 //│     return 1
-//│   } 
+//│   }
 //│   static g() {
 //│     return A1.f()
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "A"]; 
+//│   static [definitionMetadata] = ["class", "A"];
 //│ });
 //│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
 //│ let A⁰;

--- a/hkmc2/shared/src/test/mlscript/codegen/InnerNameHygiene.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/InnerNameHygiene.mls
@@ -95,11 +95,11 @@ class C with
 //│         globalThis.Object.freeze(new this$C.C());
 //│       }
 //│       toString() { return runtime.render(this); }
-//│       static [definitionMetadata] = ["class", "C"]; 
+//│       static [definitionMetadata] = ["class", "C"];
 //│     });
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "C"]; 
+//│   static [definitionMetadata] = ["class", "C"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -130,12 +130,12 @@ class CC with
 //│         globalThis.Object.freeze(new CC21());
 //│       }
 //│       toString() { return runtime.render(this); }
-//│       static [definitionMetadata] = ["class", "CC2"]; 
+//│       static [definitionMetadata] = ["class", "CC2"];
 //│     });
 //│     return globalThis.Object.freeze(new CC21());
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "CC"]; 
+//│   static [definitionMetadata] = ["class", "CC"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/ModuleMethods.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/ModuleMethods.mls
@@ -51,12 +51,12 @@ module Test with
 //│   }
 //│   static foo() {
 //│     return Predef.print(Test.#s)
-//│   } 
+//│   }
 //│   static bar() {
 //│     return Test.foo()
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Test"]; 
+//│   static [definitionMetadata] = ["class", "Test"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ > 1

--- a/hkmc2/shared/src/test/mlscript/codegen/Modules.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Modules.mls
@@ -10,7 +10,7 @@ module None
 //│     None1 = this
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "None"]; 
+//│   static [definitionMetadata] = ["class", "None"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -68,7 +68,7 @@ module M with
 //│         M.C = this
 //│       }
 //│       toString() { return runtime.render(this); }
-//│       static [definitionMetadata] = ["class", "C"]; 
+//│       static [definitionMetadata] = ["class", "C"];
 //│     });
 //│     this.D = function D() {
 //│       return globalThis.Object.freeze(new D.class());
@@ -78,14 +78,14 @@ module M with
 //│         M.D.class = this
 //│       }
 //│       toString() { return runtime.render(this); }
-//│       static [definitionMetadata] = ["class", "D", []]; 
+//│       static [definitionMetadata] = ["class", "D", []];
 //│     });
 //│     this.x = 1;
 //│     tmp = M.x + 1;
 //│     this.y = tmp;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "M"]; 
+//│   static [definitionMetadata] = ["class", "M"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -127,7 +127,7 @@ module M with
 //│     this.m = M3;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "M"]; 
+//│   static [definitionMetadata] = ["class", "M"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -165,11 +165,11 @@ module AA with
 //│         this.y = 2;
 //│       }
 //│       toString() { return runtime.render(this); }
-//│       static [definitionMetadata] = ["class", "BB"]; 
+//│       static [definitionMetadata] = ["class", "BB"];
 //│     });
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "AA"]; 
+//│   static [definitionMetadata] = ["class", "AA"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/NoFreeze.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/NoFreeze.mls
@@ -15,7 +15,7 @@ class Foo(val x)
 //│     this.x = x;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["x"]]; 
+//│   static [definitionMetadata] = ["class", "Foo", ["x"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -35,7 +35,7 @@ class Foo(val x)
 //│     this.x = x;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["x"]]; 
+//│   static [definitionMetadata] = ["class", "Foo", ["x"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/ParamClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/ParamClasses.mls
@@ -15,7 +15,7 @@ data class Foo()
 //│     Foo1.class = this
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", []]; 
+//│   static [definitionMetadata] = ["class", "Foo", []];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -52,7 +52,7 @@ data class Foo(a)
 //│     this.a = a;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["a"]]; 
+//│   static [definitionMetadata] = ["class", "Foo", ["a"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -97,7 +97,7 @@ data class Foo(a, b)
 //│     this.b = b;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["a", "b"]]; 
+//│   static [definitionMetadata] = ["class", "Foo", ["a", "b"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -178,7 +178,7 @@ data class Inner(c) with
 //│     return this.c + d
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Inner", ["c"]]; 
+//│   static [definitionMetadata] = ["class", "Inner", ["c"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -240,7 +240,7 @@ class Foo(x, val y, z, val z, z) with
 //│   #x1;
 //│   #y;
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", [null, "y", null, "z", null]]; 
+//│   static [definitionMetadata] = ["class", "Foo", [null, "y", null, "z", null]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -275,7 +275,7 @@ class Foo(val z, val z)
 //│     Foo9.class = this
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["z", "z"]]; 
+//│   static [definitionMetadata] = ["class", "Foo", ["z", "z"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/ParamClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/ParamClasses.mls
@@ -216,28 +216,24 @@ class Foo(x, val y, z, val z, z) with
 //│   }
 //│   constructor(x, y, z, z1, z2) {
 //│     let tmp3, tmp4, tmp5, tmp6, tmp7;
-//│     this.#x = x;
 //│     this.y = y;
-//│     this.#z = z;
 //│     this.z = z1;
-//│     this.#z1 = z2;
-//│     this.#x1 = 1;
+//│     this.#z = z2;
+//│     this.#x = 1;
 //│     this.#y = this.y + 1;
-//│     tmp3 = "x = " + this.#x1;
+//│     tmp3 = "x = " + this.#x;
 //│     Predef.print(tmp3);
 //│     tmp4 = "y = " + this.#y;
 //│     Predef.print(tmp4);
 //│     tmp5 = "this.y = " + this.y;
 //│     Predef.print(tmp5);
-//│     tmp6 = "z = " + this.#z1;
+//│     tmp6 = "z = " + this.#z;
 //│     Predef.print(tmp6);
 //│     tmp7 = "this.z = " + this.z;
 //│     Predef.print(tmp7);
 //│   }
-//│   #x;
 //│   #z;
-//│   #z1;
-//│   #x1;
+//│   #x;
 //│   #y;
 //│   toString() { return runtime.render(this); }
 //│   static [definitionMetadata] = ["class", "Foo", [null, "y", null, "z", null]];
@@ -260,10 +256,10 @@ Foo(10, 20, 30, 40, 50)
 class Foo(val z, val z)
 //│ ╔══[COMPILATION ERROR] Duplicate definition of member named 'z'.
 //│ ╟── Defined at: 
-//│ ║  l.260: 	class Foo(val z, val z)
+//│ ║  l.256: 	class Foo(val z, val z)
 //│ ║         	              ^
 //│ ╟── Defined at: 
-//│ ║  l.260: 	class Foo(val z, val z)
+//│ ║  l.256: 	class Foo(val z, val z)
 //│ ╙──       	                     ^
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
 //│ let Foo9;

--- a/hkmc2/shared/src/test/mlscript/codegen/PlainClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/PlainClasses.mls
@@ -184,12 +184,8 @@ class Foo with
 //│   constructor() {
 //│     this.x1 = 1;
 //│     this.x2 = 2;
-//│     this.#y1 = 3;
-//│     this.#y2 = 4;
 //│     Predef.print("hello");
 //│   }
-//│   #y1;
-//│   #y2;
 //│   z1() {
 //│     return 5
 //│   }
@@ -254,10 +250,10 @@ class Foo with
   val x = 2
 //│ ╔══[COMPILATION ERROR] Multiple definitions of symbol 'x'
 //│ ╟── defined here
-//│ ║  l.253: 	  val x = 1
+//│ ║  l.249: 	  val x = 1
 //│ ║         	  ^^^^^^^^^
 //│ ╟── defined here
-//│ ║  l.254: 	  val x = 2
+//│ ║  l.250: 	  val x = 2
 //│ ╙──       	  ^^^^^^^^^
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
 //│ let Foo12;
@@ -279,10 +275,10 @@ class Foo with
   val x = 1
   let x = 2
 //│ ╔══[COMPILATION ERROR] Name 'x' is already used
-//│ ║  l.280: 	  let x = 2
+//│ ║  l.276: 	  let x = 2
 //│ ║         	      ^^^^^
 //│ ╟── by a member declared in the same block
-//│ ║  l.279: 	  val x = 1
+//│ ║  l.275: 	  val x = 1
 //│ ╙──       	  ^^^^^^^^^
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
 //│ let Foo14;
@@ -292,9 +288,7 @@ class Foo with
 //│   }
 //│   constructor() {
 //│     this.x = 1;
-//│     this.#x = 2;
 //│   }
-//│   #x;
 //│   toString() { return runtime.render(this); }
 //│   static [definitionMetadata] = ["class", "Foo"];
 //│ });
@@ -310,7 +304,7 @@ class Foo with
 :e
 class Foo with val x = 1
 //│ ╔══[COMPILATION ERROR] Illegal body of class definition (should be a block; found term definition).
-//│ ║  l.311: 	class Foo with val x = 1
+//│ ║  l.305: 	class Foo with val x = 1
 //│ ╙──       	               ^^^^^^^^^
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
 //│ let Foo16;

--- a/hkmc2/shared/src/test/mlscript/codegen/PlainClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/PlainClasses.mls
@@ -12,7 +12,7 @@ class Foo
 //│     Foo1 = this
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo"]; 
+//│   static [definitionMetadata] = ["class", "Foo"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -68,7 +68,7 @@ print("ok")
 //│     Predef.print("hi");
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo"]; 
+//│   static [definitionMetadata] = ["class", "Foo"];
 //│ });
 //│ Predef.print("ok")
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
@@ -90,7 +90,7 @@ fun test() =
 //│       Predef.print("hi");
 //│     }
 //│     toString() { return runtime.render(this); }
-//│     static [definitionMetadata] = ["class", "Foo"]; 
+//│     static [definitionMetadata] = ["class", "Foo"];
 //│   });
 //│   Predef.print("ok");
 //│   return Foo5
@@ -162,7 +162,7 @@ class Foo with
 //│     return this.#y + this.x
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo"]; 
+//│   static [definitionMetadata] = ["class", "Foo"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -192,12 +192,12 @@ class Foo with
 //│   #y2;
 //│   z1() {
 //│     return 5
-//│   } 
+//│   }
 //│   z2() {
 //│     return 6
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo"]; 
+//│   static [definitionMetadata] = ["class", "Foo"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -217,14 +217,14 @@ class Foo with
 //│   }
 //│   foo(y) {
 //│     return this.x + y
-//│   } 
+//│   }
 //│   bar(z) {
 //│     let tmp;
 //│     tmp = this.foo(z);
 //│     return tmp + 1
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo"]; 
+//│   static [definitionMetadata] = ["class", "Foo"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -270,7 +270,7 @@ class Foo with
 //│     this.x = 2;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo"]; 
+//│   static [definitionMetadata] = ["class", "Foo"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -296,7 +296,7 @@ class Foo with
 //│   }
 //│   #x;
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo"]; 
+//│   static [definitionMetadata] = ["class", "Foo"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -319,7 +319,7 @@ class Foo with val x = 1
 //│     Foo16 = this
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo"]; 
+//│   static [definitionMetadata] = ["class", "Foo"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/RandomStuff.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/RandomStuff.mls
@@ -49,11 +49,11 @@ data class Foo(x) with
 //│         this.y = this$Foo.x;
 //│       }
 //│       toString() { return runtime.render(this); }
-//│       static [definitionMetadata] = ["class", "Bar"]; 
+//│       static [definitionMetadata] = ["class", "Bar"];
 //│     });
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["x"]]; 
+//│   static [definitionMetadata] = ["class", "Foo", ["x"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/SanityChecks.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/SanityChecks.mls
@@ -153,7 +153,7 @@ id(Cls(1, 2)).f(3, 4)(5)
 //│     }
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Cls", ["x", "y"]]; 
+//│   static [definitionMetadata] = ["class", "Cls", ["x", "y"]];
 //│ });
 //│ tmp4 = runtime.checkCall(Cls5(1, 2));
 //│ tmp5 = runtime.checkCall(Predef.id(tmp4));

--- a/hkmc2/shared/src/test/mlscript/codegen/ScopedBlocks.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/ScopedBlocks.mls
@@ -209,6 +209,6 @@ data class Baz(z) extends Bar(z * 1) with
 //│     return this.bar * 2;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Baz", ["z"]]; 
+//│   static [definitionMetadata] = ["class", "Baz", ["z"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————

--- a/hkmc2/shared/src/test/mlscript/codegen/SelfReferences.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/SelfReferences.mls
@@ -14,7 +14,7 @@ module Foo with
 //│     this.self = Foo1;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo"]; 
+//│   static [definitionMetadata] = ["class", "Foo"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -74,7 +74,7 @@ object Foo with
 //│     globalThis.Object.freeze(this);
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["object", "Foo"]; 
+//│   static [definitionMetadata] = ["object", "Foo"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/SpecialJSNames.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/SpecialJSNames.mls
@@ -25,7 +25,7 @@ module M with
 //│     Object.defineProperty(this, "name", { configurable: true, enumerable: true, writable: true, value: "Student" });
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "M"]; 
+//│   static [definitionMetadata] = ["class", "M"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -44,7 +44,7 @@ class C with
 //│     this.name = "Student";
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "C"]; 
+//│   static [definitionMetadata] = ["class", "C"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/codegen/This.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/This.mls
@@ -55,7 +55,7 @@ module Test with
 //│   }
 //│   static test1(x) {
 //│     return test1(x)
-//│   } 
+//│   }
 //│   static test2(x) {
 //│     return globalThis.Object.freeze([
 //│       Test.a,
@@ -63,7 +63,7 @@ module Test with
 //│     ])
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Test"]; 
+//│   static [definitionMetadata] = ["class", "Test"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/ctx/ClassCtxParams.mls
+++ b/hkmc2/shared/src/test/mlscript/ctx/ClassCtxParams.mls
@@ -115,7 +115,7 @@ class Foo(using T) with
 //│   }
 //│   #tmp;
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", [null]]; 
+//│   static [definitionMetadata] = ["class", "Foo", [null]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/ctx/ClassCtxParams.mls
+++ b/hkmc2/shared/src/test/mlscript/ctx/ClassCtxParams.mls
@@ -110,10 +110,8 @@ class Foo(using T) with
 //│     Foo9.class = this
 //│   }
 //│   constructor(tmp4) {
-//│     this.#tmp = tmp4;
 //│     Predef.print(T1);
 //│   }
-//│   #tmp;
 //│   toString() { return runtime.render(this); }
 //│   static [definitionMetadata] = ["class", "Foo", [null]];
 //│ });
@@ -123,10 +121,10 @@ class Foo(using T) with
 :sjs
 x => x.Foo#S
 //│ ╔══[COMPILATION ERROR] Class 'Foo' does not contain member 'S'.
-//│ ║  l.124: 	x => x.Foo#S
+//│ ║  l.122: 	x => x.Foo#S
 //│ ╙──       	           ^
 //│ ╔══[COMPILATION ERROR] Cannot query instance of type T for call: 
-//│ ║  l.124: 	x => x.Foo#S
+//│ ║  l.122: 	x => x.Foo#S
 //│ ║         	      ^^^^
 //│ ╟── Required by contextual parameter declaration: 
 //│ ║  l.101: 	class Foo(using T) with

--- a/hkmc2/shared/src/test/mlscript/dead-param-elim/class-in-fun.mls
+++ b/hkmc2/shared/src/test/mlscript/dead-param-elim/class-in-fun.mls
@@ -21,7 +21,7 @@ f(1, 2).get()
 //│ define C⁰ as class C¹ {
 //│   private val used⁰;
 //│   constructor(used) {
-//│     set used⁰ = used;
+//│     set C¹.this.used = used;
 //│     end
 //│   }
 //│   method get⁰ = fun get¹() {

--- a/hkmc2/shared/src/test/mlscript/dead-param-elim/recursive.mls
+++ b/hkmc2/shared/src/test/mlscript/dead-param-elim/recursive.mls
@@ -241,11 +241,7 @@ class Test(a) with
 //│     end
 //│   }
 //│ };
-//│ define Test⁰ as class Test²(a) {
-//│   private val a⁰;
-//│   constructor Test¹ { set Test².this.a = a; end }
-//│   method f⁰ = fun f¹() { return pong⁷(3) }
-//│ };
+//│ define Test⁰ as class Test¹(a) { method f⁰ = fun f¹() { return pong⁷(3) } };
 //│ end
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/deforest/relaxedPrograms.mls
+++ b/hkmc2/shared/src/test/mlscript/deforest/relaxedPrograms.mls
@@ -131,8 +131,6 @@ c.get() + c.get()
 //│ c = C(_)
 
 
-// TODO: private members aren't visible outside
-:fixme
 :deforest
 module M with
   let _private = 3
@@ -148,9 +146,7 @@ M.f()
 //│ deforest > 	match: scrut⁷
 //│ deforest > 	fields: scrut⁷.x⁰
 //│ deforest > <<< fusing <<<
-//│ > let M1, f_7$scrut_AA, f_6$f, f_6$scrut_AA, inlinedVal1, scrut3, AA_x3;try { globalThis.Object.freeze(class M {   static {     M1 = this   }   static #_private;   static {     M.#_private = 3;   }   static f() {     runtime.checkArgs("f", 0, true, arguments.length);     let scrut4, AA_x4;     AA_x4 = 1;     scrut4 = (fv_ctorLam__private) => {       let AA_x5, inlinedVal2;       AA_x5 = AA_x4;       inlinedVal2 = AA_x5 + fv_ctorLam__private;       return inlinedVal2     };     return runtime.checkCall(scrut4(M.#_private))   }   toString() { return runtime.render(this); }   static [definitionMetadata] = ["class", "M"];  }); AA_x3 = 1; scrut3 = (fv_ctorLam__private) => {   let AA_x4, inlinedVal2;   AA_x4 = AA_x3;   inlinedVal2 = AA_x4 + fv_ctorLam__private;   return inlinedVal2 }; inlinedVal1 = runtime.checkCall(scrut3(M.#_private)); block$res6 = inlinedVal1; undefined; undefined } catch (e) { console.log('\u200B' + e + '\u200B'); }
-//│ >                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             ^
-//│ ═══[COMPILATION ERROR] [Uncaught SyntaxError] Private field '#_private' must be declared in an enclosing class
+//│ = 4
 
 
 

--- a/hkmc2/shared/src/test/mlscript/handlers/Effects.mls
+++ b/hkmc2/shared/src/test/mlscript/handlers/Effects.mls
@@ -121,7 +121,7 @@ result
 //│     return runtime.mkEffect(this, Handler$h$perform$here)
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Handler$h$"]; 
+//│   static [definitionMetadata] = ["class", "Handler$h$"];
 //│ });
 //│ h7 = new Handler$h$15();
 //│ handleBlock$7 = (undefined, function () {

--- a/hkmc2/shared/src/test/mlscript/handlers/EffectsHygiene.mls
+++ b/hkmc2/shared/src/test/mlscript/handlers/EffectsHygiene.mls
@@ -38,7 +38,7 @@ fun foo(h): module M =
 //│         A2 = this
 //│       }
 //│       toString() { return runtime.render(this); }
-//│       static [definitionMetadata] = ["class", "A"]; 
+//│       static [definitionMetadata] = ["class", "A"];
 //│     });
 //│     return A2
 //│   }
@@ -47,7 +47,7 @@ fun foo(h): module M =
 //│       A3 = this
 //│     }
 //│     toString() { return runtime.render(this); }
-//│     static [definitionMetadata] = ["class", "A"]; 
+//│     static [definitionMetadata] = ["class", "A"];
 //│   });
 //│   return A3;
 //│ };

--- a/hkmc2/shared/src/test/mlscript/handlers/EffectsInClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/handlers/EffectsInClasses.mls
@@ -33,7 +33,7 @@ data class Lol(h) with
 //│     }
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Lol", ["h"]]; 
+//│   static [definitionMetadata] = ["class", "Lol", ["h"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/handlers/RecursiveHandlers.mls
+++ b/hkmc2/shared/src/test/mlscript/handlers/RecursiveHandlers.mls
@@ -244,7 +244,7 @@ str
 //│     return runtime.mkEffect(this, Handler$h2$perform$here)
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Handler$h2$"]; 
+//│   static [definitionMetadata] = ["class", "Handler$h2$"];
 //│ });
 //│ handleBlock$9 = (undefined, function (h22) {
 //│   let pc;
@@ -287,7 +287,7 @@ str
 //│     return runtime.mkEffect(this, Handler$h1$perform$here)
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Handler$h1$"]; 
+//│   static [definitionMetadata] = ["class", "Handler$h1$"];
 //│ });
 //│ handleBlock$10 = (undefined, function () {
 //│   let h22, tmp10, handleBlock$$here, pc;

--- a/hkmc2/shared/src/test/mlscript/invalml/InvalMLCodeGen.mls
+++ b/hkmc2/shared/src/test/mlscript/invalml/InvalMLCodeGen.mls
@@ -79,7 +79,7 @@ data class Foo(x: Int)
 //│     this.x = x;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["x"]]; 
+//│   static [definitionMetadata] = ["class", "Foo", ["x"]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/lifter/ClassInFun.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/ClassInFun.mls
@@ -84,7 +84,7 @@ fun f(x) =
 //│ define C⁰ as class C¹ {
 //│   private val x⁰;
 //│   constructor(x) {
-//│     set x⁰ = x;
+//│     set C¹.this.x = x;
 //│     end
 //│   }
 //│   method y⁰ = fun y¹ { return C¹.this.x⁰ }
@@ -126,27 +126,27 @@ f().foo()
 //│   private val x¹;
 //│   private val y²;
 //│   constructor Good¹(scope0$cap, x, y) {
-//│     set scope0$cap⁰ = scope0$cap;
-//│     set x¹ = x;
-//│     set y² = y;
+//│     set Good².this.scope0$cap = scope0$cap;
+//│     set Good².this.x = x;
+//│     set Good².this.y = y;
 //│     end
 //│   }
 //│   method foo⁰ = fun foo¹() {
 //│     let tmp1, tmp2;
-//│     set scope0$cap⁰.z$0 = 100;
+//│     set Good².this.scope0$cap⁰.z$0 = 100;
 //│     set tmp1 = +⁰(Good².this.x¹, Good².this.y²);
-//│     set tmp2 = +⁰(tmp1, scope0$cap⁰.z$0¹);
-//│     return +⁰(tmp2, scope0$cap⁰.w$1¹)
+//│     set tmp2 = +⁰(tmp1, Good².this.scope0$cap⁰.z$0¹);
+//│     return +⁰(tmp2, Good².this.scope0$cap⁰.w$1¹)
 //│   }
 //│ };
 //│ define Bad⁰ as class Bad²() {
 //│   private val scope0$cap¹;
 //│   constructor Bad¹(scope0$cap) {
-//│     set scope0$cap¹ = scope0$cap;
+//│     set Bad².this.scope0$cap = scope0$cap;
 //│     end
 //│   }
 //│   method foo² = fun foo³() {
-//│     set scope0$cap¹.w$1 = 10000;
+//│     set Bad².this.scope0$cap¹.w$1 = 10000;
 //│     return runtime⁰.Unit⁰
 //│   }
 //│ };
@@ -332,7 +332,7 @@ fun main(x) =
 //│   private val x²;
 //│   val a²;
 //│   constructor C⁶(x) {
-//│     set x² = x;
+//│     set C⁷.this.x = x;
 //│     define a² as val a³ = a;
 //│     end
 //│   }

--- a/hkmc2/shared/src/test/mlscript/lifter/CurriedClassInFun.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/CurriedClassInFun.mls
@@ -41,7 +41,7 @@ fun f(x) =
 //│   val y⁰;
 //│   val z⁰;
 //│   constructor A²(f$cap)(z) {
-//│     set f$cap⁰ = f$cap;
+//│     set A¹.this.f$cap = f$cap;
 //│     define y⁰ as val y¹ = y;
 //│     define z⁰ as val z¹ = z;
 //│     end
@@ -50,16 +50,16 @@ fun f(x) =
 //│     let tmp, tmp1;
 //│     set tmp = +⁰(A¹.this.y¹, 1);
 //│     set tmp1 = +⁰(A¹.this.z¹, 1);
-//│     return new A¹(tmp)(f$cap⁰)(tmp1)
+//│     return new A¹(tmp)(A¹.this.f$cap⁰)(tmp1)
 //│   }
 //│   method foo⁰ = fun foo¹() {
 //│     let tmp;
-//│     set tmp = +⁰(f$cap⁰.x$0⁰, 1);
-//│     set f$cap⁰.x$0 = tmp;
-//│     return f$cap⁰.x$0⁰
+//│     set tmp = +⁰(A¹.this.f$cap⁰.x$0⁰, 1);
+//│     set A¹.this.f$cap⁰.x$0 = tmp;
+//│     return A¹.this.f$cap⁰.x$0⁰
 //│   }
 //│   method getX⁰ = fun getX¹() {
-//│     return f$cap⁰.x$0⁰
+//│     return A¹.this.f$cap⁰.x$0⁰
 //│   }
 //│ };
 //│ define Capture$f⁰ as class Capture$f² {

--- a/hkmc2/shared/src/test/mlscript/lifter/DefnsInClass.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/DefnsInClass.mls
@@ -88,4 +88,4 @@ a.f()
 a.f()
 a.bruh()
 //│ = 6
-//│ a = A { A$cap: Capture$A { x$0: 6 }, bruh: fun }
+//│ a = A { bruh: fun }

--- a/hkmc2/shared/src/test/mlscript/lifter/DefnsInClass.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/DefnsInClass.mls
@@ -14,7 +14,7 @@ data class A(x) with
 //│   private val A¹;
 //│   val y⁰;
 //│   constructor B¹(A) {
-//│     set A¹ = A;
+//│     set B².this.A = A;
 //│     define y⁰ as val y¹ = y;
 //│     end
 //│   }

--- a/hkmc2/shared/src/test/mlscript/lifter/Imports.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/Imports.mls
@@ -19,7 +19,7 @@ module A with
 //│     return false;
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "A"]; 
+//│   static [definitionMetadata] = ["class", "A"];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/lifter/ModulesObjects.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/ModulesObjects.mls
@@ -38,11 +38,11 @@ foo(10)
 //│ define M⁰ as class M¹ {
 //│   private val y⁰;
 //│   constructor(y) {
-//│     set y⁰ = y;
+//│     set M¹.this.y = y;
 //│     end
 //│   }
 //│   method foo¹ = fun foo²() {
-//│     set y⁰ = 2;
+//│     set M¹.this.y = 2;
 //│     return runtime⁰.Unit⁰
 //│   }
 //│ };

--- a/hkmc2/shared/src/test/mlscript/lifter/PrivateMutableFields.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/PrivateMutableFields.mls
@@ -39,14 +39,14 @@ class Foo(x) with
 //│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
 //│ let Foo⁰, $anon⁰;
 //│ define $anon⁰ as class $anon¹ {
-//│   private val x⁰;
+//│   private val Foo¹;
 //│   private val y⁰;
 //│   private val state⁰;
-//│   constructor(x, y) {
+//│   constructor(Foo, y) {
 //│     super⁰();
-//│     set x⁰ = x;
+//│     set Foo¹ = Foo;
 //│     set y⁰ = y;
-//│     set $anon¹.this.state = $anon¹.this.x⁰;
+//│     set $anon¹.this.state = $anon¹.this.Foo¹.x⁰;
 //│     end
 //│   }
 //│   method test⁰ = fun test¹ {
@@ -56,13 +56,13 @@ class Foo(x) with
 //│     return +⁰($anon¹.this.state⁰, $anon¹.this.y⁰)
 //│   }
 //│ };
-//│ define Foo⁰ as class Foo²(x) {
-//│   private val x¹;
-//│   constructor Foo¹ {
-//│     set Foo².this.x = x;
+//│ define Foo⁰ as class Foo³(x) {
+//│   private val x⁰;
+//│   constructor Foo² {
+//│     set Foo³.this.x = x;
 //│     end
 //│   }
-//│   method foo⁰ = fun foo¹(y) { return new $anon¹(Foo².this.x¹, y) }
+//│   method foo⁰ = fun foo¹(y) { return new $anon¹(Foo³.this, y) }
 //│ };
 //│ end
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
@@ -84,4 +84,66 @@ o.test
 f.foo(456).test
 //│ = 580
 
+
+:sjs
+class AccessorBox with
+  let value = 1
+  fun accessor =
+    new with
+      fun read = value
+      fun write(next) =
+        set value = next
+        value
+//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
+//│ const accessorSymbol$1 = globalThis.Symbol("value");
+//│ let AccessorBox1, $anon5;
+//│ (class $anon4 extends globalThis.Object {
+//│   static {
+//│     $anon5 = this
+//│   }
+//│   constructor(AccessorBox2) {
+//│     super();
+//│     this.#AccessorBox = AccessorBox2;
+//│   }
+//│   #AccessorBox;
+//│   get read() {
+//│     return this.#AccessorBox[accessorSymbol$1];
+//│   }
+//│   write(next) {
+//│     this.#AccessorBox[accessorSymbol$1] = next;
+//│     return this.#AccessorBox[accessorSymbol$1]
+//│   }
+//│   toString() { return runtime.render(this); }
+//│   static [definitionMetadata] = ["class", "$anon"];
+//│ });
+//│ (class AccessorBox {
+//│   static {
+//│     AccessorBox1 = this
+//│   }
+//│   constructor() {
+//│     this.#value = 1;
+//│   }
+//│   #value;
+//│   get [accessorSymbol$1]() { return this.#value; }
+//│   set [accessorSymbol$1](value) { this.#value = value; }
+//│   get accessor() {
+//│     return globalThis.Object.freeze(new $anon5(this));
+//│   }
+//│   toString() { return runtime.render(this); }
+//│   static [definitionMetadata] = ["class", "AccessorBox"];
+//│ });
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+
+let b = new AccessorBox
+let a = b.accessor
+a.read
+//│ = 1
+//│ a = $anon
+//│ b = AccessorBox
+
+a.write(7)
+//│ = 7
+
+a.read
+//│ = 7
 

--- a/hkmc2/shared/src/test/mlscript/lifter/PrivateMutableFields.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/PrivateMutableFields.mls
@@ -44,8 +44,8 @@ class Foo(x) with
 //│   private val state⁰;
 //│   constructor(Foo, y) {
 //│     super⁰();
-//│     set Foo¹ = Foo;
-//│     set y⁰ = y;
+//│     set $anon¹.this.Foo = Foo;
+//│     set $anon¹.this.y = y;
 //│     set $anon¹.this.state = $anon¹.this.Foo¹.x⁰;
 //│     end
 //│   }

--- a/hkmc2/shared/src/test/mlscript/objbuf/Mutation.mls
+++ b/hkmc2/shared/src/test/mlscript/objbuf/Mutation.mls
@@ -48,7 +48,7 @@ class A(x) with
 //│       buf.buf[idx2] = buf.buf.at(idx1);
 //│       return idx
 //│     }
-//│   } 
+//│   }
 //│   static f(buf, idx) {
 //│     return (y) => {
 //│       let tmp, tmp1, idx1, idx2, idx3, idx4, idx5;
@@ -77,7 +77,7 @@ class A(x) with
 //│     return this.#x
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "A", [null]]; 
+//│   static [definitionMetadata] = ["class", "A", [null]];
 //│ });
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/opt/DeadObjRemoval.mls
+++ b/hkmc2/shared/src/test/mlscript/opt/DeadObjRemoval.mls
@@ -40,7 +40,7 @@ f()
 //│       globalThis.Object.freeze(this);
 //│     }
 //│     toString() { return runtime.render(this); }
-//│     static [definitionMetadata] = ["object", "A"]; 
+//│     static [definitionMetadata] = ["object", "A"];
 //│   });
 //│   return 42
 //│ };

--- a/hkmc2/shared/src/test/mlscript/opt/PrivateFields.mls
+++ b/hkmc2/shared/src/test/mlscript/opt/PrivateFields.mls
@@ -100,19 +100,20 @@ Bar.test2
 
 :soir
 object UnusedObjectPrivate with
-  let used = 1
-  let unused = 2
+  let used = print(1)
+  let unused = print(2)
   fun get = used
 module UnusedModulePrivate with
-  let used = 3
-  let unused = 4
+  let used = print(3)
+  let unused = print(4)
   fun get = used
 //│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
 //│ let UnusedModulePrivate⁰, UnusedObjectPrivate⁰;
 //│ define UnusedObjectPrivate⁰ as object UnusedObjectPrivate¹ {
 //│   private val used⁰;
 //│   constructor {
-//│     set UnusedObjectPrivate¹.this.used = 1;
+//│     set UnusedObjectPrivate¹.this.used = Predef⁰.print⁰(1);
+//│     do Predef⁰.print⁰(2);
 //│     end
 //│   }
 //│   method get⁰ = fun get¹ {
@@ -123,13 +124,20 @@ module UnusedModulePrivate with
 //│ module UnusedModulePrivate² {
 //│   private val used¹;
 //│   constructor {
-//│     set UnusedModulePrivate².this.used = 3;
+//│     set UnusedModulePrivate².this.used = Predef⁰.print⁰(3);
+//│     do Predef⁰.print⁰(4);
 //│     end
 //│   }
 //│   method get² = fun get³ { return UnusedModulePrivate².this.used¹ }
 //│ };
 //│ end
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+//│ > 1
+//│ > 2
+//│ > 3
+//│ > 4
 
 UnusedObjectPrivate.get + UnusedModulePrivate.get
-//│ = 4
+//│ = "()()"
+
+

--- a/hkmc2/shared/src/test/mlscript/opt/PrivateFields.mls
+++ b/hkmc2/shared/src/test/mlscript/opt/PrivateFields.mls
@@ -97,3 +97,39 @@ Bar.test1
 Bar.test2
 //│ = 1
 
+
+:soir
+object UnusedObjectPrivate with
+  let used = 1
+  let unused = 2
+  fun get = used
+module UnusedModulePrivate with
+  let used = 3
+  let unused = 4
+  fun get = used
+//│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
+//│ let UnusedModulePrivate⁰, UnusedObjectPrivate⁰;
+//│ define UnusedObjectPrivate⁰ as object UnusedObjectPrivate¹ {
+//│   private val used⁰;
+//│   constructor {
+//│     set UnusedObjectPrivate¹.this.used = 1;
+//│     end
+//│   }
+//│   method get⁰ = fun get¹ {
+//│     return UnusedObjectPrivate¹.this.used⁰
+//│   }
+//│ };
+//│ define UnusedModulePrivate⁰ as class UnusedModulePrivate¹
+//│ module UnusedModulePrivate² {
+//│   private val used¹;
+//│   constructor {
+//│     set UnusedModulePrivate².this.used = 3;
+//│     end
+//│   }
+//│   method get² = fun get³ { return UnusedModulePrivate².this.used¹ }
+//│ };
+//│ end
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+
+UnusedObjectPrivate.get + UnusedModulePrivate.get
+//│ = 4

--- a/hkmc2/shared/src/test/mlscript/tailrec/TailRecOpt.mls
+++ b/hkmc2/shared/src/test/mlscript/tailrec/TailRecOpt.mls
@@ -87,12 +87,12 @@ A.sum(20000)
 //│       acc = tmp1;
 //│       continue loopLabel;
 //│     }
-//│   } 
+//│   }
 //│   static sum(n) {
 //│     return A.sum_impl(n, 0)
 //│   }
 //│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "A"]; 
+//│   static [definitionMetadata] = ["class", "A"];
 //│ });
 //│ A1.sum(20000)
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————


### PR DESCRIPTION
References to private fields sometimes have to get extruded from their scope, due to things like lifting, deforestation, and (eventually) method inlining.

This PR allows the IR to refer to a class' private fields directly. When targeting JS, we now generates appropriate accessors to compile these private field accesses. We only generate those accessors that are needed for the generated code to work.

We also now eliminate unused private fields as part of the simple DCE pass.