### PR TITLE
Add metadata wrapper for `Call` and `Instantiate` IR nodes + fix ClassCtorSymbol logic

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -511,13 +511,11 @@ object HandleBlock:
 
   def suspend(tag: Path, handlerFun: Path)(using Elaborator.Ctx): Result =
     val bms = Elaborator.ctx.builtins.runtime.suspend
-    Call(bms.asMemberRef(bms.asPrincipal.get), (tag.asArg :: handlerFun.asArg :: Nil) ne_:: Nil)(
-      CallMetadata.mlsFunWithEffect)
+    Call(bms.asMemberRef(bms.asPrincipal.get), (tag.asArg :: handlerFun.asArg :: Nil) ne_:: Nil)(CallMetadata.mlsFunWithEffect)
 
   def handleSuspension(tag: Path, bodyFun: Path)(using Elaborator.Ctx): Result =
     val bms = Elaborator.ctx.builtins.runtime.handle_suspension
-    Call(bms.asMemberRef(bms.asPrincipal.get), (tag.asArg :: bodyFun.asArg :: Nil) ne_:: Nil)(
-      CallMetadata.mlsFunWithEffect)
+    Call(bms.asMemberRef(bms.asPrincipal.get), (tag.asArg :: bodyFun.asArg :: Nil) ne_:: Nil)(CallMetadata.mlsFunWithEffect)
   
   private def create(
       lhs: LocalVarSymbol,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -512,12 +512,12 @@ object HandleBlock:
   def suspend(tag: Path, handlerFun: Path)(using Elaborator.Ctx): Result =
     val bms = Elaborator.ctx.builtins.runtime.suspend
     Call(bms.asMemberRef(bms.asPrincipal.get), (tag.asArg :: handlerFun.asArg :: Nil) ne_:: Nil)(
-      CallMetadata(true, true, false))
+      CallMetadata(true, true, false, Nil))
 
   def handleSuspension(tag: Path, bodyFun: Path)(using Elaborator.Ctx): Result =
     val bms = Elaborator.ctx.builtins.runtime.handle_suspension
     Call(bms.asMemberRef(bms.asPrincipal.get), (tag.asArg :: bodyFun.asArg :: Nil) ne_:: Nil)(
-      CallMetadata(true, true, false))
+      CallMetadata(true, true, false, Nil))
   
   private def create(
       lhs: LocalVarSymbol,
@@ -558,7 +558,7 @@ object HandleBlock:
       S(par), handlerMtds, Nil, Nil,
       // Apparently, the lifter is not happy with any assignment in the preCtor...
       Assign(State.noSymbol, Call(State.builtinOpsMap("super").asSimpleRef, args.map(_.asArg) ne_:: Nil)(
-        CallMetadata(true, true, false)), End()),
+        CallMetadata(true, true, false, Nil)), End()),
       End(),
       N,
       N,
@@ -931,6 +931,7 @@ sealed abstract class Result extends AutoLocated:
     case Value.Lit(lit) => 0
     case DynSelect(qual, fld, arrayIdx) => qual.size + fld.size
 
+// In metadata annotations, `S(i)` targets the ith parameter and `N` targets the whole invocation.
 case class CallMetadata(
   isMlsFun: Bool,
   /* mayRaiseEffects indicates whether this call may raise effect (algebraic effect),
@@ -939,13 +940,14 @@ case class CallMetadata(
  * after handler is lowered does not have any effect on the code generation. */
   mayRaiseEffects: Bool,
   explicitTailCall: Bool,
+  annotations: Ls[(Annot, Opt[Int])],
 )
 
 object CallMetadata:
   def defaultMlsFun: CallMetadata =
-    CallMetadata(true, false, false)
+    CallMetadata(true, false, false, Nil)
   def defaultFun: CallMetadata =
-    CallMetadata(false, false, false)
+    CallMetadata(false, false, false, Nil)
 
 
 case class Call(fun: Path, argss: NELs[Ls[Arg]])(val metadata: CallMetadata) extends Result:
@@ -1008,10 +1010,12 @@ object Call:
 end Call
 
 
-case class InstantiateMetadata()
+case class InstantiateMetadata(
+  annotations: Ls[(Annot, Opt[Int])],
+)
 
 object InstantiateMetadata:
-  def empty: InstantiateMetadata = InstantiateMetadata()
+  def empty: InstantiateMetadata = InstantiateMetadata(Nil)
 
 case class Instantiate(mut: Bool, cls: Path, argss: Ls[Ls[Arg]])(val metadata: InstantiateMetadata) extends Result
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -512,12 +512,12 @@ object HandleBlock:
   def suspend(tag: Path, handlerFun: Path)(using Elaborator.Ctx): Result =
     val bms = Elaborator.ctx.builtins.runtime.suspend
     Call(bms.asMemberRef(bms.asPrincipal.get), (tag.asArg :: handlerFun.asArg :: Nil) ne_:: Nil)(
-      CallMetadata(true, true, false, Nil))
+      CallMetadata(true, true, Nil))
 
   def handleSuspension(tag: Path, bodyFun: Path)(using Elaborator.Ctx): Result =
     val bms = Elaborator.ctx.builtins.runtime.handle_suspension
     Call(bms.asMemberRef(bms.asPrincipal.get), (tag.asArg :: bodyFun.asArg :: Nil) ne_:: Nil)(
-      CallMetadata(true, true, false, Nil))
+      CallMetadata(true, true, Nil))
   
   private def create(
       lhs: LocalVarSymbol,
@@ -558,7 +558,7 @@ object HandleBlock:
       S(par), handlerMtds, Nil, Nil,
       // Apparently, the lifter is not happy with any assignment in the preCtor...
       Assign(State.noSymbol, Call(State.builtinOpsMap("super").asSimpleRef, args.map(_.asArg) ne_:: Nil)(
-        CallMetadata(true, true, false, Nil)), End()),
+        CallMetadata(true, true, Nil)), End()),
       End(),
       N,
       N,
@@ -938,15 +938,13 @@ case class CallMetadata(
  * Note that the check for effect is inserted during HandlerLowering and setting this to true
  * after handler is lowered does not have any effect on the code generation. */
   mayRaiseEffects: Bool,
-  explicitTailCall: Bool,
   annotations: Ls[Annot],
-)
+):
+  lazy val explicitTailCall: Bool = annotations.contains(Annot.TailCall)
 
 object CallMetadata:
-  def defaultMlsFun: CallMetadata =
-    CallMetadata(true, false, false, Nil)
-  def defaultFun: CallMetadata =
-    CallMetadata(false, false, false, Nil)
+  val defaultMlsFun = CallMetadata(true, false, Nil)
+  val defaultFun = CallMetadata(false, false, Nil)
 
 
 case class Call(fun: Path, argss: NELs[Ls[Arg]])(val metadata: CallMetadata) extends Result:

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -557,8 +557,7 @@ object HandleBlock:
       N, Nil,
       S(par), handlerMtds, Nil, Nil,
       // Apparently, the lifter is not happy with any assignment in the preCtor...
-      Assign(State.noSymbol, Call(State.builtinOpsMap("super").asSimpleRef, args.map(_.asArg) ne_:: Nil)(
-        CallMetadata.mlsFunWithEffect), End()),
+      Assign(State.noSymbol, Call(State.builtinOpsMap("super").asSimpleRef, args.map(_.asArg) ne_:: Nil)(CallMetadata.mlsFunWithEffect), End()),
       End(),
       N,
       N,
@@ -931,12 +930,12 @@ sealed abstract class Result extends AutoLocated:
     case Value.Lit(lit) => 0
     case DynSelect(qual, fld, arrayIdx) => qual.size + fld.size
 
+/* mayRaiseEffects indicates whether this call may raise effect (algebraic effect),
+ * regardless of whether the check for effect is inserted or not.
+ * Note that the check for effect is inserted during HandlerLowering and setting this to true
+ * after handler is lowered does not have any effect on the code generation. */
 case class CallMetadata(
   isMlsFun: Bool,
-  /* mayRaiseEffects indicates whether this call may raise effect (algebraic effect),
-   * regardless of whether the check for effect is inserted or not.
-   * Note that the check for effect is inserted during HandlerLowering and setting this to true
-   * after handler is lowered does not have any effect on the code generation. */
   mayRaiseEffects: Bool,
   annotations: Ls[Annot],
 ):

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -931,7 +931,6 @@ sealed abstract class Result extends AutoLocated:
     case Value.Lit(lit) => 0
     case DynSelect(qual, fld, arrayIdx) => qual.size + fld.size
 
-// In metadata annotations, `S(i)` targets the ith parameter and `N` targets the whole invocation.
 case class CallMetadata(
   isMlsFun: Bool,
   /* mayRaiseEffects indicates whether this call may raise effect (algebraic effect),
@@ -940,7 +939,7 @@ case class CallMetadata(
  * after handler is lowered does not have any effect on the code generation. */
   mayRaiseEffects: Bool,
   explicitTailCall: Bool,
-  annotations: Ls[(Annot, Opt[Int])],
+  annotations: Ls[Annot],
 )
 
 object CallMetadata:
@@ -1011,7 +1010,7 @@ end Call
 
 
 case class InstantiateMetadata(
-  annotations: Ls[(Annot, Opt[Int])],
+  annotations: Ls[Annot],
 )
 
 object InstantiateMetadata:

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -511,11 +511,13 @@ object HandleBlock:
 
   def suspend(tag: Path, handlerFun: Path)(using Elaborator.Ctx): Result =
     val bms = Elaborator.ctx.builtins.runtime.suspend
-    Call(bms.asMemberRef(bms.asPrincipal.get), (tag.asArg :: handlerFun.asArg :: Nil) ne_:: Nil)(true, true, false)
+    Call(bms.asMemberRef(bms.asPrincipal.get), (tag.asArg :: handlerFun.asArg :: Nil) ne_:: Nil)(
+      CallMetadata(true, true, false))
 
   def handleSuspension(tag: Path, bodyFun: Path)(using Elaborator.Ctx): Result =
     val bms = Elaborator.ctx.builtins.runtime.handle_suspension
-    Call(bms.asMemberRef(bms.asPrincipal.get), (tag.asArg :: bodyFun.asArg :: Nil) ne_:: Nil)(true, true, false)
+    Call(bms.asMemberRef(bms.asPrincipal.get), (tag.asArg :: bodyFun.asArg :: Nil) ne_:: Nil)(
+      CallMetadata(true, true, false))
   
   private def create(
       lhs: LocalVarSymbol,
@@ -555,7 +557,8 @@ object HandleBlock:
       N, Nil,
       S(par), handlerMtds, Nil, Nil,
       // Apparently, the lifter is not happy with any assignment in the preCtor...
-      Assign(State.noSymbol, Call(State.builtinOpsMap("super").asSimpleRef, args.map(_.asArg) ne_:: Nil)(true, true, false), End()),
+      Assign(State.noSymbol, Call(State.builtinOpsMap("super").asSimpleRef, args.map(_.asArg) ne_:: Nil)(
+        CallMetadata(true, true, false)), End()),
       End(),
       N,
       N,
@@ -564,7 +567,7 @@ object HandleBlock:
     blockBuilder
       .scopedVars(Set(clsDefn.sym, sym))
       .define(clsDefn)
-      .assign(lhs, Instantiate(mut = true, clsDefn.sym.asMemberRef(cls), Nil :: Nil))
+      .assign(lhs, Instantiate(mut = true, clsDefn.sym.asMemberRef(cls), Nil :: Nil)(InstantiateMetadata.empty))
       .define(bodyDefn)
       .assign(res, handleSuspension(lhs.asSimpleRef, bodyDefn.sym.asMemberRef(bodyDefn.dSym)))
       .rest(rest)
@@ -928,11 +931,24 @@ sealed abstract class Result extends AutoLocated:
     case Value.Lit(lit) => 0
     case DynSelect(qual, fld, arrayIdx) => qual.size + fld.size
 
-/* mayRaiseEffects indicates whether this call may raise effect (algebraic effect),
+case class CallMetadata(
+  isMlsFun: Bool,
+  /* mayRaiseEffects indicates whether this call may raise effect (algebraic effect),
  * regardless of whether the check for effect is inserted or not.
  * Note that the check for effect is inserted during HandlerLowering and setting this to true
  * after handler is lowered does not have any effect on the code generation. */
-case class Call(fun: Path, argss: NELs[Ls[Arg]])(val isMlsFun: Bool, val mayRaiseEffects: Bool, val explicitTailCall: Bool) extends Result:
+  mayRaiseEffects: Bool,
+  explicitTailCall: Bool,
+)
+
+object CallMetadata:
+  def defaultMlsFun: CallMetadata =
+    CallMetadata(true, false, false)
+  def defaultFun: CallMetadata =
+    CallMetadata(false, false, false)
+
+
+case class Call(fun: Path, argss: NELs[Ls[Arg]])(val metadata: CallMetadata) extends Result:
   lazy val isKnownUnsaturatedCall: Bool =
     fun.targetSymbol match
     case S(ts: TermSymbol) =>
@@ -943,10 +959,10 @@ case class Call(fun: Path, argss: NELs[Ls[Arg]])(val isMlsFun: Bool, val mayRais
 
 object Call:
   
-  def raw(fun: Path, argss: NELs[Ls[Arg]])(isMlsFun: Bool, mayRaiseEffects: Bool, explicitTailCall: Bool): Call =
-    new Call(fun, argss)(isMlsFun, mayRaiseEffects, explicitTailCall)
+  def raw(fun: Path, argss: NELs[Ls[Arg]])(metadata: CallMetadata): Call =
+    new Call(fun, argss)(metadata)
   
-  def apply(fun: Path, argss: NELs[Ls[Arg]])(isMlsFun: Bool, mayRaiseEffects: Bool, explicitTailCall: Bool): Result =
+  def apply(fun: Path, argss: NELs[Ls[Arg]])(metadata: CallMetadata): Result =
     fun match
     case Value.SimpleRef(sym: BuiltinSymbol) =>
       argss match
@@ -956,7 +972,7 @@ object Call:
         evalBuiltin(sym, arg1)(return _)
       case _ =>
     case _ =>
-    raw(fun, argss)(isMlsFun, mayRaiseEffects, explicitTailCall)
+    raw(fun, argss)(metadata)
   
   private def literalArgValues(args: Ls[Arg]): Opt[Ls[Value]] =
     args.foldRight[Opt[Ls[Value]]](S(Nil)):
@@ -992,7 +1008,12 @@ object Call:
 end Call
 
 
-case class Instantiate(mut: Bool, cls: Path, argss: Ls[Ls[Arg]]) extends Result
+case class InstantiateMetadata()
+
+object InstantiateMetadata:
+  def empty: InstantiateMetadata = InstantiateMetadata()
+
+case class Instantiate(mut: Bool, cls: Path, argss: Ls[Ls[Arg]])(val metadata: InstantiateMetadata) extends Result
 
 case class Lambda(params: ParamList, body: Block)(val annot: Ls[Annot]) extends Result:
   lazy val affine: Bool = annot.exists(_.isInstanceOf[Annot.Affine])

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Block.scala
@@ -512,12 +512,12 @@ object HandleBlock:
   def suspend(tag: Path, handlerFun: Path)(using Elaborator.Ctx): Result =
     val bms = Elaborator.ctx.builtins.runtime.suspend
     Call(bms.asMemberRef(bms.asPrincipal.get), (tag.asArg :: handlerFun.asArg :: Nil) ne_:: Nil)(
-      CallMetadata(true, true, Nil))
+      CallMetadata.mlsFunWithEffect)
 
   def handleSuspension(tag: Path, bodyFun: Path)(using Elaborator.Ctx): Result =
     val bms = Elaborator.ctx.builtins.runtime.handle_suspension
     Call(bms.asMemberRef(bms.asPrincipal.get), (tag.asArg :: bodyFun.asArg :: Nil) ne_:: Nil)(
-      CallMetadata(true, true, Nil))
+      CallMetadata.mlsFunWithEffect)
   
   private def create(
       lhs: LocalVarSymbol,
@@ -558,7 +558,7 @@ object HandleBlock:
       S(par), handlerMtds, Nil, Nil,
       // Apparently, the lifter is not happy with any assignment in the preCtor...
       Assign(State.noSymbol, Call(State.builtinOpsMap("super").asSimpleRef, args.map(_.asArg) ne_:: Nil)(
-        CallMetadata(true, true, Nil)), End()),
+        CallMetadata.mlsFunWithEffect), End()),
       End(),
       N,
       N,
@@ -934,9 +934,9 @@ sealed abstract class Result extends AutoLocated:
 case class CallMetadata(
   isMlsFun: Bool,
   /* mayRaiseEffects indicates whether this call may raise effect (algebraic effect),
- * regardless of whether the check for effect is inserted or not.
- * Note that the check for effect is inserted during HandlerLowering and setting this to true
- * after handler is lowered does not have any effect on the code generation. */
+   * regardless of whether the check for effect is inserted or not.
+   * Note that the check for effect is inserted during HandlerLowering and setting this to true
+   * after handler is lowered does not have any effect on the code generation. */
   mayRaiseEffects: Bool,
   annotations: Ls[Annot],
 ):
@@ -945,6 +945,7 @@ case class CallMetadata(
 object CallMetadata:
   val defaultMlsFun = CallMetadata(true, false, Nil)
   val defaultFun = CallMetadata(false, false, Nil)
+  val mlsFunWithEffect = CallMetadata(true, true, Nil)
 
 
 case class Call(fun: Path, argss: NELs[Ls[Arg]])(val metadata: CallMetadata) extends Result:

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -929,6 +929,7 @@ class BlockSimplifier
               prefix.metadata.isMlsFun,
               prefix.metadata.mayRaiseEffects || c.metadata.mayRaiseEffects,
               c.metadata.explicitTailCall,
+              prefix.metadata.annotations ++ c.metadata.annotations,
             ),
           ).withLocOf(c)
           super.applyResult(combined)(k)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -928,7 +928,6 @@ class BlockSimplifier
             CallMetadata(
               prefix.metadata.isMlsFun,
               prefix.metadata.mayRaiseEffects || c.metadata.mayRaiseEffects,
-              c.metadata.explicitTailCall,
               prefix.metadata.annotations ++ c.metadata.annotations,
             ),
           ).withLocOf(c)
@@ -1246,7 +1245,9 @@ class BlockSimplifier
                       else
                         acc(Scoped(Set(resSym), newBlk(
                           k(Call(resSym.asSimpleRef, extraArgss.ne_!)(
-                            c.metadata.copy(explicitTailCall = false))))))
+                            c.metadata.copy(
+                              annotations = c.metadata.annotations.filterNot(_ == Annot.TailCall),
+                            ))))))
                     case (sym, value) :: argRest =>
                       val newSym = VarSymbol(sym.id)
                       go(acc.assignScoped(newSym, value), argRest, mapping + (sym -> newSym))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -925,7 +925,11 @@ class BlockSimplifier
         case S(prefix) =>
           registerChange(s"${loc.showDbg} call prefix ~> ${prefix.showDbg}")
           val combined = Call(prefix.fun, (prefix.argss ::: argss).ne_!)(
-            prefix.isMlsFun, prefix.mayRaiseEffects || c.mayRaiseEffects, c.explicitTailCall,
+            CallMetadata(
+              prefix.metadata.isMlsFun,
+              prefix.metadata.mayRaiseEffects || c.metadata.mayRaiseEffects,
+              c.metadata.explicitTailCall,
+            ),
           ).withLocOf(c)
           super.applyResult(combined)(k)
         case N => super.applyResult(r)(k)
@@ -1240,7 +1244,8 @@ class BlockSimplifier
                         acc(Scoped(Set.single(resSym), newBlk(k(resSym.asSimpleRef))))
                       else
                         acc(Scoped(Set(resSym), newBlk(
-                          k(Call(resSym.asSimpleRef, extraArgss.ne_!)(c.isMlsFun, c.mayRaiseEffects, false)))))
+                          k(Call(resSym.asSimpleRef, extraArgss.ne_!)(
+                            c.metadata.copy(explicitTailCall = false))))))
                     case (sym, value) :: argRest =>
                       val newSym = VarSymbol(sym.id)
                       go(acc.assignScoped(newSym, value), argRest, mapping + (sym -> newSym))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockSimplifier.scala
@@ -752,7 +752,7 @@ class BlockSimplifier
             Set.empty[Shape]
           def getCtorShape(path: Path): Opt[Shape] =
             path.targetSymbol.flatMap:
-              case ccs: ClassCtorSymbol => ccs.owner
+              case ccs: ClassCtorSymbol => S(ccs.associatedCls)
               case sym => sym.asClsOrMod
           def isSaturatedClassCall(sym: ClassSymbol, argss: NELs[Ls[Arg]]): Bool =
             sym.irClsLikeDefn.exists: defn =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BlockTransformer.scala
@@ -164,12 +164,12 @@ class BlockTransformer(subst: SymbolSubst):
       applyPath(fun): fun2 =>
         applyListOf(argss, (args, k2) => applyArgs(args)(k2)): argss2 =>
           k(if (fun2 is fun) && (argss2 is argss) then r
-            else Call(fun2, argss2.ne_!)(r.isMlsFun, r.mayRaiseEffects, r.explicitTailCall).withLocOf(r))
-    case Instantiate(mut, cls, argss) =>
+            else Call(fun2, argss2.ne_!)(r.metadata).withLocOf(r))
+    case r @ Instantiate(mut, cls, argss) =>
       applyPath(cls): cls2 =>
         applyListOf(argss, (args, k2) => applyArgs(args)(k2)): argss2 =>
           k(if (cls2 is cls) && (argss2 is argss) then r
-            else Instantiate(mut, cls2, argss2).withLocOf(r))
+            else Instantiate(mut, cls2, argss2)(r.metadata).withLocOf(r))
     case l: Lambda => k(applyLam(l))
     case Tuple(mut, elems) =>
       applyArgs(elems): elems2 =>
@@ -349,4 +349,3 @@ class BlockTransformerShallow(subst: SymbolSubst) extends BlockTransformer(subst
 // to traverse sub-blocks while using this class to perform more complicated transformations on the blocks themselves.
 class BlockDataTransformer(subst: SymbolSubst) extends BlockTransformerShallow(subst):
   override def applySubBlock(b: Block): Block = b
-

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/BufferableTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/BufferableTransform.scala
@@ -38,11 +38,11 @@ class BufferableTransform()(using Ctx, State, Raise):
             def mkFieldReplacer(buf: VarSymbol, baseIdx: VarSymbol, symMap: Map[SimpleSymbol, SimpleSymbol]) =
               def getOffset(off: Int)(k: Path => Block): Block =
                 val idxSymbol = new TempSymbol(N, "idx")
-                Scoped(Set.single(idxSymbol), Assign(idxSymbol, Call(State.builtinOpsMap("+").asSimpleRef, (baseIdx.asSimpleRef.asArg :: Value.Lit(Tree.IntLit(off)).asArg :: Nil) ne_:: Nil)(true, false, false),
+                Scoped(Set.single(idxSymbol), Assign(idxSymbol, Call(State.builtinOpsMap("+").asSimpleRef, (baseIdx.asSimpleRef.asArg :: Value.Lit(Tree.IntLit(off)).asArg :: Nil) ne_:: Nil)(CallMetadata.defaultMlsFun),
                   k(DynSelect(buf.asSimpleRef.selSN("buf"), idxSymbol.asSimpleRef, true))))
               def assignToOffset(off: Int, r: Result, rst: Block) =
                 val idxSymbol = new TempSymbol(N, "idx")
-                Scoped(Set.single(idxSymbol), Assign(idxSymbol, Call(State.builtinOpsMap("+").asSimpleRef, (baseIdx.asSimpleRef.asArg :: Value.Lit(Tree.IntLit(off)).asArg :: Nil) ne_:: Nil)(true, false, false),
+                Scoped(Set.single(idxSymbol), Assign(idxSymbol, Call(State.builtinOpsMap("+").asSimpleRef, (baseIdx.asSimpleRef.asArg :: Value.Lit(Tree.IntLit(off)).asArg :: Nil) ne_:: Nil)(CallMetadata.defaultMlsFun),
                   AssignDynField(buf.asSimpleRef.selSN("buf"), idxSymbol.asSimpleRef, true, r, applyBlock(rst))))
               new BlockTransformer(SymbolSubst.Id):
                 override def applySimpleSymbol(sym: SimpleSymbol): SimpleSymbol = symMap.getOrElse(sym, sym)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/ClassParamFlattener.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/ClassParamFlattener.scala
@@ -85,7 +85,9 @@ class ClassParamFlattener(using State) extends BlockTransformer(SymbolSubst.Id):
             val flatArgss =
               if argss2.lengthCompare(1) > 0 then argss2.flatten ne_:: Nil
               else argss2
-            k(Instantiate(false, cls2, flatArgss)(InstantiateMetadata.empty).withLocOf(call))
+            k(Instantiate(false, cls2, flatArgss)(
+              InstantiateMetadata(call.metadata.annotations),
+            ).withLocOf(call))
       case N =>
         super.applyResult(r)(k)
     case inst @ Instantiate(mut, cls, argss) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/ClassParamFlattener.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/ClassParamFlattener.scala
@@ -76,7 +76,7 @@ class ClassParamFlattener(using State) extends BlockTransformer(SymbolSubst.Id):
           else argss2
         k:
           if flatArgss is argss then c
-          else Call(r, flatArgss)(c.isMlsFun, c.mayRaiseEffects, c.explicitTailCall).withLocOf(c)
+          else Call(r, flatArgss)(c.metadata).withLocOf(c)
     case call @ Call(fun, argss) =>
       saturatedCurriedClassCall(fun, argss) match
       case S(cls) =>
@@ -85,7 +85,7 @@ class ClassParamFlattener(using State) extends BlockTransformer(SymbolSubst.Id):
             val flatArgss =
               if argss2.lengthCompare(1) > 0 then argss2.flatten ne_:: Nil
               else argss2
-            k(Instantiate(false, cls2, flatArgss).withLocOf(call))
+            k(Instantiate(false, cls2, flatArgss)(InstantiateMetadata.empty).withLocOf(call))
       case N =>
         super.applyResult(r)(k)
     case inst @ Instantiate(mut, cls, argss) =>
@@ -96,7 +96,7 @@ class ClassParamFlattener(using State) extends BlockTransformer(SymbolSubst.Id):
             else argss2
           k:
             if (cls2 is cls) && (flatArgss is argss) then inst
-            else Instantiate(mut, cls2, flatArgss).withLocOf(inst)
+            else Instantiate(mut, cls2, flatArgss)(inst.metadata).withLocOf(inst)
     case _ =>
       super.applyResult(r)(k)
   

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/ClassParamFlattener.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/ClassParamFlattener.scala
@@ -85,9 +85,7 @@ class ClassParamFlattener(using State) extends BlockTransformer(SymbolSubst.Id):
             val flatArgss =
               if argss2.lengthCompare(1) > 0 then argss2.flatten ne_:: Nil
               else argss2
-            k(Instantiate(false, cls2, flatArgss)(
-              InstantiateMetadata(call.metadata.annotations),
-            ).withLocOf(call))
+            k(Instantiate(false, cls2, flatArgss)(InstantiateMetadata(call.metadata.annotations)).withLocOf(call))
       case N =>
         super.applyResult(r)(k)
     case inst @ Instantiate(mut, cls, argss) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/DeadParamElim.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/DeadParamElim.scala
@@ -270,7 +270,7 @@ class Rewrite(val deadParamElimSolver: DeadParamElimSolver)(using Raise):
           rewriteArgs(args, eliminable): args2 =>
             k(
               if (fun2 is fun) && (args2 is args) then c
-              else Call(fun2, args2 ne_:: restArgss)(c.isMlsFun, c.mayRaiseEffects, c.explicitTailCall).withLocOf(c)
+              else Call(fun2, args2 ne_:: restArgss)(c.metadata).withLocOf(c)
             )
       case i@Instantiate(mut, cls, args :: restArgss) if args.forall(_.spread.isEmpty) =>
         val eliminable = deadParamElimSolver.eliminableCallSiteArgsById(ConcreteId(i.uid, instId))
@@ -278,7 +278,7 @@ class Rewrite(val deadParamElimSolver: DeadParamElimSolver)(using Raise):
           rewriteArgs(args, eliminable): args2 =>
             k(
               if (cls2 is cls) && (args2 is args) then i
-              else Instantiate(mut, cls2, args2 :: restArgss).withLocOf(i)
+              else Instantiate(mut, cls2, args2 :: restArgss)(i.metadata).withLocOf(i)
             )
       case _ => super.applyResult(r)(k)
     

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/EtaExpansion.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/EtaExpansion.scala
@@ -183,7 +183,7 @@ class EtaExpansionRewrite(val etaExpansionSolver: EtaExpansionSolver)(using Rais
     
     private def etaCall(base: Path): Result =
       Call(base, activeEtaArgss.ne_!)(
-        CallMetadata(true, true, false))
+        CallMetadata(true, true, false, Nil))
     
     override def applyBlock(b: Block): Block = b match
       case Return(res) if activeEtaArgss.nonEmpty =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/EtaExpansion.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/EtaExpansion.scala
@@ -182,7 +182,8 @@ class EtaExpansionRewrite(val etaExpansionSolver: EtaExpansionSolver)(using Rais
           lastWords("not the same shape?")
     
     private def etaCall(base: Path): Result =
-      Call(base, activeEtaArgss.ne_!)(isMlsFun = true, mayRaiseEffects = true, explicitTailCall = false)
+      Call(base, activeEtaArgss.ne_!)(
+        CallMetadata(true, true, false))
     
     override def applyBlock(b: Block): Block = b match
       case Return(res) if activeEtaArgss.nonEmpty =>
@@ -193,7 +194,7 @@ class EtaExpansionRewrite(val etaExpansionSolver: EtaExpansionSolver)(using Rais
             Return(etaCall(p).withLocOf(res2))
           case c @ Call(fun, argss) =>
             Return(
-              Call(fun, (argss ++ activeEtaArgss).ne_!)(c.isMlsFun, c.mayRaiseEffects, c.explicitTailCall))
+              Call(fun, (argss ++ activeEtaArgss).ne_!)(c.metadata))
           case _ =>
             val tmp = TempSymbol(N, "eta$res")
             Scoped(

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/EtaExpansion.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/EtaExpansion.scala
@@ -182,8 +182,7 @@ class EtaExpansionRewrite(val etaExpansionSolver: EtaExpansionSolver)(using Rais
           lastWords("not the same shape?")
     
     private def etaCall(base: Path): Result =
-      Call(base, activeEtaArgss.ne_!)(
-        CallMetadata.mlsFunWithEffect)
+      Call(base, activeEtaArgss.ne_!)(CallMetadata.mlsFunWithEffect)
     
     override def applyBlock(b: Block): Block = b match
       case Return(res) if activeEtaArgss.nonEmpty =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/EtaExpansion.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/EtaExpansion.scala
@@ -183,7 +183,7 @@ class EtaExpansionRewrite(val etaExpansionSolver: EtaExpansionSolver)(using Rais
     
     private def etaCall(base: Path): Result =
       Call(base, activeEtaArgss.ne_!)(
-        CallMetadata(true, true, false, Nil))
+        CallMetadata(true, true, Nil))
     
     override def applyBlock(b: Block): Block = b match
       case Return(res) if activeEtaArgss.nonEmpty =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/EtaExpansion.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/EtaExpansion.scala
@@ -183,7 +183,7 @@ class EtaExpansionRewrite(val etaExpansionSolver: EtaExpansionSolver)(using Rais
     
     private def etaCall(base: Path): Result =
       Call(base, activeEtaArgss.ne_!)(
-        CallMetadata(true, true, Nil))
+        CallMetadata.mlsFunWithEffect)
     
     override def applyBlock(b: Block): Block = b match
       case Return(res) if activeEtaArgss.nonEmpty =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/FirstClassFunctionTransformer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/FirstClassFunctionTransformer.scala
@@ -28,11 +28,11 @@ class FirstClassFunctionTransformer
     )
     val defSym = new BlockMemberSymbol("Function$", Nil, false)
     val callDef = FunDefn.withFreshSymbol(Some(clsSym), new BlockMemberSymbol("call", Nil, true), params :: Nil,
-      Return(Call(p, params.params.map(_.sym.asSimpleRef.asArg) ne_:: Nil)(true, false, false)))(N, annotations = Nil)
+      Return(Call(p, params.params.map(_.sym.asSimpleRef.asArg) ne_:: Nil)(CallMetadata.defaultMlsFun)))(N, annotations = Nil)
     ClsLikeDefn(None, clsSym, defSym, None, syntax.Cls, None, Nil,
       Some(Select(State.globalThisSymbol.asThis, Tree.Ident("Function"))(Some(ctx.builtins.Function))),
       callDef :: Nil, Nil, Nil, Assign.discard(
-        Call(State.builtinOpsMap("super").asSimpleRef, Nil ne_:: Nil)(false, false, false),
+        Call(State.builtinOpsMap("super").asSimpleRef, Nil ne_:: Nil)(CallMetadata.defaultFun),
         End()), End(), None, None)(N, annotations = Nil)
 
   private def getParamList(l: BlockMemberSymbol): Option[ParamList] = funDefns.get(l) match
@@ -49,7 +49,7 @@ class FirstClassFunctionTransformer
         val clsDef = generateFCFunctionClass(ref, params)
         val tmp = new TempSymbol(None)
         val cls = clsDef.sym.asMemberRef(clsDef.isym)
-        Scoped(Set(clsDef.sym, tmp), Define(clsDef, Assign(tmp, Instantiate(false, cls, Nil :: Nil), k(tmp.asSimpleRef))))
+        Scoped(Set(clsDef.sym, tmp), Define(clsDef, Assign(tmp, Instantiate(false, cls, Nil :: Nil)(InstantiateMetadata.empty), k(tmp.asSimpleRef))))
       case _ => k(p)
     case sel: Select => sel.symbol match
       case Some(s: TermSymbol) if (s.k is syntax.Fun) =>
@@ -62,7 +62,7 @@ class FirstClassFunctionTransformer
         val clsDef = generateFCFunctionClass(sel, params)
         val tmp = new TempSymbol(None)
         val cls = clsDef.sym.asMemberRef(clsDef.isym)
-        Scoped(Set(clsDef.sym, tmp), Define(clsDef, Assign(tmp, Instantiate(false, cls, Nil :: Nil), k(tmp.asSimpleRef))))
+        Scoped(Set(clsDef.sym, tmp), Define(clsDef, Assign(tmp, Instantiate(false, cls, Nil :: Nil)(InstantiateMetadata.empty), k(tmp.asSimpleRef))))
       case Some(_) => k(p)
       case _ =>
         raise(ErrorReport(msg"Cannot determine if ${sel.name.name} is a function." -> sel.toLoc :: Nil,
@@ -72,7 +72,7 @@ class FirstClassFunctionTransformer
 
   override def applyResult(r: Result)(k: Result => Block): Block = r match
     case c @ Call(fun, argss) => applyListOf(argss, (args, k2) => applyArgs(args)(k2)): argss2 =>
-      def call(f: Path) = Call(f, argss2.ne_!)(c.isMlsFun, c.mayRaiseEffects, c.explicitTailCall)
+      def call(f: Path) = Call(f, argss2.ne_!)(c.metadata)
       fun match
         case ref @ Value.SimpleRef(sym) => sym match
           case _: VarSymbol |  _: TempSymbol => k(call(ref.selSN("call")))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -69,7 +69,7 @@ object HandlerLowering:
         resumeInfo.argLists ++:
         (intLit(restoreList.length) ::
         restoreList.map(_.asPath))
-      ).map(_.asArg) ne_:: Nil)(true, true, false))
+      ).map(_.asArg) ne_:: Nil)(CallMetadata(true, true, false)))
   
   // argLists: length-encoded argument list used for resumption.
   // currentLocals: All locals to be saved and reloaded, this cannot include any variables in outer scopes
@@ -87,7 +87,7 @@ object HandlerLowering:
 
   object EffectfulResult:
     def unapply(r: Result)(using Config): Bool = r match
-      case c: Call if c.mayRaiseEffects => true
+      case c: Call if c.metadata.mayRaiseEffects => true
       case _: Instantiate if config.checkInstantiateEffect => true
       case _ => false
   
@@ -125,11 +125,11 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
   
   private def rtThrowMsg(msg: Str) = Throw(
     Instantiate(mut = false, State.globalThisSymbol.asThis.selN(Tree.Ident("Error")),
-    (Value.Lit(Tree.StrLit(msg)).asArg :: Nil) :: Nil)
+    (Value.Lit(Tree.StrLit(msg)).asArg :: Nil) :: Nil)(InstantiateMetadata.empty)
   )
   
   object PureCall:
-    def apply(fun: Path, args: List[Path]) = Call(fun, args.map(Arg(N, _)) ne_:: Nil)(true, false, false)
+    def apply(fun: Path, args: List[Path]) = Call(fun, args.map(Arg(N, _)) ne_:: Nil)(CallMetadata.defaultMlsFun)
     def unapply(res: Result) = res match
       case Call(fun, args :: Nil) => args.foldRight[Opt[List[Path]]](S(Nil)): (arg, acc) =>
           acc.flatMap: acc =>
@@ -555,9 +555,9 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
     val preTransform = new BlockTransformer(SymbolSubst.Id):
       override def applyResult(r: Result)(k: Result => Block): Block = r match
         case Call(Value.MemberRef(sym, _), args) if sym is Elaborator.ctx.builtins.runtime.suspend =>
-          k(Call(paths.mkEffectPath, args)(true, true, false))
+          k(Call(paths.mkEffectPath, args)(CallMetadata(true, true, false)))
         case Call(Value.MemberRef(sym, _), args) if sym is Elaborator.ctx.builtins.runtime.handle_suspension =>
-          k(Call(paths.enterHandleBlockPath, args)(true, true, false))
+          k(Call(paths.enterHandleBlockPath, args)(CallMetadata(true, true, false)))
         case _ => super.applyResult(r)(k)
       override def applyDefn(defn: Defn)(k: Defn => Block): Block = defn match
         case fun: FunDefn =>
@@ -598,12 +598,12 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         case _ => super.applyDefn(defn)(k)
     val b = preTransform.applyBlock(blk)
     if h.inCtor then
-      return translateIllegalEffectCtx(b, Call.raw(paths.illegalEffectPath, (Value.Lit(Tree.StrLit("in a constructor")).asArg :: Nil) ne_:: Nil)(true, true, false))
+      return translateIllegalEffectCtx(b, Call.raw(paths.illegalEffectPath, (Value.Lit(Tree.StrLit("in a constructor")).asArg :: Nil) ne_:: Nil)(CallMetadata(true, true, false)))
     if h.inTopLevel then
-      return translateIllegalEffectCtx(b, Call.raw(paths.topLevelEffectPath, (Value.Lit(Tree.BoolLit(opt.debug)).asArg :: Nil) ne_:: Nil)(true, false, false))
+      return translateIllegalEffectCtx(b, Call.raw(paths.topLevelEffectPath, (Value.Lit(Tree.BoolLit(opt.debug)).asArg :: Nil) ne_:: Nil)(CallMetadata.defaultMlsFun))
     val ctx = h.asInstanceOf[HandlerCtx.FunctionLike].ctx
     if ctx.inGetter then
-      return translateIllegalEffectCtx(b, Call.raw(paths.illegalEffectPath, (Value.Lit(Tree.StrLit("in a getter")).asArg :: Nil) ne_:: Nil)(true, false, false))
+      return translateIllegalEffectCtx(b, Call.raw(paths.illegalEffectPath, (Value.Lit(Tree.StrLit("in a getter")).asArg :: Nil) ne_:: Nil)(CallMetadata.defaultMlsFun))
     given FunctionCtx = ctx
     val parts = partitionBlock(b)
     stackSafetyMap += ctx.resumeInfo.currentStackSafetySym ->
@@ -694,7 +694,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
     def getSaved(off: BigInt): (Block => Block, Path) =
       if off == 0 then
         return (id, DynSelect(paths.runtimePath.selSN("resumeArr"), paths.runtimePath.selSN("resumeIdx"), true))
-      val addOne = Assign(getSavedTmp, Call(State.builtinOpsMap("+").asSimpleRef, (paths.runtimePath.selSN("resumeIdx").asArg :: intLit(off).asArg :: Nil) ne_:: Nil)(false, false, false), _)
+      val addOne = Assign(getSavedTmp, Call(State.builtinOpsMap("+").asSimpleRef, (paths.runtimePath.selSN("resumeIdx").asArg :: intLit(off).asArg :: Nil) ne_:: Nil)(CallMetadata.defaultFun), _)
       (addOne, DynSelect(paths.runtimePath.selSN("resumeArr"), getSavedTmp.asSimpleRef, true))
 
     val resumeArrIndexed = DynSelect(paths.runtimePath.selSN("resumeArr"), getSavedTmp.asSimpleRef, true)
@@ -704,7 +704,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         .scopedVars(Set(getSavedTmp))
     val restoreVars = vars.zipWithIndex.foldLeft(preRestore):
       case (builder, (local, idx)) => builder
-        .assign(getSavedTmp, if idx == 0 then paths.resumeIdx else Call(plus, (getSavedTmp.asSimpleRef.asArg :: intLit(1).asArg :: Nil) ne_:: Nil)(false, false, false))
+        .assign(getSavedTmp, if idx == 0 then paths.resumeIdx else Call(plus, (getSavedTmp.asSimpleRef.asArg :: intLit(1).asArg :: Nil) ne_:: Nil)(CallMetadata.defaultFun))
         .assign(local, resumeArrIndexed)
 
     Scoped(
@@ -752,7 +752,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
     val blk = blockBuilder
       .staticif(
         !opt.doNotInstrumentTopLevelModCtor,
-        _.assign(NoSymbol, Call(paths.resetEffects, Nil ne_:: Nil)(true, false, false))
+        _.assign(NoSymbol, Call(paths.resetEffects, Nil ne_:: Nil)(CallMetadata.defaultMlsFun))
       )
       .rest(transformed)
     (blk, stackSafetyMap)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -69,7 +69,7 @@ object HandlerLowering:
         resumeInfo.argLists ++:
         (intLit(restoreList.length) ::
         restoreList.map(_.asPath))
-      ).map(_.asArg) ne_:: Nil)(CallMetadata(true, true, false, Nil)))
+      ).map(_.asArg) ne_:: Nil)(CallMetadata(true, true, Nil)))
   
   // argLists: length-encoded argument list used for resumption.
   // currentLocals: All locals to be saved and reloaded, this cannot include any variables in outer scopes
@@ -555,9 +555,9 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
     val preTransform = new BlockTransformer(SymbolSubst.Id):
       override def applyResult(r: Result)(k: Result => Block): Block = r match
         case Call(Value.MemberRef(sym, _), args) if sym is Elaborator.ctx.builtins.runtime.suspend =>
-          k(Call(paths.mkEffectPath, args)(CallMetadata(true, true, false, Nil)))
+          k(Call(paths.mkEffectPath, args)(CallMetadata(true, true, Nil)))
         case Call(Value.MemberRef(sym, _), args) if sym is Elaborator.ctx.builtins.runtime.handle_suspension =>
-          k(Call(paths.enterHandleBlockPath, args)(CallMetadata(true, true, false, Nil)))
+          k(Call(paths.enterHandleBlockPath, args)(CallMetadata(true, true, Nil)))
         case _ => super.applyResult(r)(k)
       override def applyDefn(defn: Defn)(k: Defn => Block): Block = defn match
         case fun: FunDefn =>
@@ -598,7 +598,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         case _ => super.applyDefn(defn)(k)
     val b = preTransform.applyBlock(blk)
     if h.inCtor then
-      return translateIllegalEffectCtx(b, Call.raw(paths.illegalEffectPath, (Value.Lit(Tree.StrLit("in a constructor")).asArg :: Nil) ne_:: Nil)(CallMetadata(true, true, false, Nil)))
+      return translateIllegalEffectCtx(b, Call.raw(paths.illegalEffectPath, (Value.Lit(Tree.StrLit("in a constructor")).asArg :: Nil) ne_:: Nil)(CallMetadata(true, true, Nil)))
     if h.inTopLevel then
       return translateIllegalEffectCtx(b, Call.raw(paths.topLevelEffectPath, (Value.Lit(Tree.BoolLit(opt.debug)).asArg :: Nil) ne_:: Nil)(CallMetadata.defaultMlsFun))
     val ctx = h.asInstanceOf[HandlerCtx.FunctionLike].ctx

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -69,7 +69,7 @@ object HandlerLowering:
         resumeInfo.argLists ++:
         (intLit(restoreList.length) ::
         restoreList.map(_.asPath))
-      ).map(_.asArg) ne_:: Nil)(CallMetadata(true, true, Nil)))
+      ).map(_.asArg) ne_:: Nil)(CallMetadata.mlsFunWithEffect))
   
   // argLists: length-encoded argument list used for resumption.
   // currentLocals: All locals to be saved and reloaded, this cannot include any variables in outer scopes
@@ -555,9 +555,9 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
     val preTransform = new BlockTransformer(SymbolSubst.Id):
       override def applyResult(r: Result)(k: Result => Block): Block = r match
         case Call(Value.MemberRef(sym, _), args) if sym is Elaborator.ctx.builtins.runtime.suspend =>
-          k(Call(paths.mkEffectPath, args)(CallMetadata(true, true, Nil)))
+          k(Call(paths.mkEffectPath, args)(CallMetadata.mlsFunWithEffect))
         case Call(Value.MemberRef(sym, _), args) if sym is Elaborator.ctx.builtins.runtime.handle_suspension =>
-          k(Call(paths.enterHandleBlockPath, args)(CallMetadata(true, true, Nil)))
+          k(Call(paths.enterHandleBlockPath, args)(CallMetadata.mlsFunWithEffect))
         case _ => super.applyResult(r)(k)
       override def applyDefn(defn: Defn)(k: Defn => Block): Block = defn match
         case fun: FunDefn =>
@@ -598,7 +598,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         case _ => super.applyDefn(defn)(k)
     val b = preTransform.applyBlock(blk)
     if h.inCtor then
-      return translateIllegalEffectCtx(b, Call.raw(paths.illegalEffectPath, (Value.Lit(Tree.StrLit("in a constructor")).asArg :: Nil) ne_:: Nil)(CallMetadata(true, true, Nil)))
+      return translateIllegalEffectCtx(b, Call.raw(paths.illegalEffectPath, (Value.Lit(Tree.StrLit("in a constructor")).asArg :: Nil) ne_:: Nil)(CallMetadata.mlsFunWithEffect))
     if h.inTopLevel then
       return translateIllegalEffectCtx(b, Call.raw(paths.topLevelEffectPath, (Value.Lit(Tree.BoolLit(opt.debug)).asArg :: Nil) ne_:: Nil)(CallMetadata.defaultMlsFun))
     val ctx = h.asInstanceOf[HandlerCtx.FunctionLike].ctx

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -69,7 +69,7 @@ object HandlerLowering:
         resumeInfo.argLists ++:
         (intLit(restoreList.length) ::
         restoreList.map(_.asPath))
-      ).map(_.asArg) ne_:: Nil)(CallMetadata(true, true, false)))
+      ).map(_.asArg) ne_:: Nil)(CallMetadata(true, true, false, Nil)))
   
   // argLists: length-encoded argument list used for resumption.
   // currentLocals: All locals to be saved and reloaded, this cannot include any variables in outer scopes
@@ -555,9 +555,9 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
     val preTransform = new BlockTransformer(SymbolSubst.Id):
       override def applyResult(r: Result)(k: Result => Block): Block = r match
         case Call(Value.MemberRef(sym, _), args) if sym is Elaborator.ctx.builtins.runtime.suspend =>
-          k(Call(paths.mkEffectPath, args)(CallMetadata(true, true, false)))
+          k(Call(paths.mkEffectPath, args)(CallMetadata(true, true, false, Nil)))
         case Call(Value.MemberRef(sym, _), args) if sym is Elaborator.ctx.builtins.runtime.handle_suspension =>
-          k(Call(paths.enterHandleBlockPath, args)(CallMetadata(true, true, false)))
+          k(Call(paths.enterHandleBlockPath, args)(CallMetadata(true, true, false, Nil)))
         case _ => super.applyResult(r)(k)
       override def applyDefn(defn: Defn)(k: Defn => Block): Block = defn match
         case fun: FunDefn =>
@@ -598,7 +598,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
         case _ => super.applyDefn(defn)(k)
     val b = preTransform.applyBlock(blk)
     if h.inCtor then
-      return translateIllegalEffectCtx(b, Call.raw(paths.illegalEffectPath, (Value.Lit(Tree.StrLit("in a constructor")).asArg :: Nil) ne_:: Nil)(CallMetadata(true, true, false)))
+      return translateIllegalEffectCtx(b, Call.raw(paths.illegalEffectPath, (Value.Lit(Tree.StrLit("in a constructor")).asArg :: Nil) ne_:: Nil)(CallMetadata(true, true, false, Nil)))
     if h.inTopLevel then
       return translateIllegalEffectCtx(b, Call.raw(paths.topLevelEffectPath, (Value.Lit(Tree.BoolLit(opt.debug)).asArg :: Nil) ne_:: Nil)(CallMetadata.defaultMlsFun))
     val ctx = h.asInstanceOf[HandlerCtx.FunctionLike].ctx

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -1052,7 +1052,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
             case (acc, sym) => Arg(N, sym.asSimpleRef) :: acc
         case None => syms.map(s => Arg(N, s.asSimpleRef))
       
-      val call = Call(fun.sym.asMemberRef(fun.dSym), args ne_:: Nil)(CallMetadata(true, true, Nil))
+      val call = Call(fun.sym.asMemberRef(fun.dSym), args ne_:: Nil)(CallMetadata.mlsFunWithEffect)
       val bod = Return(call)
       
       FunDefn(
@@ -1219,7 +1219,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         k(Call(superCall.fun, (formatArgs ::: argss.head) ne_:: argss.tail)(CallMetadata.defaultMlsFun).withLoc(superCall.toLoc))
       else
         // Parameterized class: use Instantiate with original args + lifter args inserted after the first list
-        k(Call(superCall.fun, argss.head ne_:: formatArgs ne_:: argss.tail)(CallMetadata(true, true, Nil)).withLoc(superCall.toLoc))
+        k(Call(superCall.fun, argss.head ne_:: formatArgs ne_:: argss.tail)(CallMetadata.mlsFunWithEffect).withLoc(superCall.toLoc))
     
     def rewriteCall(c: Call, argss: NELs[List[Arg]])(k: Result => Block)(using ctx: LifterCtxNew): Block =
       if obj.isObj then lastWords("tried to rewrite instantiate for an object")

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -1239,9 +1239,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         lastWords("Call to paramless class")
       else if argss.lengthCompare(clsParamLists.length) === 0 then
         // Parameterized class: Same as Instantiate case
-        k(Instantiate(false, path, argss.head :: formatArgs :: argss.tail)(
-          InstantiateMetadata(c.metadata.annotations),
-        ).withLoc(c.toLoc))
+        k(Instantiate(false, path, argss.head :: formatArgs :: argss.tail)(InstantiateMetadata(c.metadata.annotations)).withLoc(c.toLoc))
       else
         // Unsaturated constructor calls must remain ordinary curried calls to
         // the lifted wrapper; only saturated constructor applications may

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -1052,7 +1052,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
             case (acc, sym) => Arg(N, sym.asSimpleRef) :: acc
         case None => syms.map(s => Arg(N, s.asSimpleRef))
       
-      val call = Call(fun.sym.asMemberRef(fun.dSym), args ne_:: Nil)(CallMetadata(true, true, false))
+      val call = Call(fun.sym.asMemberRef(fun.dSym), args ne_:: Nil)(CallMetadata(true, true, false, Nil))
       val bod = Return(call)
       
       FunDefn(
@@ -1219,7 +1219,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         k(Call(superCall.fun, (formatArgs ::: argss.head) ne_:: argss.tail)(CallMetadata.defaultMlsFun).withLoc(superCall.toLoc))
       else
         // Parameterized class: use Instantiate with original args + lifter args inserted after the first list
-        k(Call(superCall.fun, argss.head ne_:: formatArgs ne_:: argss.tail)(CallMetadata(true, true, false)).withLoc(superCall.toLoc))
+        k(Call(superCall.fun, argss.head ne_:: formatArgs ne_:: argss.tail)(CallMetadata(true, true, false, Nil)).withLoc(superCall.toLoc))
     
     def rewriteCall(c: Call, argss: NELs[List[Arg]])(k: Result => Block)(using ctx: LifterCtxNew): Block =
       if obj.isObj then lastWords("tried to rewrite instantiate for an object")
@@ -1239,7 +1239,9 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         lastWords("Call to paramless class")
       else if argss.lengthCompare(clsParamLists.length) === 0 then
         // Parameterized class: Same as Instantiate case
-        k(Instantiate(false, path, argss.head :: formatArgs :: argss.tail)(InstantiateMetadata.empty).withLoc(c.toLoc))
+        k(Instantiate(false, path, argss.head :: formatArgs :: argss.tail)(
+          InstantiateMetadata(c.metadata.annotations),
+        ).withLoc(c.toLoc))
       else
         // Unsaturated constructor calls must remain ordinary curried calls to
         // the lifted wrapper; only saturated constructor applications may

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -585,7 +585,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
     
     val defn = ClsLikeDefn(
       None, clsSym, BlockMemberSymbol(nme, Nil),
-      S(ClassCtorSymbol(syntax.Fun, S(clsSym), clsSym.id)),
+      S(ClassCtorSymbol(syntax.Fun, N, clsSym)),
       syntax.Cls,
       N,
       PlainParamList(sortedVars.iterator.map(_.param).toList) :: Nil, None, Nil, Nil, 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -1052,7 +1052,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
             case (acc, sym) => Arg(N, sym.asSimpleRef) :: acc
         case None => syms.map(s => Arg(N, s.asSimpleRef))
       
-      val call = Call(fun.sym.asMemberRef(fun.dSym), args ne_:: Nil)(CallMetadata(true, true, false, Nil))
+      val call = Call(fun.sym.asMemberRef(fun.dSym), args ne_:: Nil)(CallMetadata(true, true, Nil))
       val bod = Return(call)
       
       FunDefn(
@@ -1219,7 +1219,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         k(Call(superCall.fun, (formatArgs ::: argss.head) ne_:: argss.tail)(CallMetadata.defaultMlsFun).withLoc(superCall.toLoc))
       else
         // Parameterized class: use Instantiate with original args + lifter args inserted after the first list
-        k(Call(superCall.fun, argss.head ne_:: formatArgs ne_:: argss.tail)(CallMetadata(true, true, false, Nil)).withLoc(superCall.toLoc))
+        k(Call(superCall.fun, argss.head ne_:: formatArgs ne_:: argss.tail)(CallMetadata(true, true, Nil)).withLoc(superCall.toLoc))
     
     def rewriteCall(c: Call, argss: NELs[List[Arg]])(k: Result => Block)(using ctx: LifterCtxNew): Block =
       if obj.isObj then lastWords("tried to rewrite instantiate for an object")

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lifter.scala
@@ -360,11 +360,11 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
                   def join2: Block =
                     // Resolve reference to unlifted object
                     resolveDefnRef(d, r) match
-                      case Some(value) => k(c.copy(fun = value, argss = newArgss.ne_!)(c.isMlsFun, c.mayRaiseEffects, c.explicitTailCall).withLoc(c.toLoc))
+                      case Some(value) => k(c.copy(fun = value, argss = newArgss.ne_!)(c.metadata).withLoc(c.toLoc))
                       case None => super.applyPath(c.fun): fun2 =>
                         // Nothing to rewrite
                         if (fun2 is c.fun) && (argss is newArgss) then k(c)
-                        else k(c.copy(fun = fun2, argss = newArgss.ne_!)(c.isMlsFun, c.mayRaiseEffects, c.explicitTailCall).withLoc(c.toLoc))
+                        else k(c.copy(fun = fun2, argss = newArgss.ne_!)(c.metadata).withLoc(c.toLoc))
                   r match
                     // Call to lifted function: Rewrite using the efficient version
                     case f: LiftedFunc => k(f.rewriteCall(c, newArgss))
@@ -378,12 +378,12 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
             applyArgss(argss): newArgss =>
               def join =
                 if argss is newArgss then inst
-                else inst.copy(argss = newArgss).withLoc(inst.toLoc)
+                else inst.copy(argss = newArgss)(inst.metadata).withLoc(inst.toLoc)
               ctx.rewrittenScopes.get(d) match
                 case N => k(join)
                 case S(c: LiftedClass) => c.rewriteInstantiate(inst, newArgss)(k)
                 case S(r) => resolveDefnRef(d, r) match
-                  case Some(value) => k(Instantiate(inst.mut, value, newArgss).withLoc(inst.toLoc))
+                  case Some(value) => k(Instantiate(inst.mut, value, newArgss)(inst.metadata).withLoc(inst.toLoc))
                   case None => k(join)
           case _ => super.applyResult(r)(k)
         
@@ -674,7 +674,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
           captureClass.sym.asMemberRef(captureClass.isym),
           captureInfo._2.map(
             (sym, _) => sym.asPath.asArg) :: Nil
-        )
+        )(InstantiateMetadata.empty)
       else lastWords("tried to instantiate an empty capture")
     
     protected final def addExtraSyms(b: Block, captureSym: LocalVarSymbol, objSyms: Iterable[ScopedSymbol]): Block =
@@ -1052,7 +1052,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
             case (acc, sym) => Arg(N, sym.asSimpleRef) :: acc
         case None => syms.map(s => Arg(N, s.asSimpleRef))
       
-      val call = Call(fun.sym.asMemberRef(fun.dSym), args ne_:: Nil)(true, true, false)
+      val call = Call(fun.sym.asMemberRef(fun.dSym), args ne_:: Nil)(CallMetadata(true, true, false))
       val bod = Return(call)
       
       FunDefn(
@@ -1068,16 +1068,12 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
     def rewriteCall(c: Call, argss: NELs[List[Arg]])(using ctx: LifterCtxNew): Call =
       if isTrivial then
         if argss is c.argss then c
-        else c.copy(argss = argss)(c.isMlsFun, c.mayRaiseEffects, c.explicitTailCall).withLocOf(c)
+        else c.copy(argss = argss)(c.metadata).withLocOf(c)
       else
         Call.raw(
           mainSym.asMemberRef(mainDsym),
           (formatArgs ::: argss.head) ne_:: argss.tail
-        )(
-          isMlsFun = true,
-          mayRaiseEffects = c.mayRaiseEffects,
-          explicitTailCall = c.explicitTailCall
-        ).withLoc(c.toLoc)
+        )(c.metadata.copy(isMlsFun = true)).withLoc(c.toLoc)
     
     def rewriteRef(using ctx: LifterCtxNew): Call =
       if isTrivial then lastWords("tried to rewrite a ref to a trivial function")
@@ -1085,11 +1081,7 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
       Call.raw(
         auxSym.asMemberRef(auxDsym),
         formatArgs ne_:: Nil
-      )(
-        isMlsFun = true,
-        mayRaiseEffects = false,
-        explicitTailCall = false
-      )
+      )(CallMetadata.defaultMlsFun)
     
     def rewriteImpl: LifterResult[FunDefn] =
       val LifterResult(lifted, extra) = mkFlattenedDefn
@@ -1187,14 +1179,14 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
       val argsList = appliedMainAndAuxArgs(appliedClsAuxArgs)
       
       val ref = obj.cls.sym.asMemberRef(obj.cls.isym)
-      val inst = Instantiate(false, ref, argsList)
+      val inst = Instantiate(false, ref, argsList)(InstantiateMetadata.empty)
       val bod = Return(inst)
       
       FunDefn(N, flattenedSym, flattenedDSym, allParamLists, bod)(N, annotations = Nil)
     
     private val flat = Lazy[Defn](mkFlattenedDefn)
     
-    def instObject = Instantiate(false, cls.sym.asMemberRef(cls.isym), formatArgs :: Nil)
+    def instObject = Instantiate(false, cls.sym.asMemberRef(cls.isym), formatArgs :: Nil)(InstantiateMetadata.empty)
     
     // Rewrite a naked reference to a parameterized class constructor.
     // Returns a Call to the curried C$ wrapper partially applied with formatArgs.
@@ -1204,34 +1196,30 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
       Call.raw(
         flattenedSym.asMemberRef(flattenedDSym),
         formatArgs ne_:: Nil
-      )(
-        isMlsFun = true,
-        mayRaiseEffects = false,
-        explicitTailCall = false
-      )
+      )(CallMetadata.defaultMlsFun)
     
     def rewriteInstantiate(inst: Instantiate, argss: List[List[Arg]])(k: Result => Block): Block =
       if obj.isObj then lastWords("tried to rewrite instantiate for an object")
       val path = cls.sym.asMemberRef(cls.isym)
       if isTrivial then
         if (inst.cls === path) && (inst.argss is argss) then k(inst)
-        else k(inst.copy(cls = path, argss = argss).withLocOf(inst))
+        else k(inst.copy(cls = path, argss = argss)(inst.metadata).withLocOf(inst))
       else if cls.paramsOpt.isEmpty && cls.auxParams.isEmpty then
         // Paramless class: lifter args go directly into the Instantiate constructor
-        k(Instantiate(inst.mut, path, (formatArgs ::: argss.head) :: argss.tail).withLoc(inst.toLoc))
+        k(Instantiate(inst.mut, path, (formatArgs ::: argss.head) :: argss.tail)(inst.metadata).withLoc(inst.toLoc))
       else
         // Parameterized class: use Instantiate with original args + lifter args inserted after the first list
-        k(Instantiate(inst.mut, path, argss.head :: formatArgs :: argss.tail).withLoc(inst.toLoc))
+        k(Instantiate(inst.mut, path, argss.head :: formatArgs :: argss.tail)(inst.metadata).withLoc(inst.toLoc))
     
     def rewriteSuperCall(superCall: Call, argss: List[List[Arg]])(k: Result => Block): Block =
       if obj.isObj then lastWords("tried to rewrite instantiate for an object")
       if isTrivial then k(superCall)
       else if cls.paramsOpt.isEmpty && cls.auxParams.isEmpty then
         // Paramless class: lifter args go directly into the Instantiate constructor
-        k(Call(superCall.fun, (formatArgs ::: argss.head) ne_:: argss.tail)(true, false, false).withLoc(superCall.toLoc))
+        k(Call(superCall.fun, (formatArgs ::: argss.head) ne_:: argss.tail)(CallMetadata.defaultMlsFun).withLoc(superCall.toLoc))
       else
         // Parameterized class: use Instantiate with original args + lifter args inserted after the first list
-        k(Call(superCall.fun, argss.head ne_:: formatArgs ne_:: argss.tail)(true, true, false).withLoc(superCall.toLoc))
+        k(Call(superCall.fun, argss.head ne_:: formatArgs ne_:: argss.tail)(CallMetadata(true, true, false)).withLoc(superCall.toLoc))
     
     def rewriteCall(c: Call, argss: NELs[List[Arg]])(k: Result => Block)(using ctx: LifterCtxNew): Block =
       if obj.isObj then lastWords("tried to rewrite instantiate for an object")
@@ -1242,20 +1230,16 @@ class Lifter(topLevelBlk: Block)(using State, Raise, Config):
         Call.raw(
           flattenedSym.asMemberRef(flattenedDSym),
           (formatArgs :: argss).ne_!
-        )(
-          isMlsFun = true,
-          mayRaiseEffects = false,
-          explicitTailCall = c.explicitTailCall
-        ).withLoc(c.toLoc)
+        )(c.metadata.copy(isMlsFun = true, mayRaiseEffects = false)).withLoc(c.toLoc)
       if isTrivial then
         if c.argss is argss then k(c)
-        else k(c.copy(argss = argss)(c.isMlsFun, c.mayRaiseEffects, c.explicitTailCall).withLocOf(c))
+        else k(c.copy(argss = argss)(c.metadata).withLocOf(c))
       else if cls.paramsOpt.isEmpty && cls.auxParams.isEmpty then
         // Paramless class: unreachable
         lastWords("Call to paramless class")
       else if argss.lengthCompare(clsParamLists.length) === 0 then
         // Parameterized class: Same as Instantiate case
-        k(Instantiate(false, path, argss.head :: formatArgs :: argss.tail).withLoc(c.toLoc))
+        k(Instantiate(false, path, argss.head :: formatArgs :: argss.tail)(InstantiateMetadata.empty).withLoc(c.toLoc))
       else
         // Unsaturated constructor calls must remain ordinary curried calls to
         // the lifted wrapper; only saturated constructor applications may

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -406,7 +406,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
               msg"Extending a partially applied class is not supported" -> loc :: Nil,
               source = Diagnostic.Source.Compilation))
           k(Call(fr, acc.reverse.ne_!)(
-            CallMetadata(isMlsFun, true, isTailCall)).withLoc(loc))
+            CallMetadata(isMlsFun, true, isTailCall, Nil)).withLoc(loc))
       zipArgs(ctorParamLists, args, Nil)
     case Nil =>
       if !ctorParamLists.isEmpty then
@@ -415,7 +415,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
           source = Diagnostic.Source.Compilation))
       // * No arguments to a super ctor means a nullary call, e.g., `extends C` means `extends C()`
       k(Call(fr, Nil ne_:: Nil)(
-        CallMetadata(isMlsFun, true, isTailCall)).withLoc(loc))
+        CallMetadata(isMlsFun, true, isTailCall, Nil)).withLoc(loc))
   
   /** Lower a call with multiple argument lists into `Call` nodes,
     * trying to group as many as possible into a single one
@@ -427,18 +427,18 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
         lowerArgs(args)(as => zipArgs(remainingParams, remainingArgs, as :: acc, mayRaiseEffects))
       case (Nil, Nil) =>
         k(Call(fr, acc.reverse.ne_!)(
-          CallMetadata(isMlsFun, mayRaiseEffects, isTailCall)).withLoc(loc))
+          CallMetadata(isMlsFun, mayRaiseEffects, isTailCall, Nil)).withLoc(loc))
       case (Nil, args :: remainingArgss) =>
         acc.reverse match
         case Nil => lowerRemainingCalls(fr, args, remainingArgss, isTailCall, loc)(k)
         case acc: NELs[Ls[Arg]] =>
           val tmp = loweringCtx.registerTempSymbol(N, "baseCall")
           val call = Call(fr, acc)(
-            CallMetadata(isMlsFun, mayRaiseEffects, isTailCall)).withLoc(loc)
+            CallMetadata(isMlsFun, mayRaiseEffects, isTailCall, Nil)).withLoc(loc)
           Assign(tmp, call, lowerRemainingCalls(tmp.asSimpleRef, args, remainingArgss, isTailCall, loc)(k))
       case (_ :: _, Nil) =>
         k(Call(fr, acc.reverse.ne_!)(
-          CallMetadata(isMlsFun, mayRaiseEffects, isTailCall)).withLoc(loc))
+          CallMetadata(isMlsFun, mayRaiseEffects, isTailCall, Nil)).withLoc(loc))
     fr.targetSymbol match
     case S(fs: TermSymbol) =>
       fs.defn match
@@ -451,7 +451,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
         (k: Result => Block)(using LoweringCtx): Block =
     lowerArgs(args): as =>
       val call = Call(base, as ne_:: Nil)(
-        CallMetadata(false, true, isTailCall)).withLoc(loc)
+        CallMetadata(false, true, isTailCall, Nil)).withLoc(loc)
       remainingArgss match
       case Nil => k(call)
       case args :: remainingArgss =>
@@ -646,7 +646,8 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
             )(CallMetadata(
               true,
               true,
-              annots.contains(Annot.TailCall))))
+              annots.contains(Annot.TailCall),
+              Nil)))
       case S(td: TermDefinition) =>
         td.tsym.owner match
         case S(owner) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -404,8 +404,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
             raise(ErrorReport(
               msg"Extending a partially applied class is not supported" -> loc :: Nil,
               source = Diagnostic.Source.Compilation))
-          k(Call(fr, acc.reverse.ne_!)(
-            CallMetadata(isMlsFun, true, Nil)).withLoc(loc))
+          k(Call(fr, acc.reverse.ne_!)(CallMetadata(isMlsFun, true, Nil)).withLoc(loc))
       zipArgs(ctorParamLists, args, Nil)
     case Nil =>
       if !ctorParamLists.isEmpty then
@@ -413,8 +412,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
           msg"Extending a partially applied class is not supported" -> loc :: Nil,
           source = Diagnostic.Source.Compilation))
       // * No arguments to a super ctor means a nullary call, e.g., `extends C` means `extends C()`
-      k(Call(fr, Nil ne_:: Nil)(
-        CallMetadata(isMlsFun, true, Nil)).withLoc(loc))
+      k(Call(fr, Nil ne_:: Nil)(CallMetadata(isMlsFun, true, Nil)).withLoc(loc))
   
   /** Lower a call with multiple argument lists into `Call` nodes,
     * trying to group as many as possible into a single one
@@ -425,19 +423,16 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
       case (ps :: remainingParams, args :: remainingArgs) =>
         lowerArgs(args)(as => zipArgs(remainingParams, remainingArgs, as :: acc, mayRaiseEffects))
       case (Nil, Nil) =>
-        k(Call(fr, acc.reverse.ne_!)(
-          CallMetadata(isMlsFun, mayRaiseEffects, annotations)).withLoc(loc))
+        k(Call(fr, acc.reverse.ne_!)(CallMetadata(isMlsFun, mayRaiseEffects, annotations)).withLoc(loc))
       case (Nil, args :: remainingArgss) =>
         acc.reverse match
         case Nil => lowerRemainingCalls(fr, args, remainingArgss, annotations, loc)(k)
         case acc: NELs[Ls[Arg]] =>
           val tmp = loweringCtx.registerTempSymbol(N, "baseCall")
-          val call = Call(fr, acc)(
-            CallMetadata(isMlsFun, mayRaiseEffects, Nil)).withLoc(loc)
+          val call = Call(fr, acc)(CallMetadata(isMlsFun, mayRaiseEffects, Nil)).withLoc(loc)
           Assign(tmp, call, lowerRemainingCalls(tmp.asSimpleRef, args, remainingArgss, annotations, loc)(k))
       case (_ :: _, Nil) =>
-        k(Call(fr, acc.reverse.ne_!)(
-          CallMetadata(isMlsFun, mayRaiseEffects, annotations)).withLoc(loc))
+        k(Call(fr, acc.reverse.ne_!)(CallMetadata(isMlsFun, mayRaiseEffects, annotations)).withLoc(loc))
     fr.targetSymbol match
     case S(fs: TermSymbol) =>
       fs.defn match
@@ -449,12 +444,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
   def lowerRemainingCalls(base: Path, args: Term, remainingArgss: Ls[Term], annotations: Ls[Annot], loc: Opt[Loc])
         (k: Result => Block)(using LoweringCtx): Block =
     lowerArgs(args): as =>
-      val call = Call(base, as ne_:: Nil)(
-        CallMetadata(
-          false,
-          true,
-          annotations,
-        )).withLoc(loc)
+      val call = Call(base, as ne_:: Nil)(CallMetadata(false, true, annotations)).withLoc(loc)
       remainingArgss match
       case Nil => k(call)
       case args :: remainingArgss =>
@@ -646,10 +636,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
         if td.params.isEmpty then
           return k(Call(
               bs.asMemberRef(disamb.get).withLocOf(ref), Nil ne_:: Nil
-            )(CallMetadata(
-              true,
-              true,
-              annots)))
+            )(CallMetadata(true, true, annots)))
       case S(td: TermDefinition) =>
         td.tsym.owner match
         case S(owner) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -405,7 +405,8 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
             raise(ErrorReport(
               msg"Extending a partially applied class is not supported" -> loc :: Nil,
               source = Diagnostic.Source.Compilation))
-          k(Call(fr, acc.reverse.ne_!)(isMlsFun, true, isTailCall).withLoc(loc))
+          k(Call(fr, acc.reverse.ne_!)(
+            CallMetadata(isMlsFun, true, isTailCall)).withLoc(loc))
       zipArgs(ctorParamLists, args, Nil)
     case Nil =>
       if !ctorParamLists.isEmpty then
@@ -413,7 +414,8 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
           msg"Extending a partially applied class is not supported" -> loc :: Nil,
           source = Diagnostic.Source.Compilation))
       // * No arguments to a super ctor means a nullary call, e.g., `extends C` means `extends C()`
-      k(Call(fr, Nil ne_:: Nil)(isMlsFun, true, isTailCall).withLoc(loc))
+      k(Call(fr, Nil ne_:: Nil)(
+        CallMetadata(isMlsFun, true, isTailCall)).withLoc(loc))
   
   /** Lower a call with multiple argument lists into `Call` nodes,
     * trying to group as many as possible into a single one
@@ -424,16 +426,19 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
       case (ps :: remainingParams, args :: remainingArgs) =>
         lowerArgs(args)(as => zipArgs(remainingParams, remainingArgs, as :: acc, mayRaiseEffects))
       case (Nil, Nil) =>
-        k(Call(fr, acc.reverse.ne_!)(isMlsFun, mayRaiseEffects, isTailCall).withLoc(loc))
+        k(Call(fr, acc.reverse.ne_!)(
+          CallMetadata(isMlsFun, mayRaiseEffects, isTailCall)).withLoc(loc))
       case (Nil, args :: remainingArgss) =>
         acc.reverse match
         case Nil => lowerRemainingCalls(fr, args, remainingArgss, isTailCall, loc)(k)
         case acc: NELs[Ls[Arg]] =>
           val tmp = loweringCtx.registerTempSymbol(N, "baseCall")
-          val call = Call(fr, acc)(isMlsFun, mayRaiseEffects, isTailCall).withLoc(loc)
+          val call = Call(fr, acc)(
+            CallMetadata(isMlsFun, mayRaiseEffects, isTailCall)).withLoc(loc)
           Assign(tmp, call, lowerRemainingCalls(tmp.asSimpleRef, args, remainingArgss, isTailCall, loc)(k))
       case (_ :: _, Nil) =>
-        k(Call(fr, acc.reverse.ne_!)(isMlsFun, mayRaiseEffects, isTailCall).withLoc(loc))
+        k(Call(fr, acc.reverse.ne_!)(
+          CallMetadata(isMlsFun, mayRaiseEffects, isTailCall)).withLoc(loc))
     fr.targetSymbol match
     case S(fs: TermSymbol) =>
       fs.defn match
@@ -445,7 +450,8 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
   def lowerRemainingCalls(base: Path, args: Term, remainingArgss: Ls[Term], isTailCall: Bool, loc: Opt[Loc])
         (k: Result => Block)(using LoweringCtx): Block =
     lowerArgs(args): as =>
-      val call = Call(base, as ne_:: Nil)(isMlsFun = false, true, isTailCall).withLoc(loc)
+      val call = Call(base, as ne_:: Nil)(
+        CallMetadata(false, true, isTailCall)).withLoc(loc)
       remainingArgss match
       case Nil => k(call)
       case args :: remainingArgss =>
@@ -461,7 +467,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
   def lowerMultiInstantiate(mut: Bool, cls: Path, args: Ls[Term])(k: Result => Block)(using LoweringCtx): Block =
     // Nullary instantiations are represented with one empty argument list, matching existing `Instantiate` usage.
     def buildInstantiate(argss: Ls[Ls[Arg]]): Instantiate =
-      Instantiate(mut, cls, if argss.isEmpty then Nil :: Nil else argss)
+      Instantiate(mut, cls, if argss.isEmpty then Nil :: Nil else argss)(InstantiateMetadata.empty)
     // * Zip constructor param lists with argument lists, accumulating lowered args.
     // * Consumes one argument list per constructor param list; when all ctor params are
     // * consumed but extra args remain, falls back to `Call` nodes on the result.
@@ -637,7 +643,10 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
         if td.params.isEmpty then
           return k(Call(
               bs.asMemberRef(disamb.get).withLocOf(ref), Nil ne_:: Nil
-            )(isMlsFun = true, true, annots.contains(Annot.TailCall)))
+            )(CallMetadata(
+              true,
+              true,
+              annots.contains(Annot.TailCall))))
       case S(td: TermDefinition) =>
         td.tsym.owner match
         case S(owner) =>
@@ -710,7 +719,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
                 Call(
                   State.builtinOpsMap("===").asSimpleRef,
                   (bodyResult.asSimpleRef.asArg :: State.runtimeSymbol.asSimpleRef.selSN("Continue").asArg :: Nil) ne_:: Nil,
-                )(true, false, false),
+                )(CallMetadata.defaultMlsFun),
                 Match(
                   isContinue.asSimpleRef,
                   (Case.Lit(Tree.BoolLit(true)) -> Continue(label)) :: Nil,
@@ -760,7 +769,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
         subTerm(arg): ar =>
           val target = wasmIntrinsicPath(sym, unary = true)
             .getOrElse(sym.asSimpleRef.withLocOf(ref))
-          k(Call(target, (Arg(N, ar) :: Nil) ne_:: Nil)(true, false, false))
+          k(Call(target, (Arg(N, ar) :: Nil) ne_:: Nil)(CallMetadata.defaultMlsFun))
       case st.Tup(Fld(FldFlags.benign(), arg1, N) :: Fld(FldFlags.benign(), arg2, N) :: Nil) =>
         if !sym.binary then raise:
           ErrorReport(
@@ -790,7 +799,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
             subTerm_nonTail(arg2): ar2 =>
               val target = wasmIntrinsicPath(sym, unary = false)
                 .getOrElse(sym.asSimpleRef.withLocOf(ref))
-              k(Call(target, (Arg(N, ar1) :: Arg(N, ar2) :: Nil) ne_:: Nil)(true, false, false))
+              k(Call(target, (Arg(N, ar1) :: Arg(N, ar2) :: Nil) ne_:: Nil)(CallMetadata.defaultMlsFun))
       case _ => fail:
         ErrorReport(
           msg"Unexpected arguments for builtin symbol '${sym.nme}'" -> arg.toLoc :: Nil, S(arg),
@@ -1014,11 +1023,11 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
     case Resolved(inner, sym) => TODO(s"lowering for Resolved($inner)")
     case Region(reg, body) =>
       loweringCtx.collectScopedSym(reg)
-      Assign(reg, Instantiate(mut = true, Select(State.globalThisSymbol.asThis, Tree.Ident("Region"))(N), Nil :: Nil),
+      Assign(reg, Instantiate(mut = true, Select(State.globalThisSymbol.asThis, Tree.Ident("Region"))(N), Nil :: Nil)(InstantiateMetadata.empty),
         term_nonTail(body)(k))
     case RegRef(reg, value) =>
       plainArgs(reg :: value :: Nil): args =>
-        k(Instantiate(mut = true, Select(State.globalThisSymbol.asThis, Tree.Ident("Ref"))(N), args :: Nil))
+        k(Instantiate(mut = true, Select(State.globalThisSymbol.asThis, Tree.Ident("Ref"))(N), args :: Nil)(InstantiateMetadata.empty))
     case Drop(ref) =>
       subTerm(ref): _ =>
         k(unit)
@@ -1053,14 +1062,14 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
     //   subTerm(t)(k)
   
   def setupTerm(name: Str, args: Ls[Path])(k: Result => Block)(using LoweringCtx): Block =
-    k(Instantiate(mut = false, State.termSymbol.asSimpleRef.selSN(name), args.map(_.asArg) :: Nil))
+    k(Instantiate(mut = false, State.termSymbol.asSimpleRef.selSN(name), args.map(_.asArg) :: Nil)(InstantiateMetadata.empty))
 
   def setupQuotedKeyword(kw: Str): Path =
     State.termSymbol.asSimpleRef.selSN("Keyword").selSN(kw)
 
   def setupSymbol(symbol: ValueSymbol)(k: Result => Block)(using LoweringCtx): Block =
     k(Instantiate(mut = false, State.termSymbol.asSimpleRef.selSN("Symbol"),
-      (Value.Lit(Tree.StrLit(symbol.nme)).asArg :: Nil) :: Nil))
+      (Value.Lit(Tree.StrLit(symbol.nme)).asArg :: Nil) :: Nil)(InstantiateMetadata.empty))
 
   def quotePattern(p: FlatPattern)(k: Result => Block)(using LoweringCtx): Block = p match
     case FlatPattern.Lit(lit) => setupTerm("LitPattern", Value.Lit(lit) :: Nil)(k)
@@ -1464,7 +1473,7 @@ trait LoweringSelSanityChecks(using Config, TL, Raise, State)
           .ifthen(selRes.asSimpleRef,
             Case.Lit(syntax.Tree.UnitLit(false)),
             Throw(Instantiate(mut = false, Select(State.globalThisSymbol.asThis, Tree.Ident("Error"))(N),
-              (Value.Lit(syntax.Tree.StrLit(s"Access to required field '${nme.name}' yielded 'undefined'")).asArg :: Nil) :: Nil))
+              (Value.Lit(syntax.Tree.StrLit(s"Access to required field '${nme.name}' yielded 'undefined'")).asArg :: Nil) :: Nil)(InstantiateMetadata.empty))
           )
           .rest(k(selRes.asSimpleRef))
 
@@ -1482,7 +1491,7 @@ trait LoweringTraceLog(instrument: Bool)(using TL, Raise, State)
       case ((sym, res), acc) => Assign(sym, res, acc)
   
   private def pureCall(fn: Path, args: Ls[Arg]): Result =
-    Call(fn, args ne_:: Nil)(true, false, false)
+    Call(fn, args ne_:: Nil)(CallMetadata.defaultMlsFun)
   
   extension (k: Block => Block)
     def |>: (b: Block): Block = k(b)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -420,25 +420,26 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
   /** Lower a call with multiple argument lists into `Call` nodes,
     * trying to group as many as possible into a single one
     * when they correspond to parameter lists of the same callee. */
-  def lowerMultiCall(fr: Path, isMlsFun: Bool, isTailCall: Bool, args: Ls[Term], loc: Opt[Loc])(k: Result => Block)(using LoweringCtx): Block =
+  def lowerMultiCall(fr: Path, isMlsFun: Bool, annotations: Ls[Annot], args: Ls[Term], loc: Opt[Loc])(k: Result => Block)(using LoweringCtx): Block =
+    val isTailCall = annotations.contains(Annot.TailCall)
     def zipArgs(remainingParamss: Ls[ParamList], remainingArgss: Ls[Term], acc: Ls[Ls[Arg]], mayRaiseEffects: Bool): Block =
       (remainingParamss, remainingArgss) match
       case (ps :: remainingParams, args :: remainingArgs) =>
         lowerArgs(args)(as => zipArgs(remainingParams, remainingArgs, as :: acc, mayRaiseEffects))
       case (Nil, Nil) =>
         k(Call(fr, acc.reverse.ne_!)(
-          CallMetadata(isMlsFun, mayRaiseEffects, isTailCall, Nil)).withLoc(loc))
+          CallMetadata(isMlsFun, mayRaiseEffects, isTailCall, annotations)).withLoc(loc))
       case (Nil, args :: remainingArgss) =>
         acc.reverse match
-        case Nil => lowerRemainingCalls(fr, args, remainingArgss, isTailCall, loc)(k)
+        case Nil => lowerRemainingCalls(fr, args, remainingArgss, annotations, loc)(k)
         case acc: NELs[Ls[Arg]] =>
           val tmp = loweringCtx.registerTempSymbol(N, "baseCall")
           val call = Call(fr, acc)(
-            CallMetadata(isMlsFun, mayRaiseEffects, isTailCall, Nil)).withLoc(loc)
-          Assign(tmp, call, lowerRemainingCalls(tmp.asSimpleRef, args, remainingArgss, isTailCall, loc)(k))
+            CallMetadata(isMlsFun, mayRaiseEffects, false, Nil)).withLoc(loc)
+          Assign(tmp, call, lowerRemainingCalls(tmp.asSimpleRef, args, remainingArgss, annotations, loc)(k))
       case (_ :: _, Nil) =>
         k(Call(fr, acc.reverse.ne_!)(
-          CallMetadata(isMlsFun, mayRaiseEffects, isTailCall, Nil)).withLoc(loc))
+          CallMetadata(isMlsFun, mayRaiseEffects, isTailCall, annotations)).withLoc(loc))
     fr.targetSymbol match
     case S(fs: TermSymbol) =>
       fs.defn match
@@ -447,27 +448,33 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
       case _ => zipArgs(Nil, args, Nil, fs.mayRaiseEffects)
     case _ => zipArgs(Nil, args, Nil, true)
   
-  def lowerRemainingCalls(base: Path, args: Term, remainingArgss: Ls[Term], isTailCall: Bool, loc: Opt[Loc])
+  def lowerRemainingCalls(base: Path, args: Term, remainingArgss: Ls[Term], annotations: Ls[Annot], loc: Opt[Loc])
         (k: Result => Block)(using LoweringCtx): Block =
     lowerArgs(args): as =>
+      val isFinalCall = remainingArgss.isEmpty
       val call = Call(base, as ne_:: Nil)(
-        CallMetadata(false, true, isTailCall, Nil)).withLoc(loc)
+        CallMetadata(
+          false,
+          true,
+          annotations.contains(Annot.TailCall),
+          annotations,
+        )).withLoc(loc)
       remainingArgss match
       case Nil => k(call)
       case args :: remainingArgss =>
         val tmp = loweringCtx.registerTempSymbol(N, "callPrefix")
         Assign(tmp, call,
-          lowerRemainingCalls(tmp.asSimpleRef, args, remainingArgss, isTailCall, loc)(k))
+          lowerRemainingCalls(tmp.asSimpleRef, args, remainingArgss, annotations, loc)(k))
   
   /** Lower an instantiation with multiple argument lists into `Instantiate` and `Call` nodes,
     * trying to group as many as possible into a single `Instantiate`
     * when they correspond to constructor parameter lists of the same class.
     * If fewer argument lists are provided than constructor parameter lists, eta-expands
     * the missing ones with fresh lambdas (avoiding reliance on mutable JS class curry semantics). */
-  def lowerMultiInstantiate(mut: Bool, cls: Path, args: Ls[Term])(k: Result => Block)(using LoweringCtx): Block =
+  def lowerMultiInstantiate(mut: Bool, cls: Path, args: Ls[Term], annotations: Ls[Annot])(k: Result => Block)(using LoweringCtx): Block =
     // Nullary instantiations are represented with one empty argument list, matching existing `Instantiate` usage.
     def buildInstantiate(argss: Ls[Ls[Arg]]): Instantiate =
-      Instantiate(mut, cls, if argss.isEmpty then Nil :: Nil else argss)(InstantiateMetadata.empty)
+      Instantiate(mut, cls, if argss.isEmpty then Nil :: Nil else argss)(InstantiateMetadata(annotations))
     // * Zip constructor param lists with argument lists, accumulating lowered args.
     // * Consumes one argument list per constructor param list; when all ctor params are
     // * consumed but extra args remain, falls back to `Call` nodes on the result.
@@ -481,7 +488,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
       case (Nil, args :: remainingArgss) =>
         val tmp = loweringCtx.registerTempSymbol(N, "baseInst")
         Assign(tmp, buildInstantiate(acc.reverse),
-          lowerRemainingCalls(tmp.asSimpleRef, args, remainingArgss, isTailCall = false, N)(k))
+          lowerRemainingCalls(tmp.asSimpleRef, args, remainingArgss, annotations, N)(k))
       case (remainingParamss, Nil) =>
         // * Eta-expand missing argument lists by creating lambdas for each remaining param list.
         // * This makes partial `new C(args...)` explicit instead of relying on the JS class curry.
@@ -515,7 +522,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
           case remainingArgss =>
             val tmp = loweringCtx.registerTempSymbol(N, "baseInst")
             Assign(tmp, buildInstantiate(as :: Nil),
-              lowerRemainingCalls(tmp.asSimpleRef, remainingArgss.head, remainingArgss.tail, isTailCall = false, N)(k))
+              lowerRemainingCalls(tmp.asSimpleRef, remainingArgss.head, remainingArgss.tail, annotations, N)(k))
     else zipArgs(ctorParamLists, args, Nil)
   
   def lowerArgs(arg: Term)(k: Ls[Arg] => Block)(using LoweringCtx): Block =
@@ -647,7 +654,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
               true,
               true,
               annots.contains(Annot.TailCall),
-              Nil)))
+              annots)))
       case S(td: TermDefinition) =>
         td.tsym.owner match
         case S(owner) =>
@@ -829,7 +836,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
           (sym is State.matchFailureClsSymbol)
       
       def conclude(fr: Path) =
-        lowerMultiCall(fr, isMlsFun, annots.contains(Annot.TailCall), allArgs, t.toLoc)(k)
+        lowerMultiCall(fr, isMlsFun, annots, allArgs, t.toLoc)(k)
       
       // * We have to instantiate `f` again because, if `f` is a Sel, the `term`
       // * function is not called again with f. See below `Sel` and `SelProj` cases.
@@ -995,7 +1002,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
         case _ => spuriousWarning
       subTerm(cls): sr =>
         rft match
-        case N => lowerMultiInstantiate(mut, sr, as)(k)
+        case N => lowerMultiInstantiate(mut, sr, as, annots)(k)
         case S((isym, rft)) =>
           val sym = new BlockMemberSymbol(isym.name, Nil)
           loweringCtx.collectScopedSym(sym)
@@ -1441,15 +1448,23 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
         WarningReport(
           msg"This annotation has no effect." -> annot.toLoc ::
           message -> receiver.toLoc :: Nil)
+
+    def isImplicitNullaryCall(defnSym: DefinitionSymbol[?]): Bool =
+      defnSym.defn.exists:
+        case td: TermDefinition => (td.k is syntax.Fun) && td.params.isEmpty
+        case _ => false
     
     annotations.foreach:
       case Annot.Untyped => ()
+      case annot: Annot.Trm => receiver match
+        case st.App(Ref(_: BuiltinSymbol), _) => warn(annot)
+        case st.App(_, _) | New(_, _, _) | DynNew(_, _) | Mut(_: New | _: DynNew) => ()
+        case st.Resolved(_, defnSym) if isImplicitNullaryCall(defnSym) => ()
+        case _ => warn(annot)
       case a @ Annot.TailCall => receiver match
         case st.App(Ref(_: BuiltinSymbol), _) => warn(a, S(msg"The @tailcall annotation has no effect on calls to built-in symbols."))
         case st.App(_, _) => ()
-        case st.Resolved(_, defnSym) => defnSym.defn match
-          case S(td: TermDefinition) if (td.k is syntax.Fun) && td.params.isEmpty => ()
-          case _ => warn(a)
+        case st.Resolved(_, defnSym) if isImplicitNullaryCall(defnSym) => ()
         case _ => warn(a)
       case annot => warn(annot)
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -377,16 +377,15 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
     
     blockImpl(imps ::: funs ::: rest, res)
   
-  def getCtorParamLists(cls: Path): Ls[ParamList] =
-    cls.targetSymbol.flatMap: sym =>
-      sym.asClsOrMod.flatMap(_.defn) orElse
-      sym.asTrm.flatMap(_.owner).flatMap(_.asDefnSym.defn)
-    .fold(Nil: Ls[ParamList]): clsDef =>
-      clsDef.paramsOpt.toList ::: clsDef.auxParams
+  def getClassParamLists(cls: Path): Ls[ParamList] =
+    cls.targetSymbol match
+    case S(clsSym: ClassSymbol) =>
+      clsSym.defn.map(clsDef => clsDef.paramsOpt.toList ::: clsDef.auxParams).getOrElse(Nil)
+    case _ => Nil
   
   // * Lowers the `super(...)(...)` call we get from the `extends C(...)(...)` syntax
   def lowerSuperCtorCall(parentClsPth: Path, fr: Path, isMlsFun: Bool, args: List[Term], loc: Opt[Loc])(k: Result => Block)(using LoweringCtx): Block =
-    val ctorParamLists = getCtorParamLists(parentClsPth)
+    val ctorParamLists = getClassParamLists(parentClsPth)
     args match
     case _ :: _ =>
       def zipArgs(remainingParamss: Ls[ParamList], args: Ls[Term], acc: Ls[Ls[Arg]]): Block = (remainingParamss, args) match
@@ -494,7 +493,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
     // * so we also look up the owner InnerSymbol via TermDefinition#owner.
     // * Note: apparently, this can also be accessed through TermDefinition#companionClass
     // * (what Copilot initially used), which is weird.
-    val ctorParamLists = getCtorParamLists(cls)
+    val ctorParamLists = getClassParamLists(cls)
     if ctorParamLists.isEmpty then
       // * Need to specially handle no-param classes
       args match
@@ -563,6 +562,11 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
     case sym =>
       lastWords(s"tried to define non-variable symbol ${sym.showDbg}")
   
+  private def isImplicitNullaryCall(defnSym: DefinitionSymbol[?]): Bool =
+    defnSym.defn.exists:
+      case td: TermDefinition => (td.k is syntax.Fun) && td.params.isEmpty
+      case _ => false
+  
   def ref(ref: st.Ref, annots: List[Annot], disamb: Opt[DefinitionSymbol[?]], inStmtPos: Bool)(k: Result => Block)(using LoweringCtx): Block =
     def warnStmt = if inStmtPos then warnPureExprInStmtPos(ref.toLoc, S(ref))
     
@@ -629,17 +633,20 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
         // * Note: the alternative below, which might seem more appealing,
         // * works but does not instrument the selection to check for `undefined`!
         // return k(Value.Ref(State.globalThisSymbol).sel(ref.tree, bs).withLocOf(ref))
-      case S(td: TermDefinition) if td.k is syntax.Fun =>
+      case S(td: TermDefinition) if isImplicitNullaryCall(td.tsym) =>
         // * Functions defined in local scopes with no parameter lists are getters
         // * and are lowered to functions with an empty parameter list
         // * (non-local functions are compiled into getter methods selected on some prefix)
-        if td.params.isEmpty then
+        if isImplicitNullaryCall(td.tsym) then
           return k(Call(
               bs.asMemberRef(disamb.get).withLocOf(ref), Nil ne_:: Nil
-            )(CallMetadata(true, true, annots)))
+            )(CallMetadata(isMlsFun = true, mayRaiseEffects = true, annots)))
       case S(td: TermDefinition) =>
         td.tsym.owner match
         case S(owner) =>
+          // * With the current Elaborator semantics, selections are already inserted for most things;
+          // * the current case can only happen if `td` is a let binding defined in some object owner.
+          softAssert(td.k is syntax.LetBind, s"Expected a let binding, got a ${td.k.str} ($td)")
           return k(Select(owner.asThis, td.tsym.id)(S(td.tsym)).withLocOf(ref))
         case N => ()
       case S(_) => ()
@@ -1420,7 +1427,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
       case Annot.MayNotRaiseEffects => ()
       case _: Annot.Config => () // Config annotations are handled during FunDefn creation
       case annot => warn(annot)
-
+  
   def reportAnnotations(receiver: Term, annotations: Ls[Annot]): Unit =
     def warn(annot: Annot, msg: Opt[Message] = N) =
       val message = msg match
@@ -1430,11 +1437,6 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
         WarningReport(
           msg"This annotation has no effect." -> annot.toLoc ::
           message -> receiver.toLoc :: Nil)
-
-    def isImplicitNullaryCall(defnSym: DefinitionSymbol[?]): Bool =
-      defnSym.defn.exists:
-        case td: TermDefinition => (td.k is syntax.Fun) && td.params.isEmpty
-        case _ => false
     
     annotations.foreach:
       case Annot.Untyped => ()

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Lowering.scala
@@ -151,7 +151,6 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
       parentClsPath,
       State.builtinOpsMap("super").asSimpleRef,
       isMlsFun = true,
-      isTailCall = false,
       args,
       N, // TODO: location?
     )(c => Assign(NoSymbol, c, End()))
@@ -386,7 +385,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
       clsDef.paramsOpt.toList ::: clsDef.auxParams
   
   // * Lowers the `super(...)(...)` call we get from the `extends C(...)(...)` syntax
-  def lowerSuperCtorCall(parentClsPth: Path, fr: Path, isMlsFun: Bool, isTailCall: Bool, args: List[Term], loc: Opt[Loc])(k: Result => Block)(using LoweringCtx): Block =
+  def lowerSuperCtorCall(parentClsPth: Path, fr: Path, isMlsFun: Bool, args: List[Term], loc: Opt[Loc])(k: Result => Block)(using LoweringCtx): Block =
     val ctorParamLists = getCtorParamLists(parentClsPth)
     args match
     case _ :: _ =>
@@ -406,7 +405,7 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
               msg"Extending a partially applied class is not supported" -> loc :: Nil,
               source = Diagnostic.Source.Compilation))
           k(Call(fr, acc.reverse.ne_!)(
-            CallMetadata(isMlsFun, true, isTailCall, Nil)).withLoc(loc))
+            CallMetadata(isMlsFun, true, Nil)).withLoc(loc))
       zipArgs(ctorParamLists, args, Nil)
     case Nil =>
       if !ctorParamLists.isEmpty then
@@ -415,31 +414,30 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
           source = Diagnostic.Source.Compilation))
       // * No arguments to a super ctor means a nullary call, e.g., `extends C` means `extends C()`
       k(Call(fr, Nil ne_:: Nil)(
-        CallMetadata(isMlsFun, true, isTailCall, Nil)).withLoc(loc))
+        CallMetadata(isMlsFun, true, Nil)).withLoc(loc))
   
   /** Lower a call with multiple argument lists into `Call` nodes,
     * trying to group as many as possible into a single one
     * when they correspond to parameter lists of the same callee. */
   def lowerMultiCall(fr: Path, isMlsFun: Bool, annotations: Ls[Annot], args: Ls[Term], loc: Opt[Loc])(k: Result => Block)(using LoweringCtx): Block =
-    val isTailCall = annotations.contains(Annot.TailCall)
     def zipArgs(remainingParamss: Ls[ParamList], remainingArgss: Ls[Term], acc: Ls[Ls[Arg]], mayRaiseEffects: Bool): Block =
       (remainingParamss, remainingArgss) match
       case (ps :: remainingParams, args :: remainingArgs) =>
         lowerArgs(args)(as => zipArgs(remainingParams, remainingArgs, as :: acc, mayRaiseEffects))
       case (Nil, Nil) =>
         k(Call(fr, acc.reverse.ne_!)(
-          CallMetadata(isMlsFun, mayRaiseEffects, isTailCall, annotations)).withLoc(loc))
+          CallMetadata(isMlsFun, mayRaiseEffects, annotations)).withLoc(loc))
       case (Nil, args :: remainingArgss) =>
         acc.reverse match
         case Nil => lowerRemainingCalls(fr, args, remainingArgss, annotations, loc)(k)
         case acc: NELs[Ls[Arg]] =>
           val tmp = loweringCtx.registerTempSymbol(N, "baseCall")
           val call = Call(fr, acc)(
-            CallMetadata(isMlsFun, mayRaiseEffects, false, Nil)).withLoc(loc)
+            CallMetadata(isMlsFun, mayRaiseEffects, Nil)).withLoc(loc)
           Assign(tmp, call, lowerRemainingCalls(tmp.asSimpleRef, args, remainingArgss, annotations, loc)(k))
       case (_ :: _, Nil) =>
         k(Call(fr, acc.reverse.ne_!)(
-          CallMetadata(isMlsFun, mayRaiseEffects, isTailCall, annotations)).withLoc(loc))
+          CallMetadata(isMlsFun, mayRaiseEffects, annotations)).withLoc(loc))
     fr.targetSymbol match
     case S(fs: TermSymbol) =>
       fs.defn match
@@ -451,12 +449,10 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
   def lowerRemainingCalls(base: Path, args: Term, remainingArgss: Ls[Term], annotations: Ls[Annot], loc: Opt[Loc])
         (k: Result => Block)(using LoweringCtx): Block =
     lowerArgs(args): as =>
-      val isFinalCall = remainingArgss.isEmpty
       val call = Call(base, as ne_:: Nil)(
         CallMetadata(
           false,
           true,
-          annotations.contains(Annot.TailCall),
           annotations,
         )).withLoc(loc)
       remainingArgss match
@@ -653,7 +649,6 @@ class Lowering()(using Config, TL, Raise, State, Ctx, SymbolPrinter):
             )(CallMetadata(
               true,
               true,
-              annots.contains(Annot.TailCall),
               annots)))
       case S(td: TermDefinition) =>
         td.tsym.owner match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
@@ -84,8 +84,11 @@ class Printer(using Raise, ShowCfg, State, SymbolPrinter, Config):
     // case _ => doc""
     // defn.configOverride.map: cfg =>
     //   if cfg.staged then doc"staged " else doc""
-    if defn.annotations.isEmpty then doc""
-    else defn.annotations.map(_.show).mkDocument(doc" ") :: doc" # "
+    printAnnotations(defn.annotations, doc" # ")
+
+  def printAnnotations(annotations: Ls[Annot], trailing: Document)(using Scope): Document =
+    if annotations.isEmpty then doc""
+    else annotations.map(_.show).mkDocument(doc" ") :: trailing
   
   def print(
       privateFields: Ls[TermSymbol],
@@ -185,12 +188,12 @@ class Printer(using Raise, ShowCfg, State, SymbolPrinter, Config):
   def print(result: Result)(using Scope): Document =
     (if !showPurity || result.isPure then "" else "!") ::
     result.match
-    case Call(fun, argss) =>
+    case call @ Call(fun, argss) =>
       val chainedArgs = argss.map(args => doc"(${args.map(print).mkDocument(", ")})").mkDocument("")
-      doc"${print(fun)}${chainedArgs}"
-    case Instantiate(mut, cls, argss) =>
+      doc"${printAnnotations(call.metadata.annotations, doc" ")}${print(fun)}${chainedArgs}"
+    case inst @ Instantiate(mut, cls, argss) =>
       val chainedArgs = argss.map(args => doc"(${args.map(print).mkDocument(", ")})").mkDocument("")
-      doc"new ${if mut then "mut " else ""}${print(cls)}${chainedArgs}"
+      doc"${printAnnotations(inst.metadata.annotations, doc" ")}new ${if mut then "mut " else ""}${print(cls)}${chainedArgs}"
     case Lambda(params, body) =>
       scope.nest.givenIn:
         val allParams =

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/Printer.scala
@@ -150,7 +150,7 @@ class Printer(using Raise, ShowCfg, State, SymbolPrinter, Config):
       val docStaged = if cls.isStaged then doc"staged " else doc""
       val docBody = print(privateFields, publicFields, methods, auxParams, S(preCtor), ctor, ctorSym)
       val clsType = k.str
-      val docCls = doc"${docStaged}${clsType}${parentSym.fold(doc"")(doc" extends " :: print(_))} ${print(isym)}${ctorParams}${docBody}"
+      val docCls = doc"${docStaged}${clsType} ${print(isym)}${parentSym.fold(doc"")(doc" extends " :: print(_))}${ctorParams}${docBody}"
       val docModule = mod match
         case Some(mod) =>
           val docStaged = if mod.isStaged then doc"staged " else doc""

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
@@ -63,7 +63,7 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
   // isMlsFun is probably always true?
   def call(fun: Path, args: Ls[ArgWrappable], isMlsFun: Bool = true, symName: Str = "tmp")(k: Path => Block): Block =
     assign(Call(fun, args.map(asArg) ne_:: Nil)(
-      CallMetadata(isMlsFun, false, false)), symName)(k)
+      CallMetadata(isMlsFun, false, false, Nil)), symName)(k)
 
   // helpers for instrumenting Block
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
@@ -63,7 +63,7 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
   // isMlsFun is probably always true?
   def call(fun: Path, args: Ls[ArgWrappable], isMlsFun: Bool = true, symName: Str = "tmp")(k: Path => Block): Block =
     assign(Call(fun, args.map(asArg) ne_:: Nil)(
-      CallMetadata(isMlsFun, false, false, Nil)), symName)(k)
+      CallMetadata(isMlsFun, false, Nil)), symName)(k)
 
   // helpers for instrumenting Block
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
@@ -62,7 +62,8 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
 
   // isMlsFun is probably always true?
   def call(fun: Path, args: Ls[ArgWrappable], isMlsFun: Bool = true, symName: Str = "tmp")(k: Path => Block): Block =
-    assign(Call(fun, args.map(asArg) ne_:: Nil)(isMlsFun, false, false), symName)(k)
+    assign(Call(fun, args.map(asArg) ne_:: Nil)(
+      CallMetadata(isMlsFun, false, false)), symName)(k)
 
   // helpers for instrumenting Block
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/ReflectionInstrumenter.scala
@@ -62,8 +62,7 @@ class ReflectionInstrumenter(using State, Raise, Ctx) extends BlockTransformer(n
 
   // isMlsFun is probably always true?
   def call(fun: Path, args: Ls[ArgWrappable], isMlsFun: Bool = true, symName: Str = "tmp")(k: Path => Block): Block =
-    assign(Call(fun, args.map(asArg) ne_:: Nil)(
-      CallMetadata(isMlsFun, false, Nil)), symName)(k)
+    assign(Call(fun, args.map(asArg) ne_:: Nil)(CallMetadata(isMlsFun, false, Nil)), symName)(k)
 
   // helpers for instrumenting Block
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
@@ -39,7 +39,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
     val bodSym = BlockMemberSymbol("‹stack safe body›", Nil, false)
     val bodFun = FunDefn.withFreshSymbol(N, bodSym, ParamList(ParamListFlags.empty, Nil, N) :: Nil, body)(configOverride = N, annotations = Nil)
     Scoped(Set.single(bodSym),
-      Define(bodFun, Assign(resSym, Call(runStackSafePath, (intLit(depthLimit).asArg :: bodSym.asMemberRef(bodSym.asPrincipal.get).asArg :: Nil) ne_:: Nil)(CallMetadata(true, true, false, Nil)), rest))
+      Define(bodFun, Assign(resSym, Call(runStackSafePath, (intLit(depthLimit).asArg :: bodSym.asMemberRef(bodSym.asPrincipal.get).asArg :: Nil) ne_:: Nil)(CallMetadata(true, true, Nil)), rest))
     )
 
   def extractResTopLevel(res: Result, isTailCall: Bool, f: Result => Block, sym: Assignable, curDepth: => LocalVarSymbol) =
@@ -135,7 +135,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
       val addStackSafeEffect = blk => blockBuilder
         .assignFieldN(runtimePath, STACK_DEPTH_IDENT, op("+", stackDepthPath, intLit(increment)))
         .staticif(usedDepth, _.assignScoped(curDepth, stackDepthPath))
-        .assignScoped(resSym, Call(checkDepthPath, Nil ne_:: Nil)(CallMetadata(true, true, false, Nil)))
+        .assignScoped(resSym, Call(checkDepthPath, Nil ne_:: Nil)(CallMetadata(true, true, Nil)))
         .ifthen(
           paths.curEffect,
           Case.Lit(Tree.UnitLit(true)),

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
@@ -39,7 +39,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
     val bodSym = BlockMemberSymbol("‹stack safe body›", Nil, false)
     val bodFun = FunDefn.withFreshSymbol(N, bodSym, ParamList(ParamListFlags.empty, Nil, N) :: Nil, body)(configOverride = N, annotations = Nil)
     Scoped(Set.single(bodSym),
-      Define(bodFun, Assign(resSym, Call(runStackSafePath, (intLit(depthLimit).asArg :: bodSym.asMemberRef(bodSym.asPrincipal.get).asArg :: Nil) ne_:: Nil)(CallMetadata(true, true, false)), rest))
+      Define(bodFun, Assign(resSym, Call(runStackSafePath, (intLit(depthLimit).asArg :: bodSym.asMemberRef(bodSym.asPrincipal.get).asArg :: Nil) ne_:: Nil)(CallMetadata(true, true, false, Nil)), rest))
     )
 
   def extractResTopLevel(res: Result, isTailCall: Bool, f: Result => Block, sym: Assignable, curDepth: => LocalVarSymbol) =
@@ -135,7 +135,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
       val addStackSafeEffect = blk => blockBuilder
         .assignFieldN(runtimePath, STACK_DEPTH_IDENT, op("+", stackDepthPath, intLit(increment)))
         .staticif(usedDepth, _.assignScoped(curDepth, stackDepthPath))
-        .assignScoped(resSym, Call(checkDepthPath, Nil ne_:: Nil)(CallMetadata(true, true, false)))
+        .assignScoped(resSym, Call(checkDepthPath, Nil ne_:: Nil)(CallMetadata(true, true, false, Nil)))
         .ifthen(
           paths.curEffect,
           Case.Lit(Tree.UnitLit(true)),

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
@@ -39,7 +39,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
     val bodSym = BlockMemberSymbol("‹stack safe body›", Nil, false)
     val bodFun = FunDefn.withFreshSymbol(N, bodSym, ParamList(ParamListFlags.empty, Nil, N) :: Nil, body)(configOverride = N, annotations = Nil)
     Scoped(Set.single(bodSym),
-      Define(bodFun, Assign(resSym, Call(runStackSafePath, (intLit(depthLimit).asArg :: bodSym.asMemberRef(bodSym.asPrincipal.get).asArg :: Nil) ne_:: Nil)(CallMetadata(true, true, Nil)), rest))
+      Define(bodFun, Assign(resSym, Call(runStackSafePath, (intLit(depthLimit).asArg :: bodSym.asMemberRef(bodSym.asPrincipal.get).asArg :: Nil) ne_:: Nil)(CallMetadata.mlsFunWithEffect), rest))
     )
 
   def extractResTopLevel(res: Result, isTailCall: Bool, f: Result => Block, sym: Assignable, curDepth: => LocalVarSymbol) =
@@ -135,7 +135,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
       val addStackSafeEffect = blk => blockBuilder
         .assignFieldN(runtimePath, STACK_DEPTH_IDENT, op("+", stackDepthPath, intLit(increment)))
         .staticif(usedDepth, _.assignScoped(curDepth, stackDepthPath))
-        .assignScoped(resSym, Call(checkDepthPath, Nil ne_:: Nil)(CallMetadata(true, true, Nil)))
+        .assignScoped(resSym, Call(checkDepthPath, Nil ne_:: Nil)(CallMetadata.mlsFunWithEffect))
         .ifthen(
           paths.curEffect,
           Case.Lit(Tree.UnitLit(true)),

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/StackSafeTransform.scala
@@ -20,7 +20,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
   private def intLit(n: BigInt) = Value.Lit(Tree.IntLit(n))
   
   private def op(op: String, a: Path, b: Path) =
-    Call(State.builtinOpsMap(op).asSimpleRef, (a.asArg :: b.asArg :: Nil) ne_:: Nil)(true, false, false)
+    Call(State.builtinOpsMap(op).asSimpleRef, (a.asArg :: b.asArg :: Nil) ne_:: Nil)(CallMetadata.defaultMlsFun)
 
   // Increases the stack depth, assigns the call to a value, then decreases the stack depth
   // then binds that value to a desired block
@@ -39,7 +39,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
     val bodSym = BlockMemberSymbol("‹stack safe body›", Nil, false)
     val bodFun = FunDefn.withFreshSymbol(N, bodSym, ParamList(ParamListFlags.empty, Nil, N) :: Nil, body)(configOverride = N, annotations = Nil)
     Scoped(Set.single(bodSym),
-      Define(bodFun, Assign(resSym, Call(runStackSafePath, (intLit(depthLimit).asArg :: bodSym.asMemberRef(bodSym.asPrincipal.get).asArg :: Nil) ne_:: Nil)(true, true, false), rest))
+      Define(bodFun, Assign(resSym, Call(runStackSafePath, (intLit(depthLimit).asArg :: bodSym.asMemberRef(bodSym.asPrincipal.get).asArg :: Nil) ne_:: Nil)(CallMetadata(true, true, false)), rest))
     )
 
   def extractResTopLevel(res: Result, isTailCall: Bool, f: Result => Block, sym: Assignable, curDepth: => LocalVarSymbol) =
@@ -135,7 +135,7 @@ class StackSafeTransform(depthLimit: Int, paths: HandlerPaths, stackSafetyMap: S
       val addStackSafeEffect = blk => blockBuilder
         .assignFieldN(runtimePath, STACK_DEPTH_IDENT, op("+", stackDepthPath, intLit(increment)))
         .staticif(usedDepth, _.assignScoped(curDepth, stackDepthPath))
-        .assignScoped(resSym, Call(checkDepthPath, Nil ne_:: Nil)(true, true, false))
+        .assignScoped(resSym, Call(checkDepthPath, Nil ne_:: Nil)(CallMetadata(true, true, false)))
         .ifthen(
           paths.curEffect,
           Case.Lit(Tree.UnitLit(true)),

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/SymbolRefresher.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/SymbolRefresher.scala
@@ -47,7 +47,9 @@ class SymbolRefresherWalker(mapping: MutMap[Symbol, Symbol])(using State) extend
     assertUpdate(s, new TopLevelSymbol(s.nme))
 
   private def refreshClassCtorSymbol(s: ClassCtorSymbol) =
-    assertUpdate(s, new ClassCtorSymbol(s.k, S(mapping.getOrElse(s.owner.value, s.owner.value).asInstanceOf[ClassSymbol]), s.id))
+    assertUpdate(s, new ClassCtorSymbol(s.k,
+      s.owner.map(o => mapping.getOrElse(o, o).asInstanceOf[InnerSymbol]),
+      mapping.getOrElse(s.associatedCls, s.associatedCls).asInstanceOf[ClassSymbol]))
 
   private def refreshParamList(pl: ParamList) =
     for

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
@@ -116,20 +116,20 @@ class TailRecOpt(using State, TL, Raise):
       case TailCallShape(r, c) => getFun(r) match
         case Some(value) =>
           if c.argss.size != value.params.size then
-            if c.explicitTailCall then
+            if c.metadata.explicitTailCall then
               raise(ErrorReport(msg"Only fully applied calls may be marked @tailcall." -> c.toLoc :: Nil))
           else edges ::= CallEdge.TailCall(f.dSym, r)(c)
         case None =>
-          if c.explicitTailCall then
+          if c.metadata.explicitTailCall then
             raise(ErrorReport(msg"Only functions in this compilation unit may be marked @tailcall." -> c.toLoc :: Nil))
       case Return(c: Call) =>
-        if c.explicitTailCall then
+        if c.metadata.explicitTailCall then
           raise(ErrorReport(msg"Only direct calls in tail position may be marked @tailcall." -> c.toLoc :: Nil))
       case _ => super.applyBlock(b)
     
     override def applyResult(r: Result): Unit = r match
       case c: Call =>
-        if c.explicitTailCall then
+        if c.metadata.explicitTailCall then
           raise(ErrorReport(msg"This call is not in tail position." -> c.toLoc :: Nil))
         c match
           case CallToFun(r) => edges ::= CallEdge.NormalCall(f.dSym, r)(c)
@@ -150,7 +150,7 @@ class TailRecOpt(using State, TL, Raise):
     val cg = buildCallGraph(fs).filter: c =>
       val cond = defnSyms.contains(c.f1) && defnSyms.contains(c.f2)
       c.match
-        case c: CallEdge.TailCall if c.call.explicitTailCall && !cond =>
+        case c: CallEdge.TailCall if c.call.metadata.explicitTailCall && !cond =>
           raise(ErrorReport(
             msg"This tail call exits the current scope and is not optimized." -> c.call.toLoc :: Nil))
         case _ =>
@@ -167,7 +167,7 @@ class TailRecOpt(using State, TL, Raise):
       .groupBy: c =>
         val s1 = sccMap(c.f1)
         val s2 = sccMap(c.f2)
-        if s1 =/= s2 && c.call.explicitTailCall then
+        if s1 =/= s2 && c.call.metadata.explicitTailCall then
           raise(ErrorReport(
             msg"This call is not optimized as it does not directly recurse through its parent function." -> c.call.toLoc :: Nil))
           -1
@@ -448,7 +448,7 @@ class TailRecOpt(using State, TL, Raise):
                               :: Value.Lit(Tree.IntLit(paramList.length)).asArg
                               :: Value.Lit(Tree.IntLit(0)).asArg
                               :: Nil) ne_:: Nil
-                          )(true, false, false)
+                          )(CallMetadata.defaultMlsFun)
                           val blk = blockBuilder
                             .assignScoped(tupleSym, tupleRes)
                             .assignScoped(sliceResSym, sliceRes)
@@ -499,7 +499,7 @@ class TailRecOpt(using State, TL, Raise):
             :: paramArgs
             ::: List.fill(maxParamLen - paramArgs.length)(Value.Lit(Tree.UnitLit(false)).asArg)
         val newBod = Return(
-          Call(sel, args ne_:: Nil)(true, false, false),
+          Call(sel, args ne_:: Nil)(CallMetadata.defaultMlsFun),
         )
         FunDefn(f.owner, f.sym, f.dSym, f.params, newBod)(N, f.annotations)
     
@@ -530,7 +530,7 @@ class TailRecOpt(using State, TL, Raise):
           case Some(value) => Select(value.asThis, Tree.Ident(loopBms.nme))(S(loopDSym))
           case None => loopBms.asMemberRef(loopDSym)
         val wrapperBod = Return(
-          Call(internalSel, paramArgs ne_:: Nil)(true, false, false),
+          Call(internalSel, paramArgs ne_:: Nil)(CallMetadata.defaultMlsFun),
         )
         val wrapperDefn = FunDefn(f.owner, f.sym, f.dSym, f.params, wrapperBod)(
           f.configOverride, annotations = f.annotations)
@@ -556,7 +556,7 @@ class TailRecOpt(using State, TL, Raise):
         if f.tailRec then
           raise(ErrorReport(msg"Class methods may not yet be marked @tailrec." -> f.dSym.toLoc :: Nil))
       override def applyResult(r: Result): Unit = r match
-        case c: Call if c.explicitTailCall =>
+        case c: Call if c.metadata.explicitTailCall =>
           raise(ErrorReport(msg"Calls from class methods cannot yet be marked @tailcall." -> c.toLoc :: Nil))
         case _ => super.applyResult(r)
   

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/WorkerWrapper.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/WorkerWrapper.scala
@@ -71,7 +71,7 @@ class WorkerWrapper
       Arg(N, param.sym.asSimpleRef)
     val wrapperBody = Return(
       Call(worker.asPath, workerArgs ne_:: Nil)(
-        CallMetadata(true, true, false)),
+        CallMetadata(true, true, false, Nil)),
     )
     val wrapper = FunDefn(
       fun.owner,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/WorkerWrapper.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/WorkerWrapper.scala
@@ -70,7 +70,8 @@ class WorkerWrapper
     val workerArgs = fun.params.flatMap(_.params).map: param =>
       Arg(N, param.sym.asSimpleRef)
     val wrapperBody = Return(
-      Call(worker.asPath, workerArgs ne_:: Nil)(isMlsFun = true, mayRaiseEffects = true, explicitTailCall = false),
+      Call(worker.asPath, workerArgs ne_:: Nil)(
+        CallMetadata(true, true, false)),
     )
     val wrapper = FunDefn(
       fun.owner,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/WorkerWrapper.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/WorkerWrapper.scala
@@ -71,7 +71,7 @@ class WorkerWrapper
       Arg(N, param.sym.asSimpleRef)
     val wrapperBody = Return(
       Call(worker.asPath, workerArgs ne_:: Nil)(
-        CallMetadata(true, true, false, Nil)),
+        CallMetadata(true, true, Nil)),
     )
     val wrapper = FunDefn(
       fun.owner,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/WorkerWrapper.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/WorkerWrapper.scala
@@ -70,8 +70,7 @@ class WorkerWrapper
     val workerArgs = fun.params.flatMap(_.params).map: param =>
       Arg(N, param.sym.asSimpleRef)
     val wrapperBody = Return(
-      Call(worker.asPath, workerArgs ne_:: Nil)(
-        CallMetadata.mlsFunWithEffect),
+      Call(worker.asPath, workerArgs ne_:: Nil)(CallMetadata.mlsFunWithEffect),
     )
     val wrapper = FunDefn(
       fun.owner,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/WorkerWrapper.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/WorkerWrapper.scala
@@ -71,7 +71,7 @@ class WorkerWrapper
       Arg(N, param.sym.asSimpleRef)
     val wrapperBody = Return(
       Call(worker.asPath, workerArgs ne_:: Nil)(
-        CallMetadata(true, true, Nil)),
+        CallMetadata.mlsFunWithEffect),
     )
     val wrapper = FunDefn(
       fun.owner,

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/deforest/Rewrite.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/deforest/Rewrite.scala
@@ -359,7 +359,7 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
           Call(
             Value.MemberRef(target._1, target._2),
             args.map(a => Arg(N, a.asPath)) ne_:: Nil
-          )(true, false, false)
+          )(CallMetadata.defaultMlsFun)
         
         // Rewrites the program under a specific instantiation id
         // from the polymorphic analysis
@@ -448,7 +448,7 @@ class DeforestRewriter(val solver: DeforestFusionSolver)(using Raise):
                   Call(
                     newScrut,
                     callWithFvs.map(s => Arg(N, s.asPath)) ne_:: Nil
-                  )(true, false, false))
+                  )(CallMetadata.defaultMlsFun))
             case Break(label) =>
               val labelRestFunId = label.withInstId(instId)
               restFunSyms.get(labelRestFunId) match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/flowAnalysis/FlowAnalysis.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/flowAnalysis/FlowAnalysis.scala
@@ -140,7 +140,7 @@ object CtorProducer:
   def unapply(r: Result)(using Elaborator.State): Opt[(ctorCls: CtorCls, args: Ls[Arg], selectedFrom: Opt[Path])] =
     r match
     case Instantiate(_, MemberRefTo(cls: ClassSymbol, qual), argss) => S(cls, argss.flatten, qual)
-    case Call(MemberRefTo(cls: ClassCtorSymbol, qual), argss) => S(cls.owner.get, argss.flatten, qual)
+    case Call(MemberRefTo(cls: ClassCtorSymbol, qual), argss) => S(cls.associatedCls, argss.flatten, qual)
     case MemberRefTo(ctor: ModuleOrObjectSymbol, qual) => S(ctor, Nil, qual)
     case Tuple(_, args) => S(args.size, args, N)
     case _ => N

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/js/JSBuilder.scala
@@ -207,7 +207,7 @@ class JSBuilder(using Config, TL, State, Ctx) extends CodeBuilder:
       val calls = argss.foldLeft(base): (acc, args) =>
         val argsDoc = args.map(argument).mkDocument(", ")
         doc"${acc}(${argsDoc})"
-      if c.isMlsFun
+      if c.metadata.isMlsFun
       then if checkMLsCalls
         then doc"$runtimeVar.checkCall(${calls})"
         else doc"${calls}"

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Elaborator.scala
@@ -379,7 +379,7 @@ object Elaborator:
         Param(flag, VarSymbol(Ident("output")), N, Modulefulness(N)(false)) ::
         Param(flag, VarSymbol(Ident("bindings")), N, Modulefulness(N)(false)) ::
         Nil)
-      val ctsym = ClassCtorSymbol(Fun, S(cs), cs.id)
+      val ctsym = ClassCtorSymbol(Fun, N/* note: no owner isn't quite right */, cs)
       cs.defn = S(ClassDef.Parameterized(N, syntax.Cls, cs, BlockMemberSymbol(cs.name, Nil), S(ctsym),
         Nil, ps, Nil, N, ObjBody(Blk(Nil, Term.Lit(UnitLit(false)))), N, Nil))
       cs -> ts
@@ -390,7 +390,7 @@ object Elaborator:
       val ts = TermSymbol(syntax.Fun, N, id)
       val flag = FldFlags.empty.copy(isVal = true)
       val ps = PlainParamList(Param(flag, VarSymbol(Ident("errors")), N, Modulefulness(N)(false)) :: Nil)
-      val ctsym = ClassCtorSymbol(Fun, S(cs), cs.id)
+      val ctsym = ClassCtorSymbol(Fun, N/* note: no owner isn't quite right */, cs)
       cs.defn = S(ClassDef.Parameterized(N, syntax.Cls, cs, BlockMemberSymbol(cs.name, td :: Nil), S(ctsym),
         Nil, ps, Nil, N, ObjBody(Blk(Nil, Term.Lit(UnitLit(false)))), N, Nil))
       cs -> ts
@@ -1820,7 +1820,7 @@ extends Importer with ucs.SplitElaborator:
               log(s"Companion: ${comp}")
               val allCtorPss = pss ::: auxCtorPss
               val tsym = if allCtorPss.nonEmpty then
-                val ctsym = ClassCtorSymbol(Fun, S(clsSym), clsSym.id)
+                val ctsym = ClassCtorSymbol(Fun, owner, clsSym)
                 val ctdef =
                   TermDefinition(
                     Fun,

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
@@ -356,11 +356,14 @@ object TermSymbol:
     TermSymbol(syntax.Fun, owner, Tree.Ident(b.nme))
 
 
+/** Represents the companion constructor function of parameterized classes,
+  * which is the one that is accessed on plain `C` references for a definition like `class C(...)`.
+  * Note that the owner of this function is NOT the class; it is the same as the class's own owner. */
 class ClassCtorSymbol(
   override val k: syntax.Fun.type,
-  override val owner: S[ClassSymbol],
-  id: Tree.Ident
-)(using State) extends TermSymbol(k, owner, id):
+  override val owner: Opt[InnerSymbol],
+  val associatedCls: ClassSymbol,
+)(using State) extends TermSymbol(k, owner, associatedCls.id):
   override def subst(using sub: SymbolSubst): ClassCtorSymbol = sub.mapClassCtorSym(this)
   override def mayRaiseEffects(using Config) =
     super.mayRaiseEffects || config.checkInstantiateEffect

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -469,7 +469,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State, C
       // NOTE: `shouldRewriteWhile` is not the same as `config.rewriteWhileLoops`
       // as shouldRewriteWhile is always true when effect handler lowering is on
       lazy val loopCont = if config.shouldRewriteWhile
-        then Return(Call(f.asMemberRef(tSym), Nil ne_:: Nil)(CallMetadata(true, true, Nil)))
+        then Return(Call(f.asMemberRef(tSym), Nil ne_:: Nil)(CallMetadata.mlsFunWithEffect))
         else Continue(loopLabel)
       val cont =
         form match
@@ -505,7 +505,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State, C
               Select(State.runtimeSymbol.asSimpleRef, Tree.Ident("LoopEnd"))(S(State.loopEndSymbol))
             val blk = blockBuilder
               .define(FunDefn(N, f, tSym, PlainParamList(Nil) :: Nil, Begin(body, Return(loopEnd)))(configOverride = N, annotations = Nil))
-              .assign(loopResult, Call(f.asMemberRef(tSym), Nil ne_:: Nil)(CallMetadata(true, true, Nil)))
+              .assign(loopResult, Call(f.asMemberRef(tSym), Nil ne_:: Nil)(CallMetadata.mlsFunWithEffect))
             if summon[LoweringCtx].mayRet then
               blk
                 .assign(isReturned, Call(State.builtinOpsMap("!==").asSimpleRef,

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -469,7 +469,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State, C
       // NOTE: `shouldRewriteWhile` is not the same as `config.rewriteWhileLoops`
       // as shouldRewriteWhile is always true when effect handler lowering is on
       lazy val loopCont = if config.shouldRewriteWhile
-        then Return(Call(f.asMemberRef(tSym), Nil ne_:: Nil)(CallMetadata(true, true, false)))
+        then Return(Call(f.asMemberRef(tSym), Nil ne_:: Nil)(CallMetadata(true, true, false, Nil)))
         else Continue(loopLabel)
       val cont =
         form match
@@ -505,7 +505,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State, C
               Select(State.runtimeSymbol.asSimpleRef, Tree.Ident("LoopEnd"))(S(State.loopEndSymbol))
             val blk = blockBuilder
               .define(FunDefn(N, f, tSym, PlainParamList(Nil) :: Nil, Begin(body, Return(loopEnd)))(configOverride = N, annotations = Nil))
-              .assign(loopResult, Call(f.asMemberRef(tSym), Nil ne_:: Nil)(CallMetadata(true, true, false)))
+              .assign(loopResult, Call(f.asMemberRef(tSym), Nil ne_:: Nil)(CallMetadata(true, true, false, Nil)))
             if summon[LoweringCtx].mayRet then
               blk
                 .assign(isReturned, Call(State.builtinOpsMap("!==").asSimpleRef,

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -469,7 +469,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State, C
       // NOTE: `shouldRewriteWhile` is not the same as `config.rewriteWhileLoops`
       // as shouldRewriteWhile is always true when effect handler lowering is on
       lazy val loopCont = if config.shouldRewriteWhile
-        then Return(Call(f.asMemberRef(tSym), Nil ne_:: Nil)(CallMetadata(true, true, false, Nil)))
+        then Return(Call(f.asMemberRef(tSym), Nil ne_:: Nil)(CallMetadata(true, true, Nil)))
         else Continue(loopLabel)
       val cont =
         form match
@@ -505,7 +505,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State, C
               Select(State.runtimeSymbol.asSimpleRef, Tree.Ident("LoopEnd"))(S(State.loopEndSymbol))
             val blk = blockBuilder
               .define(FunDefn(N, f, tSym, PlainParamList(Nil) :: Nil, Begin(body, Return(loopEnd)))(configOverride = N, annotations = Nil))
-              .assign(loopResult, Call(f.asMemberRef(tSym), Nil ne_:: Nil)(CallMetadata(true, true, false, Nil)))
+              .assign(loopResult, Call(f.asMemberRef(tSym), Nil ne_:: Nil)(CallMetadata(true, true, Nil)))
             if summon[LoweringCtx].mayRet then
               blk
                 .assign(isReturned, Call(State.builtinOpsMap("!==").asSimpleRef,

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -417,7 +417,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State, C
     */
   private def throwMatchErrorBlock =
     Throw(Instantiate(mut = false, Select(State.globalThisSymbol.asThis, Tree.Ident("Error"))(S(ctx.builtins.Error)),
-        (Value.Lit(syntax.Tree.StrLit("match error")).asArg :: Nil) :: Nil)) // TODO add failed-match scrutinee info
+        (Value.Lit(syntax.Tree.StrLit("match error")).asArg :: Nil) :: Nil)(InstantiateMetadata.empty)) // TODO add failed-match scrutinee info
   
   import syntax.Keyword.{`if`, `while`}
   
@@ -469,7 +469,7 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State, C
       // NOTE: `shouldRewriteWhile` is not the same as `config.rewriteWhileLoops`
       // as shouldRewriteWhile is always true when effect handler lowering is on
       lazy val loopCont = if config.shouldRewriteWhile
-        then Return(Call(f.asMemberRef(tSym), Nil ne_:: Nil)(true, true, false))
+        then Return(Call(f.asMemberRef(tSym), Nil ne_:: Nil)(CallMetadata(true, true, false)))
         else Continue(loopLabel)
       val cont =
         form match
@@ -505,11 +505,11 @@ class Normalization(lowering: Lowering)(using tl: TL)(using Raise, Ctx, State, C
               Select(State.runtimeSymbol.asSimpleRef, Tree.Ident("LoopEnd"))(S(State.loopEndSymbol))
             val blk = blockBuilder
               .define(FunDefn(N, f, tSym, PlainParamList(Nil) :: Nil, Begin(body, Return(loopEnd)))(configOverride = N, annotations = Nil))
-              .assign(loopResult, Call(f.asMemberRef(tSym), Nil ne_:: Nil)(true, true, false))
+              .assign(loopResult, Call(f.asMemberRef(tSym), Nil ne_:: Nil)(CallMetadata(true, true, false)))
             if summon[LoweringCtx].mayRet then
               blk
                 .assign(isReturned, Call(State.builtinOpsMap("!==").asSimpleRef,
-                  (loopResult.asPath.asArg :: loopEnd.asArg :: Nil) ne_:: Nil)(true, false, false))
+                  (loopResult.asPath.asArg :: loopEnd.asArg :: Nil) ne_:: Nil)(CallMetadata.defaultMlsFun))
                 .ifthen(isReturned.asSimpleRef, Case.Lit(Tree.BoolLit(true)),
                   Return(loopResult.asSimpleRef),
                   N

--- a/hkmc2/shared/src/test/mlscript/basics/CompanionModules_Classes.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/CompanionModules_Classes.mls
@@ -10,9 +10,9 @@ C()
 //│ ——————————————| Resolved tree |—————————————————————————————————————————————————————————————————————
 //│ Blk:
 //│   res = App{typ=class:C⁰}:
-//│     lhs = Resolved{sym=term:C⁰/C¹}:
+//│     lhs = Resolved{sym=term:C¹}:
 //│       t = Ref{sym=member:C²} of member:C²
-//│       sym = term:C⁰/C¹
+//│       sym = term:C¹
 //│     rhs = Tup of Nil
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = C()

--- a/hkmc2/shared/src/test/mlscript/basics/DynamicInstantiation.mls
+++ b/hkmc2/shared/src/test/mlscript/basics/DynamicInstantiation.mls
@@ -75,11 +75,23 @@ data class C(x, y)
 let f = new! C()
 //│ f = C(undefined, undefined)
 
+// * Note: we do _not_ eta-expand C here because this is a dynamic `new!` call
+// * on the constructor function, not on the class!
+:sjs
 let f = new! C
-//│ f = fun f
+//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
+//│ let f3; f3 = globalThis.Object.freeze(new C3());
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+//│ f = C(undefined, undefined)
 
+:re
 f(1, 2)
+//│ ═══[RUNTIME ERROR] TypeError: f3 is not a function
+
+
+new! C.class(1, 2)
 //│ = C(1, 2)
+
 
 let f = x => new! (id(C))(x, x)
 //│ f = fun f

--- a/hkmc2/shared/src/test/mlscript/block-staging/Nested.mls
+++ b/hkmc2/shared/src/test/mlscript/block-staging/Nested.mls
@@ -73,7 +73,7 @@ staged module LiftedLambda with
 //│   return +⁰(x, y)
 //│ };
 //│ @staged
-//│ define Function$ as staged class extends globalThis⁰.Function⁰ Function$⁰ {
+//│ define Function$ as staged class Function$⁰ extends globalThis⁰.Function⁰ {
 //│   private val x⁰;
 //│   constructor(x) {
 //│     do super⁰();
@@ -156,7 +156,7 @@ staged module LiftedMultParams with
 //│   return +⁰(x, y)
 //│ };
 //│ @staged
-//│ define Function$ as staged class extends globalThis⁰.Function⁰ Function$¹ {
+//│ define Function$ as staged class Function$¹ extends globalThis⁰.Function⁰ {
 //│   private val x¹;
 //│   constructor(x) {
 //│     do super⁰();

--- a/hkmc2/shared/src/test/mlscript/codegen/BlockPrinter.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/BlockPrinter.mls
@@ -202,7 +202,7 @@ class B(x) extends A with
   val y = 2
 //│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
 //│ define A⁶ as class A⁷;
-//│ define B⁰ as class extends A⁷ B² {
+//│ define B⁰ as class B² extends A⁷ {
 //│   private val x¹¹;
 //│   val y¹;
 //│   constructor B¹(x) { do super⁰(); end; set B².this.x¹¹ = x; define y¹ as val y² = 2; end }

--- a/hkmc2/shared/src/test/mlscript/codegen/FirstClassFunctionTransform.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/FirstClassFunctionTransform.mls
@@ -23,7 +23,7 @@ x => x
 //│ define lambda as fun lambda⁰(x) {
 //│   return x
 //│ };
-//│ define Function$ as class extends globalThis⁰.Function⁰ Function$⁰ {
+//│ define Function$ as class Function$⁰ extends globalThis⁰.Function⁰ {
 //│   method call⁰ = fun call¹(x) { return lambda⁰(x) }
 //│ };
 //│ set tmp = new Function$⁰();
@@ -73,7 +73,7 @@ bar(foo)
 //│ define bar⁰ as fun bar¹(f) {
 //│   return f.call﹖(0)
 //│ };
-//│ define Function$ as class extends globalThis⁰.Function⁰ Function$¹ {
+//│ define Function$ as class Function$¹ extends globalThis⁰.Function⁰ {
 //│   method call² = fun call³(x) { return foo¹(x) }
 //│ };
 //│ set tmp = new Function$¹();
@@ -154,7 +154,7 @@ Foo(1).foo(x => x - 1)
 //│ define lambda as fun lambda²(x) {
 //│   return -⁰(x, 1)
 //│ };
-//│ define Function$ as class extends globalThis⁰.Function⁰ Function$² {
+//│ define Function$ as class Function$² extends globalThis⁰.Function⁰ {
 //│   method call⁴ = fun call⁵(x) {
 //│     return lambda²(x)
 //│   }
@@ -175,7 +175,7 @@ foo()(1)
 //│ define lambda as fun lambda³(x) {
 //│   return x
 //│ };
-//│ define Function$ as class extends globalThis⁰.Function⁰ Function$³ {
+//│ define Function$ as class Function$³ extends globalThis⁰.Function⁰ {
 //│   method call⁶ = fun call⁷(x) {
 //│     return lambda³(x)
 //│   }
@@ -232,7 +232,7 @@ module Foo with
 //│   set tmp = +⁰(x, Bar.y⁰);
 //│   return +⁰(tmp, z)
 //│ };
-//│ define Function$ as class extends globalThis⁰.Function⁰ Function$⁴ {
+//│ define Function$ as class Function$⁴ extends globalThis⁰.Function⁰ {
 //│   private val Bar⁰;
 //│   private val z⁰;
 //│   constructor(Bar, z) {
@@ -285,7 +285,7 @@ y => x + y
 //│ define lambda as fun lambda⁵(y) {
 //│   return +⁰(x¹, y)
 //│ };
-//│ define Function$ as class extends globalThis⁰.Function⁰ Function$⁵ {
+//│ define Function$ as class Function$⁵ extends globalThis⁰.Function⁰ {
 //│   method call¹⁰ = fun call¹¹(y) { return lambda⁵(y) }
 //│ };
 //│ set tmp = new Function$⁵();
@@ -470,7 +470,7 @@ fun foo(x)(y) = x + y
 //│ define lambda$ as fun lambda$⁰(x, y) {
 //│   return +⁰(x, y)
 //│ };
-//│ define Function$ as class extends globalThis⁰.Function⁰ Function$⁶ {
+//│ define Function$ as class Function$⁶ extends globalThis⁰.Function⁰ {
 //│   private val x²;
 //│   constructor(x) {
 //│     do super⁰();
@@ -532,7 +532,7 @@ foo(tuple)
 //│ ╙──       	    ^^^^^
 //│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
 //│ let Function$, tmp;
-//│ define Function$ as class extends globalThis⁰.Function⁰ Function$⁷ {
+//│ define Function$ as class Function$⁷ extends globalThis⁰.Function⁰ {
 //│   method call¹⁴ = fun call¹⁵() {
 //│     return Predef⁰.tuple⁰()
 //│   }

--- a/hkmc2/shared/src/test/mlscript/codegen/ParamClasses.mls
+++ b/hkmc2/shared/src/test/mlscript/codegen/ParamClasses.mls
@@ -1,23 +1,8 @@
 :js
 
-:global
-:sjs
-
 
 :sir
 data class Foo()
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let Foo1;
-//│ Foo1 = function Foo() {
-//│   return globalThis.Object.freeze(new Foo.class());
-//│ };
-//│ (class Foo {
-//│   static {
-//│     Foo1.class = this
-//│   }
-//│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", []];
-//│ });
 //│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
 //│ @data define Foo⁰ as class Foo² { constructor Foo¹ }; end
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
@@ -25,141 +10,91 @@ data class Foo()
 // * Notice that `Foo¹` correctly refers to the ClassCtorSymbol of `Foo` shown above
 :sir
 Foo
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ return Foo1
 //│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
 //│ return Foo¹
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = fun Foo { class: class Foo }
 
 Foo()
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ return Foo1()
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = Foo()
 
 Foo.class
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ return Foo1.class
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = class Foo
 
 
-data class Foo(a)
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let Foo3;
-//│ Foo3 = function Foo(a) {
-//│   return globalThis.Object.freeze(new Foo.class(a));
+:sir
+object Foo with
+  class C()
+  print(C)
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ define Foo³ as object Foo⁴ {
+//│   constructor() {
+//│     define C⁰ as class C² { constructor C¹ };
+//│     do Predef⁰.print⁰(Foo⁴.this.C¹);
+//│     end
+//│   }
 //│ };
-//│ (class Foo2 {
-//│   static {
-//│     Foo3.class = this
-//│   }
-//│   constructor(a) {
-//│     this.a = a;
-//│   }
-//│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["a"]];
-//│ });
+//│ end
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+//│ > fun C { class: class C }
+
+// * The owner of the C¹ constructor function is correctly identified as Foo
+:lot
+Foo.C
+//│ —————————————| Lowered IR Tree |————————————————————————————————————————————————————————————————————
+//│ Program:
+//│   main = Return of Select{sym=term:Foo⁴/C¹}:
+//│     qual = MemberRef{disamb=object:Foo⁴}:
+//│       bms = member:Foo³
+//│       disamb = object:Foo⁴
+//│     name = Ident of "C"
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+//│ = fun C { class: class C }
+
+
+data class Foo(a)
 
 Foo
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ return Foo3
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = fun Foo { class: class Foo }
 
 Foo(1)
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ return Foo3(1)
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = Foo(1)
 
 Foo(1).a
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let tmp; tmp = Foo3(1); return tmp.a
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = 1
 
 fun foo(y) = Foo(y)
 foo(27)
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let foo; foo = function foo(y) { return Foo3(y) }; return Foo3(27)
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = Foo(27)
 
 
 data class Foo(a, b)
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let Foo5;
-//│ Foo5 = function Foo(a, b) {
-//│   return globalThis.Object.freeze(new Foo.class(a, b));
-//│ };
-//│ (class Foo4 {
-//│   static {
-//│     Foo5.class = this
-//│   }
-//│   constructor(a, b) {
-//│     this.a = a;
-//│     this.b = b;
-//│   }
-//│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["a", "b"]];
-//│ });
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
 let foo = Foo
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let foo1; foo1 = Foo5;
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ foo = fun Foo { class: class Foo }
 
 let f = foo(1, 2)
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let f; f = runtime.safeCall(foo1(1, 2));
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ f = Foo(1, 2)
 
 let f = new! foo(1, 2)
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let f1; f1 = globalThis.Object.freeze(new foo1(1, 2));
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ f = Foo(1, 2)
 
 f.a
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ return f1.a
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = 1
 
 f.b
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ return f1.b
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = 2
 
 let f = Foo(1, 2)
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let f2; f2 = Foo5(1, 2);
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ f = Foo(1, 2)
 
 f.a
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ return f2.a
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = 1
 
 f.b
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ return f2.b
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = 2
 
 Foo(print(1), print(2))
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let tmp1, tmp2; tmp1 = Predef.print(1); tmp2 = Predef.print(2); return Foo5(tmp1, tmp2)
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ > 1
 //│ > 2
 //│ = Foo((), ())
@@ -168,42 +103,17 @@ Foo(print(1), print(2))
 data class Inner(c) with
   fun i1(d) = c + d
   print(c)
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let Inner1;
-//│ Inner1 = function Inner(c) {
-//│   return globalThis.Object.freeze(new Inner.class(c));
-//│ };
-//│ (class Inner {
-//│   static {
-//│     Inner1.class = this
-//│   }
-//│   constructor(c) {
-//│     this.c = c;
-//│     Predef.print(this.c);
-//│   }
-//│   i1(d) {
-//│     return this.c + d
-//│   }
-//│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Inner", ["c"]];
-//│ });
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
 let i = new Inner(100)
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let i; i = globalThis.Object.freeze(new Inner1.class(100));
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ > 100
 //│ i = Inner(100)
 
 i.i1(20)
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ return runtime.safeCall(i.i1(20))
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = 120
 
 
 // * This is strange, but does not need to be an error
+:sjs
 class Foo(x, val y, z, val z, z) with
   let x = 1
   let y += 1
@@ -213,13 +123,13 @@ class Foo(x, val y, z, val z, z) with
   print("z = " + z)
   print("this.z = " + this.z)
 //│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let Foo7;
-//│ Foo7 = function Foo(x, y, z, z1, z2) {
+//│ let Foo9;
+//│ Foo9 = function Foo(x, y, z, z1, z2) {
 //│   return globalThis.Object.freeze(new Foo.class(x, y, z, z1, z2));
 //│ };
-//│ (class Foo6 {
+//│ (class Foo8 {
 //│   static {
-//│     Foo7.class = this
+//│     Foo9.class = this
 //│   }
 //│   constructor(x, y, z, z1, z2) {
 //│     let tmp3, tmp4, tmp5, tmp6, tmp7;
@@ -248,9 +158,6 @@ class Foo(x, val y, z, val z, z) with
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
 Foo(10, 20, 30, 40, 50)
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ return Foo7(10, 20, 30, 40, 50)
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ > x = 1
 //│ > y = 21
 //│ > this.y = 20
@@ -263,29 +170,13 @@ Foo(10, 20, 30, 40, 50)
 class Foo(val z, val z)
 //│ ╔══[COMPILATION ERROR] Duplicate definition of member named 'z'.
 //│ ╟── Defined at: 
-//│ ║  l.263: 	class Foo(val z, val z)
+//│ ║  l.170: 	class Foo(val z, val z)
 //│ ║         	              ^
 //│ ╟── Defined at: 
-//│ ║  l.263: 	class Foo(val z, val z)
+//│ ║  l.170: 	class Foo(val z, val z)
 //│ ╙──       	                     ^
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ let Foo9;
-//│ Foo9 = function Foo(z, z1) {
-//│   return globalThis.Object.freeze(new Foo.class(z, z1));
-//│ };
-//│ (class Foo8 {
-//│   static {
-//│     Foo9.class = this
-//│   }
-//│   toString() { return runtime.render(this); }
-//│   static [definitionMetadata] = ["class", "Foo", ["z", "z"]];
-//│ });
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 
 Foo(1, 2)
-//│ ————————————| JS (unsanitized) |————————————————————————————————————————————————————————————————————
-//│ return Foo9(1, 2)
-//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
 //│ = Foo(undefined, undefined)
 
 

--- a/hkmc2/shared/src/test/mlscript/deforest/relaxedPrograms.mls
+++ b/hkmc2/shared/src/test/mlscript/deforest/relaxedPrograms.mls
@@ -105,9 +105,7 @@ if AA(1) is
 
 
 
-// TODO: rewriting for nested classes
 :deforest
-:fixme
 fun nestedClass() =
   class Local() with
     fun get() = 0
@@ -123,7 +121,7 @@ nestedClass()
 //│ deforest > 	match: scrut⁵
 //│ deforest > 	fields: scrut⁵.x¹
 //│ deforest > <<< fusing <<<
-//│ /!!!\ Uncaught error: java.lang.AssertionError: assertion failed
+//│ = 1
 
 
 

--- a/hkmc2/shared/src/test/mlscript/deforest/todos.mls
+++ b/hkmc2/shared/src/test/mlscript/deforest/todos.mls
@@ -194,7 +194,14 @@ test()
 //│ deforest > 	match: scrut⁰
 //│ deforest > 	fields: scrut⁰.x²
 //│ deforest > <<< fusing <<<
-//│ /!!!\ Uncaught error: java.lang.AssertionError: assertion failed
+//│ ╔══[COMPILATION ERROR] No definition found in scope for member 'Local'
+//│ ║  l.187: 	    Global(x) then Local(x + 1)
+//│ ║         	                   ^^^^^
+//│ ╟── which references the symbol introduced here
+//│ ║  l.185: 	  data class Local(x)
+//│ ╙──       	             ^^^^^^^^
+//│ ═══[RUNTIME ERROR] ReferenceError: Local is not defined
+//│ ═══[RUNTIME ERROR] Expected: 'Local(2)', got: 'undefined'
 
 
 // TODO: fusion opportunity is lost

--- a/hkmc2/shared/src/test/mlscript/handlers/NonLocalLabelControlFlow.mls
+++ b/hkmc2/shared/src/test/mlscript/handlers/NonLocalLabelControlFlow.mls
@@ -133,7 +133,7 @@ continueFromNestedFunctionWithEffects()
 //│ define handleBlock$$ as fun handleBlock$$⁰(scope0$cap, nonLocalHandler$root)() {
 //│   return handleBlock$⁰(scope0$cap, nonLocalHandler$root)
 //│ };
-//│ define NonLocalLabelEffect as class extends runtime⁰.NonLocalReturn⁰ NonLocalLabelEffect⁰ {
+//│ define NonLocalLabelEffect as class NonLocalLabelEffect⁰ extends runtime⁰.NonLocalReturn⁰ {
 //│   method break⁰ = fun break¹(value) {
 //│     let suspendRes, NonLocalLabelEffectbreak$here;
 //│     set NonLocalLabelEffectbreak$here = NonLocalLabelEffectbreak$⁰(value);

--- a/hkmc2/shared/src/test/mlscript/lifter/ClassInFun.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/ClassInFun.mls
@@ -459,7 +459,7 @@ fun f(x, y, z) =
 //│     return runtime⁰.Unit⁰
 //│   }
 //│ };
-//│ define D as class extends C⁶ D⁰ {
+//│ define D as class D⁰ extends C⁶ {
 //│   private val f$cap¹;
 //│   private val x⁴;
 //│   constructor(f$cap, x) {
@@ -554,7 +554,7 @@ fun f(x, y, z) =
 //│ define f⁶ as fun f⁷(x, y, z) {
 //│   let D, x1, tmp, tmp1, f$cap;
 //│   set f$cap = new mut Capture$f³(y);
-//│   define D as class extends C⁸ D¹ {};
+//│   define D as class D¹ extends C⁸ {};
 //│   set x1 = D¹;
 //│   set tmp = new C⁸(0, f$cap, x);
 //│   set tmp1 = new D¹();

--- a/hkmc2/shared/src/test/mlscript/lifter/PrivateMutableFields.mls
+++ b/hkmc2/shared/src/test/mlscript/lifter/PrivateMutableFields.mls
@@ -38,7 +38,7 @@ class Foo(x) with
         state + y
 //│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
 //│ let $anon;
-//│ define $anon as class extends globalThis⁰.Object⁰ $anon⁰ {
+//│ define $anon as class $anon⁰ extends globalThis⁰.Object⁰ {
 //│   private val Foo⁰;
 //│   private val y⁰;
 //│   private val state⁰;

--- a/hkmc2/shared/src/test/mlscript/syntax/annotations/Call.mls
+++ b/hkmc2/shared/src/test/mlscript/syntax/annotations/Call.mls
@@ -1,0 +1,77 @@
+:sir
+
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ import "..." as Predef; end
+object special
+object static
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ define special⁰ as object special¹; define static⁰ as object static¹; end
+
+
+fun identity(x) = x
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ define identity⁰ as fun identity¹(x) { return x }; end
+
+@special identity(1)
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ return @special identity¹(1)
+
+
+@special @static identity(2)
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ return @special @static1 identity¹(2)
+
+
+fun curried(x)(y) = x
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ define curried⁰ as fun curried¹(x)(y) { return x }; end
+
+@special curried(1)(2)
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ return @special curried¹(1)(2)
+
+
+@special identity(1)(2)
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ let baseCall; set baseCall = identity¹(1); return @special baseCall(2)
+
+
+fun nullary = 1
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ define nullary⁰ as fun nullary¹() { return 1 }; end
+
+@special nullary
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ return @special nullary¹()
+
+
+class Box(value: Int)
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ define Box⁰ as class Box² {
+//│   private val value⁰;
+//│   constructor Box¹(value) { set Box².this.value⁰ = value; end }
+//│ };
+//│ end
+
+@special new Box(1)
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ return @special new Box²(1)
+
+
+class CurriedBox(first: Int)(second: Int)
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ define CurriedBox⁰ as class CurriedBox² {
+//│   private val first⁰;
+//│   private val second⁰;
+//│   constructor CurriedBox¹(first, second) {
+//│     set CurriedBox².this.first⁰ = first;
+//│     set CurriedBox².this.second⁰ = second;
+//│     end
+//│   }
+//│ };
+//│ end
+
+@special new CurriedBox(1)(2)
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ return @special new CurriedBox²(1, 2)
+

--- a/hkmc2DiffTests/src/test/scala/hkmc2/JSBackendDiffMaker.scala
+++ b/hkmc2DiffTests/src/test/scala/hkmc2/JSBackendDiffMaker.scala
@@ -301,7 +301,7 @@ abstract class JSBackendDiffMaker extends MLsDiffMaker:
               Elaborator.State.noSymbol,
               Call(
                 Elaborator.State.runtimeSymbol.asSimpleRef.selSN("printRaw"),
-                (Arg(N, sym.asPath) :: Nil) ne_:: Nil)(true, false, false),
+                (Arg(N, sym.asPath) :: Nil) ne_:: Nil)(CallMetadata.defaultMlsFun),
               End())
           val je = nestedScp.givenIn:
             jsb.block(le, endSemi = false)


### PR DESCRIPTION
- Add `CallMetadata` and `InstantiateMetadata`
- Add annotation list for metadata
- Retrieve `explicitTailCall` from annotations