### PR TITLE
Use custom Binaryen build, cleanup Wasm-related code

### DIFF
--- a/hkmc2/shared/src/test/mlscript-compile/wasm/Wasm.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/wasm/Wasm.mls
@@ -17,23 +17,23 @@ fun dumpWasmImpExp(wasmMod) =
 
 // Binaryen helpers
 fun binaryenFmtWat(wat, foldExprs): String =
-  val mod = binaryen.parseTextWithFeatures of wat, binaryen.Features.All
+  let mod = binaryen.parseTextWithFeatures of wat, binaryen.Features.All
   
   // Note: it seems `mod.validate()` sometimes returns `1` instead of `true`; so we don't use `assert` here
   Predef.js_assert of mod.validate()
 
-  val fmtWat = if foldExprs then mod.emitText() else mod.emitStackIR()
+  let fmtWat = if foldExprs then mod.emitText() else mod.emitStackIR()
 
   mod.dispose()
   fmtWat
 
 fun binaryenCompileToModule(wat, importObject): Promise =
-  val mod = binaryen.parseTextWithFeatures of wat, binaryen.Features.All
+  let mod = binaryen.parseTextWithFeatures of wat, binaryen.Features.All
 
   // Note: it seems `mod.validate()` sometimes returns `1` instead of `true`; so we don't use `assert` here
   Predef.js_assert of mod.validate()
 
-  val modBuf = mod.emitBinary()
+  let modBuf = mod.emitBinary()
   mod.dispose()
 
   Promise.resolve(modBuf).then(modBuf =>

--- a/hkmc2/shared/src/test/mlscript-compile/wasm/Wasm.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/wasm/Wasm.mls
@@ -6,14 +6,18 @@ import "../Runtime.mls"
 module Wasm with ...
 
 // WebAssembly utilities
-fun loadWasmBinary(modBuf, importObject): Promise =
+fun instantiateWasmBinary(modBuf, importObject): WebAssembly.Instance =
   assert WebAssembly.validate of modBuf
+  let mod = new WebAssembly.Module(modBuf)
+  new WebAssembly.Instance(mod, importObject)
 
-  WebAssembly.instantiate of modBuf, importObject
+fun dumpWasmModImpExp(wasmMod) =
+  console.log of "Imports: %s", WebAssembly.Module.imports(wasmMod)
+  console.log of "Exports: %s", WebAssembly.Module.exports(wasmMod)
 
-fun dumpWasmImpExp(wasmMod) =
-  console.log of "Imports: %s", WebAssembly.Module.imports(wasmMod.module)
-  console.log of "Exports: %s", WebAssembly.Module.exports(wasmMod.module)
+fun dumpWasmInstImpExp(wasmInst) =
+  console.log of "Imports: %s", wasmInst.imports
+  console.log of "Exports: %s", wasmInst.exports
 
 // Binaryen helpers
 fun binaryenFmtWat(wat, foldExprs): String =
@@ -27,7 +31,7 @@ fun binaryenFmtWat(wat, foldExprs): String =
   mod.dispose()
   fmtWat
 
-fun binaryenCompileToModule(wat, importObject): Promise =
+fun binaryenCompileToModule(wat, importObject): WebAssembly.Instance =
   let mod = binaryen.parseTextWithFeatures of wat, binaryen.Features.All
 
   // Note: it seems `mod.validate()` sometimes returns `1` instead of `true`; so we don't use `assert` here
@@ -36,9 +40,7 @@ fun binaryenCompileToModule(wat, importObject): Promise =
   let modBuf = mod.emitBinary()
   mod.dispose()
 
-  Promise.resolve(modBuf).then(modBuf =>
-    loadWasmBinary of modBuf, importObject
-  )
+  instantiateWasmBinary of modBuf, importObject
 
 fun unwrapWasmException(err, tag) =
   if (
@@ -51,17 +53,13 @@ fun unwrapWasmException(err, tag) =
   then err.getArg(tag, 0)
   else err
 
-fun binaryenRunFunc(wat, importObject, func): Promise =
-  binaryenCompileToModule(wat, importObject)
-    .then(wasmMod =>
-      let exnTag = wasmMod.instance.exports.mlx_exn
-      Runtime.try_catch of
-        () => func(wasmMod.instance.exports)
-        err => throw unwrapWasmException(err, exnTag)
-    )
+fun binaryenRunFunc(wat, importObject, func): Any =
+  let wasmInst = binaryenCompileToModule of wat, importObject
+  let exnTag = wasmInst.exports.mlx_exn
+  Runtime.try_catch of
+    () => func(wasmInst.exports)
+    err => throw unwrapWasmException(err, exnTag)
 
-fun binaryenPrintFuncRes(wat, importObject, func): Promise = 
-  binaryenRunFunc(wat, importObject, func)
-    .then(result =>
-      Predef.print of Runtime.render of result
-    )
+fun binaryenPrintFuncRes(wat, importObject, func) = 
+  let result = binaryenRunFunc of wat, importObject, func
+  Predef.print of Runtime.render of result

--- a/hkmc2/shared/src/test/mlscript-compile/wasm/Wasm.mls
+++ b/hkmc2/shared/src/test/mlscript-compile/wasm/Wasm.mls
@@ -17,8 +17,7 @@ fun dumpWasmImpExp(wasmMod) =
 
 // Binaryen helpers
 fun binaryenFmtWat(wat, foldExprs): String =
-  val mod = binaryen.parseText of wat
-  mod.setFeatures(binaryen.Features.All)
+  val mod = binaryen.parseTextWithFeatures of wat, binaryen.Features.All
   
   // Note: it seems `mod.validate()` sometimes returns `1` instead of `true`; so we don't use `assert` here
   Predef.js_assert of mod.validate()
@@ -29,8 +28,7 @@ fun binaryenFmtWat(wat, foldExprs): String =
   fmtWat
 
 fun binaryenCompileToModule(wat, importObject): Promise =
-  val mod = binaryen.parseText of wat
-  mod.setFeatures(binaryen.Features.All)
+  val mod = binaryen.parseTextWithFeatures of wat, binaryen.Features.All
 
   // Note: it seems `mod.validate()` sometimes returns `1` instead of `true`; so we don't use `assert` here
   Predef.js_assert of mod.validate()

--- a/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
+++ b/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
@@ -209,8 +209,6 @@ declare val fs // TODO make `module`
 declare val Infinity
 
 // Wasm support
-declare class Promise
-declare val Promise
 declare object WebAssembly with
   declare class Instance
   declare class Memory

--- a/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
+++ b/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
@@ -85,6 +85,9 @@ declare module BigInt64Array
 declare class BigUint64Array
 declare module BigUint64Array
 
+declare class Promise
+declare val Promise
+
 // MLscript-specific types
 declare class Bool
 declare class Int

--- a/hkmc2/shared/src/test/mlscript/wasm/Binaryen.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/Binaryen.mls
@@ -90,3 +90,21 @@ mod.dispose()
 let inst = instantiateWasm of wasmMod, {}
 inst.exports.main() |> print
 //│ > 3
+
+
+// Regression Test for Binaryen:
+// `error: invalid type: distinct rec groups would be identical after binary writing (to resolve this, use --enable-gc)`
+//
+// The error will occur if the module is parsed using `binaryen.parseText` - `parseText` only enables MVP features
+// (not GC)
+compileWatToWasm of 
+    """
+    (module
+        (type $Foo (struct (field $i i32)))
+        (type $GetI_t (func (param (ref $Foo)) (result i32)))
+        (type $Twin (func (param (ref null any)) (result i32)))
+        (func $getI (type $GetI_t) (param $f (ref $Foo)) (result i32)
+            (struct.get $Foo $i (local.get $f)))
+        (func $twin (type $Twin) (param $x (ref null any)) (result i32)
+            (i32.const 0)))
+    """

--- a/hkmc2/shared/src/test/mlscript/wasm/Binaryen.mls
+++ b/hkmc2/shared/src/test/mlscript/wasm/Binaryen.mls
@@ -5,9 +5,8 @@
 // Helper functions
 import "binaryen"
 fun compileWatToWasm(wat) = 
-  let mod = binaryen.parseText(wat)
-  mod.setFeatures(binaryen.Features.All)
-  assert mod.validate() != false
+  let mod = binaryen.parseTextWithFeatures of wat, binaryen.Features.All
+  Predef.js_assert of mod.validate()
   val modBuf = mod.emitBinary()
   mod.dispose()
   modBuf

--- a/hkmc2DiffTests/src/test/scala/hkmc2/WasmDiffMaker.scala
+++ b/hkmc2DiffTests/src/test/scala/hkmc2/WasmDiffMaker.scala
@@ -163,7 +163,7 @@ abstract class WasmDiffMaker extends InvalMLDiffMaker:
               WatBuilder().intrinsicSupportModule().mkString(output.ColWidth),
         )
         host.execute(
-          doc"""await (async () => {
+          doc"""(() => {
             # const mem = new WebAssembly.Memory({ initial: ${systemMemMinPages} });
             # const decodeUtf16 = new TextDecoder("utf-16le");
             # const system = {
@@ -171,8 +171,8 @@ abstract class WasmDiffMaker extends InvalMLDiffMaker:
             #   mlx_str_from_utf16: (ptr, byteLen) =>
             #     decodeUtf16.decode(new Uint8Array(mem.buffer, ptr, byteLen)),
             # };
-            # const intrinsicModule = await $wasmSuppNme.binaryenCompileToModule($intrinsicWatJsLit, {});
-            # Object.assign(system, intrinsicModule.instance.exports);
+            # const intrinsicModule = $wasmSuppNme.binaryenCompileToModule($intrinsicWatJsLit, {});
+            # Object.assign(system, intrinsicModule.exports);
             # $wasmReplImportsRef = {
             #   repl: Object.create(null),
             #   system,
@@ -209,7 +209,7 @@ abstract class WasmDiffMaker extends InvalMLDiffMaker:
         else
           s"""return exports["$mainFnNme"]();"""
       val jsStr =
-        s"""await wasm.binaryenPrintFuncRes($modWatJsLit, $wasmReplImportsRef, exports => { $jsBody });"""
+        s"""wasm.binaryenPrintFuncRes($modWatJsLit, $wasmReplImportsRef, exports => { $jsBody });"""
       output("Wasm result:")
       mkQuery("", jsStr): out =>
         // Omit the last line which is always "undefined" or the unit.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "node_modules/binaryen": {
       "version": "130.0.0",
-      "resolved": "git+ssh://git@github.com/Derppening/binaryen.js.git#3ca4763736179196d5a8144cc2cc2b7d3a02ce7d",
+      "resolved": "git+ssh://git@github.com/Derppening/binaryen.js.git#f10fafd3814dfedbf9b94ea11e16c9bcd081ddd0",
       "license": "Apache-2.0",
       "bin": {
         "wasm-as": "bin/wasm-as",
@@ -74,7 +74,7 @@
       }
     },
     "binaryen": {
-      "version": "git+ssh://git@github.com/Derppening/binaryen.js.git#3ca4763736179196d5a8144cc2cc2b7d3a02ce7d",
+      "version": "git+ssh://git@github.com/Derppening/binaryen.js.git#f10fafd3814dfedbf9b94ea11e16c9bcd081ddd0",
       "from": "binaryen@github:Derppening/binaryen.js#v130.0.0-mlscript"
     },
     "lodash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "mlscript",
       "dependencies": {
         "benchmark": "^2.1.4",
-        "binaryen": "^129.0.0",
+        "binaryen": "github:Derppening/binaryen.js#v130.0.0-mlscript",
         "typescript": "^4.7.4"
       }
     },
@@ -22,9 +22,8 @@
       }
     },
     "node_modules/binaryen": {
-      "version": "129.0.0",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-129.0.0.tgz",
-      "integrity": "sha512-NyF5J0SfRoLDthpPh36FGTycOEv3Eqnkq3+mP5Cqt6iD9BLGGJMEVuPzu81nhLy2MMpPKmRTM9VLZihfyRQv8A==",
+      "version": "130.0.0",
+      "resolved": "git+ssh://git@github.com/Derppening/binaryen.js.git#3ca4763736179196d5a8144cc2cc2b7d3a02ce7d",
       "license": "Apache-2.0",
       "bin": {
         "wasm-as": "bin/wasm-as",
@@ -75,9 +74,8 @@
       }
     },
     "binaryen": {
-      "version": "129.0.0",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-129.0.0.tgz",
-      "integrity": "sha512-NyF5J0SfRoLDthpPh36FGTycOEv3Eqnkq3+mP5Cqt6iD9BLGGJMEVuPzu81nhLy2MMpPKmRTM9VLZihfyRQv8A=="
+      "version": "git+ssh://git@github.com/Derppening/binaryen.js.git#3ca4763736179196d5a8144cc2cc2b7d3a02ce7d",
+      "from": "binaryen@github:Derppening/binaryen.js#v130.0.0-mlscript"
     },
     "lodash": {
       "version": "4.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "node_modules/binaryen": {
       "version": "130.0.0",
-      "resolved": "git+ssh://git@github.com/hkust-taco/binaryen.js.git#6a16149018bdc670b5d82f1c63382e0fe651a81b",
+      "resolved": "git+ssh://git@github.com/hkust-taco/binaryen.js.git#222f3382b2fb0eaddf88dd19e3ba06c9069e7632",
       "license": "Apache-2.0",
       "bin": {
         "wasm-as": "bin/wasm-as",
@@ -74,7 +74,7 @@
       }
     },
     "binaryen": {
-      "version": "git+ssh://git@github.com/hkust-taco/binaryen.js.git#6a16149018bdc670b5d82f1c63382e0fe651a81b",
+      "version": "git+ssh://git@github.com/hkust-taco/binaryen.js.git#222f3382b2fb0eaddf88dd19e3ba06c9069e7632",
       "from": "binaryen@github:hkust-taco/binaryen.js#mlscript"
     },
     "lodash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "mlscript",
       "dependencies": {
         "benchmark": "^2.1.4",
-        "binaryen": "github:Derppening/binaryen.js#v130.0.0-mlscript",
+        "binaryen": "github:hkust-taco/binaryen.js#mlscript",
         "typescript": "^4.7.4"
       }
     },
@@ -23,7 +23,7 @@
     },
     "node_modules/binaryen": {
       "version": "130.0.0",
-      "resolved": "git+ssh://git@github.com/Derppening/binaryen.js.git#f10fafd3814dfedbf9b94ea11e16c9bcd081ddd0",
+      "resolved": "git+ssh://git@github.com/hkust-taco/binaryen.js.git#6a16149018bdc670b5d82f1c63382e0fe651a81b",
       "license": "Apache-2.0",
       "bin": {
         "wasm-as": "bin/wasm-as",
@@ -74,8 +74,8 @@
       }
     },
     "binaryen": {
-      "version": "git+ssh://git@github.com/Derppening/binaryen.js.git#f10fafd3814dfedbf9b94ea11e16c9bcd081ddd0",
-      "from": "binaryen@github:Derppening/binaryen.js#v130.0.0-mlscript"
+      "version": "git+ssh://git@github.com/hkust-taco/binaryen.js.git#6a16149018bdc670b5d82f1c63382e0fe651a81b",
+      "from": "binaryen@github:hkust-taco/binaryen.js#mlscript"
     },
     "lodash": {
       "version": "4.18.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mlscript",
   "dependencies": {
     "benchmark": "^2.1.4",
-    "binaryen": "^129.0.0",
+    "binaryen": "github:Derppening/binaryen.js#v130.0.0-mlscript",
     "typescript": "^4.7.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mlscript",
   "dependencies": {
     "benchmark": "^2.1.4",
-    "binaryen": "github:Derppening/binaryen.js#v130.0.0-mlscript",
+    "binaryen": "github:hkust-taco/binaryen.js#mlscript",
     "typescript": "^4.7.4"
   }
 }


### PR DESCRIPTION
This PR switches to our (my) personally maintained build of Binaryen, which is just the latest release with the `parseTextWithFeatures` API tacked on top of it. A regression test is also added for the `parseText` issue

The relevant PR in Binaryen's repository is [here](https://github.com/WebAssembly/binaryen/pull/8872).

Also cleans up the Wasm-related code by:

- Using `let` for function locals
- Refactoring to use synchronous APIs when instantiating `WebAssembly.Instance` for execution