### PR TITLE
Improve compilation tests

### DIFF
--- a/hkmc2/shared/src/test/mlscript-compile/Iter.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/Iter.mls
@@ -1,10 +1,8 @@
 #config(liftDefns: Some(LiftDefns))
 
-import "./Predef.mls"
 import "./Option.mls"
 import "./Stack.mls"
 
-open Predef
 open Option { Some, None }
 open Stack { Nil, Cons }
 

--- a/hkmc2/shared/src/test/mlscript-compile/Option.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/Option.mls
@@ -1,7 +1,4 @@
 
-import "./Predef.mls"
-open Predef
-
 
 type Option[A] = Option.{ Some(A) | None }
 

--- a/hkmc2/shared/src/test/mlscript-compile/Rendering.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/Rendering.mls
@@ -58,7 +58,7 @@ let identifierPattern = new RegExp of
   "u" // The Unicode flag is required for `\p{...}` Unicode property escapes.
 
 // Return `true` if the identifier needs to be enclosed in quotes.
-let noNeedForQuotes(id) = identifierPattern.test(id)
+private fun noNeedForQuotes(id) = identifierPattern.test(id)
 
 // Use this object instead when no options object is given.
 let emptyOptions = new Object
@@ -68,18 +68,18 @@ let DEFAULT_BREAK_LENGTH = 80
 let symbolsForArray =
   start: "[", end: "]", separator: ",", empty: "[]", padding: true
 
-let symbolsForSet(n: Int) =
+private fun symbolsForSet(n: Int) =
   let headline = "Set(" + n + ") "
   start: headline + "{", end: "}", separator: ",",
   empty: headline + "{}", padding: true
 
-let symbolsForClass(name: Str) =
+private fun symbolsForClass(name: Str) =
   start: name + "(", end: ")", separator: ",", empty: name + "()", padding: false
 
 let symbolsForObject =
   start: "{", end: "}", entrySeparator: ",", keyValueSeparator: ": ", empty: "{}", padding: true
 
-let symbolsForMap(n: Int) =
+private fun symbolsForMap(n: Int) =
   let headline = "Map(" + n + ")"
   start: headline + " {", end: "}",
   entrySeparator: ",", keyValueSeparator: " => ", empty: headline + " {}", padding: true

--- a/hkmc2/shared/src/test/mlscript-compile/Stack.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/Stack.mls
@@ -1,7 +1,4 @@
 
-import "./Predef.mls"
-open Predef
-
 
 type Stack[A] = Stack.{ Cons[A] | Nil }
 


### PR DESCRIPTION
Remove extra imports and refactor `let` into `private fun` which will not create a lambda and directly bind as a method instead of a field storing lambda.