### PR TITLE
Allow multiple parameter lists in class extensions

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/ClassParamFlattener.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/ClassParamFlattener.scala
@@ -69,7 +69,7 @@ class ClassParamFlattener(using State) extends BlockTransformer(SymbolSubst.Id):
       case defn => k(defn)
   
   override def applyResult(r: Result)(k: Result => Block): Block = r match
-    case c @ Call(r @ Value.RefLike(sym), argss) if sym === State.superSymbol =>
+    case c @ Call(r @ Value.RefLike(State.superSymbol), argss) =>
       applyArgss(argss): argss2 =>
         val flatArgss =
           if argss2.lengthCompare(1) > 0 then argss2.flatten ne_:: Nil

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/ClassParamFlattener.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/ClassParamFlattener.scala
@@ -6,6 +6,8 @@ import hkmc2.utils.*
 
 import semantics.*
 
+import hkmc2.semantics.Elaborator.State
+
 
 /** Flattens class constructor parameter lists in the Block IR.
   *
@@ -22,7 +24,7 @@ import semantics.*
   * Argument spreads are intentionally preserved as `Arg`s while only the
   * surrounding argument-list boundary is removed.
   */
-class ClassParamFlattener extends BlockTransformer(SymbolSubst.Id):
+class ClassParamFlattener(using State) extends BlockTransformer(SymbolSubst.Id):
   
   private def flattenParamLists(paramss: Ls[ParamList]): ParamList =
     val flags = paramss.headOption.fold(ParamListFlags.empty)(_.flags)
@@ -67,6 +69,14 @@ class ClassParamFlattener extends BlockTransformer(SymbolSubst.Id):
       case defn => k(defn)
   
   override def applyResult(r: Result)(k: Result => Block): Block = r match
+    case c @ Call(r @ Value.RefLike(sym), argss) if sym === State.superSymbol =>
+      applyArgss(argss): argss2 =>
+        val flatArgss =
+          if argss2.lengthCompare(1) > 0 then argss2.flatten ne_:: Nil
+          else argss2
+        k:
+          if flatArgss is argss then c
+          else Call(r, flatArgss)(c.isMlsFun, c.mayRaiseEffects, c.explicitTailCall).withLocOf(c)
     case call @ Call(fun, argss) =>
       saturatedCurriedClassCall(fun, argss) match
       case S(cls) =>
@@ -93,8 +103,8 @@ class ClassParamFlattener extends BlockTransformer(SymbolSubst.Id):
 end ClassParamFlattener
 
 object ClassParamFlattener:
-  def apply(program: Program): Program =
+  def apply(program: Program)(using State): Program =
     new ClassParamFlattener().applyProgram(program)
   
-  def apply(block: Block): Block =
+  def apply(block: Block)(using State): Block =
     new ClassParamFlattener().applyBlock(block)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -146,18 +146,13 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
   
   def returnedTerm(t: st)(using LoweringCtx): Block = term(t)(Ret)(using LoweringCtx.nestFunc)
   
-  def parentConstructor(cls: Term, args: Ls[Term])(using LoweringCtx) = 
-    if args.length > 1 then 
-      raise:
-        ErrorReport(
-          msg"Extending a class with multiple parameter lists is not supported" -> Loc(cls :: args) :: Nil,
-          source = Diagnostic.Source.Compilation
-        )
+  def parentConstructor(parentClsPath: Path, cls: Term, args: Ls[Term])(using LoweringCtx) =
     lowerSuperCtorCall(
+      parentClsPath,
       State.builtinOpsMap("super").asSimpleRef,
       isMlsFun = true,
       isTailCall = false,
-      args.headOption,
+      args,
       N, // TODO: location?
     )(c => Assign(State.noSymbol, c, End()))
   
@@ -371,7 +366,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
             val cfgOverride = defn.extraAnnotations.collectFirst:
               case Annot.Config(modify) => modify(config)
             subTerm(ext.cls): clsp =>
-              val pctor = inScopedBlock(parentConstructor(ext.cls, ext.args))
+              val pctor = inScopedBlock(parentConstructor(clsp, ext.cls, ext.args))
               Define(
                 ClsLikeDefn(
                   defn.owner, defn.sym, defn.bsym, defn.ctorSym, defn.kind, defn.paramsOpt, defn.auxParams, S(clsp),
@@ -384,12 +379,40 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
     
     blockImpl(imps ::: funs ::: rest, res)
   
+  def getCtorParamLists(cls: Path): Ls[ParamList] =
+    cls.targetSymbol.flatMap: sym =>
+      sym.asClsOrMod.flatMap(_.defn) orElse
+      sym.asTrm.flatMap(_.owner).flatMap(_.asDefnSym.defn)
+    .fold(Nil: Ls[ParamList]): clsDef =>
+      clsDef.paramsOpt.toList ::: clsDef.auxParams
+  
   // * Lowers the `super(...)` call we get from the `extends C(...)` syntax
-  def lowerSuperCtorCall(fr: Path, isMlsFun: Bool, isTailCall: Bool, arg: Opt[Term], loc: Opt[Loc])(k: Result => Block)(using LoweringCtx): Block =
-    arg match
-    case S(arg) =>
-      lowerArgs(arg)(as => k(Call(fr, as ne_:: Nil)(isMlsFun, true, isTailCall).withLoc(loc)))
-    case N =>
+  def lowerSuperCtorCall(parentClsPth: Path, fr: Path, isMlsFun: Bool, isTailCall: Bool, args: List[Term], loc: Opt[Loc])(k: Result => Block)(using LoweringCtx): Block =
+    val ctorParamLists = getCtorParamLists(parentClsPth)
+    args match
+    case _ :: _ =>
+      def zipArgs(remainingParamss: Ls[ParamList], args: Ls[Term], acc: Ls[Ls[Arg]]): Block = (remainingParamss, args) match
+        case (_ :: remainingParamss2, arg :: remainingArgs) => lowerArgs(arg): as =>
+          zipArgs(remainingParamss2, remainingArgs, as ne_:: acc)
+        case (Nil, arg :: remainingArgs) =>
+          if remainingArgs.isEmpty then
+            raise(ErrorReport(
+              msg"Too many parameter lists for parent class" -> loc :: Nil,
+              source = Diagnostic.Source.Compilation))
+          lowerArgs(arg): as =>
+            zipArgs(Nil, remainingArgs, as ne_:: acc)
+        case (remainingParamss2, Nil) =>
+          if !remainingParamss2.isEmpty then
+            raise(ErrorReport(
+              msg"Extending a partially applied class is not yet supported" -> loc :: Nil,
+              source = Diagnostic.Source.Compilation))
+          k(Call(fr, acc.reverse.ne_!)(isMlsFun, true, isTailCall).withLoc(loc))
+      zipArgs(ctorParamLists, args, Nil)
+    case Nil =>
+      if !ctorParamLists.isEmpty then
+        raise(ErrorReport(
+          msg"Extending a partially applied class is not yet supported" -> loc :: Nil,
+          source = Diagnostic.Source.Compilation))
       // * No arguments to a super ctor means a nullary call, e.g., `extends C` means `extends C()`
       k(Call(fr, Nil ne_:: Nil)(isMlsFun, true, isTailCall).withLoc(loc))
   
@@ -473,12 +496,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
     // * so we also look up the owner InnerSymbol via TermDefinition#owner.
     // * Note: apparently, this can also be accessed through TermDefinition#companionClass
     // * (what Copilot initially used), which is weird.
-    val ctorParamLists: Ls[ParamList] =
-      cls.targetSymbol.flatMap: sym =>
-        sym.asClsOrMod.flatMap(_.defn) orElse
-        sym.asTrm.flatMap(_.owner).flatMap(_.asDefnSym.defn)
-      .fold(Nil: Ls[ParamList]): clsDef =>
-        clsDef.paramsOpt.toList ::: clsDef.auxParams
+    val ctorParamLists = getCtorParamLists(cls)
     if ctorParamLists.isEmpty then
       // * Need to specially handle no-param classes
       args match
@@ -651,7 +669,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
   final def term(t: st, inStmtPos: Bool = false)(k: Result => Block)(using LoweringCtx): Block =
     tl.log(s"Lowering.term ${t.showDbg.truncate(100, "[...]")}${
       if inStmtPos then " (in stmt)" else ""}${
-      t.resolvedSym.fold("")(" – symbol " + _)}")
+      t.resolvedSym.fold("")(" ? symbol " + _)}")
     
     def warnStmt = if inStmtPos then warnPureExprInStmtPos(t.toLoc, S(t))
     
@@ -781,7 +799,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
     case st.TyApp(f, ts) => term(f)(k) // * Type arguments are erased
     case st.App(f, arg) =>
       
-      // Collect chains of App nodes: `f(a)(b)(c)` → (f, [a, b, c])
+      // Collect chains of App nodes: `f(a)(b)(c)` ? (f, [a, b, c])
       // This allows lowering curried calls as a single `Call` with multiple arg lists.
       @tailrec
       def collectAppChain(expr: st, args: Ls[Term]): (st, Ls[Term]) =
@@ -973,7 +991,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
           val sym = new BlockMemberSymbol(isym.name, Nil)
           loweringCtx.collectScopedSym(sym)
           val (mtds, publicFlds, privateFlds, ctor) = gatherMembers(rft)
-          val pctor = parentConstructor(cls, as)
+          val pctor = parentConstructor(sr, cls, as)
           val clsDef = ClsLikeDefn(N, isym, sym, N, syntax.Cls, N, Nil, S(sr),
             mtds, privateFlds, publicFlds, pctor, ctor, N, N)(N, Nil)
           val inner = new New(sym.ref().resolved(isym), Nil, N)(N)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -386,7 +386,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
     .fold(Nil: Ls[ParamList]): clsDef =>
       clsDef.paramsOpt.toList ::: clsDef.auxParams
   
-  // * Lowers the `super(...)` call we get from the `extends C(...)` syntax
+  // * Lowers the `super(...)(...)` call we get from the `extends C(...)(...)` syntax
   def lowerSuperCtorCall(parentClsPth: Path, fr: Path, isMlsFun: Bool, isTailCall: Bool, args: List[Term], loc: Opt[Loc])(k: Result => Block)(using LoweringCtx): Block =
     val ctorParamLists = getCtorParamLists(parentClsPth)
     args match
@@ -404,14 +404,14 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
         case (remainingParamss2, Nil) =>
           if !remainingParamss2.isEmpty then
             raise(ErrorReport(
-              msg"Extending a partially applied class is not yet supported" -> loc :: Nil,
+              msg"Extending a partially applied class is not supported" -> loc :: Nil,
               source = Diagnostic.Source.Compilation))
           k(Call(fr, acc.reverse.ne_!)(isMlsFun, true, isTailCall).withLoc(loc))
       zipArgs(ctorParamLists, args, Nil)
     case Nil =>
       if !ctorParamLists.isEmpty then
         raise(ErrorReport(
-          msg"Extending a partially applied class is not yet supported" -> loc :: Nil,
+          msg"Extending a partially applied class is not supported" -> loc :: Nil,
           source = Diagnostic.Source.Compilation))
       // * No arguments to a super ctor means a nullary call, e.g., `extends C` means `extends C()`
       k(Call(fr, Nil ne_:: Nil)(isMlsFun, true, isTailCall).withLoc(loc))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -669,7 +669,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
   final def term(t: st, inStmtPos: Bool = false)(k: Result => Block)(using LoweringCtx): Block =
     tl.log(s"Lowering.term ${t.showDbg.truncate(100, "[...]")}${
       if inStmtPos then " (in stmt)" else ""}${
-      t.resolvedSym.fold("")(" ? symbol " + _)}")
+      t.resolvedSym.fold("")(" – symbol " + _)}")
     
     def warnStmt = if inStmtPos then warnPureExprInStmtPos(t.toLoc, S(t))
     
@@ -799,7 +799,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
     case st.TyApp(f, ts) => term(f)(k) // * Type arguments are erased
     case st.App(f, arg) =>
       
-      // Collect chains of App nodes: `f(a)(b)(c)` ? (f, [a, b, c])
+      // Collect chains of App nodes: `f(a)(b)(c)` → (f, [a, b, c])
       // This allows lowering curried calls as a single `Call` with multiple arg lists.
       @tailrec
       def collectAppChain(expr: st, args: Ls[Term]): (st, Ls[Term]) =

--- a/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
+++ b/hkmc2/shared/src/test/mlscript/backlog/ToTriage.mls
@@ -151,6 +151,7 @@ class D extends id(C)
 //│ ║  l.149: 	class D extends id(C)
 //│ ║         	                ^^
 //│ ╙── The 'new' keyword requires a statically known class; use the 'new!' operator for dynamic instantiation.
+//│ ═══[COMPILATION ERROR] Too many parameter lists for parent class
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
 //│ let D1;
 //│ (class D extends Predef.id {
@@ -177,14 +178,14 @@ let x = 0
 :fixme
 set x += 1; ()
 //│ ╔══[COMPILATION ERROR] Expected a right-hand side for this assignment
-//│ ║  l.178: 	set x += 1; ()
+//│ ║  l.179: 	set x += 1; ()
 //│ ╙──       	    ^^^^^^^^^^
 //│ ═══[RUNTIME ERROR] This code cannot be run as its compilation yielded an error.
 
 :e
 set (x += 1; ())
 //│ ╔══[COMPILATION ERROR] Expected a right-hand side for this assignment
-//│ ║  l.185: 	set (x += 1; ())
+//│ ║  l.186: 	set (x += 1; ())
 //│ ╙──       	    ^^^^^^^^^^^^
 //│ ═══[RUNTIME ERROR] This code cannot be run as its compilation yielded an error.
 
@@ -193,7 +194,7 @@ set (x += 1; ())
 :fixme
 [x, set x += 1; x]
 //│ ╔══[COMPILATION ERROR] Expected a right-hand side for this assignment
-//│ ║  l.194: 	[x, set x += 1; x]
+//│ ║  l.195: 	[x, set x += 1; x]
 //│ ╙──       	        ^^^^^^^^^
 //│ ═══[RUNTIME ERROR] This code cannot be run as its compilation yielded an error.
 
@@ -204,13 +205,13 @@ import "../../mlscript-compile/Stack.mls"
 // The parser rejects this, but it should be allowed.
 open Stack { ::, Nil }
 //│ ╔══[COMPILATION ERROR] Illegal 'open' statement shape.
-//│ ║  l.205: 	open Stack { ::, Nil }
+//│ ║  l.206: 	open Stack { ::, Nil }
 //│ ╙──       	     ^^^^^^^^^^^^^^^
 
 // Instead, if we parenthesize the operator, it is rejected by the elaborator.
 open Stack { (::), Nil }
 //│ ╔══[COMPILATION ERROR] Illegal 'open' statement element.
-//│ ║  l.211: 	open Stack { (::), Nil }
+//│ ║  l.212: 	open Stack { (::), Nil }
 //│ ╙──       	             ^^^^
 
 open Stack { Nil, :: }
@@ -218,7 +219,7 @@ open Stack { Nil, :: }
 :sjs
 1 :: Nil
 //│ ╔══[COMPILATION ERROR] Module 'Stack' does not contain member '::'
-//│ ║  l.219: 	1 :: Nil
+//│ ║  l.220: 	1 :: Nil
 //│ ╙──       	  ^^
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
 //│ return runtime.safeCall(Stack["::"](1, Stack.Nil))
@@ -239,46 +240,46 @@ id(Foo)(1)
 :e
 data class FooSpd(...args)
 //│ ╔══[COMPILATION ERROR] Spread parameters are not supported in class parameters.
-//│ ║  l.240: 	data class FooSpd(...args)
+//│ ║  l.241: 	data class FooSpd(...args)
 //│ ╙──       	                     ^^^^
 
 FooSpd(1, 2, 3).args
 //│ ╔══[COMPILATION ERROR] Expected 0 arguments, got 3
-//│ ║  l.245: 	FooSpd(1, 2, 3).args
+//│ ║  l.246: 	FooSpd(1, 2, 3).args
 //│ ╙──       	      ^^^^^^^^^
 //│ ═══[RUNTIME ERROR] Error: Access to required field 'args' yielded 'undefined'
 
 :todo
 if FooSpd(1, 2, 3) is FooSpd(...args) then args
 //│ ╔══[COMPILATION ERROR] Unrecognized pattern (spread).
-//│ ║  l.252: 	if FooSpd(1, 2, 3) is FooSpd(...args) then args
+//│ ║  l.253: 	if FooSpd(1, 2, 3) is FooSpd(...args) then args
 //│ ╙──       	                             ^^^^^^^
 //│ ╔══[COMPILATION ERROR] Name not found: args
-//│ ║  l.252: 	if FooSpd(1, 2, 3) is FooSpd(...args) then args
+//│ ║  l.253: 	if FooSpd(1, 2, 3) is FooSpd(...args) then args
 //│ ╙──       	                                           ^^^^
 //│ ╔══[COMPILATION ERROR] Expected 0 arguments, got 3
-//│ ║  l.252: 	if FooSpd(1, 2, 3) is FooSpd(...args) then args
+//│ ║  l.253: 	if FooSpd(1, 2, 3) is FooSpd(...args) then args
 //│ ╙──       	         ^^^^^^^^^
 //│ ╔══[COMPILATION ERROR] The constructor does not take any arguments but found one argument.
-//│ ║  l.252: 	if FooSpd(1, 2, 3) is FooSpd(...args) then args
+//│ ║  l.253: 	if FooSpd(1, 2, 3) is FooSpd(...args) then args
 //│ ╙──       	                      ^^^^^^
 //│ ═══[RUNTIME ERROR] Error: match error
 
 if FooSpd(1, 2, 3) is FooSpd(a, b, c) then [a, b, c]
 //│ ╔══[COMPILATION ERROR] Expected 0 arguments, got 3
-//│ ║  l.267: 	if FooSpd(1, 2, 3) is FooSpd(a, b, c) then [a, b, c]
+//│ ║  l.268: 	if FooSpd(1, 2, 3) is FooSpd(a, b, c) then [a, b, c]
 //│ ╙──       	         ^^^^^^^^^
 //│ ╔══[COMPILATION ERROR] The constructor does not take any arguments but found three arguments.
-//│ ║  l.267: 	if FooSpd(1, 2, 3) is FooSpd(a, b, c) then [a, b, c]
+//│ ║  l.268: 	if FooSpd(1, 2, 3) is FooSpd(a, b, c) then [a, b, c]
 //│ ╙──       	                             ^^^^^^^
 //│ ═══[RUNTIME ERROR] Error: match error
 
 if FooSpd(1, 2, 3) is FooSpd(arg) then arg
 //│ ╔══[COMPILATION ERROR] Expected 0 arguments, got 3
-//│ ║  l.276: 	if FooSpd(1, 2, 3) is FooSpd(arg) then arg
+//│ ║  l.277: 	if FooSpd(1, 2, 3) is FooSpd(arg) then arg
 //│ ╙──       	         ^^^^^^^^^
 //│ ╔══[COMPILATION ERROR] The constructor does not take any arguments but found one argument.
-//│ ║  l.276: 	if FooSpd(1, 2, 3) is FooSpd(arg) then arg
+//│ ║  l.277: 	if FooSpd(1, 2, 3) is FooSpd(arg) then arg
 //│ ╙──       	                             ^^^
 //│ ═══[RUNTIME ERROR] Error: match error
 
@@ -289,10 +290,10 @@ fun foo() =
   let bar(x: Str): Str = x + x
   bar("test")
 //│ ╔══[COMPILATION ERROR] Unsupported let binding shape
-//│ ║  l.289: 	  let bar(x: Str): Str = x + x
+//│ ║  l.290: 	  let bar(x: Str): Str = x + x
 //│ ╙──       	      ^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╔══[COMPILATION ERROR] Name not found: bar
-//│ ║  l.290: 	  bar("test")
+//│ ║  l.291: 	  bar("test")
 //│ ╙──       	  ^^^
 
 // ——— ——— ———
@@ -306,7 +307,7 @@ module Foo(x) with
   print(x)
 //│ ╔══[COMPILATION ERROR] No definition found in scope for member 'x'
 //│ ╟── which references the symbol introduced here
-//│ ║  l.305: 	module Foo(x) with
+//│ ║  l.306: 	module Foo(x) with
 //│ ╙──       	           ^
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
 //│ let Foo5;
@@ -330,7 +331,7 @@ module Foo(x) with
 module Foo(val x)
 //│ ╔══[COMPILATION ERROR] No definition found in scope for member 'x'
 //│ ╟── which references the symbol introduced here
-//│ ║  l.330: 	module Foo(val x)
+//│ ║  l.331: 	module Foo(val x)
 //│ ╙──       	               ^
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
 //│ let Foo7;
@@ -351,7 +352,7 @@ module Foo(val x)
 // TODO support syntax?
 data class Foo(mut x)
 //│ ╔══[COMPILATION ERROR] Expected a valid parameter, found 'mut'-modified identifier
-//│ ║  l.352: 	data class Foo(mut x)
+//│ ║  l.353: 	data class Foo(mut x)
 //│ ╙──       	                   ^
 
 // ——— ——— ———
@@ -371,7 +372,7 @@ class Foo
 :e
 class Id(name: UnboundName)
 //│ ╔══[COMPILATION ERROR] Name not found: UnboundName
-//│ ║  l.372: 	class Id(name: UnboundName)
+//│ ║  l.373: 	class Id(name: UnboundName)
 //│ ╙──       	               ^^^^^^^^^^^
 //│ ═══[COMPILATION ERROR] Expected a type, got a non-type ‹error›
 //│ ═══[COMPILATION ERROR] Expected a type, got ‹error›

--- a/hkmc2/shared/src/test/mlscript/basics/Inheritance.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/Inheritance.mls
@@ -97,24 +97,17 @@ data class Some[out T](x: T) extends Option[T]
 data class Barr(x: Int)(y: Int) with
   fun f = x + y
 
-:todo
-data class Bazz(z: Int) extends Bar(z % 10)(z / 10) with
+data class Bazz(z: Int) extends Barr(z % 10)(z / 10) with
   fun g = z
-//│ ╔══[COMPILATION ERROR] Extending a class with multiple parameter lists is not supported
-//│ ║  l.101: 	data class Bazz(z: Int) extends Bar(z % 10)(z / 10) with
-//│ ╙──       	                                ^^^^^^^^^^^^^^^^^^^
 
-:todo
+
 Bazz(42).f
-//│ ═══[RUNTIME ERROR] Error: Access to required field 'f' yielded 'undefined'
+//│ = 6.2
 
-:todo
+
 new Barr(40)(2) with
   fun f = 43
-//│ ╔══[COMPILATION ERROR] Extending a class with multiple parameter lists is not supported
-//│ ║  l.112: 	new Barr(40)(2) with
-//│ ╙──       	    ^^^^^^^^^^^
-//│ = $anon { x: 40, y: undefined }
+//│ = $anon { x: 40, y: 2 }
 
 
 

--- a/hkmc2/shared/src/test/mlscript/basics/ObjectExtensions.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/ObjectExtensions.mls
@@ -48,5 +48,6 @@ object Bar extends! Foo!class
 //│ ║  l.46: 	object Bar extends! Foo!class
 //│ ║        	                  ^
 //│ ╙── The 'new' keyword requires a statically known class; use the 'new!' operator for dynamic instantiation.
+//│ ═══[COMPILATION ERROR] Too many parameter lists for parent class
 
 

--- a/hkmc2/shared/src/test/mlscript/codegen/AuxiliaryConstructors.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/AuxiliaryConstructors.mls
@@ -114,7 +114,7 @@ class B extends A(1)(2)(3)
 
 :e
 class B extends A(0)
-//│ ═══[COMPILATION ERROR] Extending a partially applied class is not yet supported
+//│ ═══[COMPILATION ERROR] Extending a partially applied class is not supported
 
 new B
 //│ = B { x: 0 }
@@ -128,7 +128,7 @@ class D extends C(0)
 :e
 new A(1)(2) with
   fun a = 0
-//│ ═══[COMPILATION ERROR] Extending a partially applied class is not yet supported
+//│ ═══[COMPILATION ERROR] Extending a partially applied class is not supported
 //│ = $anon { x: 1 }
 
 :e

--- a/hkmc2/shared/src/test/mlscript/codegen/AuxiliaryConstructors.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/AuxiliaryConstructors.mls
@@ -93,4 +93,47 @@ class Qux(a) with
 Qux(10)(123).both()
 //│ = 133
 
+// === Extending classes with multiple parameter lists ===
 
+class A(val x)(val y)
+class B extends A(1)(2)
+
+:expect B { x: 1, y: 2 }
+new B
+//│ = B { x: 1, y: 2 }
+
+class A(val x) with
+  constructor(y)(z) 
+  fun bruh = x + y + z
+
+class B extends A(1)(2)(3)
+
+:expect 6
+(new B).bruh
+//│ = 6
+
+:e
+class B extends A(0)
+//│ ═══[COMPILATION ERROR] Extending a partially applied class is not yet supported
+
+new B
+//│ = B { x: 0 }
+
+class C
+
+:e
+class D extends C(0)
+//│ ═══[COMPILATION ERROR] Too many parameter lists for parent class
+
+:e
+new A(1)(2) with
+  fun a = 0
+//│ ═══[COMPILATION ERROR] Extending a partially applied class is not yet supported
+//│ = $anon { x: 1 }
+
+:e
+new A(1)(2)(3)(4) with
+  fun a = 0
+//? = $anon { x: 1 }
+//│ ═══[COMPILATION ERROR] Too many parameter lists for parent class
+//│ = $anon { x: 1 }

--- a/hkmc2/shared/src/test/mlscript/codegen/CurriedClassInheritance.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/CurriedClassInheritance.mls
@@ -3,10 +3,10 @@
 
 class Foo(val x)(val y)
 
-:todo
+:e
 :sjs
 class Bar(val a)(val d) extends Foo(a)
-//│ ═══[COMPILATION ERROR] Extending a partially applied class is not yet supported
+//│ ═══[COMPILATION ERROR] Extending a partially applied class is not supported
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
 //│ let Bar1;
 //│ Bar1 = function Bar(a) {

--- a/hkmc2/shared/src/test/mlscript/codegen/CurriedClassInheritance.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/CurriedClassInheritance.mls
@@ -3,9 +3,10 @@
 
 class Foo(val x)(val y)
 
-
+:todo
 :sjs
 class Bar(val a)(val d) extends Foo(a)
+//│ ═══[COMPILATION ERROR] Extending a partially applied class is not yet supported
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
 //│ let Bar1;
 //│ Bar1 = function Bar(a) {
@@ -80,11 +81,7 @@ c.a
 //│ ═══[RUNTIME ERROR] TypeError: Cannot read properties of undefined (reading 'x')
 
 
-:todo
 class Baz(a)(val d) extends Foo(a)(a + 1)
-//│ ╔══[COMPILATION ERROR] Extending a class with multiple parameter lists is not supported
-//│ ║  l.84: 	class Baz(a)(val d) extends Foo(a)(a + 1)
-//│ ╙──      	                            ^^^^^^^^^^^^^
 
 let b = Baz(123)(1234)
 //│ b = Baz(_)

--- a/hkmc2/shared/src/test/mlscript/ucs/hygiene/CrossBranchCapture.mls
+++ b/hkmc2/shared/src/test/mlscript/ucs/hygiene/CrossBranchCapture.mls
@@ -29,8 +29,8 @@ process(Numb(1), 10)
 
 // class Vec(xs: Array[Numb | Vec]) // Array is not available
 data abstract class Vec[out T](n: Int)
-data class Cons[out T](head: T, tail: Vec[T]) extends Vec[T]
-object Nil extends Vec[Nothing]
+data class Cons[out T](head: T, tail: Vec[T]) extends Vec[T](tail.n + 1)
+object Nil extends Vec[Nothing](0)
 
 data class Pair[A, B](a: A, b: B)
 


### PR DESCRIPTION
Support the following:
```fs
class A(x)(y)

new A(1)(2) with
  fun foo = 0

class B extends A(0)(0)
```