### PR TITLE
Make `NoSymbol` a plain `object`

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -45,7 +45,7 @@ case class Program(
 type SimpleSymbol = LocalVarSymbol | BuiltinSymbol
 
 /** Symbol that can be used as the left-hand side of an `Assign`. */
-type Assignable = LocalVarSymbol | NoSymbol.type
+type Assignable = LocalVarSymbol | NoSymbol
 
 /** Symbols that `Scoped` introduces as block-local bindings.
   * This deliberately excludes things like `TermSymbol`s, which never need to be scoped.

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -45,7 +45,7 @@ case class Program(
 type SimpleSymbol = LocalVarSymbol | BuiltinSymbol
 
 /** Symbol that can be used as the left-hand side of an `Assign`. */
-type Assignable = LocalVarSymbol | NoSymbol
+type Assignable = LocalVarSymbol | NoSymbol.type
 
 /** Symbols that `Scoped` introduces as block-local bindings.
   * This deliberately excludes things like `TermSymbol`s, which never need to be scoped.
@@ -147,7 +147,7 @@ sealed abstract class Block extends Product:
   lazy val definedVars: Set[BoundSymbol] = this match
     case _: Return | _: Throw | _: Unreachable => Set.empty
     case Begin(sub, rst) => sub.definedVars ++ rst.definedVars
-    case Assign(_: NoSymbol, r, rst) => rst.definedVars
+    case Assign(NoSymbol, r, rst) => rst.definedVars
     case Assign(l: LocalVarSymbol, r, rst) => rst.definedVars + l
     case AssignField(l, n, r, rst) => rst.definedVars
     case AssignDynField(l, n, ai, r, rst) => rst.definedVars
@@ -200,7 +200,7 @@ sealed abstract class Block extends Product:
     case Continue(label) => Set.single(label)
     case Begin(sub, rest) => sub.freeVars ++ rest.freeVars
     case TryBlock(sub, finallyDo, rest) => sub.freeVars ++ finallyDo.freeVars ++ rest.freeVars
-    case Assign(_: NoSymbol, rhs, rest) => rhs.freeVars ++ rest.freeVars
+    case Assign(NoSymbol, rhs, rest) => rhs.freeVars ++ rest.freeVars
     case Assign(lhs: LocalVarSymbol, rhs, rest) => Set.single(lhs) ++ rhs.freeVars ++ rest.freeVars
     case AssignField(lhs, nme, rhs, rest) => lhs.freeVars ++ rhs.freeVars ++ rest.freeVars
     case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => lhs.freeVars ++ fld.freeVars ++ rhs.freeVars ++ rest.freeVars
@@ -434,14 +434,14 @@ object Assign:
     case Scoped(syms, body) => Scoped(syms, Assign(lhs, rhs, body))
     case _ =>
       lhs match
-      case _: NoSymbol =>
+      case NoSymbol =>
         if rhs.isPure then rest else new Assign(lhs, rhs, rest)
       case _ => new Assign(lhs, rhs, rest)
   def discard(res: Result, rest: Block)(using State): Block =
     res match
     case _: Value | _: Lambda => rest
     case p: Path if p.isPure => rest
-    case r => Assign(State.noSymbol, r, rest)
+    case r => Assign(NoSymbol, r, rest)
 object AssignField:
   def apply(lhs: Path, nme: Tree.Ident, rhs: Result, rest: Block)(symbol: Opt[MemberSymbol]): Block = rest match
     case Scoped(syms, body) => Scoped(syms, AssignField(lhs, nme, rhs, body)(symbol))
@@ -1000,7 +1000,7 @@ object Value:
 
   @deprecated("Use Value.SimpleRef, Value.MemberRef, or Value.This instead.")
   object Ref:
-    def apply(l: ValueSymbol | NoSymbol, disamb: Opt[DefinitionSymbol[?]]): Value.RefLike =
+    def apply(l: ValueSymbol | NoSymbol.type, disamb: Opt[DefinitionSymbol[?]]): Value.RefLike =
       l match
         case l: SimpleSymbol => l.asSimpleRef
         case l: TermSymbol => l.asPath
@@ -1008,7 +1008,7 @@ object Value:
           disamb.getOrElse:
             lastWords(s"Cannot disambiguate overloaded member symbol ${bms.nme}: no disambiguation provided")
         case sym: InnerSymbol => sym.asThis
-        case _: NoSymbol => lastWords("NoSymbol should not be used as a Path/Value")
+        case NoSymbol => lastWords("NoSymbol should not be used as a Path/Value")
     
     // * Some helper constructors that allow omitting the disambiguation symbol.
     // * If the ref itself is a DefinitionSymbol, then disambiguating it results in itself.

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
@@ -213,7 +213,7 @@ class BlockTransformer(subst: SymbolSubst):
     case sym: BlockMemberSymbol => sym.subst
   
   def applyAssignLhs(sym: Assignable): Assignable = sym match
-    case sym: NoSymbol => sym
+    case NoSymbol => NoSymbol
     case sym: TempSymbol => sym.subst
     case sym: VarSymbol => sym.subst
   

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTraverser.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTraverser.scala
@@ -25,7 +25,7 @@ class BlockTraverser:
   
   
   def applyMaybeSymbol(sym: MaybeSymbol): Unit = sym match
-    case _: NoSymbol => ()
+    case NoSymbol => ()
     case sym: Symbol => applySymbol(sym)
   
   def applySymbol(sym: Symbol): Unit = ()

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -390,7 +390,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
             applyResult(rhs)
             lhs match
             case lhs: LocalVarSymbol => assignToSym(lhs)
-            case _: NoSymbol =>
+            case NoSymbol =>
             applyBlock(rest)
           case Define(defn: ValDefn, rest) =>
             applyPath(defn.rhs)
@@ -752,7 +752,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
     val blk = blockBuilder
       .staticif(
         !opt.doNotInstrumentTopLevelModCtor,
-        _.assign(State.noSymbol, Call(paths.resetEffects, Nil ne_:: Nil)(true, false, false))
+        _.assign(NoSymbol, Call(paths.resetEffects, Nil ne_:: Nil)(true, false, false))
       )
       .rest(transformed)
     (blk, stackSafetyMap)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -511,7 +511,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
           if (sub2 is sub) && (fin2 is fin) && (rst2 is rst) then rewritten else TryBlock(sub2, fin2, rst2)
         
         // Assignment to variables
-        case Assign(_: NoSymbol, _, _) => super.applyBlock(rewritten)
+        case Assign(NoSymbol, _, _) => super.applyBlock(rewritten)
         case Assign(lhs: LocalVarSymbol, rhs, rest) => ctx.symbolsMap.get(lhs) match
           case Some(path) => applyResult(rhs): rhs2 =>
             path.assign(rhs2, applySubBlock(rest))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -154,7 +154,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
       isTailCall = false,
       args,
       N, // TODO: location?
-    )(c => Assign(State.noSymbol, c, End()))
+    )(c => Assign(NoSymbol, c, End()))
   
   // * Used to work around Scala's @tailrec annotation for those few calls that are not in tail position.
   final def term_nonTail(t: st, inStmtPos: Bool = false)(k: Result => Block)(using LoweringCtx): Block =
@@ -1458,7 +1458,7 @@ trait LoweringSelSanityChecks(using Config, TL, Raise, State)
       // * the access should throw an error like `TypeError: Cannot read property 'f' of undefined`.
       blockBuilder
         .assign(selRes, Select(p, nme)(disamb))
-        .assign(State.noSymbol, Select(p, Tree.Ident(nme.name+"$__checkNotMethod"))(N))
+        .assign(NoSymbol, Select(p, Tree.Ident(nme.name+"$__checkNotMethod"))(N))
           .ifthen(selRes.asSimpleRef,
             Case.Lit(syntax.Tree.UnitLit(false)),
             Throw(Instantiate(mut = false, Select(State.globalThisSymbol.asThis, Tree.Ident("Error"))(N),

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
@@ -56,7 +56,7 @@ class Printer(using Raise, ShowCfg, State, SymbolPrinter, Config):
       doc"begin #{  # ${print(sub)}; #}  # ${print(rest)}"
     case TryBlock(sub, finallyDo, rest) =>
       doc"try #{  # ${print(sub)} #}  # finally #{  # ${print(finallyDo)}; #  #} ${print(rest)}"
-    case Assign(_: NoSymbol, rhs, rest) =>
+    case Assign(NoSymbol, rhs, rest) =>
       doc"do ${print(rhs)}; # ${print(rest)}"
     case Assign(lhs: (LocalVarSymbol | TermSymbol), rhs, rest) =>
       doc"set ${print(lhs)} = ${print(rhs)}; # ${print(rest)}"

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
@@ -121,7 +121,7 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
                 blockCtor("ConcreteClassSymbol", Ls(toValue(name), path, paramsOpt, auxParams), symName)(k)
         case _: ModuleOrObjectSymbol =>
           blockCtor("ModuleSymbol", Ls(toValue(name), path), symName)(k)
-    case _: NoSymbol =>
+    case NoSymbol =>
       blockCtor("NoSymbol", Nil, symName)(k)
     case sym: LocalVarSymbol =>
       val name = scope.allocateOrGetName(sym)
@@ -288,7 +288,7 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
           blockCtor("ValueSimpleRef", Ls(xSym)): xStaged =>
             (Assign(x, xStaged, _)):
               given Context = x match
-                case _: NoSymbol => ctx.clone()
+                case NoSymbol => ctx.clone()
                 case x: ValueSymbol => ctx.clone() += x.asPath -> xStaged
               transformBlock(b): (z, ctx) =>
                 blockCtor("Assign", Ls(xSym, y, z), "assign")(k(_, ctx))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/SpecializedSwitch.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/SpecializedSwitch.scala
@@ -150,7 +150,7 @@ private object PostCondAnalysisImpl extends CachedAnalysis[Block, PostCondRes]:
     case Scoped(syms, body) => analyze(body)
     case Begin(sub, rest) => analyze(sub) >=> analyze(rest)
     case TryBlock(sub, finallyDo, rest) => analyze(sub) >=> analyze(finallyDo) >=> analyze(rest)
-    case Assign(_: NoSymbol, rhs, rest) => res(N, rhs, rest)
+    case Assign(NoSymbol, rhs, rest) => res(N, rhs, rest)
     case Assign(lhs: ValueSymbol, rhs, rest) => res(S(lhs), rhs, rest)
     case AssignField(path, _, rhs, rest) => res(N, rhs, rest)
     case AssignDynField(lhs, fld, arrayIdx, rhs, rest) => res(N, rhs, rest)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
@@ -33,7 +33,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
         .rest:
           sym match
           case sym: LocalVarSymbol => f(sym.asSimpleRef)
-          case _: NoSymbol => f(Value.Lit(Tree.UnitLit(false)))
+          case NoSymbol => f(Value.Lit(Tree.UnitLit(false)))
   
   def wrapStackSafe(body: Block, resSym: Assignable, rest: Block) =
     val bodSym = BlockMemberSymbol("‹stack safe body›", Nil, false)
@@ -45,7 +45,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
   def extractResTopLevel(res: Result, isTailCall: Bool, f: Result => Block, sym: Assignable, curDepth: => LocalVarSymbol) =
     sym match
     case sym: LocalVarSymbol => wrapStackSafe(Ret(res), sym, f(sym.asSimpleRef))
-    case _: NoSymbol => wrapStackSafe(Ret(res), sym, f(Value.Lit(Tree.UnitLit(false))))
+    case NoSymbol => wrapStackSafe(Ret(res), sym, f(Value.Lit(Tree.UnitLit(false))))
 
   // Rewrites anything that can contain a Call to increase the stack depth
   def transform(b: Block, curDepth: => LocalVarSymbol, isTopLevel: Bool = false): Block =

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/SymbolRefresher.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/SymbolRefresher.scala
@@ -156,7 +156,7 @@ private class SymbolRefresherInternal(m: MutMap[Symbol, Symbol])(using State) ex
   override def applyImportSymbol(s: ImportSymbol): ImportSymbol = m.getOrElse(s, s).asInstanceOf[ImportSymbol]
   
   override def applyAssignLhs(s: Assignable): Assignable = s match
-    case s: NoSymbol => s
+    case NoSymbol => NoSymbol
     case s: LocalVarSymbol => m.getOrElse(s, s).asInstanceOf[LocalVarSymbol]
   
 class SymbolRefresher(m: Map[Symbol, Symbol])(using State) extends SymbolRefresherInternal(MutMap.from(m))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/UsedVarAnalyzer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/UsedVarAnalyzer.scala
@@ -58,7 +58,7 @@ class UsedVarAnalyzer(b: Block, scopeData: ScopeData)(using State):
           accessed.refdDefns.add(scopeData.getUID(s))
         case Assign(lhs, rhs, rest) =>
           lhs match
-          case _: NoSymbol => ()
+          case NoSymbol => ()
           case lhs: ScopedOrInnerSymbol =>
             accessed.accessed.add(lhs)
             accessed.mutated.add(lhs)
@@ -334,7 +334,7 @@ class UsedVarAnalyzer(b: Block, scopeData: ScopeData)(using State):
           case Assign(lhs, rhs, rest) =>
             applyResult(rhs)
             lhs match
-            case _: NoSymbol => ()
+            case NoSymbol => ()
             case lhs: ScopedOrInnerSymbol =>
               if hasReader.contains(lhs) || hasMutator.contains(lhs) then reqCapture += lhs
               if !linearValueVars.contains(lhs) then mutated += lhs

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/flowAnalysis/FlowAnalysis.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/flowAnalysis/FlowAnalysis.scala
@@ -895,7 +895,7 @@ class FlowConstraintsCollector(
       case Assign(lhs, rhs, rest) =>
         val rhsStrat = processResult(rhs)
         lhs.match
-          case _: NoSymbol => ()
+          case NoSymbol => ()
           case lhs: (LocalVarSymbol | TermSymbol) => cc.constrain(rhsStrat, generatedProdVars(lhs).asConsStrat)
         processBlock(rest)
       case TryBlock(sub, finallyDo, rest) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -338,7 +338,7 @@ class JSBuilder(using Config, TL, State, Ctx) extends CodeBuilder:
   def returningTerm(t: Block, endSemi: Bool)(using Raise, Scope): Document =
     def mkSemi = if endSemi then ";" else ""
     t match
-    case Assign(l: NoSymbol, r, rst) =>
+    case Assign(NoSymbol, r, rst) =>
       doc" # ${result(r)};${returningTerm(rst, endSemi)}"
     case Assign(l: (LocalVarSymbol | TermSymbol), r, rst) =>
       doc" # ${

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -926,7 +926,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
     def splitSuperTail(block: Block): Opt[Block -> Ls[Arg]] = block match
       case End(_) => N
-      case Assign(_: NoSymbol, Call(Value.SimpleRef(State.superSymbol), argss), _: End)
+      case Assign(NoSymbol, Call(Value.SimpleRef(State.superSymbol), argss), _: End)
       =>
         S(End("") -> argss.flatten)
       case b: NonBlockTail =>
@@ -1634,7 +1634,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
   def returningTerm(t: Block)(using Ctx, FunctionCtx, Raise, SessionExportCtx): Expr =
     t match
-      case Assign(l: NoSymbol, r, rst) =>
+      case Assign(NoSymbol, r, rst) =>
         val rExpr = result(r)
         val evalExpr = rExpr.resultType match
           case S(_) => drop(rExpr)

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
@@ -336,7 +336,7 @@ object Elaborator:
     val strSymbol = ModuleOrObjectSymbol(DummyTypeDef(syntax.Mod), Ident("Str"))
     // In JavaScript, `import` can be used for getting current file path, as `import.meta`
     val importSymbol = new VarSymbol(Ident("import"))
-    val noSymbol = NoSymbol()
+    val noSymbol = NoSymbol
     val runtimeSymbol = TempSymbol(N, "runtime")
     val definitionMetadataSymbol = TempSymbol(N, "definitionMetadata")
     val prettyPrintSymbol = TempSymbol(N, "prettyPrint")

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
@@ -157,6 +157,7 @@ end Symbol
 object NoSymbol extends MaybeSymbol:
   def nme: Str = "‹no symbol›"
   override def toString: Str = nme
+type NoSymbol = NoSymbol.type
 
 
 /** Symbols bound by `Program.imports`.

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
@@ -154,7 +154,7 @@ end Symbol
 
 
 // * Used, eg, as the Assign receiver of intermediate computations whose result is not used
-final class NoSymbol(using State) extends MaybeSymbol:
+object NoSymbol extends MaybeSymbol:
   def nme: Str = "‹no symbol›"
   override def toString: Str = nme
 

--- a/hkmc2/shared/src/main/scala/hkmc2/utils/utils.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/utils/utils.scala
@@ -92,7 +92,7 @@ class DebugPrinter:
       case codegen.Scoped(syms, body) =>
         val symsStr = "{" + syms.toArray.sortBy(_.uid).map(_.showAsPlain).mkString(", ") + "}"
         s"Scoped(syms = $symsStr): \n" + s"body = ${printProduct(false, body)}".indent("  ")
-      
+
       case t: Product => printProduct(inTailPos, t)
       case v => printPlain(v)
     

--- a/hkmc2/shared/src/main/scala/hkmc2/utils/utils.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/utils/utils.scala
@@ -92,7 +92,7 @@ class DebugPrinter:
       case codegen.Scoped(syms, body) =>
         val symsStr = "{" + syms.toArray.sortBy(_.uid).map(_.showAsPlain).mkString(", ") + "}"
         s"Scoped(syms = $symsStr): \n" + s"body = ${printProduct(false, body)}".indent("  ")
-
+      
       case t: Product => printProduct(inTailPos, t)
       case v => printPlain(v)
     


### PR DESCRIPTION
This PR simplifies `NoSymbol` by removing its dependency on `State` and converting it into a plain singleton `object`. The legacy `State.noSymbol` is now deprecated in favor of directly using `NoSymbol`.

No functional changes.