### PR TITLE
codegen/wasm: Make codegen APIs multi-value aware

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Ctx.scala
@@ -130,7 +130,7 @@ final case class SessionSingleton(
     globalTy: RefType,
 ) extends SessionBinding:
   def bindingKey: Str = s"singleton:$moduleName:$exportName"
-  def bindingSyms: Seq[ValueSymbol] = blockSym +: objectSym.toSeq
+  def bindingSyms: Ls[ValueSymbol] = blockSym +: objectSym.toList
   override def exportNameOpt: Opt[Str] = S(exportName)
 
 /** The emitted Wasm module together with REPL/session export metadata.

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Instructions.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Instructions.scala
@@ -440,7 +440,7 @@ object Instructions:
     /** Creates a `struct.set` instruction. */
     def set(index: FieldIdx, ref: Expr, value: FoldedInstr): FoldedInstr = FoldedInstr(
       mnemonic = "struct.set",
-      instrargs = Seq(ref.resultType_!.asInstanceOf[RefType].heapType, index),
+      instrargs = Seq(ref.resultType.map(_.asInstanceOf[RefType].heapType).get, index),
       stackargs = Seq(ref, value),
       resultType = N,
     )
@@ -448,7 +448,7 @@ object Instructions:
     /** Creates a `struct.get` instruction. */
     def get(index: FieldIdx, ref: Expr, ty: Type): FoldedInstr = FoldedInstr(
       mnemonic = "struct.get",
-      instrargs = Seq(ref.resultType_!.asInstanceOf[RefType].heapType, index),
+      instrargs = Seq(ref.resultType.map(_.asInstanceOf[RefType].heapType).get, index),
       stackargs = Seq(ref),
       resultType = S(ty),
     )

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Instructions.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Instructions.scala
@@ -103,7 +103,7 @@ object Instructions:
     mnemonic = "drop",
     instrargs = Seq.empty,
     stackargs = Seq(value),
-    resultType = N,
+    resultTypes = value.resultTypes.init,
   )
 
   /** Creates a `return` instruction with an optional return value. */

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
@@ -414,12 +414,14 @@ case class FoldedInstr(
   /** Returns the result type of this instruction if this instruction only has 0-1 result values. */
   def resultType: Opt[Type] = resultTypes match
     case Seq() => N
-    case ty :: Seq() => S(ty)
-    case _ => lastWords(s"resultType_! called on instruction with multi-value result type: $this")
+    case Seq(ty) => S(ty)
+    case tys => 
+      lastWords(s"resultType called on instruction `$mnemonic` with multi-value result type: ${tys.map(ty => doc"`${ty.toWat}`").mkDocument(doc"[", doc", ", doc"]").mkString()}")
 
   /** Returns the singular result type of this instruction, otherwise throws an exception. */
   def resultType_! : Type = resultType.getOrElse:
-    lastWords(s"resultType_! called on instruction with a non-unique result type: $this")
+    lastWords:
+      s"resultType_! called on instruction `$mnemonic` with non-unique result type(s): ${resultTypes.map(_.toWat).mkDocument(doc"[", doc", ", doc"]").mkString()}"
 
   def toWat: Document = doc"($mnemonic${
       instrargs.map: a =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
@@ -416,12 +416,13 @@ case class FoldedInstr(
     case Seq() => N
     case Seq(ty) => S(ty)
     case tys => 
-      lastWords(s"resultType called on instruction `$mnemonic` with multi-value result type: ${tys.map(ty => doc"`${ty.toWat}`").mkDocument(doc"[", doc", ", doc"]").mkString()}")
+      lastWords:
+        s"resultType called on instruction `$mnemonic` with multi-value result type: ${tys.map(ty => doc"`${ty.toWat}`").mkDocument(doc"[", doc", ", doc"]").mkString()}"
 
   /** Returns the singular result type of this instruction, otherwise throws an exception. */
   def resultType_! : Type = resultType.getOrElse:
     lastWords:
-      s"resultType_! called on instruction `$mnemonic` with non-unique result type(s): ${resultTypes.map(_.toWat).mkDocument(doc"[", doc", ", doc"]").mkString()}"
+      s"resultType_! called on instruction `$mnemonic` with no result type: ${resultTypes.map(_.toWat).mkDocument(doc"[", doc", ", doc"]").mkString()}"
 
   def toWat: Document = doc"($mnemonic${
       instrargs.map: a =>

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
@@ -411,7 +411,23 @@ case class FoldedInstr(
     resultTypes: Seq[Type],
 ) extends Instruction:
 
-  /** Returns the result type of this instruction if this instruction only has 0-1 result values. */
+  /** Returns the result type of this instruction if this instruction has exactly 0-1 result values.
+    *
+    * This is provided as a shorthand since the majority of instruction builders (in [[Instructions]]) are designed to
+    * take one value per operand argument, and either place no value (represented by `N`) or one value (represented by
+    * `S(ty)`) on the stack.
+    * 
+    * The use of these APIs with multi-value instructions, for instance:
+    *
+    * ```scala
+    * i32.add(
+    *   call(returnTypes = Seq(Result(I32Type), Result(I32Type)), /* ... */),
+    *   i32.const(1),
+    * )
+    * ```
+    *
+    * is not supported and is therefore rejected by this function, which throws an exception.
+    */
   def resultType: Opt[Type] = resultTypes match
     case Seq() => N
     case Seq(ty) => S(ty)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/Wasm.scala
@@ -419,11 +419,6 @@ case class FoldedInstr(
       lastWords:
         s"resultType called on instruction `$mnemonic` with multi-value result type: ${tys.map(ty => doc"`${ty.toWat}`").mkDocument(doc"[", doc", ", doc"]").mkString()}"
 
-  /** Returns the singular result type of this instruction, otherwise throws an exception. */
-  def resultType_! : Type = resultType.getOrElse:
-    lastWords:
-      s"resultType_! called on instruction `$mnemonic` with no result type: ${resultTypes.map(_.toWat).mkDocument(doc"[", doc", ", doc"]").mkString()}"
-
   def toWat: Document = doc"($mnemonic${
       instrargs.map: a =>
         a match

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -983,7 +983,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       exprs: Seq[Expr],
       isAbortive: Bool,
   )(using Ctx, FunctionCtx, Raise, SessionExportCtx): Seq[Expr] =
-    if exprs.flatMap(_.resultTypes).isEmpty && !isAbortive then
+    if exprs.forall(_.resultTypes.isEmpty) && !isAbortive then
       exprs :+ result(State.unitBlockMemberSymbol.asMemberRef(State.unitSymbol))
     else
       exprs

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -26,6 +26,27 @@ extension (instr: FoldedInstr)
   private def mnemonicPrefix: Opt[Str] =
     instr.mnemonic.split('.').optionUnless(_.size == 1).map(_.head)
 
+extension (exprs: Seq[Expr])
+  /** Merges a sequence of expressions to a single `block` expression if needed. */
+  def mergeAsBlock: Opt[Expr] =
+    exprs match
+      case Seq() => N
+      case Seq(e) => S(e)
+      case exprs => S(Instructions.block(
+          label = N,
+          children = exprs,
+          resultTypes = exprs
+            .flatMap(_.resultTypes)
+            .optionUnless(_.exists(_ is UnreachableType))
+            .fold(Seq.empty)(_.map(ty => Result(ty.asValType_!))),
+        ))
+
+  /** Similar to [[`mergeAsBlock`]], but throws an exception if `exprs` is empty. */
+  def mergeAsBlock_! : Expr =
+    exprs.mergeAsBlock.getOrElse:
+      lastWords("Merging zero expressions into a block should not occur")
+end extension
+
 object WatBuilder:
   /** The maximum number of characters taken to be part of the identifier asscoiated with string constants. */
   val StringConstantIdentMaxLength = 16
@@ -135,54 +156,47 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     val resultTmp = mkTempLocal("typeInfoMatch")
     funcCtx.withLabel(LabelSymbol(N, "typeInfo"), hasContinueLabel = true):
       case LabelTarget(breakLabel, S(continueLabel)) =>
-        blockInstr(
-          label = N,
-          children = Seq(
-            local.set(currentTmp, scrutTypeInfo),
-            local.set(targetTmp, targetTypeInfo),
-            local.set(resultTmp, ref.i31(i32.const(0))),
-            blockInstr(
-              label = S(breakLabel),
-              children = Seq(
-                loopInstr(
-                  label = S(continueLabel),
-                  children = Seq(
-                    `if`(
-                      condition = ref.is_null(getLocalAnyref(currentTmp)),
-                      ifTrue = br(breakLabel),
-                      ifFalse = N,
-                      resultTypes = Seq.empty,
-                    ),
-                    `if`(
-                      condition = ref.eq(
-                        ref.cast(getLocalAnyref(currentTmp), RefType(HeapType.Eq, nullable = true)),
-                        ref.cast(getLocalAnyref(targetTmp), RefType(HeapType.Eq, nullable = true)),
-                      ),
-                      ifTrue = blockInstr(
-                        label = N,
-                        children = Seq(
-                          local.set(resultTmp, ref.i31(i32.const(1))),
-                          br(breakLabel),
-                        ),
-                        resultTypes = Seq.empty,
-                      ),
-                      ifFalse = N,
-                      resultTypes = Seq.empty,
-                    ),
-                    local.set(currentTmp, readTypeInfoParent(getLocalAnyref(currentTmp))),
-                    br(continueLabel),
+        Seq(
+          local.set(currentTmp, scrutTypeInfo),
+          local.set(targetTmp, targetTypeInfo),
+          local.set(resultTmp, ref.i31(i32.const(0))),
+          blockInstr(
+            label = S(breakLabel),
+            children = Seq(
+              loopInstr(
+                label = S(continueLabel),
+                children = Seq(
+                  `if`(
+                    condition = ref.is_null(getLocalAnyref(currentTmp)),
+                    ifTrue = br(breakLabel),
+                    ifFalse = N,
+                    resultTypes = Seq.empty,
                   ),
-                  resultTypes = Seq.empty,
+                  `if`(
+                    condition = ref.eq(
+                      ref.cast(getLocalAnyref(currentTmp), RefType(HeapType.Eq, nullable = true)),
+                      ref.cast(getLocalAnyref(targetTmp), RefType(HeapType.Eq, nullable = true)),
+                    ),
+                    ifTrue = Seq(
+                      local.set(resultTmp, ref.i31(i32.const(1))),
+                      br(breakLabel),
+                    ).mergeAsBlock_!,
+                    ifFalse = N,
+                    resultTypes = Seq.empty,
+                  ),
+                  local.set(currentTmp, readTypeInfoParent(getLocalAnyref(currentTmp))),
+                  br(continueLabel),
                 ),
+                resultTypes = Seq.empty,
               ),
-              resultTypes = Seq.empty,
             ),
-            i31.get(ref.cast(getLocalAnyref(resultTmp), RefType.i31ref), signed = true),
+            resultTypes = Seq.empty,
           ),
-          resultTypes = Seq(Result(I32Type)),
-        )
+          i31.get(ref.cast(getLocalAnyref(resultTmp), RefType.i31ref), signed = true),
+        ).mergeAsBlock_!
       case LabelTarget(_, N) =>
         lastWords("unreachable: loop-based RTTI traversal expects a continue label")
+  end isSubtypeByTypeInfo
 
   /** True if this top-level class can be declared as a Wasm struct type. */
   private def isSupportedTopLevelClass(defn: ClsLikeDefn): Bool =
@@ -268,7 +282,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       typeref: TypeIdx,
   )(using Ctx, Raise): Unit =
     if ctx.containsSingleton(clsLikeDefn.sym) then return
-  
+    
     val globalSym = BlockMemberSymbol(s"${clsLikeDefn.sym.nme}$$inst", Nil, nameIsMeaningful = false)
     val globalTy = RefType(typeref, nullable = true)
 
@@ -439,6 +453,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
         virtualMethodSlots = virtualMethodSlots.toMap,
       ),
     )
+  end predeclareClassVirtualTable
 
   /** Declares one supported top-level class type for early wasm registration. */
   private def predeclareClassType(defn: ClsLikeDefn)(using Ctx, Raise): Unit =
@@ -466,6 +481,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       objectTag = S(runtimeTag),
     ))
   end predeclareClassType
+  
   /** Declares the shared Wasm function type used by a class-associated function placeholder. */
   private def declareClassFuncType(
       defn: ClsLikeDefn,
@@ -536,13 +552,18 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     ))
   end predeclareClassFuncWithType
 
-  /** Returns the single flattened constructor parameter list.
-    * After ClassParamFlattener, all classes have paramsOpt = N and exactly one auxParams entry. */
+  /** Returns the single flattened constructor parameter list. After ClassParamFlattener, all classes have paramsOpt = N
+    * and exactly one auxParams entry.
+    */
   private def classCtorParamList(defn: ClsLikeDefn): ParamList =
-    assert(defn.paramsOpt.isEmpty,
-      s"WatBuilder: expected paramsOpt to be None after flattening for class ${defn.sym.nme}")
-    assert(defn.auxParams.sizeCompare(1) == 0,
-      s"WatBuilder: expected exactly one auxParams entry after flattening for class ${defn.sym.nme}")
+    assert(
+      defn.paramsOpt.isEmpty,
+      s"WatBuilder: expected paramsOpt to be None after flattening for class ${defn.sym.nme}",
+    )
+    assert(
+      defn.auxParams.sizeCompare(1) == 0,
+      s"WatBuilder: expected exactly one auxParams entry after flattening for class ${defn.sym.nme}",
+    )
     defn.auxParams.head
 
   /** Declares one top-level class init function. */
@@ -761,6 +782,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     )
     val globalIdx = ctx.addGlobal(globalInfo)
     typeInfoGlobals(defn.sym) = globalIdx
+  end predeclareClassTypeInfoGlobal
 
   /** Declares one top-level class method. */
   private def predeclareMethod(methodDefn: FunDefn, ownerCls: ClsLikeDefn)(using Ctx, Raise): Unit =
@@ -896,15 +918,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       val thisVar = funcCtx.lookupLocal_!(clsLikeDefn.isym, N)
       val preCtorWat = compilePreCtor(clsLikeDefn, thisVar)
       val ctorWat = block(clsLikeDefn.ctor)
-      blockInstr(
-        label = N,
-        children = Seq(
-          preCtorWat,
-          ctorWat,
-          `return`(S(local.get(thisVar, RefType.anyref))),
-        ),
-        resultTypes = Seq(Result(RefType.anyref)),
-      )
+      (preCtorWat ++ ctorWat :+ `return`(S(local.get(thisVar, RefType.anyref)))).mergeAsBlock_!
 
   /** Lowers an inherited pre-constructor by preserving its setup code and rewriting the final `super(...)` into
     * `Parent_init(this, ...)`.
@@ -912,7 +926,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   private def compilePreCtor(
       clsLikeDefn: ClsLikeDefn,
       thisVar: LocalIdx,
-  )(using Ctx, FunctionCtx, Raise, SessionExportCtx): Expr =
+  )(using Ctx, FunctionCtx, Raise, SessionExportCtx): Seq[Expr] =
     def withRest(block: NonBlockTail, rest: Block): Block = block match
       case Scoped(syms, _) => Scoped(syms, rest)
       case Begin(sub, _) => Begin(sub, rest)
@@ -926,8 +940,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
     def splitSuperTail(block: Block): Opt[Block -> Ls[Arg]] = block match
       case End(_) => N
-      case Assign(NoSymbol, Call(Value.SimpleRef(State.superSymbol), argss), _: End)
-      =>
+      case Assign(NoSymbol, Call(Value.SimpleRef(State.superSymbol), argss), _: End) =>
         S(End("") -> argss.flatten)
       case b: NonBlockTail =>
         splitSuperTail(b.rest).map: (prefix, args) =>
@@ -935,7 +948,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       case _ => N
 
     clsLikeDefn.preCtor match
-      case End(_) => nop
+      case End(_) => Seq.empty
       case _ =>
         splitSuperTail(clsLikeDefn.preCtor) match
           case S((prefixBlock, args)) =>
@@ -948,13 +961,8 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                   operands = local.get(thisVar, RefType.anyref) +: args.map(argument),
                   returnTypes = Seq(Result(RefType.anyref)),
                 )
-                blockInstr(
-                  label = N,
-                  children = Seq(asStatement(prefixWat), drop(superCall)),
-                  resultTypes = Seq.empty,
-                )
-              case N =>
-                nop
+                prefixWat.toSeq :+ drop(superCall)
+              case N => Seq.empty
           case N =>
             raise(ErrorReport(
               msg"Wasm preCtor lowering only supports lowered super(...) shapes." ->
@@ -962,28 +970,23 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
               extraInfo = S(clsLikeDefn.preCtor.showAsTree),
               source = Diagnostic.Source.Compilation,
             ))
-            nop
+            Seq.empty
     end match
   end compilePreCtor
 
-  /** Converts expression result types to WAT result clauses, dropping unreachable types. */
-  private def resultClauses(expr: Expr): Seq[Result] =
-    if expr.resultTypes.exists(_ is UnreachableType) then Seq.empty
-    else expr.resultTypes.map(ty => Result(ty.asValType_!))
-
-  /** Normalizes the exported `entry` body so it always returns single result. */
-  private def normalizeEntryExpr(
-      expr: Expr,
+  /** Normalizes a [[`Seq`]] of expressions such that it always leaves at least one more value on the stack.
+    *
+    * If the expressions do not emit any values on the stack, this method appends a `$Unit` value on the stack for
+    * consumption.
+    */
+  private def normalizeValueExprs(
+      exprs: Seq[Expr],
       isAbortive: Bool,
-  )(using Ctx, FunctionCtx, Raise, SessionExportCtx): Expr =
-    if expr.resultTypes.isEmpty && !isAbortive then
-      blockInstr(
-        label = N,
-        children = Seq(expr, result(State.unitBlockMemberSymbol.asMemberRef(State.unitSymbol))),
-        resultTypes = Seq(Result(RefType.anyref)),
-      )
+  )(using Ctx, FunctionCtx, Raise, SessionExportCtx): Seq[Expr] =
+    if exprs.flatMap(_.resultTypes).isEmpty && !isAbortive then
+      exprs :+ result(State.unitBlockMemberSymbol.asMemberRef(State.unitSymbol))
     else
-      expr
+      exprs
 
   /** Validates an IntLit value fits signed 32-bit and delegates codegen to `onValid`.
     */
@@ -1062,11 +1065,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
             resultTypes = Seq(Result(I32Type)),
           )
 
-          blockInstr(
-            label = N,
-            children = Seq(storeIdx, normalizedIdx),
-            resultTypes = Seq(Result(I32Type)),
-          )
+          Seq(storeIdx, normalizedIdx).mergeAsBlock_!
 
   /** Raises a [[WarningReport]] with the given `warnMsgs` and `extraInfo`, and emits the `defaultValue` instruction.
     */
@@ -1151,7 +1150,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       qual: Path,
       methodSym: BlockMemberSymbol,
       args: Seq[Arg],
-  )(using Ctx, FunctionCtx, Raise, SessionExportCtx): Expr =
+  )(using Ctx, FunctionCtx, Raise, SessionExportCtx): Seq[Expr] =
     val ownerCls = fieldOwner(methodSym).get
     ctx.getVirtualTable(ownerCls).flatMap(_.virtualMethodSlots.get(methodSym)) match
       case S(slot) =>
@@ -1176,17 +1175,15 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
           typeIdx = virtualMethodTypeIdx,
           funcType = virtualMethodSignature(virtualArity),
         )
-        blockInstr(
-          label = N,
-          children = Seq(receiverExpr, virtualCall),
-          resultTypes = Seq(Result(RefType.anyref)),
-        )
+        Seq(receiverExpr, virtualCall)
       case N =>
-        call(
+        Seq(call(
           funcidx = ctx.getFunc_!(methodSym),
           operands = result(qual) +: args.map(argument),
           returnTypes = Seq(Result(RefType.anyref)),
-        )
+        ))
+    end match
+  end lowerClassMethodCall
 
   def result(r: codegen.Result)(using Ctx, FunctionCtx, Raise, SessionExportCtx): Expr = r match
     case Value.Lit(BoolLit(value)) =>
@@ -1256,7 +1253,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
         )
       val args = argss.flatten
       val methodSym = sel.symbol.flatMap(predeclaredClassMethodSym).get
-      lowerClassMethodCall(qual, methodSym, args)
+      lowerClassMethodCall(qual, methodSym, args).mergeAsBlock_!
 
     case c @ Call(fun, argss) =>
       if argss.length > 1 then
@@ -1344,6 +1341,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                 typeIdx = baseTypeIdx,
                 funcType = baseTypeInfo.compType.asInstanceOf[FunctionType],
               )
+      end match
 
     case sel @ Select(qual, id) =>
       sel.symbol match
@@ -1362,7 +1360,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
           val methodSym = predeclaredClassMethodSym(selSym).get
           methodSym.asTrm.flatMap(_.defn) match
             case S(defn: TermDefinition) if defn.params.isEmpty =>
-              lowerClassMethodCall(qual, methodSym, Nil)
+              lowerClassMethodCall(qual, methodSym, Nil).mergeAsBlock_!
             case _ =>
               errExpr(
                 Ls(
@@ -1484,7 +1482,8 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   /** Returns the intrinsic name if `path` refers to a builtin under `wasm`, or `N` otherwise.
     */
   private def wasmIntrinsicName(path: Path): Opt[Str] = path match
-    case Select(Value.SimpleRef(sym), ident) if (sym eq State.wasmSymbol) && wasmIntrinsicNameSet.contains(ident.name) =>
+    case Select(Value.SimpleRef(sym), ident)
+        if (sym eq State.wasmSymbol) && wasmIntrinsicNameSet.contains(ident.name) =>
       S(ident.name)
     case _ => N
 
@@ -1628,11 +1627,13 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   private def asStatement(expr: Expr): Expr =
     if expr.isControlTransfer then expr
     else
-      expr.resultType match
-        case S(_) => drop(expr)
-        case N => expr
+      (1 to expr.resultTypes.size).foldRight(expr): (_, acc) =>
+        drop(acc)
 
-  def returningTerm(t: Block)(using Ctx, FunctionCtx, Raise, SessionExportCtx): Expr =
+  private def asStatement(exprs: Seq[Expr]): Opt[Expr] =
+    exprs.mergeAsBlock.map(asStatement(_))
+
+  def returningTerm(t: Block)(using Ctx, FunctionCtx, Raise, SessionExportCtx): Seq[Expr] =
     t match
       case Assign(NoSymbol, r, rst) =>
         val rExpr = result(r)
@@ -1640,11 +1641,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
           case S(_) => drop(rExpr)
           case N => rExpr
         val rstBlk = returningTerm(rst)
-        blockInstr(
-          label = N,
-          children = Seq(evalExpr, rstBlk),
-          resultTypes = rstBlk.resultTypes.map(r => Result(r.asValType_!)),
-        )
+        evalExpr +: rstBlk
 
       case Assign(l: ValueSymbol, r, rst) =>
         val lExpr = getVar(l, l.toLoc)
@@ -1660,11 +1657,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
             )
 
         val rstBlk = returningTerm(rst)
-        blockInstr(
-          label = N,
-          children = Seq(assignExpr, rstBlk),
-          resultTypes = resultClauses(rstBlk),
-        )
+        assignExpr +: rstBlk
 
       case assign @ AssignField(lhs, nme, rhs, rst) =>
         val lhsExpr = result(lhs)
@@ -1702,11 +1695,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
             )
 
         val rstBlk = returningTerm(rst)
-        blockInstr(
-          label = N,
-          children = Seq(assignInstr, rstBlk),
-          resultTypes = resultClauses(rstBlk),
-        )
+        assignInstr +: rstBlk
 
       case assign @ AssignDynField(lhs, fld, arrayIdx, rhs, rst) =>
         val lhsExpr = result(lhs)
@@ -1731,11 +1720,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
             )
 
         val rstBlk = returningTerm(rst)
-        blockInstr(
-          label = N,
-          children = Seq(assignInstr, rstBlk),
-          resultTypes = resultClauses(rstBlk),
-        )
+        assignInstr +: rstBlk
 
       case Define(defn, rst) =>
         def mkThis(sym: InnerSymbol): Expr = result(sym.asThis)
@@ -1757,44 +1742,31 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                       s"Expected `global.*` or `local.*` when compiling definition for `$sym`, but got ${symExpr.mnemonic}",
                     )
                 val rstWat = returningTerm(rst)
-                blockInstr(
-                  label = N,
-                  children = Seq(
-                    defineExpr,
-                    rstWat,
-                  ),
-                  resultTypes = rstWat.resultTypes.map(r => Result(r.asValType_!)),
-                )
+                defineExpr +: rstWat
               case S(owner) =>
                 val ownerBlkMem = owner.asBlkMember.get
-                val rstWat = returningTerm(rst)
-                blockInstr(
-                  label = N,
-                  children = Seq(
-                    struct.set(
-                      index = fieldSelect(ownerBlkMem, tsym),
-                      ref = mkThis(owner),
-                      value = result(p),
-                    ),
-                    rstWat,
-                  ),
-                  resultTypes = resultClauses(rstWat),
+                val assignInstr = struct.set(
+                  index = fieldSelect(ownerBlkMem, tsym),
+                  ref = mkThis(owner),
+                  value = result(p),
                 )
+                val rstWat = returningTerm(rst)
+                assignInstr +: rstWat
 
           case defn: (FunDefn | ClsLikeDefn) =>
-            val res = boundary:
+            val res: Opt[Expr] = boundary:
               defn match
                 case FunDefn(params = Nil) =>
                   lastWords("cannot generate function with no parameter list")
                 case fd @ FunDefn(own, sym, dSym, ps :: pss, bod) =>
                   if own.nonEmpty then
-                    break(errExpr(
+                    break(S(errExpr(
                       Ls(
                         msg"WatBuilder::returningTerm for Define(...) with `owner.nonEmpty` not implemented yet" ->
                           defn.sym.toLoc,
                       ),
                       extraInfo = S(defn.showAsTree),
-                    ))
+                    )))
 
                   val result = pss.foldRight(bod):
                     case (ps, block) =>
@@ -1831,25 +1803,25 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                         funcType = FunctionType(funcInfo.getSignatureType),
                       ))
 
-                    nop
+                    N
                   else
-                    errExpr(
+                    S(errExpr(
                       Ls(
                         msg"WatBuilder::returningTerm for FunDefn(...) where `!sym.nameIsMeaningful` not implemented yet" ->
                           defn.sym.toLoc,
                       ),
                       extraInfo = S(defn.showAsTree),
-                    )
+                    ))
                   end if
                 case clsLikeDefn: ClsLikeDefn =>
                   // Guard against unsupported features
-                  def errUnimplExpr(cond: Str): Nothing = break(errExpr(
+                  def errUnimplExpr(cond: Str): Nothing = break(S(errExpr(
                     Ls(
                       msg"WatBuilder::returningTerm for ClsLikeDefn(...) where `$cond` not implemented yet" ->
                         clsLikeDefn.sym.toLoc,
                     ),
                     extraInfo = S(defn.showAsTree),
-                  ))
+                  )))
                   val isSingletonObj = clsLikeDefn.k is syntax.Obj
                   if clsLikeDefn.owner.nonEmpty then
                     break(errUnimplExpr("owner.nonEmpty"))
@@ -1895,15 +1867,13 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                         funcCtx.params.map((_, nme) => getLocalAnyref(LocalIdx(nme))),
                       returnTypes = Seq(Result(RefType.anyref)),
                     )
-                    blockInstr(
-                      label = N,
-                      Seq(
-                        local.set(thisVar, struct.`new`(typeref, instanceFields)),
-                        drop(initCall),
-                        `return`(S(local.get(thisVar, RefType(typeref, nullable = false)))),
-                      ),
-                      resultTypes = Seq(Result(RefType.anyref)),
-                    )
+                    Seq(
+                      local.set(thisVar, struct.`new`(typeref, instanceFields)),
+                      drop(initCall),
+                      // TODO(Derppening): Restore once we fix custom reftypes
+                      // `return`(S(local.get(thisVar, RefType(typeref, nullable = false)))),
+                      `return`(S(local.get(thisVar, RefType.anyref))),
+                    ).mergeAsBlock_!
 
                   val predeclaredInit = ctx.getFuncInfo_!(initFuncRef)
                   ctx.addFunc(FuncInfo(
@@ -2000,22 +1970,17 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                           exportName = info.globalName,
                           globalTy = info.globalTy,
                         ))
-
-                  nop
+                  N
 
                 case defn =>
-                  errExpr(
+                  S(errExpr(
                     Ls(msg"WatBuilder::returningTerm for Define(...) not implemented yet" -> defn.sym.toLoc),
                     extraInfo = S(defn.showAsTree),
-                  )
+                  ))
               end match
 
             val rstBlk = returningTerm(rst)
-            blockInstr(
-              label = N,
-              children = Seq(res, rstBlk),
-              resultTypes = resultClauses(rstBlk),
-            )
+            res.toSeq ++ rstBlk
         end match
 
       case Return(res) =>
@@ -2030,40 +1995,40 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
               case _ => ()
           case _ => ()
 
-        `return`(S(resWat))
+        Seq(`return`(S(resWat)))
 
       case Scoped(syms, body) =>
         blockPreamble(syms)
         returningTerm(body)
       case Break(label) =>
         funcCtx.lookupLabel(label) match
-          case S(target) => br(target.breakLabel)
+          case S(target) => Seq(br(target.breakLabel))
           case N =>
-            errExpr(
+            Seq(errExpr(
               Ls(
                 msg"WatBuilder::returningTerm for Break(...) to unknown label `${label.nme}`" -> label.toLoc,
               ),
               extraInfo = S(t.showAsTree),
-            )
+            ))
       case Continue(label) =>
         funcCtx.lookupLabel(label) match
           case S(target) =>
             target.continueLabel match
-              case S(continueLabel) => br(continueLabel)
+              case S(continueLabel) => Seq(br(continueLabel))
               case N =>
-                errExpr(
+                Seq(errExpr(
                   Ls(
                     msg"WatBuilder::returningTerm for Continue(...) to non-loop label `${label.nme}`" -> label.toLoc,
                   ),
                   extraInfo = S(t.showAsTree),
-                )
+                ))
           case N =>
-            errExpr(
+            Seq(errExpr(
               Ls(
                 msg"WatBuilder::returningTerm for Continue(...) to unknown label `${label.nme}`" -> label.toLoc,
               ),
               extraInfo = S(t.showAsTree),
-            )
+            ))
       case Label(label, loop, body, rst) =>
         val labeledRegion = funcCtx.withLabel(label, hasContinueLabel = loop):
           case LabelTarget(breakLabel, continueLabel) =>
@@ -2076,7 +2041,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                 children = Seq(
                   loopInstr(
                     label = continueLabel,
-                    children = Seq(bodyStmt),
+                    children = bodyStmt.toSeq,
                     resultTypes = Seq.empty,
                   ),
                 ),
@@ -2085,17 +2050,12 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
             else
               blockInstr(
                 label = S(breakLabel),
-                children = Seq(bodyStmt),
+                children = bodyStmt.toSeq,
                 resultTypes = Seq.empty,
               )
 
         val rstExpr = returningTerm(rst)
-        val rstResultTypes = rstExpr.resultTypes.flatMap(ty => ty.asValType.map(Result(_)))
-        blockInstr(
-          label = N,
-          children = Seq(labeledRegion, rstExpr),
-          resultTypes = rstResultTypes,
-        )
+        labeledRegion +: rstExpr
       case Match(scrut, arms, dflt, rst) =>
         val tailMode = rst.isInstanceOf[End]
         val matchResLocal =
@@ -2111,24 +2071,28 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
         def getScrutExpr: Expr =
           scrutLocalResult.fold(result(scrut))(getLocalAnyref)
 
-        def assignTailResult(target: LocalIdx, expr: Expr): Expr =
-          if expr.isControlTransfer then expr
+        def assignTailResult(target: LocalIdx, exprs: Seq[Expr]): Seq[Expr] =
+          if exprs.isEmpty || exprs.last.isControlTransfer then exprs
           else
-            expr.resultType match
-              case S(_) => local.set(target, expr)
-              case N => blockInstr(
-                  label = N,
-                  children = Seq(
-                    expr,
-                    local.set(target, result(State.unitBlockMemberSymbol.asMemberRef(State.unitSymbol))),
+            (exprs.mergeAsBlock, exprs.flatMap(_.resultTypes)) match
+              case (S(expr), Seq(_)) => Seq(local.set(target, expr))
+              case (S(expr), Seq()) => exprs :+
+                  local.set(target, result(State.unitBlockMemberSymbol.asMemberRef(State.unitSymbol)))
+              case (S(expr), _) => Seq(errExpr(
+                  Ls(
+                    msg"WatBuilder::assignTailResult expected 0 or 1 values on the stack, but got ${
+                        exprs.flatMap(_.resultTypes).size
+                      }" -> N,
                   ),
-                  resultTypes = Seq.empty,
-                )
+                  extraInfo = S(exprs.map(_.toString).mkString(", ")),
+                ))
+              case (N, _) => Seq.empty
 
-        def lowerMatchBody(expr: Expr): Expr =
+        def lowerMatchBody(exprs: Seq[Expr]): Seq[Expr] =
           matchResLocal match
-            case S(localIdx) => assignTailResult(localIdx, expr)
-            case N => asStatement(expr)
+            case S(localIdx) =>
+              assignTailResult(localIdx, exprs)
+            case N => asStatement(exprs).toSeq
 
         val matchResInitExpr = matchResLocal.map: localIdx =>
           local.set(localIdx, ref.`null`(HeapType.Any))
@@ -2161,7 +2125,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                           condition = testExpr,
                           ifTrue = blockInstr(
                             label = S(armLabel),
-                            children = Seq(armBodyExpr, br(matchLabel)),
+                            children = armBodyExpr :+ br(matchLabel),
                             resultTypes = Seq.empty,
                           ),
                           ifFalse = N,
@@ -2190,7 +2154,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                             condition = classMatchExpr,
                             ifTrue = blockInstr(
                               label = S(armLabel),
-                              children = Seq(armBodyExpr, br(matchLabel)),
+                              children = armBodyExpr :+ br(matchLabel),
                               resultTypes = Seq.empty,
                             ),
                             ifFalse = N,
@@ -2220,7 +2184,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                           condition = testExpr,
                           ifTrue = blockInstr(
                             label = S(armLabel),
-                            children = Seq(armBodyExpr, br(matchLabel)),
+                            children = armBodyExpr :+ br(matchLabel),
                             resultTypes = Seq.empty,
                           ),
                           ifFalse = N,
@@ -2236,56 +2200,44 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                     ))
                 end match
 
-              val defaultExpr =
-                val rawDefaultExpr = dflt match
-                  case S(defaultBody) => returningTerm(defaultBody)
-                  case N => nop
-                lowerMatchBody(rawDefaultExpr)
+              val defaultExpr = lowerMatchBody(dflt.toSeq.flatMap(returningTerm))
 
               // Generate the match block
               blockInstr(
                 label = S(matchLabel),
-                children = scrutInitExpr.toSeq ++ matchResInitExpr.toSeq ++ armExprs :+ defaultExpr,
+                children = scrutInitExpr.toSeq ++ matchResInitExpr.toSeq ++ armExprs ++ defaultExpr,
                 resultTypes = Seq.empty,
               )
 
         if tailMode then
-          blockInstr(
-            label = N,
-            children = Seq(
-              matchBlock,
-              local.get(matchResLocal.get, RefType.anyref),
-            ),
-            resultTypes = Seq(Result(RefType.anyref)),
+          Seq(
+            matchBlock,
+            local.get(matchResLocal.get, RefType.anyref),
           )
         else
           val rstExpr = returningTerm(rst)
-          blockInstr(
-            label = N,
-            children = Seq(matchBlock, rstExpr),
-            resultTypes = rstExpr.resultTypes.flatMap(ty => ty.asValType.map(Result(_))),
-          )
+          matchBlock +: rstExpr
 
       // * Try/finally lowering is intentionally rejected for now: the previous implementation required `exnref` support
       // * which can only be enabled with the `--experimental-wasm-exnref` flag.
       // * Later, it will be implemented using intrinsic function.
       case TryBlock(sub, _, _) =>
-        errExpr(
+        Seq(errExpr(
           Ls(msg"WatBuilder::returningTerm for TryBlock(...) not implemented yet" -> N),
           extraInfo = S(sub.showAsTree),
-        )
+        ))
 
       case Throw(res) =>
         val excWat = result(res)
-        `throw`(exnTagIdx, Seq(excWat))
+        Seq(`throw`(exnTagIdx, Seq(excWat)))
 
-      case End(_) => nop
+      case End(_) => Seq.empty
 
       case t =>
-        errExpr(
+        Seq(errExpr(
           Ls(msg"WatBuilder::returningTerm for ${t.getClass.getSimpleName} block not implemented yet" -> N),
           extraInfo = S(t.showAsTree),
-        )
+        ))
     end match
   end returningTerm
 
@@ -2379,8 +2331,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       // Compile the entry function under a dedicated local scope so that any temp locals introduced
       // during codegen (e.g., via `local.tee`) are declared in the entry function.
       val (entryFnExpr, entryFnCtx) = genFuncBody(Nil, thisSym = N):
-        val rawEntryFnExpr = block(p.main)
-        normalizeEntryExpr(rawEntryFnExpr, p.main.isAbortive)
+        normalizeValueExprs(block(p.main), p.main.isAbortive).mergeAsBlock.getOrElse(nop)
 
       val entrySym = BlockMemberSymbol("entry", Nil)
 
@@ -2416,16 +2367,12 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
           compType = FunctionType(params = Seq.empty, results = Seq.empty),
           objectTag = N,
         ))
-        val initBody = blockInstr(
-          label = N,
-          children = initActions,
-          resultTypes = Seq.empty,
-        )
+        val initBody = initActions.mergeAsBlock_!
         val initFn = ctx.addFunc(FuncInfo(
           sym = TempSymbol(N, "start"),
           typeUse = TypeUse(initTy),
           params = Seq.empty,
-          resultTypes = Seq.empty,
+          resultTypes = initBody.resultTypes.map(ty => Result(ty.asValType_!)),
           locals = Seq.empty,
           body = initBody,
           exportName = N,
@@ -2446,13 +2393,13 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
   def nonNestedScoped(
       blk: Block,
-  )(k: Block => Expr)(using Ctx, FunctionCtx, Raise, SessionExportCtx): Expr = blk match
+  )(k: Block => Seq[Expr])(using Ctx, FunctionCtx, Raise, SessionExportCtx): Seq[Expr] = blk match
     case Scoped(syms, body) =>
       blockPreamble(syms.view.filter(body.freeVars))
       k(body)
     case _ => k(blk)
 
-  def block(t: Block)(using Ctx, FunctionCtx, Raise, SessionExportCtx): Expr =
+  def block(t: Block)(using Ctx, FunctionCtx, Raise, SessionExportCtx): Seq[Expr] =
     nonNestedScoped(t)(returningTerm)
 
   def setupFunction(
@@ -2461,6 +2408,6 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       body: Block,
   )(using Ctx, Raise, SessionExportCtx): (Expr, FunctionCtx) =
     genFuncBody(params :: Nil, thisSym = thisParam):
-      block(body)
+      block(body).mergeAsBlock.getOrElse(nop)
 
 end WatBuilder

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -918,7 +918,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       val thisVar = funcCtx.lookupLocal_!(clsLikeDefn.isym, N)
       val preCtorWat = compilePreCtor(clsLikeDefn, thisVar)
       val ctorWat = block(clsLikeDefn.ctor)
-      (preCtorWat ++ ctorWat :+ `return`(S(local.get(thisVar, RefType.anyref)))).mergeAsBlock_!
+      (preCtorWat ++ ctorWat.toVector :+ `return`(S(local.get(thisVar, RefType.anyref)))).mergeAsBlock_!
 
   /** Lowers an inherited pre-constructor by preserving its setup code and rewriting the final `super(...)` into
     * `Parent_init(this, ...)`.
@@ -961,7 +961,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                   operands = local.get(thisVar, RefType.anyref) +: args.map(argument),
                   returnTypes = Seq(Result(RefType.anyref)),
                 )
-                prefixWat.toSeq :+ drop(superCall)
+                prefixWat.toVector :+ drop(superCall)
               case N => Seq.empty
           case N =>
             raise(ErrorReport(
@@ -984,7 +984,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       isAbortive: Bool,
   )(using Ctx, FunctionCtx, Raise, SessionExportCtx): Seq[Expr] =
     if exprs.forall(_.resultTypes.isEmpty) && !isAbortive then
-      exprs :+ result(State.unitBlockMemberSymbol.asMemberRef(State.unitSymbol))
+      exprs.toVector :+ result(State.unitBlockMemberSymbol.asMemberRef(State.unitSymbol))
     else
       exprs
 
@@ -1980,7 +1980,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
               end match
 
             val rstBlk = returningTerm(rst)
-            res.toSeq ++ rstBlk
+            res.toVector ++ rstBlk
         end match
 
       case Return(res) =>
@@ -2076,7 +2076,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
           else
             (exprs.mergeAsBlock, exprs.flatMap(_.resultTypes)) match
               case (S(expr), Seq(_)) => Seq(local.set(target, expr))
-              case (S(expr), Seq()) => exprs :+
+              case (S(expr), Seq()) => exprs.toVector :+
                   local.set(target, result(State.unitBlockMemberSymbol.asMemberRef(State.unitSymbol)))
               case (S(expr), _) => Seq(errExpr(
                   Ls(
@@ -2125,7 +2125,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                           condition = testExpr,
                           ifTrue = blockInstr(
                             label = S(armLabel),
-                            children = armBodyExpr :+ br(matchLabel),
+                            children = armBodyExpr.toVector :+ br(matchLabel),
                             resultTypes = Seq.empty,
                           ),
                           ifFalse = N,
@@ -2154,7 +2154,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                             condition = classMatchExpr,
                             ifTrue = blockInstr(
                               label = S(armLabel),
-                              children = armBodyExpr :+ br(matchLabel),
+                              children = armBodyExpr.toVector :+ br(matchLabel),
                               resultTypes = Seq.empty,
                             ),
                             ifFalse = N,
@@ -2184,7 +2184,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                           condition = testExpr,
                           ifTrue = blockInstr(
                             label = S(armLabel),
-                            children = armBodyExpr :+ br(matchLabel),
+                            children = armBodyExpr.toVector :+ br(matchLabel),
                             resultTypes = Seq.empty,
                           ),
                           ifFalse = N,
@@ -2200,12 +2200,12 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                     ))
                 end match
 
-              val defaultExpr = lowerMatchBody(dflt.toSeq.flatMap(returningTerm))
+              val defaultExpr = lowerMatchBody(dflt.toVector.flatMap(returningTerm))
 
               // Generate the match block
               blockInstr(
                 label = S(matchLabel),
-                children = scrutInitExpr.toSeq ++ matchResInitExpr.toSeq ++ armExprs ++ defaultExpr,
+                children = scrutInitExpr.toVector ++ matchResInitExpr.toVector ++ armExprs ++ defaultExpr,
                 resultTypes = Seq.empty,
               )
 

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -2072,7 +2072,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
           scrutLocalResult.fold(result(scrut))(getLocalAnyref)
 
         def assignTailResult(target: LocalIdx, exprs: Seq[Expr]): Seq[Expr] =
-          if exprs.isEmpty || exprs.last.isControlTransfer then exprs
+          if exprs.lastOption.forall(_.isControlTransfer) then exprs
           else
             (exprs.mergeAsBlock, exprs.flatMap(_.resultTypes)) match
               case (S(expr), Seq(_)) => Seq(local.set(target, expr))

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -264,7 +264,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       objectTag = typeInfo.objectTag,
       rttiTypeInfo = unitRttiTypeInfo,
       rttiGlobalExportName = unitTypeInfoGlobalInfo.exportName.get,
-      aliasSyms = singletonOwner.toSeq,
+      aliasSyms = singletonOwner.toList,
     ))
     summon[SessionExportCtx].emit(SessionSingleton(
       blockSym = unitDefn.sym,
@@ -918,7 +918,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       val thisVar = funcCtx.lookupLocal_!(clsLikeDefn.isym, N)
       val preCtorWat = compilePreCtor(clsLikeDefn, thisVar)
       val ctorWat = block(clsLikeDefn.ctor)
-      (preCtorWat ++ ctorWat.toVector :+ `return`(S(local.get(thisVar, RefType.anyref)))).mergeAsBlock_!
+      (preCtorWat ++ ctorWat :+ `return`(S(local.get(thisVar, RefType.anyref)))).mergeAsBlock_!
 
   /** Lowers an inherited pre-constructor by preserving its setup code and rewriting the final `super(...)` into
     * `Parent_init(this, ...)`.
@@ -926,7 +926,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   private def compilePreCtor(
       clsLikeDefn: ClsLikeDefn,
       thisVar: LocalIdx,
-  )(using Ctx, FunctionCtx, Raise, SessionExportCtx): Seq[Expr] =
+  )(using Ctx, FunctionCtx, Raise, SessionExportCtx): Vector[Expr] =
     def withRest(block: NonBlockTail, rest: Block): Block = block match
       case Scoped(syms, _) => Scoped(syms, rest)
       case Begin(sub, _) => Begin(sub, rest)
@@ -948,7 +948,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       case _ => N
 
     clsLikeDefn.preCtor match
-      case End(_) => Seq.empty
+      case End(_) => Vector.empty
       case _ =>
         splitSuperTail(clsLikeDefn.preCtor) match
           case S((prefixBlock, args)) =>
@@ -961,8 +961,8 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                   operands = local.get(thisVar, RefType.anyref) +: args.map(argument),
                   returnTypes = Seq(Result(RefType.anyref)),
                 )
-                prefixWat.toVector :+ drop(superCall)
-              case N => Seq.empty
+                prefixWat :+ drop(superCall)
+              case N => Vector.empty
           case N =>
             raise(ErrorReport(
               msg"Wasm preCtor lowering only supports lowered super(...) shapes." ->
@@ -970,19 +970,19 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
               extraInfo = S(clsLikeDefn.preCtor.showAsTree),
               source = Diagnostic.Source.Compilation,
             ))
-            Seq.empty
+            Vector.empty
     end match
   end compilePreCtor
 
-  /** Normalizes a [[`Seq`]] of expressions such that it always leaves at least one more value on the stack.
+  /** Normalizes a [[`Vector`]] of expressions such that it always leaves at least one more value on the stack.
     *
     * If the expressions do not emit any values on the stack, this method appends a `$Unit` value on the stack for
     * consumption.
     */
   private def normalizeValueExprs(
-      exprs: Seq[Expr],
+      exprs: Vector[Expr],
       isAbortive: Bool,
-  )(using Ctx, FunctionCtx, Raise, SessionExportCtx): Seq[Expr] =
+  )(using Ctx, FunctionCtx, Raise, SessionExportCtx): Vector[Expr] =
     if exprs.forall(_.resultTypes.isEmpty) && !isAbortive then
       exprs.toVector :+ result(State.unitBlockMemberSymbol.asMemberRef(State.unitSymbol))
     else
@@ -1150,7 +1150,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       qual: Path,
       methodSym: BlockMemberSymbol,
       args: Seq[Arg],
-  )(using Ctx, FunctionCtx, Raise, SessionExportCtx): Seq[Expr] =
+  )(using Ctx, FunctionCtx, Raise, SessionExportCtx): Ls[Expr] =
     val ownerCls = fieldOwner(methodSym).get
     ctx.getVirtualTable(ownerCls).flatMap(_.virtualMethodSlots.get(methodSym)) match
       case S(slot) =>
@@ -1175,9 +1175,9 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
           typeIdx = virtualMethodTypeIdx,
           funcType = virtualMethodSignature(virtualArity),
         )
-        Seq(receiverExpr, virtualCall)
+        Ls(receiverExpr, virtualCall)
       case N =>
-        Seq(call(
+        Ls(call(
           funcidx = ctx.getFunc_!(methodSym),
           operands = result(qual) +: args.map(argument),
           returnTypes = Seq(Result(RefType.anyref)),
@@ -1294,7 +1294,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
               call(
                 funcidx = baseFuncIdx,
-                operands = wasmArgs.toSeq,
+                operands = wasmArgs,
                 returnTypes = baseTypeInfo.compType.asInstanceOf[FunctionType].sigType.results,
               )
             case Value.MemberRef(l, _) =>
@@ -1310,7 +1310,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
               call(
                 funcidx = baseFuncIdx,
-                operands = wasmArgs.toSeq,
+                operands = wasmArgs,
                 returnTypes = baseTypeInfo.compType.asInstanceOf[FunctionType].sigType.results,
               )
             case _ =>
@@ -1337,7 +1337,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
               call_ref(
                 target = base,
-                operands = wasmArgs.toSeq,
+                operands = wasmArgs,
                 typeIdx = baseTypeIdx,
                 funcType = baseTypeInfo.compType.asInstanceOf[FunctionType],
               )
@@ -1507,8 +1507,8 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     else if unaryOps.contains(name) then createUnaryInt31Func(name, unaryOps(name), exportName)
     else lastWords(s"Unsupported wasm intrinsic '$name'")
 
-  private def intrinsicParamSuffixes(name: Str): Seq[Str] =
-    if binaryOps.contains(name) then Seq("lhs", "rhs") else Seq("arg")
+  private def intrinsicParamSuffixes(name: Str): Ls[Str] =
+    if binaryOps.contains(name) then Ls("lhs", "rhs") else Ls("arg")
 
   private def declareIntrinsicType(name: Str)(using Ctx, Raise): TypeIdx =
     ctx.addType(TypeInfo(
@@ -1527,7 +1527,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       op: (Expr, Expr) => Expr,
       exportName: Opt[Str],
   )(using Ctx, Raise): FuncIdx =
-    val params = mkIntrinsicParams(name, Seq("lhs", "rhs"))
+    val params = mkIntrinsicParams(name, Ls("lhs", "rhs"))
     val lhsName = params.head._2
     val rhsName = params(1)._2
     val body = binaryInt31Body(LocalIdx(lhsName), LocalIdx(rhsName), op)
@@ -1540,7 +1540,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       op: Expr => Expr,
       exportName: Opt[Str],
   )(using Ctx, Raise): FuncIdx =
-    val params = mkIntrinsicParams(name, Seq("arg"))
+    val params = mkIntrinsicParams(name, Ls("arg"))
     val argName = params.head._2
     val body = unaryInt31Body(LocalIdx(argName), op)
     createIntrinsicFunc(name, params, body, exportName)
@@ -1549,7 +1549,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     */
   private def createIntrinsicFunc(
       name: Str,
-      params: Seq[TempSymbol -> SymIdx],
+      params: Ls[TempSymbol -> SymIdx],
       body: Expr,
       exportName: Opt[Str],
   )(using Ctx, Raise): FuncIdx =
@@ -1568,7 +1568,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   def intrinsicSupportModule()(using Raise): Document =
     val ctx = Ctx.empty
     given Ctx = ctx
-    wasmIntrinsicNameSet.toSeq.sorted.foreach: name =>
+    wasmIntrinsicNameSet.toVector.sorted.foreach: name =>
       createIntrinsic(name, S(name))
     ctx.toWat
 
@@ -1605,7 +1605,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
 
   /** Creates parameters for an intrinsic.
     */
-  private def mkIntrinsicParams(name: Str, suffixes: Seq[Str]): Seq[TempSymbol -> SymIdx] =
+  private def mkIntrinsicParams(name: Str, suffixes: Ls[Str]): Ls[TempSymbol -> SymIdx] =
     suffixes.map: suffix =>
       val sym = TempSymbol(N, suffix)
       sym -> SymIdx(suffix)
@@ -1633,7 +1633,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   private def asStatement(exprs: Seq[Expr]): Opt[Expr] =
     exprs.mergeAsBlock.map(asStatement(_))
 
-  def returningTerm(t: Block)(using Ctx, FunctionCtx, Raise, SessionExportCtx): Seq[Expr] =
+  def returningTerm(t: Block)(using Ctx, FunctionCtx, Raise, SessionExportCtx): Vector[Expr] =
     t match
       case Assign(NoSymbol, r, rst) =>
         val rExpr = result(r)
@@ -1995,16 +1995,16 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
               case _ => ()
           case _ => ()
 
-        Seq(`return`(S(resWat)))
+        Vector(`return`(S(resWat)))
 
       case Scoped(syms, body) =>
         blockPreamble(syms)
         returningTerm(body)
       case Break(label) =>
         funcCtx.lookupLabel(label) match
-          case S(target) => Seq(br(target.breakLabel))
+          case S(target) => Vector(br(target.breakLabel))
           case N =>
-            Seq(errExpr(
+            Vector(errExpr(
               Ls(
                 msg"WatBuilder::returningTerm for Break(...) to unknown label `${label.nme}`" -> label.toLoc,
               ),
@@ -2014,16 +2014,16 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
         funcCtx.lookupLabel(label) match
           case S(target) =>
             target.continueLabel match
-              case S(continueLabel) => Seq(br(continueLabel))
+              case S(continueLabel) => Vector(br(continueLabel))
               case N =>
-                Seq(errExpr(
+                Vector(errExpr(
                   Ls(
                     msg"WatBuilder::returningTerm for Continue(...) to non-loop label `${label.nme}`" -> label.toLoc,
                   ),
                   extraInfo = S(t.showAsTree),
                 ))
           case N =>
-            Seq(errExpr(
+            Vector(errExpr(
               Ls(
                 msg"WatBuilder::returningTerm for Continue(...) to unknown label `${label.nme}`" -> label.toLoc,
               ),
@@ -2041,7 +2041,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                 children = Seq(
                   loopInstr(
                     label = continueLabel,
-                    children = bodyStmt.toSeq,
+                    children = bodyStmt.toList,
                     resultTypes = Seq.empty,
                   ),
                 ),
@@ -2050,7 +2050,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
             else
               blockInstr(
                 label = S(breakLabel),
-                children = bodyStmt.toSeq,
+                children = bodyStmt.toList,
                 resultTypes = Seq.empty,
               )
 
@@ -2071,14 +2071,14 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
         def getScrutExpr: Expr =
           scrutLocalResult.fold(result(scrut))(getLocalAnyref)
 
-        def assignTailResult(target: LocalIdx, exprs: Seq[Expr]): Seq[Expr] =
+        def assignTailResult(target: LocalIdx, exprs: Vector[Expr]): Vector[Expr] =
           if exprs.lastOption.forall(_.isControlTransfer) then exprs
           else
             (exprs.mergeAsBlock, exprs.flatMap(_.resultTypes)) match
-              case (S(expr), Seq(_)) => Seq(local.set(target, expr))
-              case (S(expr), Seq()) => exprs.toVector :+
+              case (S(expr), Seq(_)) => Vector(local.set(target, expr))
+              case (S(expr), Seq()) => exprs :+
                   local.set(target, result(State.unitBlockMemberSymbol.asMemberRef(State.unitSymbol)))
-              case (S(expr), _) => Seq(errExpr(
+              case (S(expr), _) => Vector(errExpr(
                   Ls(
                     msg"WatBuilder::assignTailResult expected 0 or 1 values on the stack, but got ${
                         exprs.flatMap(_.resultTypes).size
@@ -2086,13 +2086,13 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                   ),
                   extraInfo = S(exprs.map(_.toString).mkString(", ")),
                 ))
-              case (N, _) => Seq.empty
+              case (N, _) => Vector.empty
 
-        def lowerMatchBody(exprs: Seq[Expr]): Seq[Expr] =
+        def lowerMatchBody(exprs: Vector[Expr]): Vector[Expr] =
           matchResLocal match
             case S(localIdx) =>
               assignTailResult(localIdx, exprs)
-            case N => asStatement(exprs).toSeq
+            case N => asStatement(exprs).toVector
 
         val matchResInitExpr = matchResLocal.map: localIdx =>
           local.set(localIdx, ref.`null`(HeapType.Any))
@@ -2210,7 +2210,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
               )
 
         if tailMode then
-          Seq(
+          Vector(
             matchBlock,
             local.get(matchResLocal.get, RefType.anyref),
           )
@@ -2222,19 +2222,19 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       // * which can only be enabled with the `--experimental-wasm-exnref` flag.
       // * Later, it will be implemented using intrinsic function.
       case TryBlock(sub, _, _) =>
-        Seq(errExpr(
+        Vector(errExpr(
           Ls(msg"WatBuilder::returningTerm for TryBlock(...) not implemented yet" -> N),
           extraInfo = S(sub.showAsTree),
         ))
 
       case Throw(res) =>
         val excWat = result(res)
-        Seq(`throw`(exnTagIdx, Seq(excWat)))
+        Vector(`throw`(exnTagIdx, Seq(excWat)))
 
-      case End(_) => Seq.empty
+      case End(_) => Vector.empty
 
       case t =>
-        Seq(errExpr(
+        Vector(errExpr(
           Ls(msg"WatBuilder::returningTerm for ${t.getClass.getSimpleName} block not implemented yet" -> N),
           extraInfo = S(t.showAsTree),
         ))
@@ -2281,7 +2281,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
       ).fold(0)(_.memType.lim.min)
 
     def compiledModule(entryName: Str): CompiledWasmModule =
-      CompiledWasmModule(ctx.toWat, entryName, systemMemMinPages, sessionExportCtx.collectedBindings.toSeq)
+      CompiledWasmModule(ctx.toWat, entryName, systemMemMinPages, sessionExportCtx.collectedBindings.toVector)
 
     // Create the two Wasm intrinsic struct types shared across class lowering:
     // the base RTTI layout (`TypeInfoBase`) and the base object layout (`Object`).
@@ -2311,7 +2311,7 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
     collectSessionGlobalSymbols(
       p.main,
       sessionExportCtx,
-    ).toSeq.sortBy(_.uid).foreach: sym =>
+    ).toVector.sortBy(_.uid).foreach: sym =>
       registerSessionGlobal(sym)
 
     boundary[CompiledWasmModule]:
@@ -2386,20 +2386,20 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
   end program
 
   def blockPreamble(ss: Iterable[ValueSymbol])(using Ctx, FunctionCtx, Raise): Unit =
-    ss.toArray.sortBy(_.uid).toSeq.filter: sym =>
+    ss.toVector.sortBy(_.uid).filter: sym =>
       !ctx.containsGlobal(sym) && ctx.getFunc(sym).isEmpty
     .foreach: sym =>
       funcCtx.addLocal(sym)
 
   def nonNestedScoped(
       blk: Block,
-  )(k: Block => Seq[Expr])(using Ctx, FunctionCtx, Raise, SessionExportCtx): Seq[Expr] = blk match
+  )(k: Block => Vector[Expr])(using Ctx, FunctionCtx, Raise, SessionExportCtx): Vector[Expr] = blk match
     case Scoped(syms, body) =>
       blockPreamble(syms.view.filter(body.freeVars))
       k(body)
     case _ => k(blk)
 
-  def block(t: Block)(using Ctx, FunctionCtx, Raise, SessionExportCtx): Seq[Expr] =
+  def block(t: Block)(using Ctx, FunctionCtx, Raise, SessionExportCtx): Vector[Expr] =
     nonNestedScoped(t)(returningTerm)
 
   def setupFunction(

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -2103,6 +2103,17 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
             boundary:
               val armExprs = arms.zipWithIndex.flatMap: (caseAndBody, armIdx) =>
                 val (cse, body) = caseAndBody
+                lazy val ifTrue =
+                  funcCtx.withLabel(LabelSymbol(N, "arm"), hasContinueLabel = false):
+                    case LabelTarget(armLabel, _) =>
+                      val bodyExpr = returningTerm(body)
+                      val armBodyExpr = lowerMatchBody(bodyExpr)
+                      blockInstr(
+                        label = S(armLabel),
+                        children = armBodyExpr :+ br(matchLabel),
+                        resultTypes = Seq.empty,
+                      )
+                
                 cse match
                   case Case.Lit(lit) =>
                     val testExpr: FoldedInstr = lit match
@@ -2117,20 +2128,12 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                       case _ =>
                         break(errExpr(Ls(msg"Pattern matching for unit literals not implemented yet" -> lit.toLoc)))
 
-                    val bodyExpr = returningTerm(body)
-                    val armBodyExpr = lowerMatchBody(bodyExpr)
-                    funcCtx.withLabel(LabelSymbol(N, "arm"), hasContinueLabel = false):
-                      case LabelTarget(armLabel, _) =>
-                        S(`if`(
-                          condition = testExpr,
-                          ifTrue = blockInstr(
-                            label = S(armLabel),
-                            children = armBodyExpr.toVector :+ br(matchLabel),
-                            resultTypes = Seq.empty,
-                          ),
-                          ifFalse = N,
-                          resultTypes = Seq.empty,
-                        ))
+                    S(`if`(
+                      condition = testExpr,
+                      ifTrue = ifTrue,
+                      ifFalse = N,
+                      resultTypes = Seq.empty,
+                    ))
 
                   case Case.Cls(cls, _) =>
                     val clsBlkMemberSym = cls.asBlkMember getOrElse:
@@ -2143,26 +2146,17 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                     val targetRtti = getClassTypeInfoGlobal(clsBlkMemberSym).get
                     val classMatchExpr = isSubtypeByTypeInfo(scrutRtti, targetRtti)
 
-                    val bodyExpr = returningTerm(body)
-                    val armBodyExpr = lowerMatchBody(bodyExpr)
-
-                    funcCtx.withLabel(LabelSymbol(N, "arm"), hasContinueLabel = false):
-                      case LabelTarget(armLabel, _) =>
-                        S(`if`(
-                          condition = isStructCompatible,
-                          ifTrue = `if`(
-                            condition = classMatchExpr,
-                            ifTrue = blockInstr(
-                              label = S(armLabel),
-                              children = armBodyExpr.toVector :+ br(matchLabel),
-                              resultTypes = Seq.empty,
-                            ),
-                            ifFalse = N,
-                            resultTypes = Seq.empty,
-                          ),
-                          ifFalse = N,
-                          resultTypes = Seq.empty,
-                        ))
+                    S(`if`(
+                      condition = isStructCompatible,
+                      ifTrue = `if`(
+                        condition = classMatchExpr,
+                        ifTrue = ifTrue,
+                        ifFalse = N,
+                        resultTypes = Seq.empty,
+                      ),
+                      ifFalse = N,
+                      resultTypes = Seq.empty,
+                    ))
                   case Case.Tup(len, inf) =>
                     val arrayRefType = RefType(HeapType.Array, nullable = true)
                     val isArrayTest = ref.test(getScrutExpr, arrayRefType)
@@ -2176,20 +2170,12 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                       i32.eq(arrayLength, i32.const(len))
 
                     val testExpr = i32.and(isArrayTest, lengthTest)
-                    val bodyExpr = returningTerm(body)
-                    val armBodyExpr = lowerMatchBody(bodyExpr)
-                    funcCtx.withLabel(LabelSymbol(N, "arm"), hasContinueLabel = false):
-                      case LabelTarget(armLabel, _) =>
-                        S(`if`(
-                          condition = testExpr,
-                          ifTrue = blockInstr(
-                            label = S(armLabel),
-                            children = armBodyExpr.toVector :+ br(matchLabel),
-                            resultTypes = Seq.empty,
-                          ),
-                          ifFalse = N,
-                          resultTypes = Seq.empty,
-                        ))
+                    S(`if`(
+                      condition = testExpr,
+                      ifTrue = ifTrue,
+                      ifFalse = N,
+                      resultTypes = Seq.empty,
+                    ))
                   case _ =>
                     break(errExpr(
                       Ls(

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/wasm/text/WatBuilder.scala
@@ -2108,9 +2108,10 @@ class WatBuilder(using TraceLogger, State) extends CodeBuilder:
                     case LabelTarget(armLabel, _) =>
                       val bodyExpr = returningTerm(body)
                       val armBodyExpr = lowerMatchBody(bodyExpr)
+                      val armIsCtrlXfer = armBodyExpr.lastOption.exists(_.isControlTransfer)
                       blockInstr(
                         label = S(armLabel),
-                        children = armBodyExpr :+ br(matchLabel),
+                        children = armBodyExpr ++ br(matchLabel).optionUnless(armIsCtrlXfer).toVector,
                         resultTypes = Seq.empty,
                       )
                 

--- a/hkmc2/shared/src/test/mlscript/wasm/Basics.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/Basics.mls
@@ -67,14 +67,12 @@ foo() + foo()
 //│       (ref.i31
 //│         (i32.const 42))))
 //│   (func $entry (export "entry") (type $entry) (result (ref null any))
-//│     (block (result (ref null any))
-//│       (nop)
-//│       (return
-//│         (call $plus_impl
-//│           (ref.i31
-//│             (i32.const 42))
-//│           (ref.i31
-//│             (i32.const 42))))))
+//│     (return
+//│       (call $plus_impl
+//│         (ref.i31
+//│           (i32.const 42))
+//│         (ref.i31
+//│           (i32.const 42)))))
 //│   (elem $foo declare func $foo)
 //│   (elem $entry declare func $entry))
 //│ Wasm result:
@@ -110,13 +108,10 @@ class Foo(val a)
 //│     (ref.null $TypeInfoBase)))
 //│   (func $Foo_init (type $Foo_init) (param $this (ref null any)) (param $a (ref null any)) (result (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block
-//│         (struct.set $Foo $a
-//│           (ref.cast (ref $Foo)
-//│             (local.get $this))
-//│           (local.get $a))
-//│         (nop))
+//│       (struct.set $Foo $a
+//│         (ref.cast (ref $Foo)
+//│           (local.get $this))
+//│         (local.get $a))
 //│       (return
 //│         (local.get $this))))
 //│   (func $Foo_ctor (export "Foo") (type $Foo_ctor) (param $a (ref null any)) (result (ref null any))
@@ -135,16 +130,14 @@ class Foo(val a)
 //│   (func $entry (export "entry") (type $entry) (result (ref null any))
 //│     (local $tmp (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block (result (ref null any))
-//│         (local.set $tmp
-//│           (call $Foo_ctor
-//│             (ref.i31
-//│               (i32.const 42))))
-//│         (return
-//│           (struct.get $Foo $a
-//│             (ref.cast (ref $Foo)
-//│               (local.get $tmp)))))))
+//│       (local.set $tmp
+//│         (call $Foo_ctor
+//│           (ref.i31
+//│             (i32.const 42))))
+//│       (return
+//│         (struct.get $Foo $a
+//│           (ref.cast (ref $Foo)
+//│             (local.get $tmp))))))
 //│   (elem $Foo_init declare func $Foo_init)
 //│   (elem $Foo_ctor declare func $Foo_ctor)
 //│   (elem $entry declare func $entry))
@@ -176,20 +169,16 @@ class Foo(val x) with
 //│     (ref.null $TypeInfoBase)))
 //│   (func $Foo_init (type $Foo_init) (param $this (ref null any)) (param $x (ref null any)) (result (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block
-//│         (struct.set $Foo $x
+//│       (struct.set $Foo $x
+//│         (ref.cast (ref $Foo)
+//│           (local.get $this))
+//│         (local.get $x))
+//│       (struct.set $Foo $y
+//│         (ref.cast (ref $Foo)
+//│           (local.get $this))
+//│         (struct.get $Foo $x
 //│           (ref.cast (ref $Foo)
-//│             (local.get $this))
-//│           (local.get $x))
-//│         (block
-//│           (struct.set $Foo $y
-//│             (ref.cast (ref $Foo)
-//│               (local.get $this))
-//│             (struct.get $Foo $x
-//│               (ref.cast (ref $Foo)
-//│                 (local.get $this))))
-//│           (nop)))
+//│             (local.get $this))))
 //│       (return
 //│         (local.get $this))))
 //│   (func $Foo_ctor (export "Foo") (type $Foo_ctor) (param $x (ref null any)) (result (ref null any))
@@ -209,16 +198,14 @@ class Foo(val x) with
 //│   (func $entry (export "entry") (type $entry) (result (ref null any))
 //│     (local $tmp (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block (result (ref null any))
-//│         (local.set $tmp
-//│           (call $Foo_ctor
-//│             (ref.i31
-//│               (i32.const 42))))
-//│         (return
-//│           (struct.get $Foo $y
-//│             (ref.cast (ref $Foo)
-//│               (local.get $tmp)))))))
+//│       (local.set $tmp
+//│         (call $Foo_ctor
+//│           (ref.i31
+//│             (i32.const 42))))
+//│       (return
+//│         (struct.get $Foo $y
+//│           (ref.cast (ref $Foo)
+//│             (local.get $tmp))))))
 //│   (elem $Foo_init declare func $Foo_init)
 //│   (elem $Foo_ctor declare func $Foo_ctor)
 //│   (elem $entry declare func $entry))
@@ -247,21 +234,17 @@ O.y
 //│   (global $O$inst (export "O$inst") (mut (ref null $O)) (ref.null $O))
 //│   (func $O_init (type $O_init) (param $this (ref null any)) (result (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block
-//│         (struct.set $O $x
+//│       (struct.set $O $x
+//│         (ref.cast (ref $O)
+//│           (local.get $this))
+//│         (ref.i31
+//│           (i32.const 1)))
+//│       (struct.set $O $y
+//│         (ref.cast (ref $O)
+//│           (local.get $this))
+//│         (struct.get $O $x
 //│           (ref.cast (ref $O)
-//│             (local.get $this))
-//│           (ref.i31
-//│             (i32.const 1)))
-//│         (block
-//│           (struct.set $O $y
-//│             (ref.cast (ref $O)
-//│               (local.get $this))
-//│             (struct.get $O $x
-//│               (ref.cast (ref $O)
-//│                 (local.get $this))))
-//│           (nop)))
+//│             (local.get $this))))
 //│       (return
 //│         (local.get $this))))
 //│   (func $O_ctor (type $O_ctor) (result (ref null any))
@@ -278,17 +261,14 @@ O.y
 //│       (return
 //│         (local.get $this))))
 //│   (func $start (type $start)
-//│     (block
-//│       (global.set $O$inst
-//│         (ref.cast (ref null $O)
-//│           (call $O_ctor)))))
+//│     (global.set $O$inst
+//│       (ref.cast (ref null $O)
+//│         (call $O_ctor))))
 //│   (func $entry (export "entry") (type $entry) (result (ref null any))
-//│     (block (result (ref null any))
-//│       (nop)
-//│       (return
-//│         (struct.get $O $y
-//│           (ref.cast (ref $O)
-//│             (global.get $O$inst))))))
+//│     (return
+//│       (struct.get $O $y
+//│         (ref.cast (ref $O)
+//│           (global.get $O$inst)))))
 //│   (elem $O_init declare func $O_init)
 //│   (elem $O_ctor declare func $O_ctor)
 //│   (elem $start declare func $start)
@@ -303,5 +283,5 @@ fun bar() = 42
 fun foo() = bar
 foo()()
 //│ ╔══[COMPILATION ERROR] Returning function instances is not supported
-//│ ║  l.303: 	fun foo() = bar
+//│ ║  l.283: 	fun foo() = bar
 //│ ╙──       	            ^^^

--- a/hkmc2/shared/src/test/mlscript/wasm/ClassInheritance.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/ClassInheritance.mls
@@ -162,8 +162,7 @@ c.Parent#x + (c is Parent)
 //│                         (ref.cast (ref $Parent)
 //│                           (global.get $c)))
 //│                       (ref.i31
-//│                         (i32.const 1))))
-//│                   (br $match))))))
+//│                         (i32.const 1)))))))))
 //│         (return
 //│           (call $plus_impl
 //│             (struct.get $Parent $x
@@ -268,5 +267,5 @@ class B
 class A extends B
 class B extends A
 //│ ╔══[COMPILATION ERROR] Inheritance cycles are not supported.
-//│ ║  l.268: 	class A extends B
+//│ ║  l.267: 	class A extends B
 //│ ╙──       	^^^^^^^^^^^^^^^^^

--- a/hkmc2/shared/src/test/mlscript/wasm/ClassInheritance.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/ClassInheritance.mls
@@ -48,13 +48,10 @@ c.Parent#x + (c is Parent)
 //│     (global.get $Parent_typeinfo)))
 //│   (func $Parent_init (type $Parent_init) (param $this (ref null any)) (param $x (ref null any)) (result (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block
-//│         (struct.set $Parent $x
-//│           (ref.cast (ref $Parent)
-//│             (local.get $this))
-//│           (local.get $x))
-//│         (nop))
+//│       (struct.set $Parent $x
+//│         (ref.cast (ref $Parent)
+//│           (local.get $this))
+//│         (local.get $x))
 //│       (return
 //│         (local.get $this))))
 //│   (func $Parent_ctor (export "Parent") (type $Parent_ctor) (param $x (ref null any)) (result (ref null any))
@@ -73,24 +70,19 @@ c.Parent#x + (c is Parent)
 //│   (func $Child_init (type $Child_init) (param $this (ref null any)) (param $y (ref null any)) (result (ref null any))
 //│     (local $tmp (ref null any))
 //│     (block (result (ref null any))
-//│       (block
-//│         (block
-//│           (local.set $tmp
-//│             (call $plus_impl
-//│               (local.get $y)
-//│               (ref.i31
-//│                 (i32.const 1))))
-//│           (nop))
-//│         (drop
-//│           (call $Parent_init
-//│             (local.get $this)
-//│             (local.get $tmp))))
-//│       (block
-//│         (struct.set $Child $y
-//│           (ref.cast (ref $Child)
-//│             (local.get $this))
-//│           (local.get $y))
-//│         (nop))
+//│       (local.set $tmp
+//│         (call $plus_impl
+//│           (local.get $y)
+//│           (ref.i31
+//│             (i32.const 1))))
+//│       (drop
+//│         (call $Parent_init
+//│           (local.get $this)
+//│           (local.get $tmp)))
+//│       (struct.set $Child $y
+//│         (ref.cast (ref $Child)
+//│           (local.get $this))
+//│         (local.get $y))
 //│       (return
 //│         (local.get $this))))
 //│   (func $Child_ctor (export "Child") (type $Child_ctor) (param $y (ref null any)) (result (ref null any))
@@ -117,74 +109,69 @@ c.Parent#x + (c is Parent)
 //│         (call $Child_ctor
 //│           (ref.i31
 //│             (i32.const 2))))
-//│       (block (result (ref null any))
-//│         (nop)
-//│         (block (result (ref null any))
-//│           (nop)
-//│           (block (result (ref null any))
-//│             (block $match
-//│               (local.set $matchRes
-//│                 (ref.null any))
-//│               (if
-//│                 (ref.test (ref $Object)
-//│                   (global.get $c))
-//│                 (then
-//│                   (if
-//│                     (block (result i32)
-//│                       (local.set $currentTypeInfo
-//│                         (struct.get $Object $$typeinfo
-//│                           (ref.cast (ref $Object)
-//│                             (global.get $c))))
-//│                       (local.set $targetTypeInfo
-//│                         (global.get $Parent_typeinfo))
-//│                       (local.set $typeInfoMatch
-//│                         (ref.i31
-//│                           (i32.const 0)))
-//│                       (block $typeInfo
-//│                         (loop $typeInfo_cont
-//│                           (if
-//│                             (ref.is_null
-//│                               (local.get $currentTypeInfo))
-//│                             (then
-//│                               (br $typeInfo)))
-//│                           (if
-//│                             (ref.eq
-//│                               (ref.cast (ref null eq)
-//│                                 (local.get $currentTypeInfo))
-//│                               (ref.cast (ref null eq)
-//│                                 (local.get $targetTypeInfo)))
-//│                             (then
-//│                               (block
-//│                                 (local.set $typeInfoMatch
-//│                                   (ref.i31
-//│                                     (i32.const 1)))
-//│                                 (br $typeInfo))))
-//│                           (local.set $currentTypeInfo
-//│                             (struct.get $TypeInfoBase $$parent
-//│                               (ref.cast (ref $TypeInfoBase)
-//│                                 (local.get $currentTypeInfo))))
-//│                           (br $typeInfo_cont)))
-//│                       (i31.get_s
-//│                         (ref.cast (ref null i31)
-//│                           (local.get $typeInfoMatch))))
-//│                     (then
-//│                       (block $arm
-//│                         (return
-//│                           (call $plus_impl
-//│                             (struct.get $Parent $x
-//│                               (ref.cast (ref $Parent)
-//│                                 (global.get $c)))
-//│                             (ref.i31
-//│                               (i32.const 1))))
-//│                         (br $match))))))
-//│               (return
-//│                 (call $plus_impl
-//│                   (struct.get $Parent $x
-//│                     (ref.cast (ref $Parent)
-//│                       (global.get $c)))
+//│       (block $match
+//│         (local.set $matchRes
+//│           (ref.null any))
+//│         (if
+//│           (ref.test (ref $Object)
+//│             (global.get $c))
+//│           (then
+//│             (if
+//│               (block (result i32)
+//│                 (local.set $currentTypeInfo
+//│                   (struct.get $Object $$typeinfo
+//│                     (ref.cast (ref $Object)
+//│                       (global.get $c))))
+//│                 (local.set $targetTypeInfo
+//│                   (global.get $Parent_typeinfo))
+//│                 (local.set $typeInfoMatch
 //│                   (ref.i31
-//│                     (i32.const 0)))))
-//│             (local.get $matchRes))))))
+//│                     (i32.const 0)))
+//│                 (block $typeInfo
+//│                   (loop $typeInfo_cont
+//│                     (if
+//│                       (ref.is_null
+//│                         (local.get $currentTypeInfo))
+//│                       (then
+//│                         (br $typeInfo)))
+//│                     (if
+//│                       (ref.eq
+//│                         (ref.cast (ref null eq)
+//│                           (local.get $currentTypeInfo))
+//│                         (ref.cast (ref null eq)
+//│                           (local.get $targetTypeInfo)))
+//│                       (then
+//│                         (block
+//│                           (local.set $typeInfoMatch
+//│                             (ref.i31
+//│                               (i32.const 1)))
+//│                           (br $typeInfo))))
+//│                     (local.set $currentTypeInfo
+//│                       (struct.get $TypeInfoBase $$parent
+//│                         (ref.cast (ref $TypeInfoBase)
+//│                           (local.get $currentTypeInfo))))
+//│                     (br $typeInfo_cont)))
+//│                 (i31.get_s
+//│                   (ref.cast (ref null i31)
+//│                     (local.get $typeInfoMatch))))
+//│               (then
+//│                 (block $arm
+//│                   (return
+//│                     (call $plus_impl
+//│                       (struct.get $Parent $x
+//│                         (ref.cast (ref $Parent)
+//│                           (global.get $c)))
+//│                       (ref.i31
+//│                         (i32.const 1))))
+//│                   (br $match))))))
+//│         (return
+//│           (call $plus_impl
+//│             (struct.get $Parent $x
+//│               (ref.cast (ref $Parent)
+//│                 (global.get $c)))
+//│             (ref.i31
+//│               (i32.const 0)))))
+//│       (local.get $matchRes)))
 //│   (elem $Parent_init declare func $Parent_init)
 //│   (elem $Parent_ctor declare func $Parent_ctor)
 //│   (elem $Child_init declare func $Child_init)
@@ -281,5 +268,5 @@ class B
 class A extends B
 class B extends A
 //│ ╔══[COMPILATION ERROR] Inheritance cycles are not supported.
-//│ ║  l.281: 	class A extends B
+//│ ║  l.268: 	class A extends B
 //│ ╙──       	^^^^^^^^^^^^^^^^^

--- a/hkmc2/shared/src/test/mlscript/wasm/ClassMethods.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/ClassMethods.mls
@@ -26,13 +26,10 @@ a.A#get() + A(2).get()
 //│     (ref.null $TypeInfoBase)))
 //│   (func $A_init (type $A_init) (param $this (ref null any)) (param $x (ref null any)) (result (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block
-//│         (struct.set $A $x
-//│           (ref.cast (ref $A)
-//│             (local.get $this))
-//│           (local.get $x))
-//│         (nop))
+//│       (struct.set $A $x
+//│         (ref.cast (ref $A)
+//│           (local.get $this))
+//│         (local.get $x))
 //│       (return
 //│         (local.get $this))))
 //│   (func $A_ctor (export "A") (type $A_ctor) (param $x (ref null any)) (result (ref null any))
@@ -58,29 +55,24 @@ a.A#get() + A(2).get()
 //│     (local $tmp1 (ref null any))
 //│     (local $tmp2 (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block (result (ref null any))
-//│         (global.set $a
-//│           (call $A_ctor
-//│             (ref.i31
-//│               (i32.const 1))))
-//│         (block (result (ref null any))
-//│           (local.set $tmp
-//│             (call $A_get
-//│               (global.get $a)))
-//│           (block (result (ref null any))
-//│             (local.set $tmp1
-//│               (call $A_ctor
-//│                 (ref.i31
-//│                   (i32.const 2))))
-//│             (block (result (ref null any))
-//│               (local.set $tmp2
-//│                 (call $A_get
-//│                   (local.get $tmp1)))
-//│               (return
-//│                 (call $plus_impl
-//│                   (local.get $tmp)
-//│                   (local.get $tmp2)))))))))
+//│       (global.set $a
+//│         (call $A_ctor
+//│           (ref.i31
+//│             (i32.const 1))))
+//│       (local.set $tmp
+//│         (call $A_get
+//│           (global.get $a)))
+//│       (local.set $tmp1
+//│         (call $A_ctor
+//│           (ref.i31
+//│             (i32.const 2))))
+//│       (local.set $tmp2
+//│         (call $A_get
+//│           (local.get $tmp1)))
+//│       (return
+//│         (call $plus_impl
+//│           (local.get $tmp)
+//│           (local.get $tmp2)))))
 //│   (elem $A_init declare func $A_init)
 //│   (elem $A_ctor declare func $A_ctor)
 //│   (elem $A_get declare func $A_get)
@@ -188,7 +180,7 @@ let d = Counter(c.Counter#get())
 :todo
 d.Counter#inc().Counter#double().Counter#get()
 //│ ╔══[COMPILATION ERROR] Cannot find variable `d` (VarSymbol) in local or global scope.
-//│ ║  l.185: 	let d = Counter(c.Counter#get())
+//│ ║  l.177: 	let d = Counter(c.Counter#get())
 //│ ╙──       	    ^
 //│ /!!!\ Uncaught error: java.lang.Exception: Internal Error: Missing type definition for symbol `member:Counter`
 
@@ -209,5 +201,5 @@ class A(val x) with
   fun get() = x
 A(1).get
 //│ ╔══[COMPILATION ERROR] `member:get` is neither a field access nor a callable method
-//│ ║  l.210: 	A(1).get
+//│ ║  l.202: 	A(1).get
 //│ ╙──       	    ^^^^

--- a/hkmc2/shared/src/test/mlscript/wasm/ControlFlow.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/ControlFlow.mls
@@ -57,8 +57,7 @@ let i = 0 in
 //│                             (i32.const 1))))
 //│                       (local.set $i
 //│                         (local.get $tmp))
-//│                       (br $lbl_cont)
-//│                       (br $match)))))
+//│                       (br $lbl_cont)))))
 //│               (local.get $matchRes)))))
 //│       (return
 //│         (local.get $i))))
@@ -163,8 +162,7 @@ tailMatchAllValue(1)
 //│             (block $arm
 //│               (return
 //│                 (ref.i31
-//│                   (i32.const 10)))
-//│               (br $match))))
+//│                   (i32.const 10))))))
 //│         (if
 //│           (i32.eq
 //│             (i31.get_s
@@ -175,8 +173,7 @@ tailMatchAllValue(1)
 //│             (block $arm
 //│               (return
 //│                 (ref.i31
-//│                   (i32.const 20)))
-//│               (br $match))))
+//│                   (i32.const 20))))))
 //│         (return
 //│           (ref.i31
 //│             (i32.const 30))))
@@ -198,8 +195,7 @@ tailMatchAllValue(1)
 //│             (block $arm
 //│               (return
 //│                 (ref.i31
-//│                   (i32.const 10)))
-//│               (br $match))))
+//│                   (i32.const 10))))))
 //│         (if
 //│           (i32.eq
 //│             (i31.get_s
@@ -211,8 +207,7 @@ tailMatchAllValue(1)
 //│             (block $arm
 //│               (return
 //│                 (ref.i31
-//│                   (i32.const 20)))
-//│               (br $match))))
+//│                   (i32.const 20))))))
 //│         (return
 //│           (ref.i31
 //│             (i32.const 30))))

--- a/hkmc2/shared/src/test/mlscript/wasm/ControlFlow.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/ControlFlow.mls
@@ -18,40 +18,9 @@ let i = 0 in
 //│   (type $Object (sub (struct (field $$typeinfo (mut (ref $TypeInfoBase))))))
 //│   (type $lt_impl (func (param $lhs (ref null any)) (param $rhs (ref null any)) (result (ref null any))))
 //│   (type $plus_impl (func (param $lhs (ref null any)) (param $rhs (ref null any)) (result (ref null any))))
-//│   (type $Unit_typeinfo (sub $TypeInfoBase (struct (field $$tag i32) (field $$parent (ref null $TypeInfoBase)))))
-//│   (type $Unit (sub $Object (struct (field $$typeinfo (mut (ref $TypeInfoBase))))))
-//│   (type $Unit_init (func (param $this (ref null any)) (result (ref null any))))
-//│   (type $Unit_ctor (func (result (ref null any))))
 //│   (type $entry (func (result (ref null any))))
-//│   (type $start (func))
 //│   (import "system" "lt_impl" (func $lt_impl (type $lt_impl)))
 //│   (import "system" "plus_impl" (func $plus_impl (type $plus_impl)))
-//│   (global $Unit_typeinfo (export "Unit_typeinfo") (ref $Unit_typeinfo) (struct.new $Unit_typeinfo
-//│     (i32.const 1)
-//│     (ref.null $TypeInfoBase)))
-//│   (global $Unit$inst (export "Unit$inst") (mut (ref null $Unit)) (ref.null $Unit))
-//│   (func $Unit_init (type $Unit_init) (param $this (ref null any)) (result (ref null any))
-//│     (block (result (ref null any))
-//│       (nop)
-//│       (nop)
-//│       (return
-//│         (local.get $this))))
-//│   (func $Unit_Unit (type $Unit_ctor) (result (ref null any))
-//│     (local $this (ref null any))
-//│     (block (result (ref null any))
-//│       (local.set $this
-//│         (struct.new $Unit
-//│           (global.get $Unit_typeinfo)))
-//│       (drop
-//│         (call $Unit_init
-//│           (local.get $this)))
-//│       (return
-//│         (local.get $this))))
-//│   (func $start (type $start)
-//│     (block
-//│       (global.set $Unit$inst
-//│         (ref.cast (ref null $Unit)
-//│           (call $Unit_Unit)))))
 //│   (func $entry (export "entry") (type $entry) (result (ref null any))
 //│     (local $i (ref null any))
 //│     (local $scrut (ref null any))
@@ -61,54 +30,39 @@ let i = 0 in
 //│       (local.set $i
 //│         (ref.i31
 //│           (i32.const 0)))
-//│       (block (result (ref null any))
-//│         (block $lbl
-//│           (loop $lbl_cont
-//│             (drop
-//│               (block (result (ref null any))
-//│                 (local.set $scrut
-//│                   (call $lt_impl
-//│                     (local.get $i)
-//│                     (ref.i31
-//│                       (i32.const 10))))
-//│                 (block (result (ref null any))
-//│                   (block $match
-//│                     (local.set $matchRes
-//│                       (ref.null any))
-//│                     (if
-//│                       (i32.eq
-//│                         (i31.get_s
-//│                           (ref.cast (ref null i31)
-//│                             (local.get $scrut)))
-//│                         (i32.const 1))
-//│                       (then
-//│                         (block $arm
-//│                           (block
-//│                             (block
-//│                               (local.set $tmp
-//│                                 (call $plus_impl
-//│                                   (local.get $i)
-//│                                   (ref.i31
-//│                                     (i32.const 1))))
-//│                               (block
-//│                                 (local.set $i
-//│                                   (local.get $tmp))
-//│                                 (br $lbl_cont)))
-//│                             (local.set $matchRes
-//│                               (global.get $Unit$inst)))
-//│                           (br $match))))
-//│                     (block
-//│                       (nop)
-//│                       (local.set $matchRes
-//│                         (global.get $Unit$inst))))
-//│                   (local.get $matchRes))))))
-//│         (return
-//│           (local.get $i)))))
-//│   (elem $Unit_init declare func $Unit_init)
-//│   (elem $Unit_Unit declare func $Unit_Unit)
-//│   (elem $start declare func $start)
-//│   (elem $entry declare func $entry)
-//│   (start $start))
+//│       (block $lbl
+//│         (loop $lbl_cont
+//│           (drop
+//│             (block (result (ref null any))
+//│               (local.set $scrut
+//│                 (call $lt_impl
+//│                   (local.get $i)
+//│                   (ref.i31
+//│                     (i32.const 10))))
+//│               (block $match
+//│                 (local.set $matchRes
+//│                   (ref.null any))
+//│                 (if
+//│                   (i32.eq
+//│                     (i31.get_s
+//│                       (ref.cast (ref null i31)
+//│                         (local.get $scrut)))
+//│                     (i32.const 1))
+//│                   (then
+//│                     (block $arm
+//│                       (local.set $tmp
+//│                         (call $plus_impl
+//│                           (local.get $i)
+//│                           (ref.i31
+//│                             (i32.const 1))))
+//│                       (local.set $i
+//│                         (local.get $tmp))
+//│                       (br $lbl_cont)
+//│                       (br $match)))))
+//│               (local.get $matchRes)))))
+//│       (return
+//│         (local.get $i))))
+//│   (elem $entry declare func $entry))
 //│ Wasm result:
 //│ = 10
 
@@ -230,41 +184,39 @@ tailMatchAllValue(1)
 //│   (func $entry (export "entry") (type $entry) (result (ref null any))
 //│     (local $matchRes (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block (result (ref null any))
-//│         (block $match
-//│           (local.set $matchRes
-//│             (ref.null any))
-//│           (if
-//│             (i32.eq
-//│               (i31.get_s
-//│                 (ref.cast (ref null i31)
-//│                   (ref.i31
-//│                     (i32.const 1))))
-//│               (i32.const 0))
-//│             (then
-//│               (block $arm
-//│                 (return
-//│                   (ref.i31
-//│                     (i32.const 10)))
-//│                 (br $match))))
-//│           (if
-//│             (i32.eq
-//│               (i31.get_s
-//│                 (ref.cast (ref null i31)
-//│                   (ref.i31
-//│                     (i32.const 1))))
-//│               (i32.const 1))
-//│             (then
-//│               (block $arm
-//│                 (return
-//│                   (ref.i31
-//│                     (i32.const 20)))
-//│                 (br $match))))
-//│           (return
-//│             (ref.i31
-//│               (i32.const 30))))
-//│         (local.get $matchRes))))
+//│       (block $match
+//│         (local.set $matchRes
+//│           (ref.null any))
+//│         (if
+//│           (i32.eq
+//│             (i31.get_s
+//│               (ref.cast (ref null i31)
+//│                 (ref.i31
+//│                   (i32.const 1))))
+//│             (i32.const 0))
+//│           (then
+//│             (block $arm
+//│               (return
+//│                 (ref.i31
+//│                   (i32.const 10)))
+//│               (br $match))))
+//│         (if
+//│           (i32.eq
+//│             (i31.get_s
+//│               (ref.cast (ref null i31)
+//│                 (ref.i31
+//│                   (i32.const 1))))
+//│             (i32.const 1))
+//│           (then
+//│             (block $arm
+//│               (return
+//│                 (ref.i31
+//│                   (i32.const 20)))
+//│               (br $match))))
+//│         (return
+//│           (ref.i31
+//│             (i32.const 30))))
+//│       (local.get $matchRes)))
 //│   (elem $tailMatchAllValue declare func $tailMatchAllValue)
 //│   (elem $entry declare func $entry))
 //│ Wasm result:

--- a/hkmc2/shared/src/test/mlscript/wasm/Matching.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/Matching.mls
@@ -62,13 +62,10 @@ if Bar(true) is
 //│     (ref.null $TypeInfoBase)))
 //│   (func $Bar_init (type $Bar_init) (param $this (ref null any)) (param $y (ref null any)) (result (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block
-//│         (struct.set $Bar $y
-//│           (ref.cast (ref $Bar)
-//│             (local.get $this))
-//│           (local.get $y))
-//│         (nop))
+//│       (struct.set $Bar $y
+//│         (ref.cast (ref $Bar)
+//│           (local.get $this))
+//│         (local.get $y))
 //│       (return
 //│         (local.get $this))))
 //│   (func $Bar_ctor (export "Bar") (type $Bar_ctor) (param $y (ref null any)) (result (ref null any))
@@ -86,13 +83,10 @@ if Bar(true) is
 //│         (local.get $this))))
 //│   (func $Baz_init (type $Baz_init) (param $this (ref null any)) (param $z (ref null any)) (result (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block
-//│         (struct.set $Baz $z
-//│           (ref.cast (ref $Baz)
-//│             (local.get $this))
-//│           (local.get $z))
-//│         (nop))
+//│       (struct.set $Baz $z
+//│         (ref.cast (ref $Baz)
+//│           (local.get $this))
+//│         (local.get $z))
 //│       (return
 //│         (local.get $this))))
 //│   (func $Baz_ctor (export "Baz") (type $Baz_ctor) (param $z (ref null any)) (result (ref null any))
@@ -120,142 +114,136 @@ if Bar(true) is
 //│     (local $targetTypeInfo1 (ref null any))
 //│     (local $typeInfoMatch1 (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block (result (ref null any))
-//│         (nop)
-//│         (block (result (ref null any))
-//│           (local.set $scrut
-//│             (call $Bar_ctor
-//│               (ref.i31
-//│                 (i32.const 1))))
-//│           (block (result (ref null any))
-//│             (block $match
-//│               (local.set $matchRes
-//│                 (ref.null any))
-//│               (if
-//│                 (ref.test (ref $Object)
-//│                   (local.get $scrut))
-//│                 (then
-//│                   (if
-//│                     (block (result i32)
-//│                       (local.set $currentTypeInfo
-//│                         (struct.get $Object $$typeinfo
-//│                           (ref.cast (ref $Object)
+//│       (local.set $scrut
+//│         (call $Bar_ctor
+//│           (ref.i31
+//│             (i32.const 1))))
+//│       (block $match
+//│         (local.set $matchRes
+//│           (ref.null any))
+//│         (if
+//│           (ref.test (ref $Object)
+//│             (local.get $scrut))
+//│           (then
+//│             (if
+//│               (block (result i32)
+//│                 (local.set $currentTypeInfo
+//│                   (struct.get $Object $$typeinfo
+//│                     (ref.cast (ref $Object)
+//│                       (local.get $scrut))))
+//│                 (local.set $targetTypeInfo
+//│                   (global.get $Bar_typeinfo))
+//│                 (local.set $typeInfoMatch
+//│                   (ref.i31
+//│                     (i32.const 0)))
+//│                 (block $typeInfo
+//│                   (loop $typeInfo_cont
+//│                     (if
+//│                       (ref.is_null
+//│                         (local.get $currentTypeInfo))
+//│                       (then
+//│                         (br $typeInfo)))
+//│                     (if
+//│                       (ref.eq
+//│                         (ref.cast (ref null eq)
+//│                           (local.get $currentTypeInfo))
+//│                         (ref.cast (ref null eq)
+//│                           (local.get $targetTypeInfo)))
+//│                       (then
+//│                         (block
+//│                           (local.set $typeInfoMatch
+//│                             (ref.i31
+//│                               (i32.const 1)))
+//│                           (br $typeInfo))))
+//│                     (local.set $currentTypeInfo
+//│                       (struct.get $TypeInfoBase $$parent
+//│                         (ref.cast (ref $TypeInfoBase)
+//│                           (local.get $currentTypeInfo))))
+//│                     (br $typeInfo_cont)))
+//│                 (i31.get_s
+//│                   (ref.cast (ref null i31)
+//│                     (local.get $typeInfoMatch))))
+//│               (then
+//│                 (block $arm
+//│                   (local.set $matchRes
+//│                     (block (result (ref null any))
+//│                       (local.set $arg$Bar$0$
+//│                         (struct.get $Bar $y
+//│                           (ref.cast (ref $Bar)
 //│                             (local.get $scrut))))
-//│                       (local.set $targetTypeInfo
-//│                         (global.get $Bar_typeinfo))
-//│                       (local.set $typeInfoMatch
-//│                         (ref.i31
-//│                           (i32.const 0)))
-//│                       (block $typeInfo
-//│                         (loop $typeInfo_cont
-//│                           (if
-//│                             (ref.is_null
-//│                               (local.get $currentTypeInfo))
-//│                             (then
-//│                               (br $typeInfo)))
-//│                           (if
-//│                             (ref.eq
-//│                               (ref.cast (ref null eq)
-//│                                 (local.get $currentTypeInfo))
-//│                               (ref.cast (ref null eq)
-//│                                 (local.get $targetTypeInfo)))
-//│                             (then
-//│                               (block
-//│                                 (local.set $typeInfoMatch
-//│                                   (ref.i31
-//│                                     (i32.const 1)))
-//│                                 (br $typeInfo))))
-//│                           (local.set $currentTypeInfo
-//│                             (struct.get $TypeInfoBase $$parent
-//│                               (ref.cast (ref $TypeInfoBase)
-//│                                 (local.get $currentTypeInfo))))
-//│                           (br $typeInfo_cont)))
-//│                       (i31.get_s
-//│                         (ref.cast (ref null i31)
-//│                           (local.get $typeInfoMatch))))
-//│                     (then
-//│                       (block $arm
-//│                         (local.set $matchRes
-//│                           (block (result (ref null any))
-//│                             (local.set $arg$Bar$0$
-//│                               (struct.get $Bar $y
-//│                                 (ref.cast (ref $Bar)
-//│                                   (local.get $scrut))))
-//│                             (block (result (ref null any))
-//│                               (block $match1
-//│                                 (local.set $matchRes1
-//│                                   (ref.null any))
-//│                                 (if
-//│                                   (i32.eq
-//│                                     (i31.get_s
-//│                                       (ref.cast (ref null i31)
-//│                                         (local.get $arg$Bar$0$)))
-//│                                     (i32.const 1))
-//│                                   (then
-//│                                     (block $arm
-//│                                       (return
-//│                                         (ref.i31
-//│                                           (i32.const 3)))
-//│                                       (br $match1))))
-//│                                 (return
-//│                                   (ref.i31
-//│                                     (i32.const 4))))
-//│                               (local.get $matchRes1))))
-//│                         (br $match))))))
-//│               (if
-//│                 (ref.test (ref $Object)
-//│                   (local.get $scrut))
-//│                 (then
-//│                   (if
-//│                     (block (result i32)
-//│                       (local.set $currentTypeInfo1
-//│                         (struct.get $Object $$typeinfo
-//│                           (ref.cast (ref $Object)
-//│                             (local.get $scrut))))
-//│                       (local.set $targetTypeInfo1
-//│                         (global.get $Baz_typeinfo))
-//│                       (local.set $typeInfoMatch1
-//│                         (ref.i31
-//│                           (i32.const 0)))
-//│                       (block $typeInfo
-//│                         (loop $typeInfo_cont
-//│                           (if
-//│                             (ref.is_null
-//│                               (local.get $currentTypeInfo1))
-//│                             (then
-//│                               (br $typeInfo)))
-//│                           (if
-//│                             (ref.eq
-//│                               (ref.cast (ref null eq)
-//│                                 (local.get $currentTypeInfo1))
-//│                               (ref.cast (ref null eq)
-//│                                 (local.get $targetTypeInfo1)))
-//│                             (then
-//│                               (block
-//│                                 (local.set $typeInfoMatch1
-//│                                   (ref.i31
-//│                                     (i32.const 1)))
-//│                                 (br $typeInfo))))
-//│                           (local.set $currentTypeInfo1
-//│                             (struct.get $TypeInfoBase $$parent
-//│                               (ref.cast (ref $TypeInfoBase)
-//│                                 (local.get $currentTypeInfo1))))
-//│                           (br $typeInfo_cont)))
-//│                       (i31.get_s
-//│                         (ref.cast (ref null i31)
-//│                           (local.get $typeInfoMatch1))))
-//│                     (then
-//│                       (block $arm
+//│                       (block $match1
+//│                         (local.set $matchRes1
+//│                           (ref.null any))
+//│                         (if
+//│                           (i32.eq
+//│                             (i31.get_s
+//│                               (ref.cast (ref null i31)
+//│                                 (local.get $arg$Bar$0$)))
+//│                             (i32.const 1))
+//│                           (then
+//│                             (block $arm
+//│                               (return
+//│                                 (ref.i31
+//│                                   (i32.const 3)))
+//│                               (br $match1))))
 //│                         (return
-//│                           (struct.get $Baz $z
-//│                             (ref.cast (ref $Baz)
-//│                               (local.get $scrut))))
-//│                         (br $match))))))
-//│               (return
-//│                 (ref.i31
-//│                   (i32.const 2))))
-//│             (local.get $matchRes))))))
+//│                           (ref.i31
+//│                             (i32.const 4))))
+//│                       (local.get $matchRes1)))
+//│                   (br $match))))))
+//│         (if
+//│           (ref.test (ref $Object)
+//│             (local.get $scrut))
+//│           (then
+//│             (if
+//│               (block (result i32)
+//│                 (local.set $currentTypeInfo1
+//│                   (struct.get $Object $$typeinfo
+//│                     (ref.cast (ref $Object)
+//│                       (local.get $scrut))))
+//│                 (local.set $targetTypeInfo1
+//│                   (global.get $Baz_typeinfo))
+//│                 (local.set $typeInfoMatch1
+//│                   (ref.i31
+//│                     (i32.const 0)))
+//│                 (block $typeInfo
+//│                   (loop $typeInfo_cont
+//│                     (if
+//│                       (ref.is_null
+//│                         (local.get $currentTypeInfo1))
+//│                       (then
+//│                         (br $typeInfo)))
+//│                     (if
+//│                       (ref.eq
+//│                         (ref.cast (ref null eq)
+//│                           (local.get $currentTypeInfo1))
+//│                         (ref.cast (ref null eq)
+//│                           (local.get $targetTypeInfo1)))
+//│                       (then
+//│                         (block
+//│                           (local.set $typeInfoMatch1
+//│                             (ref.i31
+//│                               (i32.const 1)))
+//│                           (br $typeInfo))))
+//│                     (local.set $currentTypeInfo1
+//│                       (struct.get $TypeInfoBase $$parent
+//│                         (ref.cast (ref $TypeInfoBase)
+//│                           (local.get $currentTypeInfo1))))
+//│                     (br $typeInfo_cont)))
+//│                 (i31.get_s
+//│                   (ref.cast (ref null i31)
+//│                     (local.get $typeInfoMatch1))))
+//│               (then
+//│                 (block $arm
+//│                   (return
+//│                     (struct.get $Baz $z
+//│                       (ref.cast (ref $Baz)
+//│                         (local.get $scrut))))
+//│                   (br $match))))))
+//│         (return
+//│           (ref.i31
+//│             (i32.const 2))))
+//│       (local.get $matchRes)))
 //│   (elem $Bar_init declare func $Bar_init)
 //│   (elem $Bar_ctor declare func $Bar_ctor)
 //│   (elem $Baz_init declare func $Baz_init)

--- a/hkmc2/shared/src/test/mlscript/wasm/Matching.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/Matching.mls
@@ -184,8 +184,7 @@ if Bar(true) is
 //│                             (block $arm1
 //│                               (return
 //│                                 (ref.i31
-//│                                   (i32.const 3)))
-//│                               (br $match1))))
+//│                                   (i32.const 3))))))
 //│                         (return
 //│                           (ref.i31
 //│                             (i32.const 4))))
@@ -238,8 +237,7 @@ if Bar(true) is
 //│                   (return
 //│                     (struct.get $Baz $z
 //│                       (ref.cast (ref $Baz)
-//│                         (local.get $scrut))))
-//│                   (br $match))))))
+//│                         (local.get $scrut)))))))))
 //│         (return
 //│           (ref.i31
 //│             (i32.const 2))))

--- a/hkmc2/shared/src/test/mlscript/wasm/Matching.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/Matching.mls
@@ -181,7 +181,7 @@ if Bar(true) is
 //│                                 (local.get $arg$Bar$0$)))
 //│                             (i32.const 1))
 //│                           (then
-//│                             (block $arm
+//│                             (block $arm1
 //│                               (return
 //│                                 (ref.i31
 //│                                   (i32.const 3)))

--- a/hkmc2/shared/src/test/mlscript/wasm/ScopedLocals.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/ScopedLocals.mls
@@ -21,16 +21,15 @@ topA + topB
 //│       (global.set $topA
 //│         (ref.i31
 //│           (i32.const 1)))
-//│       (block (result (ref null any))
-//│         (global.set $topB
+//│       (global.set $topB
+//│         (ref.i31
+//│           (i32.const 2)))
+//│       (return
+//│         (call $plus_impl
 //│           (ref.i31
-//│             (i32.const 2)))
-//│         (return
-//│           (call $plus_impl
-//│             (ref.i31
-//│               (i32.const 1))
-//│             (ref.i31
-//│               (i32.const 2)))))))
+//│             (i32.const 1))
+//│           (ref.i31
+//│             (i32.const 2))))))
 //│   (elem $entry declare func $entry))
 //│ Wasm result:
 //│ = 3
@@ -59,38 +58,34 @@ chain(1)
 //│           (local.get $x)
 //│           (ref.i31
 //│             (i32.const 1))))
-//│       (block (result (ref null any))
-//│         (local.set $b
-//│           (call $plus_impl
-//│             (local.get $a)
-//│             (ref.i31
-//│               (i32.const 1))))
-//│         (return
-//│           (call $plus_impl
-//│             (local.get $a)
-//│             (local.get $b))))))
+//│       (local.set $b
+//│         (call $plus_impl
+//│           (local.get $a)
+//│           (ref.i31
+//│             (i32.const 1))))
+//│       (return
+//│         (call $plus_impl
+//│           (local.get $a)
+//│           (local.get $b)))))
 //│   (func $entry (export "entry") (type $entry) (result (ref null any))
 //│     (local $a (ref null any))
 //│     (local $b (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block (result (ref null any))
-//│         (local.set $a
-//│           (call $plus_impl
-//│             (ref.i31
-//│               (i32.const 1))
-//│             (ref.i31
-//│               (i32.const 1))))
-//│         (block (result (ref null any))
-//│           (local.set $b
-//│             (call $plus_impl
-//│               (local.get $a)
-//│               (ref.i31
-//│                 (i32.const 1))))
-//│           (return
-//│             (call $plus_impl
-//│               (local.get $a)
-//│               (local.get $b)))))))
+//│       (local.set $a
+//│         (call $plus_impl
+//│           (ref.i31
+//│             (i32.const 1))
+//│           (ref.i31
+//│             (i32.const 1))))
+//│       (local.set $b
+//│         (call $plus_impl
+//│           (local.get $a)
+//│           (ref.i31
+//│             (i32.const 1))))
+//│       (return
+//│         (call $plus_impl
+//│           (local.get $a)
+//│           (local.get $b)))))
 //│   (elem $chain declare func $chain)
 //│   (elem $entry declare func $entry))
 //│ Wasm result:
@@ -161,18 +156,14 @@ class Foo(val a, val b)
 //│     (ref.null $TypeInfoBase)))
 //│   (func $Foo_init (type $Foo_init) (param $this (ref null any)) (param $a (ref null any)) (param $b (ref null any)) (result (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block
-//│         (struct.set $Foo $a
-//│           (ref.cast (ref $Foo)
-//│             (local.get $this))
-//│           (local.get $a))
-//│         (block
-//│           (struct.set $Foo $b
-//│             (ref.cast (ref $Foo)
-//│               (local.get $this))
-//│             (local.get $b))
-//│           (nop)))
+//│       (struct.set $Foo $a
+//│         (ref.cast (ref $Foo)
+//│           (local.get $this))
+//│         (local.get $a))
+//│       (struct.set $Foo $b
+//│         (ref.cast (ref $Foo)
+//│           (local.get $this))
+//│         (local.get $b))
 //│       (return
 //│         (local.get $this))))
 //│   (func $Foo_ctor (export "Foo") (type $Foo_ctor) (param $a (ref null any)) (param $b (ref null any)) (result (ref null any))
@@ -193,18 +184,16 @@ class Foo(val a, val b)
 //│   (func $entry (export "entry") (type $entry) (result (ref null any))
 //│     (local $tmp (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block (result (ref null any))
-//│         (local.set $tmp
-//│           (call $Foo_ctor
-//│             (ref.i31
-//│               (i32.const 42))
-//│             (ref.i31
-//│               (i32.const 1))))
-//│         (return
-//│           (struct.get $Foo $a
-//│             (ref.cast (ref $Foo)
-//│               (local.get $tmp)))))))
+//│       (local.set $tmp
+//│         (call $Foo_ctor
+//│           (ref.i31
+//│             (i32.const 42))
+//│           (ref.i31
+//│             (i32.const 1))))
+//│       (return
+//│         (struct.get $Foo $a
+//│           (ref.cast (ref $Foo)
+//│             (local.get $tmp))))))
 //│   (elem $Foo_init declare func $Foo_init)
 //│   (elem $Foo_ctor declare func $Foo_ctor)
 //│   (elem $entry declare func $entry))

--- a/hkmc2/shared/src/test/mlscript/wasm/SingletonUnit.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/SingletonUnit.mls
@@ -19,11 +19,8 @@
 //│     (ref.null $TypeInfoBase)))
 //│   (global $Unit$inst (export "Unit$inst") (mut (ref null $Unit)) (ref.null $Unit))
 //│   (func $Unit_init (type $Unit_init) (param $this (ref null any)) (result (ref null any))
-//│     (block (result (ref null any))
-//│       (nop)
-//│       (nop)
-//│       (return
-//│         (local.get $this))))
+//│     (return
+//│       (local.get $this)))
 //│   (func $Unit_Unit (type $Unit_ctor) (result (ref null any))
 //│     (local $this (ref null any))
 //│     (block (result (ref null any))
@@ -36,10 +33,9 @@
 //│       (return
 //│         (local.get $this))))
 //│   (func $start (type $start)
-//│     (block
-//│       (global.set $Unit$inst
-//│         (ref.cast (ref null $Unit)
-//│           (call $Unit_Unit)))))
+//│     (global.set $Unit$inst
+//│       (ref.cast (ref null $Unit)
+//│         (call $Unit_Unit))))
 //│   (func $entry (export "entry") (type $entry) (result (ref null any))
 //│     (return
 //│       (global.get $Unit$inst)))

--- a/hkmc2/shared/src/test/mlscript/wasm/Singletons.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/Singletons.mls
@@ -33,14 +33,11 @@ Bar.y
 //│   (global $Bar$inst (export "Bar$inst") (mut (ref null $Bar)) (ref.null $Bar))
 //│   (func $Foo_init (type $Foo_init) (param $this (ref null any)) (result (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block
-//│         (struct.set $Foo $x
-//│           (ref.cast (ref $Foo)
-//│             (local.get $this))
-//│           (ref.i31
-//│             (i32.const 1)))
-//│         (nop))
+//│       (struct.set $Foo $x
+//│         (ref.cast (ref $Foo)
+//│           (local.get $this))
+//│         (ref.i31
+//│           (i32.const 1)))
 //│       (return
 //│         (local.get $this))))
 //│   (func $Foo_ctor (type $Foo_ctor) (result (ref null any))
@@ -57,14 +54,11 @@ Bar.y
 //│         (local.get $this))))
 //│   (func $Bar_init (type $Bar_init) (param $this (ref null any)) (result (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block
-//│         (struct.set $Bar $y
-//│           (ref.cast (ref $Bar)
-//│             (local.get $this))
-//│           (ref.i31
-//│             (i32.const 2)))
-//│         (nop))
+//│       (struct.set $Bar $y
+//│         (ref.cast (ref $Bar)
+//│           (local.get $this))
+//│         (ref.i31
+//│           (i32.const 2)))
 //│       (return
 //│         (local.get $this))))
 //│   (func $Bar_ctor (type $Bar_ctor) (result (ref null any))
@@ -88,14 +82,10 @@ Bar.y
 //│         (ref.cast (ref null $Bar)
 //│           (call $Bar_ctor)))))
 //│   (func $entry (export "entry") (type $entry) (result (ref null any))
-//│     (block (result (ref null any))
-//│       (nop)
-//│       (block (result (ref null any))
-//│         (nop)
-//│         (return
-//│           (struct.get $Bar $y
-//│             (ref.cast (ref $Bar)
-//│               (global.get $Bar$inst)))))))
+//│     (return
+//│       (struct.get $Bar $y
+//│         (ref.cast (ref $Bar)
+//│           (global.get $Bar$inst)))))
 //│   (elem $Foo_init declare func $Foo_init)
 //│   (elem $Foo_ctor declare func $Foo_ctor)
 //│   (elem $Bar_init declare func $Bar_init)

--- a/hkmc2/shared/src/test/mlscript/wasm/Strings.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/Strings.mls
@@ -36,41 +36,39 @@ let dup2 = "dup"
 //│             (i32.const 0))
 //│           (ref.i31
 //│             (i32.const 6))))
-//│       (block (result (ref null any))
-//│         (global.set $dup2
+//│       (global.set $dup2
+//│         (call $mlx_str_from_utf16
+//│           (ref.i31
+//│             (i32.const 0))
+//│           (ref.i31
+//│             (i32.const 6))))
+//│       (local.set $tmp
+//│         (array.new_fixed $TupleArray 2
 //│           (call $mlx_str_from_utf16
 //│             (ref.i31
 //│               (i32.const 0))
 //│             (ref.i31
-//│               (i32.const 6))))
-//│         (block (result (ref null any))
-//│           (local.set $tmp
-//│             (array.new_fixed $TupleArray 2
-//│               (call $mlx_str_from_utf16
-//│                 (ref.i31
-//│                   (i32.const 0))
-//│                 (ref.i31
-//│                   (i32.const 6)))
-//│               (call $mlx_str_from_utf16
-//│                 (ref.i31
-//│                   (i32.const 0))
-//│                 (ref.i31
-//│                   (i32.const 6)))))
-//│           (return
-//│             (if (result (ref null any))
-//│               (ref.test (ref null $TupleArrayMut)
-//│                 (local.tee $tuple
-//│                   (local.get $tmp)))
-//│               (then
-//│                 (array.get $TupleArrayMut
-//│                   (ref.cast (ref $TupleArrayMut)
-//│                     (local.get $tuple))
-//│                   (i32.const 1)))
-//│               (else
-//│                 (array.get $TupleArray
-//│                   (ref.cast (ref $TupleArray)
-//│                     (local.get $tuple))
-//│                   (i32.const 1)))))))))
+//│               (i32.const 6)))
+//│           (call $mlx_str_from_utf16
+//│             (ref.i31
+//│               (i32.const 0))
+//│             (ref.i31
+//│               (i32.const 6)))))
+//│       (return
+//│         (if (result (ref null any))
+//│           (ref.test (ref null $TupleArrayMut)
+//│             (local.tee $tuple
+//│               (local.get $tmp)))
+//│           (then
+//│             (array.get $TupleArrayMut
+//│               (ref.cast (ref $TupleArrayMut)
+//│                 (local.get $tuple))
+//│               (i32.const 1)))
+//│           (else
+//│             (array.get $TupleArray
+//│               (ref.cast (ref $TupleArray)
+//│                 (local.get $tuple))
+//│               (i32.const 1)))))))
 //│   (data $dup (i32.const 0) "\64\00\75\00\70\00")
 //│   (elem $entry declare func $entry))
 //│ Wasm result:

--- a/hkmc2/shared/src/test/mlscript/wasm/VirtualMethods.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/VirtualMethods.mls
@@ -48,11 +48,8 @@ callF(B())
 //│     (global.get $A_typeinfo)
 //│     (ref.func $B_f)))
 //│   (func $A_init (type $A_init) (param $this (ref null any)) (result (ref null any))
-//│     (block (result (ref null any))
-//│       (nop)
-//│       (nop)
-//│       (return
-//│         (local.get $this))))
+//│     (return
+//│       (local.get $this)))
 //│   (func $A_ctor (export "A") (type $A_ctor) (result (ref null any))
 //│     (local $this (ref null any))
 //│     (block (result (ref null any))
@@ -72,12 +69,9 @@ callF(B())
 //│           (i32.const 1)))))
 //│   (func $B_init (type $B_init) (param $this (ref null any)) (result (ref null any))
 //│     (block (result (ref null any))
-//│       (block
-//│         (nop)
-//│         (drop
-//│           (call $A_init
-//│             (local.get $this))))
-//│       (nop)
+//│       (drop
+//│         (call $A_init
+//│           (local.get $this)))
 //│       (return
 //│         (local.get $this))))
 //│   (func $B_ctor (export "B") (type $B_ctor) (result (ref null any))
@@ -116,27 +110,21 @@ callF(B())
 //│     (local $tmp (ref null any))
 //│     (local $receiver (ref null any))
 //│     (block (result (ref null any))
-//│       (nop)
-//│       (block (result (ref null any))
-//│         (nop)
+//│       (local.set $tmp
+//│         (call $B_ctor))
+//│       (return
 //│         (block (result (ref null any))
-//│           (nop)
-//│           (block (result (ref null any))
-//│             (local.set $tmp
-//│               (call $B_ctor))
-//│             (return
-//│               (block (result (ref null any))
-//│                 (local.set $receiver
-//│                   (local.get $tmp))
-//│                 (call_ref $virtual2
-//│                   (local.get $receiver)
-//│                   (ref.i31
-//│                     (i32.const 5))
-//│                   (struct.get $A_typeinfo $slot0
-//│                     (ref.cast (ref $A_typeinfo)
-//│                       (struct.get $Object $$typeinfo
-//│                         (ref.cast (ref $Object)
-//│                           (local.get $receiver)))))))))))))
+//│           (local.set $receiver
+//│             (local.get $tmp))
+//│           (call_ref $virtual2
+//│             (local.get $receiver)
+//│             (ref.i31
+//│               (i32.const 5))
+//│             (struct.get $A_typeinfo $slot0
+//│               (ref.cast (ref $A_typeinfo)
+//│                 (struct.get $Object $$typeinfo
+//│                   (ref.cast (ref $Object)
+//│                     (local.get $receiver))))))))))
 //│   (elem $A_init declare func $A_init)
 //│   (elem $A_ctor declare func $A_ctor)
 //│   (elem $A_f declare func $A_f)


### PR DESCRIPTION
Reduces the need to emit a lot of `nop` and `block`s.