### PR TITLE
Implement inline wrappers

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -610,8 +610,6 @@ sealed abstract class Defn:
         -- auxParams.flatMap(_.paramSyms)
   
 
-// NOTE: Setting isTailRec to false does not affect whether the function is optimized.
-// It only affects whether a warning is thrown if the function is not actually tailrec.
 final case class FunDefn(
     owner: Opt[InnerSymbol],
     sym: BlockMemberSymbol,
@@ -625,6 +623,7 @@ final case class FunDefn(
   val innerSym = N
   val asPath = Value.Ref(sym, S(dSym))
   lazy val forceTailRec: Bool = annotations.contains(Annot.TailRec)
+  lazy val inline: Bool = annotations.contains(Annot.Inline)
   lazy val visibility: Visibility = annotations.collectFirst:
     case Annot.Modifier(Keyword.`private`) => Visibility.Private
     case Annot.Modifier(Keyword.`public`) => Visibility.Public

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -622,7 +622,7 @@ final case class FunDefn(
 ) extends Defn:
   val innerSym = N
   val asPath = Value.Ref(sym, S(dSym))
-  lazy val forceTailRec: Bool = annotations.contains(Annot.TailRec)
+  lazy val tailRec: Bool = annotations.contains(Annot.TailRec)
   lazy val inline: Bool = annotations.contains(Annot.Inline)
   lazy val visibility: Visibility = annotations.collectFirst:
     case Annot.Modifier(Keyword.`private`) => Visibility.Private

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -881,7 +881,7 @@ class BlockSimplifier
         
         // Whether this function can be inlined without causing any code duplication,
         // i.e. the original definition can be removed and there is only one usage.
-        def canBeInlineEliminated =
+        def canBeInlineEliminated: Bool =
           isPrivate && !isMethod && useCount <= 1 && !disallowElimination && !isLoopBreaker
           // false
         
@@ -889,6 +889,8 @@ class BlockSimplifier
           if isLoopBreaker then return false
           // method requires the capturing of `this`, which is not supported currently.
           if isMethod then return false
+          // If the definition is marked with inline, we should inline it regardless of the size of the body.
+          if defn.inline then return true
           val threshold = summon[Config.Inliner].inlineThreshold
           newBlk.size <= threshold || canBeInlineEliminated
         
@@ -896,6 +898,7 @@ class BlockSimplifier
       
       case class FunLikeContext(
         curFunSym: Opt[TermSymbol],
+        hasInlineAnnot: Bool,
       )
       
       class Traverser extends BlockTraverser:
@@ -903,21 +906,21 @@ class BlockSimplifier
         val useCnt = MutMap.WithDefault(MutMap.empty[TermSymbol, Int], _ => 0)
         val usages = MutMap.WithDefault(MutMap.empty[TermSymbol, List[(Option[TermSymbol], Call)]], _ => Nil)
         val hasNakedRef = MutMap.WithDefault(MutMap.empty[TermSymbol, Bool], _ => false)
-        var contextList: List[FunLikeContext] = FunLikeContext(N) :: Nil
+        var contextList: List[FunLikeContext] = FunLikeContext(N, false) :: Nil
         
         def currentContext = contextList.head
         
         def currentFunSym = currentContext.curFunSym
         
-        def nested(ts: Option[TermSymbol])(thunk: => Unit) =
-          contextList = FunLikeContext(ts) :: contextList
+        def nested(ts: Option[TermSymbol], hasInlineAnnot: Bool)(thunk: => Unit) =
+          contextList = FunLikeContext(ts, hasInlineAnnot) :: contextList
           thunk
           val res = contextList.head
           contextList = contextList.tail
           res
         
         def addFunctionAndApplyBody(f: FunDefn, isMethod: Bool) =
-          val r = nested(S(f.dSym)):
+          val r = nested(S(f.dSym), f.inline):
             applyBlock(f.body)
           map = map + (f.dSym -> InlinerFunInfo(f, isMethod, 0, false, false))
         
@@ -929,7 +932,7 @@ class BlockSimplifier
             c.methods.foreach: f =>
               addFunctionAndApplyBody(f, true)
             // Note: no tracking, since `Instantiate` will not be inlined and won't cause cycles.
-            nested(N):
+            nested(N, false):
               applySubBlock(c.preCtor)
               applySubBlock(c.ctor)
             c.companion.foreach: m =>
@@ -941,6 +944,9 @@ class BlockSimplifier
         
         override def applyResult(r: Result): Unit = r match
           case c @ Call(TermSymbolPath(ts), argss) =>
+            if currentContext.hasInlineAnnot then
+              // Not eligible for inline elimination
+              hasNakedRef(ts) = true
             useCnt(ts) += 1
             usages(ts) ::= (currentFunSym, c)
             argss.foreach(_.foreach(applyArg))
@@ -1020,6 +1026,14 @@ class BlockSimplifier
         // Key in map but value is None -> the optimized body is being computed
         // Key in map with value -> the function is optimized
         val newFunctionBody = MutMap.empty[TermSymbol, Option[Block]]
+        var insideInlineAnnotatedFunction = false
+
+        inline def enterFunBlock[T](inlineAnnot: Bool, inline thunk: => T): T =
+          val old = insideInlineAnnotatedFunction
+          insideInlineAnnotatedFunction = inlineAnnot
+          val res = thunk
+          insideInlineAnnotatedFunction = old
+          res
         
         override def applyMainBlock(main: Block): Block =
           super.applyMainBlock(main).flattened
@@ -1036,7 +1050,7 @@ class BlockSimplifier
           newFunctionBody.get(fun.dSym) match
             case N =>
               newFunctionBody(fun.dSym) = N
-              val newBdy = applyBlock(fun.body)
+              val newBdy = enterFunBlock(fun.inline, applyBlock(fun.body))
               newFunctionBody(fun.dSym) = S(newBdy)
               if newBdy is fun.body then fun else
               FunDefn(fun.owner, fun.sym, fun.dSym, fun.params, newBdy)(fun.configOverride, fun.annotations)
@@ -1052,12 +1066,12 @@ class BlockSimplifier
             newFunctionBody.get(ts)
             .getOrElse:
               newFunctionBody(ts) = N
-              val newBdy = applyBlock(m(ts).defn.body)
+              val newBdy = enterFunBlock(m(ts).defn.inline, applyBlock(m(ts).defn.body))
               newFunctionBody(ts) = S(newBdy)
               S(newBdy)
             .fold(super.applyResult(r)(k)): blk =>
               val info = m(ts)
-              if !info.shouldBeInlined(blk) then
+              if !info.shouldBeInlined(blk) || insideInlineAnnotatedFunction then
                 super.applyResult(r)(k)
               else
                 val matchedArgs = matchAllArgs(argss, info.defn.params)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -905,7 +905,7 @@ class BlockSimplifier
         var map: InlinerMap = Map.empty
         val useCnt = MutMap.WithDefault(MutMap.empty[TermSymbol, Int], _ => 0)
         val usages = MutMap.WithDefault(MutMap.empty[TermSymbol, List[(Option[TermSymbol], Call)]], _ => Nil)
-        val hasNakedRef = MutMap.WithDefault(MutMap.empty[TermSymbol, Bool], _ => false)
+        val disallowElimination = MutMap.WithDefault(MutMap.empty[TermSymbol, Bool], _ => false)
         var contextList: List[FunLikeContext] = FunLikeContext(N, false) :: Nil
         
         def currentContext = contextList.head
@@ -946,7 +946,7 @@ class BlockSimplifier
           case c @ Call(TermSymbolPath(ts), argss) =>
             if currentContext.hasInlineAnnot then
               // Not eligible for inline elimination
-              hasNakedRef(ts) = true
+              disallowElimination(ts) = true
             useCnt(ts) += 1
             usages(ts) ::= (currentFunSym, c)
             argss.foreach(_.foreach(applyArg))
@@ -955,13 +955,13 @@ class BlockSimplifier
         override def applySymbol(sym: Symbol): Unit =
           sym.asTrm.foreach: ts =>
             useCnt(ts) += 1
-            hasNakedRef(ts) = true
+            disallowElimination(ts) = true
         
         def analyze(blk: Block): InlinerMap =
           applyBlock(blk)
           map.foreach: (sym, info) =>
             info.useCount = useCnt(sym)
-            info.disallowElimination = info.disallowElimination || hasNakedRef(sym)
+            info.disallowElimination = info.disallowElimination || disallowElimination(sym)
           val edges: Buffer[(TermSymbol, TermSymbol)] = Buffer.empty
           usages.foreach: (sym, calls) =>
             calls.foreach: (caller, call) =>
@@ -1071,7 +1071,10 @@ class BlockSimplifier
               S(newBdy)
             .fold(super.applyResult(r)(k)): blk =>
               val info = m(ts)
-              if !info.shouldBeInlined(blk) || insideInlineAnnotatedFunction then
+              // If both callee and caller are marked with inline, inlining will not be blocked.
+              // Remark: the case of a recursive function marked with inline will be blocked by loop breaker logic.
+              val inliningBlocked = insideInlineAnnotatedFunction && !info.defn.inline
+              if !info.shouldBeInlined(blk) || inliningBlocked then
                 super.applyResult(r)(k)
               else
                 val matchedArgs = matchAllArgs(argss, info.defn.params)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -985,7 +985,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         else fun.annotations)
       LifterResult(newDefn, rewriter.extraDefns.toList)
     
-    // Definition with the auxiliary parameters merged into the second parameter list.
+    // Definition with the auxiliary parameters as a new first parameter list.
     private def mkAuxDefn: FunDefn =
       val newPList = PlainParamList(dupParams(auxParams))
       val (newPlists, syms, restSym) = fun.params match
@@ -1012,7 +1012,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         auxDsym,
         newPlists,
         bod
-      )(N, fun.annotations)
+      )(N, Annot.Inline :: fun.annotations)
     
     private val aux = Lazy[Defn](mkAuxDefn)
     

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -1307,10 +1307,9 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
       msg match
         case S(value) => WarningReport(value -> annot.toLoc :: Nil)
         case N => WarningReport(msg"This annotation has no effect." -> annot.toLoc :: Nil)
-    annotations.foreach: a =>
-      a match
+    annotations.foreach:
       case Annot.Untyped => ()
-      case Annot.TailRec | Annot.Inline =>
+      case a @ (Annot.TailRec | Annot.Inline) =>
         val annot = a match
           case Annot.TailRec => "@tailrec"
           case Annot.Inline => "@inline"

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -1308,7 +1308,6 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
         case S(value) => WarningReport(value -> annot.toLoc :: Nil)
         case N => WarningReport(msg"This annotation has no effect." -> annot.toLoc :: Nil)
     annotations.foreach: a =>
-      tl.log(s"wwww $a")
       a match
       case Annot.Untyped => ()
       case Annot.TailRec | Annot.Inline =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -1307,12 +1307,18 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
       msg match
         case S(value) => WarningReport(value -> annot.toLoc :: Nil)
         case N => WarningReport(msg"This annotation has no effect." -> annot.toLoc :: Nil)
-    annotations.foreach:
+    annotations.foreach: a =>
+      tl.log(s"wwww $a")
+      a match
       case Annot.Untyped => ()
-      case a @ Annot.TailRec =>
+      case Annot.TailRec | Annot.Inline =>
+        val annot = a match
+          case Annot.TailRec => "@tailrec"
+          case Annot.Inline => "@inline"
+        
         target match
           case TermDefinition(body = S(bod), k = syntax.Fun) => ()
-          case TermDefinition(k = syntax.Fun) => warn(a, S(msg"Only functions with a body may be marked as @tailrec."))
+          case TermDefinition(k = syntax.Fun) => warn(a, S(msg"Only functions with a body may be marked as $annot."))
           case _ => warn(a)
         
       case Annot.Modifier(syntax.Keyword.`public` | syntax.Keyword.`private` | syntax.Keyword.`virtual`) => ()

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
@@ -246,12 +246,12 @@ class TailRecOpt(using State, TL, Raise):
     val nonTailCalls = nonTailCallsLs.toMap
     
     if nonTailCallsLs.sizeCompare(calls) === 0 then
-      for f <- funs if f.forceTailRec do
+      for f <- funs if f.tailRec do
         raise(WarningReport(msg"This function does not directly self-recurse, but is marked @tailrec." -> f.dSym.toLoc :: Nil))
       return (N, funs)
     
     if !nonTailCalls.isEmpty then
-      for f <- funs if f.forceTailRec do
+      for f <- funs if f.tailRec do
         val reportLoc = nonTailCalls.get(f.dSym) match
           // always display a call to f, if possible
           case Some(value) => value.toLoc 
@@ -555,7 +555,7 @@ class TailRecOpt(using State, TL, Raise):
     new BlockTraverserShallow():
       for f <- c.methods do
         applyBlock(f.body)
-        if f.forceTailRec then
+        if f.tailRec then
           raise(ErrorReport(msg"Class methods may not yet be marked @tailrec." -> f.dSym.toLoc :: Nil))
       override def applyResult(r: Result): Unit = r match
         case c: Call if c.explicitTailCall =>
@@ -641,7 +641,7 @@ class TailRecOpt(using State, TL, Raise):
     val tailRecFunSyms = tailRecFuns.map(_.dSym).toSet
     new BlockTraverser:
       override def applyFunDefn(fun: FunDefn): Unit =
-        if fun.forceTailRec && !tailRecFunSyms.contains(fun.dSym) then
+        if fun.tailRec && !tailRecFunSyms.contains(fun.dSym) then
           raise(ErrorReport(
             msg"This @tailrec function was not processed by the tail-call optimizer." -> fun.dSym.toLoc :: Nil))
         super.applyFunDefn(fun)

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
@@ -231,9 +231,6 @@ object Elaborator:
       val Object = assumeBuiltinCls("Object")
       val Array = assumeBuiltinCls("Array")
       val TypedArray = assumeBuiltinCls("TypedArray")
-      val untyped = assumeBuiltinTpe("untyped")
-      val tailrec = assumeBuiltinTpe("tailrec")
-      val tailcall = assumeBuiltinTpe("tailcall")
       // println(s"Builtins: $Int, $Num, $Str, $untyped")
       class VirtualModule(val module: ModuleOrObjectSymbol):
         val bms = getBuiltin(module.nme) match
@@ -274,6 +271,10 @@ object Elaborator:
       object debug extends VirtualModule(assumeBuiltinMod("debug")):
         val printStack = assumeObject("printStack")
       object annotations extends VirtualModule(assumeBuiltinMod("annotations")):
+        val untyped = assumeObject("untyped")
+        val tailrec = assumeObject("tailrec")
+        val tailcall = assumeObject("tailcall")
+        val inline = assumeObject("inline")
         val compile = assumeObject("compile")
         val buffered = assumeObject("buffered")
         val bufferable = assumeObject("bufferable")
@@ -467,13 +468,15 @@ extends Importer with ucs.SplitElaborator:
       case trm =>
         trm.symbol match
         case S(sym) =>
-          sym.asTpe match
-          case S(ctx.builtins.untyped) =>
+          sym match
+          case ctx.builtins.annotations.untyped =>
             return S(Annot.Untyped)
-          case S(ctx.builtins.tailcall) =>
+          case ctx.builtins.annotations.tailcall =>
             return S(Annot.TailCall)
-          case S(ctx.builtins.tailrec) =>
+          case ctx.builtins.annotations.tailrec =>
             return S(Annot.TailRec)
+          case ctx.builtins.annotations.inline =>
+            return S(Annot.Inline)
           case _ => ()
         case _ => ()
         S(Annot.Trm(trm))

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
@@ -22,7 +22,8 @@ enum Annot extends AutoLocated:
   case Untyped
   case Modifier(mod: Keyword)
   case Trm(trm: Term)
-  // This is for generation of warnings and does not affect whether a function is optimized or not.
+  // NOTE: The presence of TailRec and TailCall annotations does not affect whether a function is optimized or not;
+  // it only affects whether a warning is thrown if the function/call is not actually tail-recursive.
   case TailRec
   case TailCall
   case Inline

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Term.scala
@@ -22,8 +22,10 @@ enum Annot extends AutoLocated:
   case Untyped
   case Modifier(mod: Keyword)
   case Trm(trm: Term)
+  // This is for generation of warnings and does not affect whether a function is optimized or not.
   case TailRec
   case TailCall
+  case Inline
   case Config(modify: hkmc2.Config => hkmc2.Config)
   
   def symbol: Opt[Symbol] = this match
@@ -32,11 +34,11 @@ enum Annot extends AutoLocated:
   
   def subTerms: Vector[Term] = this match
     case Trm(trm) => Vector.single(trm)
-    case _: Modifier | Untyped | TailRec | TailCall | _: Config => Vector.empty
+    case _: Modifier | Untyped | TailRec | TailCall | Inline | _: Config => Vector.empty
   
   def children: Vector[Located] = this match
     case Trm(trm) => Vector.single(trm)
-    case _: Modifier | Untyped | TailRec | TailCall | _: Config => Vector.empty
+    case _: Modifier | Untyped | TailRec | TailCall | Inline | _: Config => Vector.empty
   
   def show(using Scope, ShowCfg, Raise): Document = this match
     case Untyped => doc"‹untyped›"
@@ -50,6 +52,7 @@ enum Annot extends AutoLocated:
     case Trm(trm) => Trm(trm.mkClone)
     case TailRec => TailRec
     case TailCall => TailCall
+    case Inline => Inline
     case c: Config => c
 
 object Annot:

--- a/hkmc2/shared/src/test/mlscript/codegen/CurriedFunctions.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/CurriedFunctions.mls
@@ -45,10 +45,12 @@ foo(1)(2)(3)
 //│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
 //│ let foo², baseCall, lambda¹, lambda$⁰;
 //│ define lambda$⁰ as fun lambda$¹(x, y)(z) {
-//│   let inlinedVal, tmp;
+//│   return lambda²(x, y, z)
+//│ };
+//│ define lambda¹ as fun lambda²(x, y, z) {
+//│   let tmp;
 //│   set tmp = +⁰(x, y);
-//│   set inlinedVal = +⁰(tmp, z);
-//│   return inlinedVal
+//│   return +⁰(tmp, z)
 //│ };
 //│ define foo² as fun foo³(x)(y) {
 //│   let lambda$here;

--- a/hkmc2/shared/src/test/mlscript/codegen/Inliner.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Inliner.mls
@@ -201,11 +201,11 @@ f()
 open annotations
 
 // f1 does not inline into f, despite being small enough
+// The call to f is inlined
 :sjs
 :inlineThreshold 100
 fun f1(a, b, c) = a + b + c
-@inline
-fun f(a)(b)(c) = f1(a, b, c)
+@inline fun f(a)(b)(c) = f1(a, b, c)
 f(1)(2)(3)
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
 //│ let f10, f11;
@@ -254,6 +254,21 @@ foo(1)(2)(3)
 //│ > 7
 //│ = 6
 
+// Pathological cases
+:soir
+:noTailRec
+@inline fun f() = f()
+//│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
+//│ let f¹⁶; define f¹⁶ as fun f¹⁷() { return f¹⁷() }; end
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+
+// inlining done inside function with inline annotation
+:soir
+@inline fun f() = 1
+@inline fun g() = f()
+//│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
+//│ let f¹⁸, g⁰; define f¹⁸ as fun f¹⁹() { return 1 }; define g⁰ as fun g¹() { return 1 }; end
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
 // Methods (not implemented currently)
 // NOTE: only final (ie, non-virtual) method may be inlined, as they could be overriden
@@ -282,7 +297,7 @@ module A with
 //│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
 //│ let A⁰;
 //│ define A⁰ as class A¹
-//│ module A² { method f¹⁶ = fun f¹⁷() { return 1 } method g⁰ = fun g¹() { return A².f¹⁷() } };
+//│ module A² { method f²⁰ = fun f²¹() { return 1 } method g² = fun g³() { return A².f²¹() } };
 //│ end
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -293,19 +308,19 @@ module A with
 fun f() = if hide(false) do f() + 1
 f()
 //│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
-//│ let f¹⁸;
-//│ define f¹⁸ as fun f¹⁹() {
+//│ let f²²;
+//│ define f²² as fun f²³() {
 //│   let scrut;
 //│   set scrut = Predef⁰.hide⁰(false);
 //│   match scrut
 //│     true =>
-//│       do f¹⁹();
+//│       do f²³();
 //│       return runtime⁰.Unit⁰
 //│     else
 //│       return runtime⁰.Unit⁰
 //│   end
 //│ };
-//│ f¹⁹()
+//│ f²³()
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
 
@@ -315,7 +330,7 @@ fun g() =
   fun f() = f()
   f()
 //│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
-//│ let g²; define g² as fun g³() { let f; define f as fun f²⁰() { return f²⁰() }; return f²⁰() }; end
+//│ let g⁴; define g⁴ as fun g⁵() { let f; define f as fun f²⁴() { return f²⁴() }; return f²⁴() }; end
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
 

--- a/hkmc2/shared/src/test/mlscript/codegen/Inliner.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Inliner.mls
@@ -197,6 +197,64 @@ f()
 //│ = true
 
 
+// Inline annotations
+open annotations
+
+// f1 does not inline into f, despite being small enough
+:sjs
+:inlineThreshold 100
+fun f1(a, b, c) = a + b + c
+@inline
+fun f(a)(b)(c) = f1(a, b, c)
+f(1)(2)(3)
+//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
+//│ let f10, f11;
+//│ f11 = function f1(a, b, c3) {
+//│   let tmp8;
+//│   tmp8 = a + b;
+//│   return tmp8 + c3
+//│ };
+//│ f10 = function f(a) { return (b) => { return (c3) => { return f11(a, b, c3) } } };
+//│ 6
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+//│ = 6
+
+// lifter wrapper uses inline annotation under the hood
+// currently no inlining happens because multi-call isn't recognized
+:soir
+:lift
+:inlineThreshold 100
+fun foo(x)(y) =
+  let lam = z => x + y + z
+  print(lam(4))
+  lam
+foo(1)(2)(3)
+//│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
+//│ let foo⁰, lam⁰, lam$⁰, tmp, lam$here;
+//│ define lam$⁰ as fun lam$¹(x, y)(z) {
+//│   return lam¹(x, y, z)
+//│ };
+//│ define lam⁰ as fun lam¹(x, y, z) {
+//│   let tmp1;
+//│   set tmp1 = +⁰(x, y);
+//│   return +⁰(tmp1, z)
+//│ };
+//│ define foo⁰ as fun foo¹(x)(y) {
+//│   let tmp1, lam$here1;
+//│   set lam$here1 = lam$¹(x, y);
+//│   set tmp1 = lam$here1(4);
+//│   do Predef⁰.print⁰(tmp1);
+//│   return lam$here1
+//│ };
+//│ set lam$here = lam$¹(1, 2);
+//│ set tmp = lam$here(4);
+//│ do Predef⁰.print⁰(tmp);
+//│ lam$here(3)
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+//│ > 7
+//│ = 6
+
+
 // Methods (not implemented currently)
 // NOTE: only final (ie, non-virtual) method may be inlined, as they could be overriden
 

--- a/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
+++ b/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
@@ -4,11 +4,6 @@ declare type Any
 declare type Anything
 declare type Nothing
 
-declare type untyped
-
-declare type tailrec
-declare type tailcall
-
 declare class Object
 declare module Object with
   fun
@@ -268,6 +263,10 @@ declare module debug with
   fun printStack
 
 declare module annotations with
+  object untyped
+  object tailrec
+  object tailcall
+  object inline
   object compile
   object buffered
   object bufferable

--- a/hkmc2/shared/src/test/mlscript/deforest/fusibility.mls
+++ b/hkmc2/shared/src/test/mlscript/deforest/fusibility.mls
@@ -97,7 +97,7 @@ fun c(x) = if x is AA(_) then 0
 let p = AA(10)
 c(p) + c(p)
 //│ deforest > >>> non-affine syms >>>
-//│ deforest > p@1
+//│ deforest > p@3
 //│ deforest > <<< non-affine syms <<<
 //│ deforest > >>> fusing >>>
 //│ deforest > <<< fusing <<<
@@ -200,10 +200,10 @@ nest_consume(nest_pickB, nest_prod(10))
 //│ deforest > arg$AA$0$_for_nest_consume@48
 //│ deforest > arg$AA$0$_for_nest_consume@77
 //│ deforest > cap_ub_(term:nest_pickB,0)_for_nest_pickB@53
-//│ deforest > f_for_nest_consume@37
-//│ deforest > f_for_nest_consume@66
-//│ deforest > i_for_nest_consume@38
-//│ deforest > i_for_nest_consume@67
+//│ deforest > f_for_nest_consume@38
+//│ deforest > f_for_nest_consume@67
+//│ deforest > i_for_nest_consume@37
+//│ deforest > i_for_nest_consume@66
 //│ deforest > nest_pickB_for_nest_pickB@50
 //│ deforest > sel_res_for_nest_consume@49
 //│ deforest > sel_res_for_nest_consume@78

--- a/hkmc2/shared/src/test/mlscript/invalml/InvalMLPrelude.mls
+++ b/hkmc2/shared/src/test/mlscript/invalml/InvalMLPrelude.mls
@@ -1,15 +1,10 @@
 :ignore
 // ^ Ignore the silly warnings below, which are due to `untyped` not being treated as THE `untyped` builtin
-
+open annotations
 
 declare class Any
 declare class Nothing
 declare class Object
-
-declare class untyped
-
-declare class tailrec
-declare class tailcall
 
 declare class Unit
 declare class Bool
@@ -34,24 +29,6 @@ set
   globalThis.CodeBase = CodeBase
   globalThis.Region = Region
   globalThis.Ref = (r, v) => new mut Ref(r, v)
-//│ ╔══[WARNING] This annotation has no effect.
-//│ ║  l.32: 	@untyped
-//│ ║        	^^^^^^^^
-//│ ╟── This annotation is not supported on assignment terms.
-//│ ║  l.34: 	  globalThis.CodeBase = CodeBase
-//│ ╙──      	  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╔══[WARNING] This annotation has no effect.
-//│ ║  l.32: 	@untyped
-//│ ║        	^^^^^^^^
-//│ ╟── This annotation is not supported on assignment terms.
-//│ ║  l.35: 	  globalThis.Region = Region
-//│ ╙──      	  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╔══[WARNING] This annotation has no effect.
-//│ ║  l.32: 	@untyped
-//│ ║        	^^^^^^^^
-//│ ╟── This annotation is not supported on assignment terms.
-//│ ║  l.36: 	  globalThis.Ref = (r, v) => new mut Ref(r, v)
-//│ ╙──      	  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 declare class Function
 
@@ -104,6 +81,10 @@ declare module debug with
   fun printStack
 
 declare module annotations with
+  object untyped
+  object tailrec
+  object tailcall
+  object inline
   object compile
   object buffered
   object bufferable
@@ -144,11 +125,5 @@ declare fun (||): (Bool, Bool) -> Bool
 
 
 fun print(x) = @untyped globalThis.console.log(x)
-//│ ╔══[WARNING] This annotation has no effect.
-//│ ║  l.146: 	fun print(x) = @untyped globalThis.console.log(x)
-//│ ║         	               ^^^^^^^^
-//│ ╟── This annotation is not supported on application terms.
-//│ ║  l.146: 	fun print(x) = @untyped globalThis.console.log(x)
-//│ ╙──       	                        ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 

--- a/hkmc2/shared/src/test/mlscript/invalml/InvalMLPrelude.mls
+++ b/hkmc2/shared/src/test/mlscript/invalml/InvalMLPrelude.mls
@@ -1,5 +1,4 @@
-:ignore
-// ^ Ignore the silly warnings below, which are due to `untyped` not being treated as THE `untyped` builtin
+
 open annotations
 
 declare class Any

--- a/hkmc2/shared/src/test/mlscript/tailrec/Annots.mls
+++ b/hkmc2/shared/src/test/mlscript/tailrec/Annots.mls
@@ -1,4 +1,6 @@
 :js
+open annotations
+
 
 :w
 @tailrec
@@ -14,7 +16,7 @@ class A
 @tailrec 2 + 2
 //│ ╔══[WARNING] This annotation has no effect.
 //│ ╟── This annotation is not supported on application terms.
-//│ ║  l.14: 	@tailrec 2 + 2
+//│ ║  l.16: 	@tailrec 2 + 2
 //│ ╙──      	         ^^^^^
 //│ = 4
 
@@ -36,7 +38,7 @@ fun test =
   @tailcall f
 //│ ╔══[WARNING] This annotation has no effect.
 //│ ╟── This annotation is not supported on reference terms.
-//│ ║  l.36: 	  @tailcall f
+//│ ║  l.38: 	  @tailcall f
 //│ ╙──      	            ^
 //│ f = 0
 
@@ -46,7 +48,7 @@ class A with
   fun f() = g()
   fun g() = f()
 //│ ╔══[COMPILATION ERROR] Class methods may not yet be marked @tailrec.
-//│ ║  l.46: 	  fun f() = g()
+//│ ║  l.48: 	  fun f() = g()
 //│ ╙──      	      ^
 
 :w
@@ -61,7 +63,7 @@ module A with
   @tailrec
   fun f = 2
 //│ ╔══[WARNING] This function does not directly self-recurse, but is marked @tailrec.
-//│ ║  l.62: 	  fun f = 2
+//│ ║  l.64: 	  fun f = 2
 //│ ╙──      	      ^
 
 :w
@@ -85,5 +87,5 @@ fun test =
   @tailcall 1 + 2
 //│ ╔══[WARNING] This annotation has no effect.
 //│ ╟── The @tailcall annotation has no effect on calls to built-in symbols.
-//│ ║  l.85: 	  @tailcall 1 + 2
+//│ ║  l.87: 	  @tailcall 1 + 2
 //│ ╙──      	            ^^^^^

--- a/hkmc2/shared/src/test/mlscript/tailrec/Errors.mls
+++ b/hkmc2/shared/src/test/mlscript/tailrec/Errors.mls
@@ -1,18 +1,20 @@
 :js
+open annotations
+
 
 :e
 fun f(x) =
   @tailcall f(x)
   f(x)
 //│ ╔══[COMPILATION ERROR] This call is not in tail position.
-//│ ║  l.5: 	  @tailcall f(x)
+//│ ║  l.7: 	  @tailcall f(x)
 //│ ╙──     	            ^^^^
 
 :e
 fun f(x) = 2
 fun g(x) = @tailcall f(x)
 //│ ╔══[COMPILATION ERROR] This call is not optimized as it does not directly recurse through its parent function.
-//│ ║  l.13: 	fun g(x) = @tailcall f(x)
+//│ ║  l.15: 	fun g(x) = @tailcall f(x)
 //│ ╙──      	                     ^^^^
 
 :e
@@ -20,10 +22,10 @@ fun g(x) = @tailcall f(x)
   g(x)
 fun g(x) = f(x); f(x)
 //│ ╔══[COMPILATION ERROR] This function is not tail recursive.
-//│ ║  l.19: 	@tailrec fun f(x) =
+//│ ║  l.21: 	@tailrec fun f(x) =
 //│ ║        	             ^
 //│ ╟── It could self-recurse through this call, which is not a tail call.
-//│ ║  l.21: 	fun g(x) = f(x); f(x)
+//│ ║  l.23: 	fun g(x) = f(x); f(x)
 //│ ╙──      	           ^^^^
 
 :e
@@ -35,10 +37,10 @@ fun g(x) =
 fun h(x) =
   g(x)
 //│ ╔══[COMPILATION ERROR] This function is not tail recursive.
-//│ ║  l.30: 	@tailrec fun f(x) =
+//│ ║  l.32: 	@tailrec fun f(x) =
 //│ ║        	             ^
 //│ ╟── It could self-recurse through this call, which is not a tail call.
-//│ ║  l.33: 	  f(x)
+//│ ║  l.35: 	  f(x)
 //│ ╙──      	  ^^^^
 
 :e
@@ -50,10 +52,10 @@ fun g(x) =
 fun h(x) =
   f(x)
 //│ ╔══[COMPILATION ERROR] This function is not tail recursive.
-//│ ║  l.45: 	@tailrec fun f(x) =
+//│ ║  l.47: 	@tailrec fun f(x) =
 //│ ║        	             ^
 //│ ╟── It could self-recurse through this call, which is not a tail call.
-//│ ║  l.48: 	  h(x)
+//│ ║  l.50: 	  h(x)
 //│ ╙──      	  ^^^^
 
 :e
@@ -63,14 +65,14 @@ module A with
     @tailcall f(x - 1)
     @tailcall f(x - 1)
 //│ ╔══[COMPILATION ERROR] This call is not in tail position.
-//│ ║  l.63: 	    @tailcall f(x - 1)
+//│ ║  l.65: 	    @tailcall f(x - 1)
 //│ ╙──      	              ^^^^^^^^
 
 :w
 @tailrec
 fun f = 2
 //│ ╔══[WARNING] This function does not directly self-recurse, but is marked @tailrec.
-//│ ║  l.71: 	fun f = 2
+//│ ║  l.73: 	fun f = 2
 //│ ╙──      	    ^
 
 :w
@@ -78,7 +80,7 @@ module A with
   @tailrec
   fun f() = 2
 //│ ╔══[WARNING] This function does not directly self-recurse, but is marked @tailrec.
-//│ ║  l.79: 	  fun f() = 2
+//│ ║  l.81: 	  fun f() = 2
 //│ ╙──      	      ^
 
 :fixme // TODO: support
@@ -87,7 +89,7 @@ fun foo() = Foo.bar()
 module Foo with
   fun bar() = foo()
 //│ ╔══[WARNING] This function does not directly self-recurse, but is marked @tailrec.
-//│ ║  l.86: 	fun foo() = Foo.bar()
+//│ ║  l.88: 	fun foo() = Foo.bar()
 //│ ╙──      	    ^^^
 
 :e
@@ -96,7 +98,7 @@ fun f(x) =
   fun g() = g()
   g()
 //│ ╔══[COMPILATION ERROR] This @tailrec function was not processed by the tail-call optimizer.
-//│ ║  l.96: 	  fun g() = g()
+//│ ║  l.98: 	  fun g() = g()
 //│ ╙──      	      ^
 
 :e
@@ -105,7 +107,7 @@ fun scan(idx, acc) =
   fun go(idx, tok) = scan(idx, tok)
   go(idx, acc)
 //│ ╔══[COMPILATION ERROR] This @tailrec function was not processed by the tail-call optimizer.
-//│ ║  l.105: 	  fun go(idx, tok) = scan(idx, tok)
+//│ ║  l.107: 	  fun go(idx, tok) = scan(idx, tok)
 //│ ╙──       	      ^^
 
 :e
@@ -116,10 +118,10 @@ fun scan(idx, acc) =
   fun go(idx, tok) = scan(idx, tok)
   go(idx, acc)
 //│ ╔══[WARNING] This function does not directly self-recurse, but is marked @tailrec.
-//│ ║  l.114: 	fun scan(idx, acc) =
+//│ ║  l.116: 	fun scan(idx, acc) =
 //│ ╙──       	    ^^^^
 //│ ╔══[COMPILATION ERROR] This @tailrec function was not processed by the tail-call optimizer.
-//│ ║  l.116: 	  fun go(idx, tok) = scan(idx, tok)
+//│ ║  l.118: 	  fun go(idx, tok) = scan(idx, tok)
 //│ ╙──       	      ^^
 
 :e
@@ -127,21 +129,21 @@ fun scan(idx, acc) =
 @config(tailRecOpt: false)
 fun foo() = foo()
 //│ ╔══[COMPILATION ERROR] This @tailrec function was not processed by the tail-call optimizer.
-//│ ║  l.128: 	fun foo() = foo()
+//│ ║  l.130: 	fun foo() = foo()
 //│ ╙──       	    ^^^
 
 :e
 fun f =
   @tailcall id(2)
 //│ ╔══[COMPILATION ERROR] Only functions in this compilation unit may be marked @tailcall.
-//│ ║  l.135: 	  @tailcall id(2)
+//│ ║  l.137: 	  @tailcall id(2)
 //│ ╙──       	            ^^^^^
 
 :e
 fun f(x)(y) =
   @tailcall f(x)
 //│ ╔══[COMPILATION ERROR] Only fully applied calls may be marked @tailcall.
-//│ ║  l.142: 	  @tailcall f(x)
+//│ ║  l.144: 	  @tailcall f(x)
 //│ ╙──       	            ^^^^
 
 :e
@@ -150,8 +152,8 @@ fun f(x)() =
 fun g(x)(y) =
   @tailcall f(x)
 //│ ╔══[COMPILATION ERROR] Only fully applied calls may be marked @tailcall.
-//│ ║  l.151: 	  @tailcall f(x)
+//│ ║  l.153: 	  @tailcall f(x)
 //│ ╙──       	            ^^^^
 //│ ╔══[COMPILATION ERROR] This call is not optimized as it does not directly recurse through its parent function.
-//│ ║  l.149: 	  @tailcall g(x)(0)
+//│ ║  l.151: 	  @tailcall g(x)(0)
 //│ ╙──       	            ^^^^^^^

--- a/hkmc2/shared/src/test/mlscript/tailrec/MultiArgLists.mls
+++ b/hkmc2/shared/src/test/mlscript/tailrec/MultiArgLists.mls
@@ -1,4 +1,6 @@
 :js
+open annotations
+
 
 // Test: Tail-recursive function with single parameter list works correctly
 :expect 5050

--- a/hkmc2/shared/src/test/mlscript/tailrec/Simple.mls
+++ b/hkmc2/shared/src/test/mlscript/tailrec/Simple.mls
@@ -1,4 +1,5 @@
 :js
+open annotations
 
 
 :sjs
@@ -13,7 +14,7 @@ module Foo with
   @tailrec
   fun bar = bar
 //│ ╔══[WARNING] This function does not directly self-recurse, but is marked @tailrec.
-//│ ║  l.14: 	  fun bar = bar
+//│ ║  l.15: 	  fun bar = bar
 //│ ╙──      	      ^^^
 
 @tailrec
@@ -51,7 +52,7 @@ module A with
 module B with
   fun g(x) = A.f(x * 2)
 //│ ╔══[WARNING] This function does not directly self-recurse, but is marked @tailrec.
-//│ ║  l.50: 	  fun f(x) = B.g(x + 1)
+//│ ║  l.51: 	  fun f(x) = B.g(x + 1)
 //│ ╙──      	      ^
 
 

--- a/hkmc2/shared/src/test/mlscript/tailrec/TailRecOpt.mls
+++ b/hkmc2/shared/src/test/mlscript/tailrec/TailRecOpt.mls
@@ -1,4 +1,6 @@
 :js
+open annotations
+
 
 :expect 200010000
 fun sum_impl(n, acc) = if n == 0 then acc else sum_impl(n - 1, n + acc)
@@ -196,7 +198,7 @@ fun f(x) =
     @tailcall f(x)
   @tailcall g()
 //│ ╔══[COMPILATION ERROR] This call is not in tail position.
-//│ ║  l.195: 	    @tailcall f(x)
+//│ ║  l.197: 	    @tailcall f(x)
 //│ ╙──       	              ^^^^
 
 :lift
@@ -284,10 +286,10 @@ module A with
     @tailcall g(x - 1)
 A.f(10000)
 //│ ╔══[COMPILATION ERROR] This tail call exits the current scope and is not optimized.
-//│ ║  l.283: 	    fun g(x) = if x < 0 then 0 else @tailcall f(x)
+//│ ║  l.285: 	    fun g(x) = if x < 0 then 0 else @tailcall f(x)
 //│ ╙──       	                                              ^^^^
 //│ ╔══[COMPILATION ERROR] This tail call exits the current scope and is not optimized.
-//│ ║  l.284: 	    @tailcall g(x - 1)
+//│ ║  l.286: 	    @tailcall g(x - 1)
 //│ ╙──       	              ^^^^^^^^
 //│ ═══[RUNTIME ERROR] RangeError: Maximum call stack size exceeded
 
@@ -314,12 +316,12 @@ class A with
   fun g(x) = if x == 0 then 1 else @tailcall f(x - 1)
 (new A).f(10)
 //│ ╔══[COMPILATION ERROR] Calls from class methods cannot yet be marked @tailcall.
-//│ ║  l.313: 	  @tailrec fun f(x) = if x == 0 then 0 else @tailcall g(x - 1)
+//│ ║  l.315: 	  @tailrec fun f(x) = if x == 0 then 0 else @tailcall g(x - 1)
 //│ ╙──       	                                                      ^^^^^^^^
 //│ ╔══[COMPILATION ERROR] Class methods may not yet be marked @tailrec.
-//│ ║  l.313: 	  @tailrec fun f(x) = if x == 0 then 0 else @tailcall g(x - 1)
+//│ ║  l.315: 	  @tailrec fun f(x) = if x == 0 then 0 else @tailcall g(x - 1)
 //│ ╙──       	               ^
 //│ ╔══[COMPILATION ERROR] Calls from class methods cannot yet be marked @tailcall.
-//│ ║  l.314: 	  fun g(x) = if x == 0 then 1 else @tailcall f(x - 1)
+//│ ║  l.316: 	  fun g(x) = if x == 0 then 1 else @tailcall f(x - 1)
 //│ ╙──       	                                             ^^^^^^^^
 //│ = 0


### PR DESCRIPTION
Add a new annotation `@inline` on functions that
1. Block inlining inside the body of the function (unless the functions considered for inlining are themselves `@inline`)
2. Make the function itself always eligible for inlining in terms of bypassing size checks.

Also move all annotations to be under the `annotations` virtual module.