### PR TITLE
Fix issue with HandlerLowering not instrumenting class inside modules

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/HandlerLowering.scala
@@ -585,8 +585,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
             // TODO: Companion's ctor is more well behaved so it is possible to handle it
             // However, JSBuilder inserts extra statements between preCtor and ctor and it's not possible to replicate the exact behavior
             // without many special handling.
-            val newCtor = if opt.doNotInstrumentTopLevelModCtor && !h.innerDefIsTrulyNested then bod.ctor else
-              translateCtorLike(bod.ctor, bod.isym.asThis, true)
+            val newCtor = translateCtorLike(bod.ctor, bod.isym.asThis, true)
             tl.log(s"companion name: ${bod.isym.nme}")
             ClsLikeBody(bod.isym, newMtds, bod.privateFields, bod.publicFields, newCtor, bod.annotations)
           val c2 = ClsLikeDefn(owner, isym, sym, ctorSym, kind, paramsOpt, auxParams, parentPath, newMtds, privateFields, publicFields,
@@ -721,6 +720,7 @@ class HandlerLowering(paths: HandlerPaths, opt: EffectHandlers)(using TL, Raise,
     translateBlock(b, if isModCtor then HandlerCtx.ModCtor(h.innerDefIsTrulyNested) else HandlerCtx.Ctor, Set.empty)
 
   private def translateIllegalEffectCtx(b: Block, onEffect: Call)(using HandlerCtx): Block =
+    if opt.doNotInstrumentTopLevelModCtor && !summon[HandlerCtx].innerDefIsTrulyNested then return b
     def effectCheck(l: Assignable, r: Result, rst: Block): Block =
       blockBuilder
         .assign(l, r)

--- a/hkmc2/shared/src/test/mlscript/handlers/TopLevelModule.mls
+++ b/hkmc2/shared/src/test/mlscript/handlers/TopLevelModule.mls
@@ -1,0 +1,94 @@
+:js
+
+import "../../mlscript-compile/Option.mls"
+
+open Option
+
+#config(liftDefns: Some(LiftDefns), effectHandlers: EffectHandlers(doNotInstrumentTopLevelModCtor: true, stackSafety: 100))
+
+fun maybeEffects(x) =
+  if maybe do return x
+  maybeEffects(x)
+
+// Inner class should be instrumented but module constructor code should not be instrumented
+:soir
+module A with
+  data class Lazy[out A](init: () -> A) with
+    fun get() =
+      maybeEffects(maybeEffects(init()))
+    maybeEffects(maybeEffects(1))
+  maybeEffects(maybeEffects(1))
+//│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
+//│ define A⁰ as class A¹
+//│ module A² {
+//│   constructor {
+//│     let tmp;
+//│     @data
+//│     define Lazy⁰ as class Lazy² {
+//│       val init⁰;
+//│       constructor Lazy¹(init) {
+//│         let tmp1;
+//│         define init⁰ as val init¹ = init;
+//│         set tmp1 = maybeEffects⁰(1);
+//│         match runtime⁰.curEffect﹖
+//│           null =>
+//│             end
+//│           else
+//│             set tmp1 = runtime⁰.illegalEffect﹖("in a constructor");
+//│             end
+//│         do maybeEffects⁰(tmp1);
+//│         match runtime⁰.curEffect﹖
+//│           null =>
+//│             end
+//│           else
+//│             do runtime⁰.illegalEffect﹖("in a constructor");
+//│             end
+//│         end
+//│       }
+//│       method get⁰ = fun get¹() {
+//│         let tmp1, tmp2, pc;
+//│         match runtime⁰.resumePc﹖
+//│           -1 =>
+//│             set pc = 0;
+//│             end
+//│           else
+//│             set pc = runtime⁰.resumePc﹖;
+//│             set runtime⁰.resumePc﹖ = -1;
+//│             end
+//│         match pc
+//│           0 =>
+//│             set runtime⁰.resumeValue﹖ = Lazy².this.init¹();
+//│             match runtime⁰.curEffect﹖
+//│               null =>
+//│                 set pc = 2;
+//│                 end
+//│               else
+//│                 return runtime⁰.unwind﹖(Lazy².this.get¹, 2, "TopLevelModule.mls:18:33", null, Lazy².this, 1, 0, 0)
+//│             end
+//│         match pc
+//│           2 =>
+//│             set tmp1 = runtime⁰.resumeValue﹖;
+//│             set runtime⁰.resumeValue﹖ = maybeEffects⁰(tmp1);
+//│             match runtime⁰.curEffect﹖
+//│               null =>
+//│                 set pc = 1;
+//│                 end
+//│               else
+//│                 return runtime⁰.unwind﹖(Lazy².this.get¹, 1, "TopLevelModule.mls:18:20", null, Lazy².this, 1, 0, 0)
+//│             end
+//│         match pc
+//│           1 =>
+//│             set tmp2 = runtime⁰.resumeValue﹖;
+//│             return maybeEffects⁰(tmp2)
+//│           else
+//│             end
+//│         end
+//│       }
+//│     };
+//│     set tmp = maybeEffects⁰(1);
+//│     do maybeEffects⁰(tmp);
+//│     end
+//│   }
+//│ };
+//│ end
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————

--- a/hkmc2/shared/src/test/mlscript/handlers/TopLevelModule.mls
+++ b/hkmc2/shared/src/test/mlscript/handlers/TopLevelModule.mls
@@ -1,9 +1,5 @@
 :js
 
-import "../../mlscript-compile/Option.mls"
-
-open Option
-
 #config(liftDefns: Some(LiftDefns), effectHandlers: EffectHandlers(doNotInstrumentTopLevelModCtor: true, stackSafety: 100))
 
 fun maybeEffects(x) =
@@ -63,7 +59,7 @@ module A with
 //│                 set pc = 2;
 //│                 end
 //│               else
-//│                 return runtime⁰.unwind﹖(Lazy².this.get¹, 2, "TopLevelModule.mls:18:33", null, Lazy².this, 1, 0, 0)
+//│                 return runtime⁰.unwind﹖(Lazy².this.get¹, 2, "TopLevelModule.mls:14:33", null, Lazy².this, 1, 0, 0)
 //│             end
 //│         match pc
 //│           2 =>
@@ -74,7 +70,7 @@ module A with
 //│                 set pc = 1;
 //│                 end
 //│               else
-//│                 return runtime⁰.unwind﹖(Lazy².this.get¹, 1, "TopLevelModule.mls:18:20", null, Lazy².this, 1, 0, 0)
+//│                 return runtime⁰.unwind﹖(Lazy².this.get¹, 1, "TopLevelModule.mls:14:20", null, Lazy².this, 1, 0, 0)
 //│             end
 //│         match pc
 //│           1 =>


### PR DESCRIPTION
Previously, `doNotInstrumentTopLevelModCtor` will skip all module constructor, even if they contain a inner class. This behaviour is now fixed. The instrumentation should only be disabled for actual code inside the constructor and not inner class or functions, as those functions and class could potentially be used later.

From the config description, this is mainly used for resolving a cyclic dependency problem while preserving stack safety checks.
```scala
// Skips instrumenting module constructors, this can be used when the file is statically known to not
// raise any effect and cannot use the Runtime.mls module during module construction due to cyclic dependency.
// One specific scenario is Rendering.mls, which Runtime.mls depends on, and hence using stack safety will
// reference Runtime.mls during construction of the Rendering module, causing a cyclic dependency error.
doNotInstrumentTopLevelModCtor: Bool = false,
```