### PR TITLE
misc: Update SBT and flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759763021,
-        "narHash": "sha256-mKdRzhp5Vnd3Q8fKdl3URYoBAINVCcjm7E0/xCtv2xQ=",
+        "lastModified": 1779809079,
+        "narHash": "sha256-FZOORCdWviHiUgwBBRmT3amneBay12qYDjGXD5SEG2I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fce27362e1d5f990b04ae79faecf56e028075c85",
+        "rev": "a52cd4a6abb542ebbf048cf5a28734273da5ef88",
         "type": "github"
       },
       "original": {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.8
+sbt.version=1.12.11


### PR DESCRIPTION
Version Changes:

- SBT: 1.12.8 -> 1.12.11
- Clang: 21.1.1 -> 21.1.8
- GCC: 14.3.0 -> 15.2.0
- SBT Runner: 1.11.7 -> 1.12.11
- NodeJS: 24.9.0 -> 24.15.0
- Java 17: 17.0.16 -> 17.0.20

No functional or test changes.