### PR TITLE
Add small threshold and fix issue in size calculation

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/Config.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/Config.scala
@@ -69,7 +69,7 @@ object Config:
     stageCode = false,
     tailRecOpt = true,
     deforest = N,
-    inlining = S(Inliner(1)),
+    inlining = S(Inliner(10)),
     deadBranchRemoval = default.deadBranchRemoval,
     qqEnabled = false,
     funcToCls = false,
@@ -162,7 +162,7 @@ object Config:
       logAccumulator = false,
     ))
   
-  case class Inliner(inlineThreshold: Int)
+  case class Inliner(inlineThreshold: Int, altSmallThreshold: Int = 2)
 
   def extractConfigFromStats(prgm: semantics.Term.Blk)(using Config) =
     // Extract cumulative config modifications from SetConfig statements
@@ -395,7 +395,7 @@ object ConfigParser:
         case N => identity
     case "inlining" =>
       parseOpt(value)(parseInt) match
-        case S(v) => _.copy(inlining = v.map(Inliner.apply))
+        case S(v) => _.copy(inlining = v.map(Inliner(_)))
         case _ => identity
     case "deadBranchRemoval" =>
       parseBool(value) match

--- a/hkmc2/shared/src/main/scala/hkmc2/Config.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/Config.scala
@@ -162,8 +162,10 @@ object Config:
       logAccumulator = false,
     ))
   
+  /** `altSmallThreshold` is the alternative threshold for inlining things into @inline functions.
+    * Normally, we avoid inlining into @inline functions as that could lead to unexpected code bloat. */
   case class Inliner(inlineThreshold: Int, altSmallThreshold: Int = 2)
-
+  
   def extractConfigFromStats(prgm: semantics.Term.Blk)(using Config) =
     // Extract cumulative config modifications from SetConfig statements
     val configModify = prgm.stats.collect:

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -114,13 +114,15 @@ sealed abstract class Block extends Product:
     case Scoped(syms, body) => body.definedVars ++ syms
   
   lazy val size: Int = this match
-    case _: Return | _: Throw | _: End | _: Break | _: Continue | _: Unreachable => 1
+    case Return(r: Result, _) => 1 + r.size
+    case Throw(r: Result) => 1 + r.size
+    case _: End | _: Break | _: Continue | _: Unreachable => 1
     case Begin(sub, rst) => sub.size + rst.size
-    case Assign(_, _, rst) => 1 + rst.size
-    case AssignField(_, _, _, rst) => 1 + rst.size
-    case AssignDynField(_, _, _, _, rst) => 1 + rst.size
-    case Match(_, arms, dflt, rst) =>
-      1 + arms.map(_._2.size).sum + dflt.map(_.size).getOrElse(0) + rst.size
+    case Assign(_, r, rst) => 1 + r.size + rst.size
+    case AssignField(p, _, r, rst) => 1 + p.size + r.size + rst.size
+    case AssignDynField(p, fld, _, r, rst) => 1 + p.size + fld.size + r.size + rst.size
+    case Match(p, arms, dflt, rst) =>
+      1 + p.size + arms.map(_._2.size).sum + dflt.map(_.size).getOrElse(0) + rst.size
     case Define(defn, rst) => 1 + defn.size + rst.size
     case TryBlock(sub, fin, rst) => 1 + sub.size + fin.size + rst.size
     case Label(_, _, bod, rst) => 1 + bod.size + rst.size
@@ -890,6 +892,21 @@ sealed abstract class Result extends AutoLocated:
     case Value.This(sym) => Set.empty
     case Value.Lit(lit) => Set.empty
     case DynSelect(qual, fld, arrayIdx) => qual.freeVarsLLIR ++ fld.freeVarsLLIR
+
+  lazy val size: Int = extraSize
+  
+  lazy val extraSize: Int = this match
+    case Call(fun, argss) => fun.extraSize + argss.flatten.map(_.value.extraSize).sum
+    case Instantiate(mut, cls, argss) => cls.extraSize + argss.flatten.map(_.value.extraSize).sum
+    case Select(qual, name) => qual.extraSize
+    case Lambda(params, body) => body.size
+    case Tuple(mut, elems) => elems.map(_.value.extraSize).sum
+    case Record(mut, args) => args.map(arg => arg.idx.fold(0)(_.extraSize) + arg.value.extraSize).sum
+    case Value.Ref(l, disamb) => 0
+    case Value.This(sym) => 0
+    case Value.Lit(l: Tree.StrLit) => l.value.length / 4
+    case Value.Lit(lit) => 0
+    case DynSelect(qual, fld, arrayIdx) => qual.extraSize + fld.extraSize
   
 // type Local = LocalSymbol
 type Local = Symbol

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -121,7 +121,7 @@ sealed abstract class Block extends Product:
     case AssignDynField(_, _, _, _, rst) => 1 + rst.size
     case Match(_, arms, dflt, rst) =>
       1 + arms.map(_._2.size).sum + dflt.map(_.size).getOrElse(0) + rst.size
-    case Define(_, rst) => 1 + rst.size
+    case Define(defn, rst) => defn.size + rst.size
     case TryBlock(sub, fin, rst) => 1 + sub.size + fin.size + rst.size
     case Label(_, _, bod, rst) => 1 + bod.size + rst.size
     case Scoped(_, body) => body.size
@@ -608,6 +608,12 @@ sealed abstract class Defn:
       preCtor.freeVarsLLIR
         ++ ctor.freeVarsLLIR ++ methods.flatMap(_.freeVarsLLIR) ++ stat.iterator.flatMap(_.freeVarsLLIR)
         -- auxParams.flatMap(_.paramSyms)
+
+  lazy val size: Int = this match
+    case FunDefn(_, _, _, params, body) => 1 + body.size
+    case ValDefn(_, _, rhs) => 1
+    case ClsLikeDefn(_, _, _, _, _, paramsOpt, auxParams, parentSym, methods, privateFields, publicFields, preCtor, ctor, stat, bufferable) =>
+      1 + methods.map(_.size).sum + preCtor.size + ctor.size
   
 
 final case class FunDefn(

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -613,7 +613,7 @@ sealed abstract class Defn:
     case FunDefn(_, _, _, params, body) => 1 + body.size
     case ValDefn(_, _, rhs) => 1
     case ClsLikeDefn(_, _, _, _, _, paramsOpt, auxParams, parentSym, methods, privateFields, publicFields, preCtor, ctor, stat, bufferable) =>
-      1 + methods.map(_.size).sum + preCtor.size + ctor.size
+      1 + methods.map(_.size).sum + preCtor.size + ctor.size + stat.fold(0)(_.size)
   
 
 final case class FunDefn(
@@ -740,6 +740,7 @@ final case class ClsLikeBody(
   lazy val freeVars: Set[Local] =
     ctor.freeVars ++ methods.flatMap(_.freeVars)
   lazy val freeVarsLLIR: Set[Local] = ???
+  lazy val size = 1 + methods.map(_.size).sum + ctor.size
 
 /*
 object ClsLikeBody:

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -121,7 +121,7 @@ sealed abstract class Block extends Product:
     case AssignDynField(_, _, _, _, rst) => 1 + rst.size
     case Match(_, arms, dflt, rst) =>
       1 + arms.map(_._2.size).sum + dflt.map(_.size).getOrElse(0) + rst.size
-    case Define(defn, rst) => defn.size + rst.size
+    case Define(defn, rst) => 1 + defn.size + rst.size
     case TryBlock(sub, fin, rst) => 1 + sub.size + fin.size + rst.size
     case Label(_, _, bod, rst) => 1 + bod.size + rst.size
     case Scoped(_, body) => body.size

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -113,20 +113,20 @@ sealed abstract class Block extends Product:
     case Label(lbl, _, bod, rst) => bod.definedVars ++ rst.definedVars
     case Scoped(syms, body) => body.definedVars ++ syms
   
-  lazy val size: Int = this match
-    case Return(r: Result, _) => 1 + r.size
-    case Throw(r: Result) => 1 + r.size
-    case _: End | _: Break | _: Continue | _: Unreachable => 1
+  lazy val size: Int = 1 + this.match
+    case Return(r: Result, _) => r.size
+    case Throw(r: Result) => r.size
+    case _: End | _: Break | _: Continue | _: Unreachable => 0
     case Begin(sub, rst) => sub.size + rst.size
-    case Assign(_, r, rst) => 1 + r.size + rst.size
-    case AssignField(p, _, r, rst) => 1 + p.size + r.size + rst.size
-    case AssignDynField(p, fld, _, r, rst) => 1 + p.size + fld.size + r.size + rst.size
+    case Assign(_, r, rst) => r.size + rst.size
+    case AssignField(p, _, r, rst) => p.size + r.size + rst.size
+    case AssignDynField(p, fld, _, r, rst) => p.size + fld.size + r.size + rst.size
     case Match(p, arms, dflt, rst) =>
-      1 + p.size + arms.map(_._2.size).sum + dflt.map(_.size).getOrElse(0) + rst.size
-    case Define(defn, rst) => 1 + defn.size + rst.size
-    case TryBlock(sub, fin, rst) => 1 + sub.size + fin.size + rst.size
-    case Label(_, _, bod, rst) => 1 + bod.size + rst.size
-    case Scoped(_, body) => body.size
+      p.size + arms.iterator.map(_._2.size).sum + dflt.fold(0)(_.size) + rst.size
+    case Define(defn, rst) => defn.size + rst.size
+    case TryBlock(sub, fin, rst) => sub.size + fin.size + rst.size
+    case Label(_, _, bod, rst) => bod.size + rst.size
+    case Scoped(_, body) => body.size - 1
   
   
   // TODO: make patmat use unreach
@@ -892,22 +892,21 @@ sealed abstract class Result extends AutoLocated:
     case Value.This(sym) => Set.empty
     case Value.Lit(lit) => Set.empty
     case DynSelect(qual, fld, arrayIdx) => qual.freeVarsLLIR ++ fld.freeVarsLLIR
-
-  lazy val size: Int = extraSize
   
-  lazy val extraSize: Int = this match
-    case Call(fun, argss) => fun.extraSize + argss.flatten.map(_.value.extraSize).sum
-    case Instantiate(mut, cls, argss) => cls.extraSize + argss.flatten.map(_.value.extraSize).sum
-    case Select(qual, name) => qual.extraSize
-    case Lambda(params, body) => body.size
-    case Tuple(mut, elems) => elems.map(_.value.extraSize).sum
-    case Record(mut, args) => args.map(arg => arg.idx.fold(0)(_.extraSize) + arg.value.extraSize).sum
+  lazy val size: Int = this match
+    case Call(fun, argss) => fun.size + argss.iterator.flatten.map(_.value.size).sum
+    case Instantiate(mut, cls, argss) => cls.size + argss.iterator.flatten.map(_.value.size).sum
+    case Select(qual, name) => qual.size
+    case Lambda(params, body) => 1 + body.size
+    case Tuple(mut, elems) => elems.iterator.map(_.value.size).sum
+    case Record(mut, args) => args.iterator.map(arg => arg.idx.fold(0)(_.size) + arg.value.size).sum
     case Value.Ref(l, disamb) => 0
     case Value.This(sym) => 0
     case Value.Lit(l: Tree.StrLit) => l.value.length / 4
     case Value.Lit(lit) => 0
-    case DynSelect(qual, fld, arrayIdx) => qual.extraSize + fld.extraSize
-  
+    case DynSelect(qual, fld, arrayIdx) => qual.size + fld.size
+
+// * TODO: refine this very loose type
 // type Local = LocalSymbol
 type Local = Symbol
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -1129,8 +1129,7 @@ class BlockSimplifier
               val info = m(ts)
               val cfg = summon[Config.Inliner]
               val threshold = if insideInlineAnnotatedFunction then cfg.altSmallThreshold else cfg.inlineThreshold
-              val inliningBlocked = insideInlineAnnotatedFunction && !info.defn.inline
-              if !info.shouldBeInlined(blk, threshold) || inliningBlocked then
+              if !info.shouldBeInlined(blk, threshold) then
                 super.applyResult(r)(k)
               else
                 val matchedArgs = matchAllArgs(argss, info.defn.params)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -940,13 +940,14 @@ class BlockSimplifier
           isPrivate && !isMethod && useCount <= 1 && !disallowElimination && !isLoopBreaker
           // false
         
-        def shouldBeInlined(newBlk: Block): Bool =
+        def shouldBeInlined(newBlk: Block, threshold: Int): Bool =
           if isLoopBreaker then return false
           // method requires the capturing of `this`, which is not supported currently.
           if isMethod then return false
           // If the definition is marked with inline, we should inline it regardless of the size of the body.
+          // If both callee and caller are marked with inline, inlining will ignore the stricter @inline limits.
+          // Remark: the case of a recursive function marked with inline will be blocked by loop breaker logic.
           if defn.inline then return true
-          val threshold = summon[Config.Inliner].inlineThreshold
           newBlk.size <= threshold || canBeInlineEliminated
         
       type InlinerMap = Map[TermSymbol, InlinerFunInfo]
@@ -1126,10 +1127,10 @@ class BlockSimplifier
               S(newBdy)
             .fold(super.applyResult(r)(k)): blk =>
               val info = m(ts)
-              // If both callee and caller are marked with inline, inlining will not be blocked.
-              // Remark: the case of a recursive function marked with inline will be blocked by loop breaker logic.
+              val cfg = summon[Config.Inliner]
+              val threshold = if insideInlineAnnotatedFunction then cfg.altSmallThreshold else cfg.inlineThreshold
               val inliningBlocked = insideInlineAnnotatedFunction && !info.defn.inline
-              if !info.shouldBeInlined(blk) || inliningBlocked then
+              if !info.shouldBeInlined(blk, threshold) || inliningBlocked then
                 super.applyResult(r)(k)
               else
                 val matchedArgs = matchAllArgs(argss, info.defn.params)

--- a/hkmc2/shared/src/test/mlscript/backlog/UCS.mls
+++ b/hkmc2/shared/src/test/mlscript/backlog/UCS.mls
@@ -90,7 +90,7 @@ let foo =
 //│ ╔══[COMPILATION ERROR] Expected three arguments, but found only one argument.
 //│ ║  l.83: 	    Tuple(...elements) then elements
 //│ ╙──      	    ^^^^^
-//│ foo = fun foo
+//│ foo = fun
 
 foo(Tuple(1, 2, 3))
 //│ ═══[RUNTIME ERROR] This code cannot be run as its compilation yielded an error.

--- a/hkmc2/shared/src/test/mlscript/codegen/ClassMatching.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/ClassMatching.mls
@@ -68,21 +68,23 @@ if s is
 //│   throw new globalThis⁰.Error⁰("match error")
 //│ tmp
 //│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
-//│ let arg$Some$0$;
-//│ match s⁰
-//│   Some⁰ =>
-//│     set arg$Some$0$ = s⁰.value⁰;
-//│     match arg$Some$0$
-//│       1 =>
-//│         0
-//│       else
-//│         throw new globalThis⁰.Error⁰("match error")
-//│     end
-//│   None⁰ =>
-//│     1
-//│   else
-//│     throw new globalThis⁰.Error⁰("match error")
-//│ end
+//│ let arg$Some$0$, tmp;
+//│ block split_root$:
+//│   match s⁰
+//│     Some⁰ =>
+//│       set arg$Some$0$ = s⁰.value⁰;
+//│       match arg$Some$0$
+//│         1 =>
+//│           set tmp = 0;
+//│           break split_root$
+//│         else
+//│           end
+//│       end
+//│     None⁰ =>
+//│       set tmp = 1;
+//│       break split_root$
+//│   throw new globalThis⁰.Error⁰("match error")
+//│ tmp
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ ═══[RUNTIME ERROR] Error: match error
 

--- a/hkmc2/shared/src/test/mlscript/codegen/CurriedFunctions.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/CurriedFunctions.mls
@@ -43,14 +43,12 @@ foo(1)(2)(3)
 //│ set baseCall = foo³(1)(2);
 //│ baseCall(3)
 //│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
-//│ let foo², baseCall, lambda¹, lambda$⁰;
+//│ let foo², baseCall, lambda$⁰;
 //│ define lambda$⁰ as fun lambda$¹(x, y)(z) {
-//│   return lambda²(x, y, z)
-//│ };
-//│ define lambda¹ as fun lambda²(x, y, z) {
-//│   let tmp;
+//│   let inlinedVal, tmp;
 //│   set tmp = +⁰(x, y);
-//│   return +⁰(tmp, z)
+//│   set inlinedVal = +⁰(tmp, z);
+//│   return inlinedVal
 //│ };
 //│ define foo² as fun foo³(x)(y) {
 //│   let lambda$here;

--- a/hkmc2/shared/src/test/mlscript/codegen/Inliner.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Inliner.mls
@@ -201,32 +201,29 @@ f()
 open annotations
 
 // f1 does not inline into f, despite being small enough
+// The threshold for inlining this is separate and stricter than the usual limit
 // The call to f is inlined
 :sjs
 :inlineThreshold 100
-fun f1(a, b, c) = a + b + c
+fun f1(a, b, c) = (a + b + c + 1) * 2
 @inline fun f(a)(b)(c) = f1(a, b, c)
 f(1)(2)(3)
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let f10, f11;
+//│ let f10, f11, inlinedVal1;
 //│ f11 = function f1(a, b, c3) {
-//│   let tmp8;
+//│   let tmp8, tmp9, tmp10;
 //│   tmp8 = a + b;
-//│   return tmp8 + c3
+//│   tmp9 = tmp8 + c3;
+//│   tmp10 = tmp9 + 1;
+//│   return tmp10 * 2
 //│ };
 //│ f10 = function f(a) {
-//│   return (b) => {
-//│     return (c3) => {
-//│       let inlinedVal1, tmp8;
-//│       tmp8 = a + b;
-//│       inlinedVal1 = tmp8 + c3;
-//│       return inlinedVal1
-//│     }
-//│   }
+//│   return (b) => { return (c3) => { return f11(a, b, c3) } }
 //│ };
-//│ 6
+//│ inlinedVal1 = 14;
+//│ inlinedVal1
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
-//│ = 6
+//│ = 14
 
 // lifter wrapper uses inline annotation under the hood
 // currently no inlining happens because multi-call isn't recognized

--- a/hkmc2/shared/src/test/mlscript/codegen/Inliner.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/Inliner.mls
@@ -214,7 +214,16 @@ f(1)(2)(3)
 //│   tmp8 = a + b;
 //│   return tmp8 + c3
 //│ };
-//│ f10 = function f(a) { return (b) => { return (c3) => { return f11(a, b, c3) } } };
+//│ f10 = function f(a) {
+//│   return (b) => {
+//│     return (c3) => {
+//│       let inlinedVal1, tmp8;
+//│       tmp8 = a + b;
+//│       inlinedVal1 = tmp8 + c3;
+//│       return inlinedVal1
+//│     }
+//│   }
+//│ };
 //│ 6
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = 6
@@ -230,14 +239,12 @@ fun foo(x)(y) =
   lam
 foo(1)(2)(3)
 //│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
-//│ let foo⁰, lam⁰, lam$⁰, tmp, lam$here;
+//│ let foo⁰, lam$⁰, tmp, lam$here;
 //│ define lam$⁰ as fun lam$¹(x, y)(z) {
-//│   return lam¹(x, y, z)
-//│ };
-//│ define lam⁰ as fun lam¹(x, y, z) {
-//│   let tmp1;
+//│   let inlinedVal, tmp1;
 //│   set tmp1 = +⁰(x, y);
-//│   return +⁰(tmp1, z)
+//│   set inlinedVal = +⁰(tmp1, z);
+//│   return inlinedVal
 //│ };
 //│ define foo⁰ as fun foo¹(x)(y) {
 //│   let tmp1, lam$here1;

--- a/hkmc2/shared/src/test/mlscript/codegen/MergeMatchArms.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/MergeMatchArms.mls
@@ -69,23 +69,26 @@ if a is
   B then 2
   C then 3
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ if (a instanceof A1.class) {
-//│   if (b instanceof A1.class) {
-//│     1
-//│   } else if (b instanceof B1.class) {
-//│     2
-//│   } else {
-//│     throw globalThis.Object.freeze(new globalThis.Error("match error"))
+//│ let tmp;
+//│ split_root$: {
+//│   if (a instanceof A1.class) {
+//│     if (b instanceof A1.class) {
+//│       tmp = 1;
+//│       break split_root$
+//│     } else if (b instanceof B1.class) {
+//│       tmp = 2;
+//│       break split_root$
+//│     }
+//│   } else if (a instanceof B1.class) {
+//│     tmp = 2;
+//│     break split_root$
+//│   } else if (a instanceof C1.class) {
+//│     tmp = 3;
+//│     break split_root$
 //│   }
-//│   /* Rest moved to non-abortive branch(es) */
-//│ } else if (a instanceof B1.class) {
-//│   2
-//│ } else if (a instanceof C1.class) {
-//│   3
-//│ } else {
-//│   throw globalThis.Object.freeze(new globalThis.Error("match error"))
+//│   throw globalThis.Object.freeze(new globalThis.Error("match error"));
 //│ }
-//│ /* Rest moved to non-abortive branch(es) */
+//│ tmp
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = 2
 
@@ -108,25 +111,25 @@ let x = if a is
     print("done")
 print(x)
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let x, tmp;
+//│ let x, tmp1;
 //│ if (a instanceof A1.class) {
-//│   tmp = 1;
+//│   tmp1 = 1;
 //│ } else if (a instanceof B1.class) {
-//│   tmp = 2;
+//│   tmp1 = 2;
 //│ } else if (a instanceof C1.class) {
-//│   tmp = 3;
+//│   tmp1 = 3;
 //│ } else if (a instanceof D1.class) {
 //│   if (a instanceof A1.class) {} else if (a instanceof B1.class) {} else {
 //│     throw globalThis.Object.freeze(new globalThis.Error("match error"))
 //│   }
-//│   tmp = Predef.print("done");
+//│   tmp1 = Predef.print("done");
 //│ } else if (a instanceof E1.class) {
-//│   tmp = Predef.print("done");
+//│   tmp1 = Predef.print("done");
 //│ } else {
 //│   throw globalThis.Object.freeze(new globalThis.Error("match error"))
 //│ }
-//│ x = tmp;
-//│ Predef.print(tmp)
+//│ x = tmp1;
+//│ Predef.print(tmp1)
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ > 1
 //│ x = 1
@@ -164,13 +167,13 @@ if a is
   let tmp = printAndId(3)
   B then 2 + tmp
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let tmp1;
+//│ let tmp2;
 //│ if (a instanceof A1.class) {
 //│   1
 //│ } else {
-//│   tmp1 = printAndId(3);
+//│   tmp2 = printAndId(3);
 //│   if (a instanceof B1.class) {
-//│     2 + tmp1
+//│     2 + tmp2
 //│   } else {
 //│     throw globalThis.Object.freeze(new globalThis.Error("match error"))
 //│   }
@@ -220,22 +223,22 @@ if a is
     print(x + 1)
     print(x + 2)
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let tmp2, tmp3, tmp4;
+//│ let tmp3, tmp4, tmp5;
 //│ if (a instanceof B1.class) {
 //│   1
 //│ } else {
 //│   if (a instanceof A1.class) {
-//│     tmp2 = 2;
+//│     tmp3 = 2;
 //│   } else if (a instanceof C1.class) {
-//│     tmp2 = 3;
+//│     tmp3 = 3;
 //│   } else {
 //│     throw globalThis.Object.freeze(new globalThis.Error("match error"))
 //│   }
-//│   Predef.print(tmp2);
-//│   tmp3 = tmp2 + 1;
 //│   Predef.print(tmp3);
-//│   tmp4 = tmp2 + 2;
-//│   Predef.print(tmp4)
+//│   tmp4 = tmp3 + 1;
+//│   Predef.print(tmp4);
+//│   tmp5 = tmp3 + 2;
+//│   Predef.print(tmp5)
 //│ }
 //│ /* Rest moved to non-abortive branch(es) */
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————

--- a/hkmc2/shared/src/test/mlscript/handlers/Effects.mls
+++ b/hkmc2/shared/src/test/mlscript/handlers/Effects.mls
@@ -71,14 +71,14 @@ in
   h.perform("5")
 result
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let result, h7, handleBlock$7, Handler$h$perform7, Handler$h$15, Handler$h$perform$4;
+//│ let result, h7, handleBlock$7, Handler$h$perform5, Handler$h$15, Handler$h$perform$4;
 //│ runtime.resetEffects();
 //│ Handler$h$perform$4 = function Handler$h$perform$(arg) {
 //│   return (k) => {
-//│     return Handler$h$perform7(arg, k)
+//│     return Handler$h$perform5(arg, k)
 //│   }
 //│ };
-//│ Handler$h$perform7 = function Handler$h$perform(arg, k) {
+//│ Handler$h$perform5 = function Handler$h$perform(arg, k) {
 //│   let v, pc;
 //│   if (runtime.resumePc === -1) {
 //│     pc = 0;
@@ -92,7 +92,7 @@ result
 //│       if (runtime.curEffect === null) {
 //│         pc = 1;
 //│       } else {
-//│         return runtime.unwind(Handler$h$perform7, 1, "Effects.mls:63:13", null, null, 1, 2, arg, k, 0)
+//│         return runtime.unwind(Handler$h$perform5, 1, "Effects.mls:63:13", null, null, 1, 2, arg, k, 0)
 //│       }
 //│     case 1:
 //│       v = runtime.resumeValue;

--- a/hkmc2/shared/src/test/mlscript/handlers/ReturnInHandler.mls
+++ b/hkmc2/shared/src/test/mlscript/handlers/ReturnInHandler.mls
@@ -42,7 +42,7 @@ let l = () =>
 //│ ╔══[COMPILATION ERROR] Return statements are not allowed outside of functions.
 //│ ║  l.40: 	  return 3
 //│ ╙──      	  ^^^^^^^^
-//│ l = fun l
+//│ l = fun
 
 :re
 l()

--- a/hkmc2/shared/src/test/mlscript/opt/AbortivePrefix.mls
+++ b/hkmc2/shared/src/test/mlscript/opt/AbortivePrefix.mls
@@ -50,11 +50,9 @@ fun f =
 //│         true =>
 //│           return runtime⁰.Unit⁰
 //│         else
-//│           throw new globalThis⁰.Error⁰("match error")
+//│           end
 //│       end
-//│     else
-//│       throw new globalThis⁰.Error⁰("match error")
-//│   end
+//│   throw new globalThis⁰.Error⁰("match error")
 //│ };
 //│ end
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
@@ -74,11 +72,9 @@ fun f =
 //│         true =>
 //│           return "1"
 //│         else
-//│           return "2 long long long long long long long long long long long long long long"
+//│           end
 //│       end
-//│     else
-//│       return "2 long long long long long long long long long long long long long long"
-//│   end
+//│   return "2 long long long long long long long long long long long long long long"
 //│ };
 //│ end
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————

--- a/hkmc2/shared/src/test/mlscript/ucs/general/JoinPoints.mls
+++ b/hkmc2/shared/src/test/mlscript/ucs/general/JoinPoints.mls
@@ -30,11 +30,9 @@ x => if x is [[0]] then 1
 //│       if (element0$1 === 0) {
 //│         return 1
 //│       }
-//│       throw globalThis.Object.freeze(new globalThis.Error("match error"))
 //│     }
-//│     throw globalThis.Object.freeze(new globalThis.Error("match error"));
 //│   }
-//│   throw globalThis.Object.freeze(new globalThis.Error("match error"));
+//│   throw globalThis.Object.freeze(new globalThis.Error("match error"))
 //│ });
 //│ lambda1
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————

--- a/hkmc2/shared/src/test/mlscript/ucs/normalization/Deduplication.mls
+++ b/hkmc2/shared/src/test/mlscript/ucs/normalization/Deduplication.mls
@@ -389,11 +389,11 @@ fun foo(x, y, z) = if x is
 //│             case 1:
 //│               return "001";
 //│           }
-//│           return expensive_call("hello");
+//│           break;
 //│         case 1:
 //│           return "01";
 //│       }
-//│       return expensive_call("hello");
+//│       break;
 //│     case 1:
 //│       return "1";
 //│   }
@@ -444,14 +444,10 @@ fun foo(x, y, z) =
 //│ foo4 = function foo(x1, y1, z1) {
 //│   if (x1 instanceof A1.class) {
 //│     if (y1 instanceof B1.class) {
-//│       if (z1 instanceof C1.class) {
-//│         return "Hello"
-//│       }
-//│       return "Goodbye"
+//│       if (z1 instanceof C1.class) { return "Hello" }
 //│     }
-//│     return "Goodbye";
 //│   }
-//│   return "Goodbye";
+//│   return "Goodbye"
 //│ };
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
@@ -467,11 +463,9 @@ fun foo(x, y, z) =
 //│       if (z1 instanceof C1.class) {
 //│         return "Hello"
 //│       }
-//│       throw globalThis.Object.freeze(new globalThis.Error("match error"))
 //│     }
-//│     throw globalThis.Object.freeze(new globalThis.Error("match error"));
 //│   }
-//│   throw globalThis.Object.freeze(new globalThis.Error("match error"));
+//│   throw globalThis.Object.freeze(new globalThis.Error("match error"))
 //│ };
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/ucs/normalization/InheritanceNormalization.mls
+++ b/hkmc2/shared/src/test/mlscript/ucs/normalization/InheritanceNormalization.mls
@@ -8,7 +8,7 @@ class B extends A
 let f = case
   A then "A"
   B then "B"
-//│ f = fun f
+//│ f = fun
 
 f(new A)
 //│ = "A"
@@ -20,7 +20,7 @@ f(new B)
 let f = case
   B then "B"
   A then "A"
-//│ f = fun f
+//│ f = fun
 
 f(new A)
 //│ = "A"

--- a/hkmc2/shared/src/test/mlscript/ucs/normalization/SimplePairMatches.mls
+++ b/hkmc2/shared/src/test/mlscript/ucs/normalization/SimplePairMatches.mls
@@ -19,11 +19,9 @@ x => if x is Pair(A, B) then 1
 //│       if (arg$Pair$1$ instanceof B1) {
 //│         return 1
 //│       }
-//│       throw globalThis.Object.freeze(new globalThis.Error("match error"))
 //│     }
-//│     throw globalThis.Object.freeze(new globalThis.Error("match error"));
 //│   }
-//│   throw globalThis.Object.freeze(new globalThis.Error("match error"));
+//│   throw globalThis.Object.freeze(new globalThis.Error("match error"))
 //│ });
 //│ lambda
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
@@ -46,16 +44,13 @@ fun f(x) = if x is
 //│       if (arg$Pair$1$ instanceof A1) {
 //│         return 1
 //│       }
-//│       throw globalThis.Object.freeze(new globalThis.Error("match error"))
 //│     } else if (arg$Pair$0$ instanceof B1) {
 //│       if (arg$Pair$1$ instanceof B1) {
 //│         return 2
 //│       }
-//│       throw globalThis.Object.freeze(new globalThis.Error("match error"))
 //│     }
-//│     throw globalThis.Object.freeze(new globalThis.Error("match error"));
 //│   }
-//│   throw globalThis.Object.freeze(new globalThis.Error("match error"));
+//│   throw globalThis.Object.freeze(new globalThis.Error("match error"))
 //│ };
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 

--- a/hkmc2/shared/src/test/mlscript/ucs/patterns/RestTuple.mls
+++ b/hkmc2/shared/src/test/mlscript/ucs/patterns/RestTuple.mls
@@ -75,11 +75,10 @@ fun nested_tuple_patterns(xs) = if xs is
 //│       tmp7 = tmp6 + element1$;
 //│       return tmp7 + lastElement1$
 //│     }
-//│     throw globalThis.Object.freeze(new globalThis.Error("match error"));
 //│   } else if (runtime.Tuple.isArrayLike(xs) && xs.length === 0) {
 //│     return 0
 //│   }
-//│   throw globalThis.Object.freeze(new globalThis.Error("match error"));
+//│   throw globalThis.Object.freeze(new globalThis.Error("match error"))
 //│ };
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 


### PR DESCRIPTION
There was an issue in size calculation, which causes Define node to be inlined very aggressively. This PR fix this issue.

Also add a secondary inlining threshold for functions with `@inline` annotation, allowing some inlining to happen inside it.