### PR TITLE
Fix tailrec miscompilation with spreads

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
@@ -508,9 +508,13 @@ class TailRecOpt(using State, TL, Raise):
       if funs.length === 1 then initial
       else Param.simple(curIdSym) :: initial
     
+    val newParamLists =
+      if funs.length === 1 && funs.head.params.size <= 1 then funs.head.params
+      else PlainParamList(params) :: Nil
+    
     val loopDefn = FunDefn(
       owner, bms, dSym,
-      PlainParamList(params) :: Nil,
+      newParamLists,
       loop)(N, annotations = Nil) // Q: maybe should be Private?
     
     if funs.size === 1 then

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
@@ -264,7 +264,13 @@ class TailRecOpt(using State, TL, Raise):
 
     val maxParamLen = maxInt(funs, paramsLen)
     val paramSyms =
-        if funs.length === 1 then (getParamSyms(funs.head))
+        if funs.length === 1 then
+          val syms = getParamSyms(funs.head)
+          if funs.head.params.length === 1 then syms
+          else
+            // Duplicate the params for the internal loop defn (see the doc at the 
+            // end of this function), but preserve the names.
+            syms.map(v => VarSymbol(Tree.Ident(v.id.name)))
         else
           for i <- 0 until maxParamLen yield VarSymbol(Tree.Ident("param" + i))
       .toList

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
@@ -526,10 +526,13 @@ class TailRecOpt(using State, TL, Raise):
         
         val loopBms = BlockMemberSymbol(bms.nme + "$tailrec", Nil, true)
         val loopDSym = TermSymbol(syntax.Fun, owner, Tree.Ident(loopBms.nme))
+        val loopAnnots =
+          if f.inline then Annot.Inline :: Annot.Private :: Nil
+          else Annot.Private :: Nil
         val internalLoopDefn = FunDefn(
           owner, loopBms, loopDSym,
           PlainParamList(params) :: Nil,
-          loop)(N, annotations = Annot.Private :: Nil)
+          loop)(N, annotations = loopAnnots)
         val paramArgs = getParamSyms(f).map(s => s.asSimpleRef.asArg)
         val internalSel = owner match
           case Some(value) => Select(value.asThis, Tree.Ident(loopBms.nme))(S(loopDSym))
@@ -537,7 +540,7 @@ class TailRecOpt(using State, TL, Raise):
         val wrapperBod = Return(
           Call(internalSel, paramArgs ne_:: Nil)(CallMetadata.defaultMlsFun),
         )
-        val newAnnots = if f.annotations.contains(Annot.Inline) then f.annotations else Annot.Inline :: f.annotations
+        val newAnnots = if f.inline then f.annotations else Annot.Inline :: f.annotations
         val wrapperDefn = FunDefn(f.owner, f.sym, f.dSym, f.params, wrapperBod)(
           f.configOverride, annotations = newAnnots)
         (S(internalLoopDefn), wrapperDefn :: Nil)

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
@@ -233,10 +233,12 @@ class TailRecOpt(using State, TL, Raise):
   def optScc(scc: SccOfCalls, owner: Opt[InnerSymbol])(using accessInfo: (ScopeData, AccessMap)): (Opt[FunDefn], List[FunDefn]) =
     // sort the functions so the order is more predictable
     val funs = scc.funs.sortBy(f => f.dSym.uid)
-    val fSyms = funs.map(_.dSym).toSet
-    val funsMap = funs.map: f =>
+    val fSyms = funs.iterator.map(_.dSym).toSet
+    val funsMap = funs.iterator.map: f =>
         f.dSym -> f
       .toMap
+    
+    val funsLen = funs.length
     
     // remove calls which don't flow into this scc
     val calls = scc.calls.filter(c => fSyms.contains(c.f2)) 
@@ -277,21 +279,21 @@ class TailRecOpt(using State, TL, Raise):
     val paramSymsArr = ArrayBuffer.from(paramSyms)
     // Function -> param -> param symbol in the rewritten function
     val paramSymsMap: Map[TermSymbol, Map[VarSymbol, VarSymbol]] = 
-      funs.map: f =>
-        val flattenedSyms = f.params.flatMap(_.paramSyms)
+      funs.iterator.map: f =>
+        val flattenedSyms = f.params.iterator.flatMap(_.paramSyms)
         val mp = flattenedSyms.zipWithIndex.map:
             case (l, i) => l -> paramSymsArr(i)
           .toMap
         f.dSym -> mp
       .toMap
     
-    val dSymIds = funs.map(_.dSym).zipWithIndex.toMap
-    val dSymToDefn = funs.map(f => f.dSym -> f).toMap
+    val dSymIds = funs.iterator.map(_.dSym).zipWithIndex.toMap
+    val dSymToDefn = funs.iterator.map(f => f.dSym -> f).toMap
     val bms =
-      if funs.size === 1 then funs.head.sym
-      else BlockMemberSymbol(funs.map(_.sym.nme).mkString("_"), Nil, true)
+      if funsLen === 1 then funs.head.sym
+      else BlockMemberSymbol(funs.iterator.map(_.sym.nme).mkString("_"), Nil, true)
     val dSym =
-      if funs.size === 1 then funs.head.dSym
+      if funsLen === 1 then funs.head.dSym
       else TermSymbol(syntax.Fun, owner, Tree.Ident(bms.nme))
     val loopSym = LabelSymbol(N, "loopLabel")
     val curIdSym = VarSymbol(Tree.Ident("id"))
@@ -355,7 +357,7 @@ class TailRecOpt(using State, TL, Raise):
             else
               // The code used to continute the loop.
               val cont =
-                if scc.funs.size === 1 then Continue(loopSym)
+                if funsLen === 1 then Continue(loopSym)
                 else Assign(curIdSym, Value.Lit(Tree.IntLit(dSymIds(calleeSym))), Continue(loopSym))
               // In some cases, we could have assignments like this:
               // param0 = whatever
@@ -497,7 +499,7 @@ class TailRecOpt(using State, TL, Raise):
       case None => bms.asMemberRef(dSym)
     
     val rewrittenFuns =
-      if funs.size === 1 then Nil
+      if funsLen === 1 then Nil
       else funs.map: f =>
         val paramArgs = getParamSyms(f).map(s => s.asSimpleRef.asArg)
         val args = 
@@ -509,32 +511,25 @@ class TailRecOpt(using State, TL, Raise):
         )
         FunDefn(f.owner, f.sym, f.dSym, f.params, newBod)(N, f.annotations)
     
-    val params =
-      val initial = paramSyms.map(Param.simple(_))
-      if funs.length === 1 then initial
-      else Param.simple(curIdSym) :: initial
-    
-    val newParamLists =
-      if funs.length === 1 && funs.head.params.size <= 1 then funs.head.params
-      else PlainParamList(params) :: Nil
-    
-    val loopDefn = FunDefn(
-      owner, bms, dSym,
-      newParamLists,
-      loop)(N, annotations = Nil) // Q: maybe should be Private?
-    
-    if funs.size === 1 then
-      val f = funs.head
-      if f.params.length > 1 then
+    funs match
+      case (f @ FunDefn(params = _ :: Nil | Nil)) :: Nil =>
+        val defn = FunDefn(
+          owner, bms, dSym,
+          f.params,
+          loop)(N, annotations = Nil)
+        (N, defn :: Nil)
+      case f :: Nil =>
         // When a function has multiple param lists, TailRecOpt flattens them into a single
         // param list for the internal loop. We need a wrapper function that preserves the
         // original multi-param-list interface and delegates to the flattened internal loop.
+        val params = paramSyms.map(Param.simple(_))
+        
         val loopBms = BlockMemberSymbol(bms.nme + "$tailrec", Nil, true)
         val loopDSym = TermSymbol(syntax.Fun, owner, Tree.Ident(loopBms.nme))
         val internalLoopDefn = FunDefn(
           owner, loopBms, loopDSym,
           PlainParamList(params) :: Nil,
-          loop)(N, annotations = Annot.Private :: Nil)
+          loop)(N, annotations = Annot.Inline :: Annot.Private :: Nil)
         val paramArgs = getParamSyms(f).map(s => s.asSimpleRef.asArg)
         val internalSel = owner match
           case Some(value) => Select(value.asThis, Tree.Ident(loopBms.nme))(S(loopDSym))
@@ -545,9 +540,17 @@ class TailRecOpt(using State, TL, Raise):
         val wrapperDefn = FunDefn(f.owner, f.sym, f.dSym, f.params, wrapperBod)(
           f.configOverride, annotations = f.annotations)
         (S(internalLoopDefn), wrapperDefn :: Nil)
-      else
-        (N, loopDefn :: Nil)
-    else (S(loopDefn), rewrittenFuns)
+      case _ =>
+        val newParamLists =
+          val initial = paramSyms.map(Param.simple(_))
+          PlainParamList(Param.simple(curIdSym) :: initial) :: Nil
+        
+        val loopDefn = FunDefn(
+          owner, bms, dSym,
+          newParamLists,
+          loop)(N, annotations = Nil) // Q: maybe should be Private?
+        
+        (S(loopDefn), rewrittenFuns)
   
   def optFunctions(fs: List[FunDefn], owner: Opt[InnerSymbol])(using (ScopeData, AccessMap)) =
     val (newFsOpt, fsOpt) = partFns(fs).map(optScc(_, owner)).foldLeft[(List[FunDefn], List[FunDefn])](Nil, Nil):

--- a/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/codegen/TailRecOpt.scala
@@ -516,7 +516,7 @@ class TailRecOpt(using State, TL, Raise):
         val defn = FunDefn(
           owner, bms, dSym,
           f.params,
-          loop)(N, annotations = Nil)
+          loop)(N, annotations = f.annotations)
         (N, defn :: Nil)
       case f :: Nil =>
         // When a function has multiple param lists, TailRecOpt flattens them into a single
@@ -529,7 +529,7 @@ class TailRecOpt(using State, TL, Raise):
         val internalLoopDefn = FunDefn(
           owner, loopBms, loopDSym,
           PlainParamList(params) :: Nil,
-          loop)(N, annotations = Annot.Inline :: Annot.Private :: Nil)
+          loop)(N, annotations = Annot.Private :: Nil)
         val paramArgs = getParamSyms(f).map(s => s.asSimpleRef.asArg)
         val internalSel = owner match
           case Some(value) => Select(value.asThis, Tree.Ident(loopBms.nme))(S(loopDSym))
@@ -537,8 +537,9 @@ class TailRecOpt(using State, TL, Raise):
         val wrapperBod = Return(
           Call(internalSel, paramArgs ne_:: Nil)(CallMetadata.defaultMlsFun),
         )
+        val newAnnots = if f.annotations.contains(Annot.Inline) then f.annotations else Annot.Inline :: f.annotations
         val wrapperDefn = FunDefn(f.owner, f.sym, f.dSym, f.params, wrapperBod)(
-          f.configOverride, annotations = f.annotations)
+          f.configOverride, annotations = newAnnots)
         (S(internalLoopDefn), wrapperDefn :: Nil)
       case _ =>
         val newParamLists =

--- a/hkmc2/shared/src/test/mlscript/dead-param-elim/recursive.mls
+++ b/hkmc2/shared/src/test/mlscript/dead-param-elim/recursive.mls
@@ -40,6 +40,7 @@ countdown(5)
 //│ dead-param-elim > >>> dead-param-elim results >>>
 //│ dead-param-elim > <<< dead-param-elim results <<<
 //│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
+//│ @private
 //│ define countdown² as fun countdown³(n) {
 //│   loop loopLabel:
 //│     let scrut, tmp;

--- a/hkmc2/shared/src/test/mlscript/tailrec/MultiArgLists.mls
+++ b/hkmc2/shared/src/test/mlscript/tailrec/MultiArgLists.mls
@@ -194,3 +194,38 @@ fun g(n)(m) =
 :expect [[4, 5, 1, 7, 1], 9]
 g(10)(0)
 //│ = [[4, 5, 1, 7, 1], 9]
+
+:sir
+fun f(a)(...z) = if z is
+  [] then a
+  [x, ...xs] then f(a + 1)(...xs)
+//│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
+//│ let f$tailrec;
+//│ @private
+//│ define f$tailrec as fun f$tailrec⁰(a, z) {
+//│   loop loopLabel:
+//│     let x, xs, middleElements, element0$, tmp;
+//│     match z
+//│       Array(0) =>
+//│         return a
+//│       Array(1+) =>
+//│         set element0$ = runtime⁰.Tuple⁰.get⁰(z, 0);
+//│         set middleElements = runtime⁰.Tuple⁰.slice⁰(z, 1, 0);
+//│         set xs = middleElements;
+//│         set x = element0$;
+//│         set tmp = +⁰(a, 1);
+//│         set a = tmp;
+//│         set z = xs;
+//│         continue loopLabel
+//│       else
+//│         throw new globalThis⁰.Error⁰("match error")
+//│     end
+//│   end
+//│ };
+//│ define f² as fun f³(a)(...z) { return f$tailrec⁰(a, z) };
+//│ end
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+
+:expect 4
+f(0)(1, 2, 3, 4)
+//│ = 4

--- a/hkmc2/shared/src/test/mlscript/tailrec/MultiArgLists.mls
+++ b/hkmc2/shared/src/test/mlscript/tailrec/MultiArgLists.mls
@@ -283,3 +283,60 @@ fun f(a)(b) = f(a)(b)
 //│               Arg:
 //│                 value = SimpleRef of b¹
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
+
+
+// Ensure the function is inlined
+:soir
+@tailrec @inline
+fun loop(x)(y) =
+  if x == 0 then y
+  else loop(x - 1)(y + x)
+fun f = loop(1000)(0)
+//│ ——————————————| Optimized IR |——————————————————————————————————————————————————————————————————————
+//│ @tailrec @inline
+//│ define loop² as fun loop³(x)(y) {
+//│   let x1, y1, inlinedVal;
+//│   set x1 = x;
+//│   set y1 = y;
+//│   block inlinedLbl:
+//│     loop loopLabel:
+//│       let scrut, tmp, tmp1;
+//│       set scrut = Predef⁰.equals⁰(x1, 0);
+//│       match scrut
+//│         true =>
+//│           set inlinedVal = y1;
+//│           break inlinedLbl
+//│         else
+//│           set tmp = -⁰(x1, 1);
+//│           set tmp1 = +⁰(y1, x1);
+//│           set x1 = tmp;
+//│           set y1 = tmp1;
+//│           continue loopLabel
+//│       end
+//│     unreachable /* Rest of abortive labelled block */
+//│   return inlinedVal
+//│ };
+//│ define f⁶ as fun f⁷() {
+//│   let x, y, inlinedVal;
+//│   set x = 1000;
+//│   set y = 0;
+//│   block inlinedLbl:
+//│     loop loopLabel:
+//│       let scrut, tmp, tmp1;
+//│       set scrut = Predef⁰.equals⁰(x, 0);
+//│       match scrut
+//│         true =>
+//│           set inlinedVal = y;
+//│           break inlinedLbl
+//│         else
+//│           set tmp = -⁰(x, 1);
+//│           set tmp1 = +⁰(y, x);
+//│           set x = tmp;
+//│           set y = tmp1;
+//│           continue loopLabel
+//│       end
+//│     unreachable /* Rest of abortive labelled block */
+//│   return inlinedVal
+//│ };
+//│ end
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————

--- a/hkmc2/shared/src/test/mlscript/tailrec/MultiArgLists.mls
+++ b/hkmc2/shared/src/test/mlscript/tailrec/MultiArgLists.mls
@@ -229,3 +229,55 @@ fun f(a)(...z) = if z is
 :expect 4
 f(0)(1, 2, 3, 4)
 //│ = 4
+
+
+// Ensure that the internal loop and the outer-facing definition have different param symbol IDs.
+:lot
+:noInline
+fun f(a)(b) = f(a)(b)
+//│ —————————————| Lowered IR Tree |————————————————————————————————————————————————————————————————————
+//│ Program:
+//│   main = Scoped(syms = {member:f$tailrec¹}):
+//│     body = Define:
+//│       defn = FunDefn:
+//│         sym = member:f$tailrec¹
+//│         dSym = term:f$tailrec²
+//│         params = Ls of 
+//│           ParamList:
+//│             params = Ls of 
+//│               Param:
+//│                 sym = a⁰
+//│                 modulefulness = Modulefulness of N
+//│               Param:
+//│                 sym = b⁰
+//│                 modulefulness = Modulefulness of N
+//│         body = Label:
+//│           label = label:loopLabel⁰
+//│           loop = true
+//│           body = Continue of label:loopLabel⁰
+//│       rest = Define: \
+//│       defn = FunDefn:
+//│         sym = member:f⁴
+//│         dSym = term:f⁵
+//│         params = Ls of 
+//│           ParamList:
+//│             params = Ls of 
+//│               Param:
+//│                 sym = a¹
+//│                 modulefulness = Modulefulness of N
+//│           ParamList:
+//│             params = Ls of 
+//│               Param:
+//│                 sym = b¹
+//│                 modulefulness = Modulefulness of N
+//│         body = Return of Call:
+//│           fun = MemberRef{disamb=term:f$tailrec²}:
+//│             bms = member:f$tailrec¹
+//│             disamb = term:f$tailrec²
+//│           argss = Ls of 
+//│             Ls of 
+//│               Arg:
+//│                 value = SimpleRef of a¹
+//│               Arg:
+//│                 value = SimpleRef of b¹
+//│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————

--- a/hkmc2/shared/src/test/mlscript/tailrec/MultiArgLists.mls
+++ b/hkmc2/shared/src/test/mlscript/tailrec/MultiArgLists.mls
@@ -20,7 +20,7 @@ fun loop(x)(y) =
 loop(1000)(0)
 //│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
 //│ let loop$tailrec;
-//│ @inline @private
+//│ @private
 //│ define loop$tailrec as fun loop$tailrec⁰(x, y) {
 //│   loop loopLabel:
 //│     let scrut, tmp, tmp1;
@@ -37,7 +37,7 @@ loop(1000)(0)
 //│     end
 //│   end
 //│ };
-//│ @tailrec
+//│ @inline @tailrec
 //│ define loop⁰ as fun loop¹(x)(y) { return loop$tailrec⁰(x, y) };
 //│ return loop¹(1000)(0)
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————
@@ -52,7 +52,7 @@ fun count(start)(stop) =
 count(0)(100)
 //│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
 //│ let count$tailrec;
-//│ @inline @private
+//│ @private
 //│ define count$tailrec as fun count$tailrec⁰(start, stop) {
 //│   loop loopLabel:
 //│     let scrut, tmp;
@@ -67,6 +67,7 @@ count(0)(100)
 //│     end
 //│   end
 //│ };
+//│ @inline
 //│ define count⁰ as fun count¹(start)(stop) {
 //│   return count$tailrec⁰(start, stop)
 //│ };
@@ -201,7 +202,7 @@ fun f(a)(...z) = if z is
   [x, ...xs] then f(a + 1)(...xs)
 //│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
 //│ let f$tailrec;
-//│ @inline @private
+//│ @private
 //│ define f$tailrec as fun f$tailrec⁰(a, z) {
 //│   loop loopLabel:
 //│     let x, xs, middleElements, element0$, tmp;
@@ -222,6 +223,7 @@ fun f(a)(...z) = if z is
 //│     end
 //│   end
 //│ };
+//│ @inline
 //│ define f² as fun f³(a)(...z) { return f$tailrec⁰(a, z) };
 //│ end
 //│ —————————————————| Output |—————————————————————————————————————————————————————————————————————————

--- a/hkmc2/shared/src/test/mlscript/tailrec/MultiArgLists.mls
+++ b/hkmc2/shared/src/test/mlscript/tailrec/MultiArgLists.mls
@@ -20,7 +20,7 @@ fun loop(x)(y) =
 loop(1000)(0)
 //│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
 //│ let loop$tailrec;
-//│ @private
+//│ @inline @private
 //│ define loop$tailrec as fun loop$tailrec⁰(x, y) {
 //│   loop loopLabel:
 //│     let scrut, tmp, tmp1;
@@ -52,7 +52,7 @@ fun count(start)(stop) =
 count(0)(100)
 //│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
 //│ let count$tailrec;
-//│ @private
+//│ @inline @private
 //│ define count$tailrec as fun count$tailrec⁰(start, stop) {
 //│   loop loopLabel:
 //│     let scrut, tmp;
@@ -201,7 +201,7 @@ fun f(a)(...z) = if z is
   [x, ...xs] then f(a + 1)(...xs)
 //│ ———————————————| Lowered IR |———————————————————————————————————————————————————————————————————————
 //│ let f$tailrec;
-//│ @private
+//│ @inline @private
 //│ define f$tailrec as fun f$tailrec⁰(a, z) {
 //│   loop loopLabel:
 //│     let x, xs, middleElements, element0$, tmp;

--- a/hkmc2/shared/src/test/mlscript/tailrec/TailRecOpt.mls
+++ b/hkmc2/shared/src/test/mlscript/tailrec/TailRecOpt.mls
@@ -134,6 +134,14 @@ fun f(n, x, y, z) =
 f(10, 0, 0, 0)
 //│ = 2
 
+fun f(a, ...z) = if z is
+  [] then a
+  [x, ...xs] then f(a + 1, ...xs)
+
+:expect 4
+f(0, 1, 2, 3, 4)
+//│ = 4
+
 :sir
 fun f(n, a, b, c, d, ...e) =
   if n > 0 then @tailcall g(n - 1)
@@ -198,7 +206,7 @@ fun f(x) =
     @tailcall f(x)
   @tailcall g()
 //│ ╔══[COMPILATION ERROR] This call is not in tail position.
-//│ ║  l.197: 	    @tailcall f(x)
+//│ ║  l.205: 	    @tailcall f(x)
 //│ ╙──       	              ^^^^
 
 :lift
@@ -285,10 +293,10 @@ module A with
     @tailcall g(x - 1)
 A.f(10000)
 //│ ╔══[COMPILATION ERROR] This tail call exits the current scope and is not optimized.
-//│ ║  l.284: 	    fun g(x) = if x < 0 then 0 else @tailcall f(x)
+//│ ║  l.292: 	    fun g(x) = if x < 0 then 0 else @tailcall f(x)
 //│ ╙──       	                                              ^^^^
 //│ ╔══[COMPILATION ERROR] This tail call exits the current scope and is not optimized.
-//│ ║  l.285: 	    @tailcall g(x - 1)
+//│ ║  l.293: 	    @tailcall g(x - 1)
 //│ ╙──       	              ^^^^^^^^
 //│ ═══[RUNTIME ERROR] RangeError: Maximum call stack size exceeded
 
@@ -315,12 +323,12 @@ class A with
   fun g(x) = if x == 0 then 1 else @tailcall f(x - 1)
 (new A).f(10)
 //│ ╔══[COMPILATION ERROR] Calls from class methods cannot yet be marked @tailcall.
-//│ ║  l.314: 	  @tailrec fun f(x) = if x == 0 then 0 else @tailcall g(x - 1)
+//│ ║  l.322: 	  @tailrec fun f(x) = if x == 0 then 0 else @tailcall g(x - 1)
 //│ ╙──       	                                                      ^^^^^^^^
 //│ ╔══[COMPILATION ERROR] Class methods may not yet be marked @tailrec.
-//│ ║  l.314: 	  @tailrec fun f(x) = if x == 0 then 0 else @tailcall g(x - 1)
+//│ ║  l.322: 	  @tailrec fun f(x) = if x == 0 then 0 else @tailcall g(x - 1)
 //│ ╙──       	               ^
 //│ ╔══[COMPILATION ERROR] Calls from class methods cannot yet be marked @tailcall.
-//│ ║  l.315: 	  fun g(x) = if x == 0 then 1 else @tailcall f(x - 1)
+//│ ║  l.323: 	  fun g(x) = if x == 0 then 1 else @tailcall f(x - 1)
 //│ ╙──       	                                             ^^^^^^^^
 //│ = 0


### PR DESCRIPTION
Fixes a bug where the following
```fs
fun f(a, ...z) = if z is
  [] then a
  [x, ...xs] then f(a + 1, ...xs)
```
would have the spread parameter changed into a normal parameter by the tailrec optimizer.