### PR TITLE
Never retry a failed fixed-point machine run naively

### DIFF
--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/Symbol.scala
@@ -535,10 +535,9 @@ class PatternSymbol(val id: Tree.Ident, val params: Opt[Tree.Tup], val body: Tre
   def toLoc: Option[Loc] = id.toLoc // TODO track source tree of pattern here
   override def prefix: Str = "pattern:"
 
-  /** The fixed-point machine compiled from this definition, paired with
-    * whether a failed run must be retried with the naive translation;
-    * memoized across `@compile` match sites (see `ups.FixedPointCompiler`). */
-  var fixedPointMachine: Opt[(ups.FixedPointCompiler.Machine, Bool)] = N
+  /** The fixed-point machine compiled from this definition, memoized across
+    * `@compile` match sites (see `ups.FixedPointCompiler`). */
+  var fixedPointMachine: Opt[ups.FixedPointCompiler.Machine] = N
 
   override def subst(using sub: SymbolSubst): PatternSymbol = sub.mapPatSym(this)
 

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -637,7 +637,7 @@ object Normalization:
         case S(parentSym) =>
           (parentSym is parent) || go(parentSym, visited + sym)
         case N => false)
-    (child is parent) || go(child, Set.empty)
+    !(child is parent) && go(child, Set.empty)
 
   final case class VarSet(declared: Set[LocalVarSymbol]):
     def +(nme: LocalVarSymbol): VarSet = copy(declared + nme)

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -600,9 +600,10 @@ object Normalization:
     // Under the single-inheritance restriction, two classes where neither is a
     // subclass of the other are provably disjoint. When we add matchable
     // class-like things with multiple inheritance (e.g., interfaces), this check
-    // will need to be refined. Note that `isSubclassOf` is strict, so the same
-    // class has to be ruled out separately: callers reaching this method with
-    // two occurrences of one class used to be told they were disjoint.
+    // will need to be refined. Note that `isStrictSubclassOf` excludes the
+    // class itself, so the same class has to be ruled out separately: callers
+    // reaching this method with two occurrences of one class used to be told
+    // they were disjoint.
     case (ClassLike(_, lhsSym, _, _), ClassLike(_, rhsSym, _, _)) =>
       !(lhsSym === rhsSym) && !isStrictSubclassOf(lhsSym, rhsSym) && !isStrictSubclassOf(rhsSym, lhsSym)
     case _ => false

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -604,7 +604,7 @@ object Normalization:
     // class has to be ruled out separately: callers reaching this method with
     // two occurrences of one class used to be told they were disjoint.
     case (ClassLike(_, lhsSym, _, _), ClassLike(_, rhsSym, _, _)) =>
-      !(lhsSym === rhsSym) && !isSubclassOf(lhsSym, rhsSym) && !isSubclassOf(rhsSym, lhsSym)
+      !(lhsSym === rhsSym) && !isStrictSubclassOf(lhsSym, rhsSym) && !isStrictSubclassOf(rhsSym, lhsSym)
     case _ => false
   
   /** Get the parent class-like symbol from the extends clause of a class or module. */
@@ -615,9 +615,16 @@ object Normalization:
       case mod: ModuleOrObjectSymbol => mod.defn.flatMap(_.ext)
     ext.flatMap(nw => nw.cls.symbol.flatMap(_.asClsOrMod))
   
-  /** Check if `child` is a subclass of `parent` by traversing the class hierarchy.
-    * Uses a visited set to avoid infinite loops in case of cyclic inheritance. */
   private def isSubclassOf(
+      child: ClassSymbol | ModuleOrObjectSymbol,
+      parent: ClassSymbol | ModuleOrObjectSymbol
+  ): Bool =
+    child === parent || isStrictSubclassOf(child, parent)
+  
+  /** Check if `child` is a subclass of `parent` by traversing the class hierarchy.
+    * Uses a visited set to avoid infinite loops in case of cyclic inheritance.
+    * TODO: Cache the subclasses set!! */
+  private def isStrictSubclassOf(
       child: ClassSymbol | ModuleOrObjectSymbol,
       parent: ClassSymbol | ModuleOrObjectSymbol
   ): Bool =

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -557,9 +557,6 @@ object Normalization:
     case (ClassLike(_, cs: ModuleOrObjectSymbol, _, _), ClassLike(symbol = blt.`Object`)) => true
     case (Tuple(n1, false), Tuple(n2, false)) if n1 === n2 => true
     case (Tuple(n1, _), Tuple(n2, true)) if n2 <= n1 => true
-    // Note: We don't make Int31 compatible with Num, since Int31 needs to know how it should be
-    // sign-extended in order to convert into a Num.
-    case (ClassLike(symbol = blt.`Int`), ClassLike(symbol = blt.`Num`)) => true
     // TODO(Derppening): Do we limit IntLit to (1 << 31) - 1 for `Int31`?
     case (Lit(Tree.IntLit(_)), ClassLike(symbol = blt.`Int` | blt.`Int31` | blt.`Num`)) => true
     case (Lit(Tree.StrLit(_)), ClassLike(symbol = blt.`Str`)) => true
@@ -576,7 +573,10 @@ object Normalization:
       entries.forall { (fieldName, _) => clsParams.exists {
         case Param(flags = FldFlags(isVal = isVal), sym = sym) => isVal && fieldName === sym.id
       }}
-    // Check user-defined class hierarchy via extends clauses.
+    // Check the class hierarchy via extends clauses. This includes virtual
+    // classes such as `Int <: Num`, whose relationship is declared in Prelude.
+    // `Int31` deliberately does not extend `Num`: converting it to a `Num`
+    // needs to know how the value should be sign-extended.
     case (ClassLike(_, lhsSym, _, _), ClassLike(_, rhsSym, _, _)) =>
       isSubclassOf(lhsSym, rhsSym)
     case (_: FlatPattern, _: FlatPattern) => false
@@ -602,10 +602,9 @@ object Normalization:
     // Under the single-inheritance restriction, two classes where neither is a
     // subclass of the other are provably disjoint. When we add matchable
     // class-like things with multiple inheritance (e.g., interfaces), this check
-    // will need to be refined. Note that `isStrictSubclassOf` excludes the
-    // class itself, so the same class has to be ruled out separately: callers
-    // reaching this method with two occurrences of one class used to be told
-    // they were disjoint.
+    // will need to be refined. `compareCasePattern` includes reflexive
+    // subtyping, so two occurrences of the same class are not considered
+    // disjoint.
     case (ClassLike(_, lhsSym, _, _), ClassLike(_, rhsSym, _, _)) =>
       !compareCasePattern(lhs, rhs) && !compareCasePattern(rhs, lhs)
     case _ => false
@@ -618,16 +617,10 @@ object Normalization:
       case mod: ModuleOrObjectSymbol => mod.defn.flatMap(_.ext)
     ext.flatMap(nw => nw.cls.resolvedSym.flatMap(_.asClsOrMod))
   
-  private def isSubclassOf(
-      child: ClassSymbol | ModuleOrObjectSymbol,
-      parent: ClassSymbol | ModuleOrObjectSymbol
-  ): Bool =
-    child === parent || isStrictSubclassOf(child, parent)
-  
   /** Check if `child` is a subclass of `parent` by traversing the class hierarchy.
     * Uses a visited set to avoid infinite loops in case of cyclic inheritance.
     * TODO: Cache the subclasses set!! */
-  private def isStrictSubclassOf(
+  private def isSubclassOf(
       child: ClassSymbol | ModuleOrObjectSymbol,
       parent: ClassSymbol | ModuleOrObjectSymbol
   ): Bool =
@@ -637,7 +630,7 @@ object Normalization:
         case S(parentSym) =>
           (parentSym is parent) || go(parentSym, visited + sym)
         case N => false)
-    !(child is parent) && go(child, Set.empty)
+    (child is parent) || go(child, Set.empty)
 
   final case class VarSet(declared: Set[LocalVarSymbol]):
     def +(nme: LocalVarSymbol): VarSet = copy(declared + nme)

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -600,9 +600,11 @@ object Normalization:
     // Under the single-inheritance restriction, two classes where neither is a
     // subclass of the other are provably disjoint. When we add matchable
     // class-like things with multiple inheritance (e.g., interfaces), this check
-    // will need to be refined.
+    // will need to be refined. Note that `isSubclassOf` is strict, so the same
+    // class has to be ruled out separately: callers reaching this method with
+    // two occurrences of one class used to be told they were disjoint.
     case (ClassLike(_, lhsSym, _, _), ClassLike(_, rhsSym, _, _)) =>
-      !isSubclassOf(lhsSym, rhsSym) && !isSubclassOf(rhsSym, lhsSym)
+      !(lhsSym === rhsSym) && !isSubclassOf(lhsSym, rhsSym) && !isSubclassOf(rhsSym, lhsSym)
     case _ => false
   
   /** Get the parent class-like symbol from the extends clause of a class or module. */

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ucs/Normalization.scala
@@ -607,7 +607,7 @@ object Normalization:
     // reaching this method with two occurrences of one class used to be told
     // they were disjoint.
     case (ClassLike(_, lhsSym, _, _), ClassLike(_, rhsSym, _, _)) =>
-      !(lhsSym === rhsSym) && !isStrictSubclassOf(lhsSym, rhsSym) && !isStrictSubclassOf(rhsSym, lhsSym)
+      !compareCasePattern(lhs, rhs) && !compareCasePattern(rhs, lhs)
     case _ => false
   
   /** Get the parent class-like symbol from the extends clause of a class or module. */

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
@@ -186,9 +186,9 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
                   val machine = recognized match
                     case S((steps, middles, catchAll, requireProgress)) =>
                       scoped("ucs:fixpoint")(compileMachine(
-                        steps, middles, catchAll, requireProgress, defn.pattern.toLoc))
+                        steps, middles, catchAll, requireProgress, pattern.toLoc))
                     case N => cycle.flatMap: links =>
-                      scoped("ucs:fixpoint")(compileAlternatingMachine(links))
+                      scoped("ucs:fixpoint")(compileAlternatingMachine(links, pattern.toLoc))
                   machine match
                     case S(machine) =>
                       patternSymbol.fixedPointMachine = S(machine)
@@ -231,7 +231,8 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
               case -1 => N
               case index => S(links.drop(index) ::: links.take(index))
           val machine = rotated.flatMap: links =>
-            scoped("ucs:fixpoint")(compileAlternatingMachine(links)).map((links.head._1, _))
+            scoped("ucs:fixpoint")(compileAlternatingMachine(links, body.toLoc))
+              .map((links.head._1, _))
           machine match
             case S((owner, machine)) =>
               owner.fixedPointMachine = S(machine)
@@ -501,15 +502,17 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
         msg"A term this step can still rewrite" -> step.toLoc ::
         msg"can already be matched by this trailing alternative." -> alternative.toLoc :: Nil
 
-  /** Report a rejection: the head bit states the failure and points at the
-    * pattern declaration, and the rejection's own bits point at the individual
-    * patterns at fault. */
-  private def warnUnmatchedIntermediates(rejection: Rejection, declaration: Opt[Loc]): Unit =
-    warn(msg"This fixed-point pattern is not supported by pattern compilation." -> declaration ::
+  /** Report a rejection. The head bit states the failure at `origin`, the
+    * pattern whose `@compile` asked for the machine — that is where the
+    * warning comes from, and where a definition used at several match sites
+    * produces one warning per site. The rejection's own bits then point at the
+    * individual patterns at fault, which live in the definition. */
+  private def warnUnmatchedIntermediates(rejection: Rejection, origin: Opt[Loc]): Unit =
+    warn(msg"This fixed-point pattern is not supported by pattern compilation." -> origin ::
       rejection ::: (msg"Falling back to the naive translation." -> N) :: Nil*)
   
   private def compileMachine(steps: Ls[Ls[SP]], middles: Ls[SP], catchAll: Bool,
-      requireProgress: Bool, declaration: Opt[Loc]): Opt[Machine] =
+      requireProgress: Bool, origin: Opt[Loc]): Opt[Machine] =
     val (halves, context) = instantiateHalves((steps, middles, catchAll) :: Nil)
     val definition = halves.head
     val entry = definition.entry
@@ -529,7 +532,7 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     val missing = if post.forall(_.isTotal) then N else unmatchedIntermediates(definition)
     missing match
       case S(rejection) =>
-        warnUnmatchedIntermediates(rejection, declaration)
+        warnUnmatchedIntermediates(rejection, origin)
         N
       case N => chase(entry, Set.empty) match
         case N =>
@@ -636,7 +639,7 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
   /** Compile an indirect recursion cycle. Each link contributes its steps and
     * its trailing alternatives, turned into a post pattern as in
     * `compileMachine`. */
-  private def compileAlternatingMachine(links: Ls[Link]): Opt[Machine] =
+  private def compileAlternatingMachine(links: Ls[Link], origin: Opt[Loc]): Opt[Machine] =
     val (halves, context) =
       instantiateHalves(links.map((_, steps, middles, catchAll) => (steps, middles, catchAll)))
     val compiled = halves.map(link => (link.entry, link.post))
@@ -670,7 +673,7 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
           else unmatchedIntermediates(link)
       offending match
         case S(rejection) =>
-          warnUnmatchedIntermediates(rejection, declarationOf(links.head._1))
+          warnUnmatchedIntermediates(rejection, origin)
           N
         case N => S(assembleAlternating(compiled))
   

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
@@ -230,7 +230,8 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
             links.indexWhere((symbol, _, _, _) =>
               symbol.defn.exists(defn => stripAnnotations(defn.pattern) eq body)) match
               case -1 => L(
-                msg"This is not the body of any link of the recursion cycle through `${tailSymbol.nme}`.")
+                msg"`@compile` has to be placed on the whole body of a definition " +
+                  msg"taking part in the recursion through `${tailSymbol.nme}`.")
               case index =>
                 val rotated = links.drop(index) ::: links.take(index)
                 R(scoped("ucs:fixpoint")(compileAlternatingMachine(rotated, body.toLoc))
@@ -270,7 +271,7 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     * be. */
   private def classifyRest(rest: Ls[SP]): Message \/ (Ls[SP], Bool) =
     if rest.isEmpty then
-      L(msg"It has no alternative besides its recursive ones, so it never matches.")
+      L(msg"It has only recursive alternatives, so a match can never finish.")
     else
       val catchAll = rest.last.isInstanceOf[SP.Wildcard]
       val middles = if catchAll then rest.init else rest
@@ -348,22 +349,26 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
           recognizeShape(stripAnnotations(defn.pattern)) match
             case S((next, steps, rest, requireProgress)) =>
               if requireProgress then L(
-                msg"`${current.nme}` requires its step to fire, which is not supported for indirect recursion.")
+                msg"`${current.nme}` cannot match without applying its recursive part at least " +
+                  msg"once, which is not supported when definitions recurse through one another.")
               else classifyRest(rest).map: (middles, catchAll) =>
                 (next, (current, steps, middles, catchAll))
-            case N => L(msg"`${current.nme}` is not fixed-point shaped, so the recursion does not come back.")
-        case _ => L(msg"`${current.nme}` is not a parameterless pattern definition.")
+            case N => L(
+              msg"`${current.nme}` does not recurse back, so this pattern applies once rather than repeatedly.")
+        case _ => L(
+          msg"The recursion goes through `${current.nme}`, which is not a parameterless pattern definition.")
       linkOpt match
         case R((next, link)) =>
           if next is start then R((link :: acc).reverse)
           else if (next is current) || acc.exists(_._1 is next) then
-            L(msg"The recursion through `${current.nme}` does not come back to `${start.nme}`.")
+            L(msg"The recursion goes through `${current.nme}` but never comes back to `${start.nme}`.")
           else walk(next, link :: acc)
         case L(reason) => L(reason)
     walk(start, Nil) match
       // Cycles of length one are the direct shape, handled in `compile`.
       case R(_ :: Nil) => L(
-        msg"`${start.nme}` recurses directly rather than through a cycle, so only its whole body can be compiled.")
+        msg"`${start.nme}` is recursive and must be compiled as a whole" +
+          msg" (rather than just part of it).")
       case recognized => recognized
 
   /** Does `pattern` mention the given instantiation anywhere? Used to locate
@@ -504,14 +509,19 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
       case Nil => Iterator.empty
     .nextOption()
     overlappingSteps match
-      case S((step, other)) => S(
-        msg"Its recursive alternatives can rewrite the same term in more than one way: this step" -> step.toLoc ::
-        msg"and this one." -> other.toLoc :: Nil)
+      case S((step, other)) =>
+        val ol = other.toLoc
+        val sl = step.toLoc orElse ol
+        S:
+          msg"Some recursive alternatives can rewrite the same term in more than one way${
+            if sl.isEmpty then msg"" else msg", including this one"}" -> step.toLoc ::
+          (if ol.isEmpty then Nil else
+            msg"and this one." -> other.toLoc :: Nil)
       // Every alternative of every step is checked against the trailing
       // alternatives: a strict intermediate is one some step produced, whichever.
       case N => overlapping(halves.steps.flatten, halves.alternatives).map: (step, alternative) =>
-        msg"A term this step can still rewrite" -> step.toLoc ::
-        msg"can already be matched by this trailing alternative." -> alternative.toLoc :: Nil
+        msg"A term this pattern can still rewrite" -> step.toLoc ::
+        msg"can also be matched by a trailing alternative." -> alternative.toLoc :: Nil
 
   /** Report a rejection. The head bit states the failure at `origin`, the
     * pattern whose `@compile` asked for the machine — that is where the
@@ -679,8 +689,8 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
             // Not every link is total, or we would not be here.
             zipped.collectFirst:
               case (other, (otherSymbol, _, _, _)) if !isTotal(other.post) =>
-                msg"One of its recursive parts accepts any term:" -> declarationOf(symbol) ::
-                msg"while this one can fail on the final term." -> declarationOf(otherSymbol) :: Nil
+                msg"One of its recursive parts accepts any term" -> declarationOf(symbol) ::
+                msg"while another can fail." -> declarationOf(otherSymbol) :: Nil
           else unmatchedIntermediates(link)
       offending match
         case S(rejection) =>

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
@@ -34,12 +34,11 @@ object FixedPointCompiler:
   /** The outcome of `compile` on a fixed-point-shaped pattern. */
   enum Outcome:
     /** The compiled machine, paired with the output sub-pattern of the
-      * match-site shorthand (`x is @compile S(q)`). For non-catch-all
-      * definitions, `fallback` holds the pattern with which a failed machine
-      * run must be retried — the naive backtracking translation implements
-      * the deepest-first try order on intermediate results that the machine
-      * does not keep around. */
-    case Compiled(machine: Machine, outputPattern: Opt[SP], fallback: Opt[SP])
+      * match-site shorthand (`x is @compile S(q)`). A compiled machine is
+      * always a *complete* implementation of the pattern: a failed run means
+      * the match failed, never that something else should be tried. This is
+      * what keeps `@compile` from performing any rewriting step twice. */
+    case Compiled(machine: Machine, outputPattern: Opt[SP])
     /** The pattern is fixed-point shaped but not supported by the machine
       * compilation; a warning has been reported and the caller should use the
       * naive backtracking translation. */
@@ -110,6 +109,20 @@ object FixedPointCompiler:
   * order. For non-overlapping grammars such as CBV evaluation contexts the
   * two agree.
   *
+  * A trailing wildcard is not required: `pattern S = P as S | a` is also a
+  * fixed point. Its naive meaning, however, is subtler than "normalize, then
+  * match `a`" — the alternatives are disjuncts of the whole chains rather
+  * than of their tails, so `a` is tried against *every* intermediate result,
+  * latest first. The machine only ever produces the normal form, so it
+  * implements such a definition only when no intermediate could have matched
+  * `a` anyway; `unmatchedIntermediates` decides that and rejects the machine
+  * compilation otherwise. Rejecting is the point: compiling a machine and
+  * retrying a failed run naively — which is what this used to do — performs
+  * every rewriting step twice, and for a definition whose own `unapply`
+  * embeds the machine, the retry re-enters it once per step, for a quadratic
+  * number of contractions. Both are observable as soon as a transformation
+  * has side effects.
+  *
   * Like the rest of the efficient pattern compilation, this is opt-in via
   * the `@compile` pattern annotation — either at a match site
   * (`x is @compile Steps`) or on the definition's right-hand side
@@ -147,31 +160,31 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
               // patterns; let the regular path report the mismatch.
               case S(_) => N
             outputPattern.flatMap: outputPattern =>
-              def compiled(machine: Machine, needsFallback: Bool): Opt[Outcome] =
-                S(Outcome.Compiled(machine, outputPattern, if needsFallback then S(pattern) else N))
               patternSymbol.fixedPointMachine match
-                case S((machine, needsFallback)) => compiled(machine, needsFallback)
+                case S(machine) => S(Outcome.Compiled(machine, outputPattern))
                 case N =>
                   val shape = recognizeShape(stripAnnotations(defn.pattern))
                   val recognized = shape.filter(_._1 is patternSymbol).flatMap:
                     (_, stepPattern, rest, requireProgress) =>
                       classifyRest(rest).map((middles, catchAll) =>
                         (stepPattern, middles, catchAll, requireProgress))
+                  // The definition may instead be a link of an indirect
+                  // recursion cycle.
+                  val cycle = if recognized.isDefined then N else recognizeCycle(patternSymbol)
                   val machine = recognized match
                     case S((stepPattern, middles, catchAll, requireProgress)) =>
                       scoped("ucs:fixpoint")(compileMachine(stepPattern, middles, catchAll, requireProgress))
-                        .map((_, !catchAll))
-                    case N =>
-                      // The definition may instead be a link of an indirect
-                      // recursion cycle.
-                      recognizeCycle(patternSymbol).flatMap: links =>
-                        scoped("ucs:fixpoint")(compileAlternatingMachine(links))
-                          .map((_, links.exists(!_._4)))
+                    case N => cycle.flatMap: links =>
+                      scoped("ucs:fixpoint")(compileAlternatingMachine(links))
                   machine match
-                    case S((machine, needsFallback)) =>
-                      patternSymbol.fixedPointMachine = S((machine, needsFallback))
-                      compiled(machine, needsFallback)
-                    case N => unsupported(recognized.isDefined, shape.isDefined, pattern.toLoc)
+                    case S(machine) =>
+                      patternSymbol.fixedPointMachine = S(machine)
+                      S(Outcome.Compiled(machine, outputPattern))
+                    // Whenever a machine build was *attempted* and gave up, the
+                    // rejecting check has already reported a specific
+                    // diagnostic, so `unsupported` must not warn again.
+                    case N => unsupported(recognized.isDefined || cycle.isDefined,
+                      shape.isDefined, pattern.toLoc)
           case _ => N
     case body: (SP.Chain | SP.Composition) =>
       // The body-annotated form. The body must belong to the very definition
@@ -188,30 +201,28 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
           val recognized = classifyRest(rest)
           val machine = recognized.flatMap: (middles, catchAll) =>
             scoped("ucs:fixpoint")(compileMachine(stepPattern, middles, catchAll, requireProgress))
-              .map((_, !catchAll))
           machine match
-            case S((machine, needsFallback)) =>
-              patternSymbol.fixedPointMachine = S((machine, needsFallback))
-              S(Outcome.Compiled(machine, N, if needsFallback then S(body) else N))
+            case S(machine) =>
+              patternSymbol.fixedPointMachine = S(machine)
+              S(Outcome.Compiled(machine, N))
             case N => unsupported(recognized.isDefined, true, body.toLoc)
         case S((tailSymbol, _, _, _)) =>
           // The body may be a link of an indirect recursion cycle; its tail
           // then refers to the next link rather than the definition itself.
           // Locate the definition the body belongs to in the cycle and
           // rotate its link to the front.
-          val machine = recognizeCycle(tailSymbol).flatMap: links =>
+          val rotated = recognizeCycle(tailSymbol).flatMap: links =>
             links.indexWhere((symbol, _, _, _) =>
               symbol.defn.exists(defn => stripAnnotations(defn.pattern) eq body)) match
               case -1 => N
-              case index =>
-                val rotated = links.drop(index) ::: links.take(index)
-                scoped("ucs:fixpoint")(compileAlternatingMachine(rotated)).map: machine =>
-                  (rotated.head._1, machine, links.exists(!_._4))
+              case index => S(links.drop(index) ::: links.take(index))
+          val machine = rotated.flatMap: links =>
+            scoped("ucs:fixpoint")(compileAlternatingMachine(links)).map((links.head._1, _))
           machine match
-            case S((owner, machine, needsFallback)) =>
-              owner.fixedPointMachine = S((machine, needsFallback))
-              S(Outcome.Compiled(machine, N, if needsFallback then S(body) else N))
-            case N => unsupported(false, true, body.toLoc)
+            case S((owner, machine)) =>
+              owner.fixedPointMachine = S(machine)
+              S(Outcome.Compiled(machine, N))
+            case N => unsupported(rotated.isDefined, true, body.toLoc)
         case N => N
     case _ => N
 
@@ -297,7 +308,12 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     * cycle order, and whenever a step fails, the failing link's alternatives
     * process the current term — the original scrutinee when even the first
     * step fails. Returns the links in cycle order, beginning with `start`'s
-    * own. */
+    * own.
+    *
+    * One-or-more links (`step as (Next | rest)`) are rejected: they fail
+    * outright when their step does not apply, whereas `assembleAlternating`
+    * has no notion of required progress and would let the failing link's
+    * alternatives process the term regardless. */
   private def recognizeCycle(start: PatternSymbol)
       : Opt[Ls[(PatternSymbol, SP, Ls[SP], Bool)]] =
     @tailrec def walk(
@@ -307,7 +323,7 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
       val linkOpt = current.defn match
         case S(defn) if defn.patternParams.isEmpty && defn.extractionParams.isEmpty =>
           recognizeShape(stripAnnotations(defn.pattern)) match
-            case S((next, stepPattern, rest, _)) =>
+            case S((next, stepPattern, rest, requireProgress)) if !requireProgress =>
               classifyRest(rest).map: (middles, catchAll) =>
                 (next, (current, stepPattern, middles, catchAll))
             case _ => N
@@ -354,6 +370,76 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
       if middles.isEmpty then N else S(Or(middles :+ Wildcard))
     else S(Or(middles))
 
+  /** Can a single value match both patterns? Conservatively `true` whenever
+    * disjointness cannot be proved, reusing the same subtyping knowledge the
+    * UCS normalizer applies to branch elimination. */
+  private def mayOverlap(left: Pat, right: Pat)(using Context): Bool =
+    // Only the symbol and the literal matter to `areProvablyDisjoint`; the
+    // constructor term of a `FlatPattern.ClassLike` is never inspected by it.
+    def flatten(head: Head): FlatPattern = head match
+      case lit: syntax.Literal => FlatPattern.Lit(lit)
+      case sym: ClassSymbol => flattenClassLike(sym)
+      case sym: ModuleOrObjectSymbol => flattenClassLike(sym)
+    def flattenClassLike(sym: ClassSymbol | ModuleOrObjectSymbol): FlatPattern =
+      FlatPattern.ClassLike(
+        Compiler.reference(sym, N).getOrElse(Term.Error()), sym, N, false)(Tree.Dummy)
+    (left.matchableHeads, right.matchableHeads) match
+      case (S(leftHeads), S(rightHeads)) => leftHeads.exists: leftHead =>
+        rightHeads.exists: rightHead =>
+          !ucs.Normalization.areProvablyDisjoint(flatten(leftHead), flatten(rightHead))
+      case _ => true
+
+  /** Whether the single post-pattern test the machine performs — against the
+    * final normal form — accounts for the whole naive search, and if it does
+    * not, the reason to report.
+    *
+    * The naive translation of `P as S | a` tries `a` against *every*
+    * intermediate result, latest first: it returns `a(x_k)` for the largest
+    * `k` such that `a` matches, where `x_0` is the scrutinee, `x_{i+1}` is the
+    * result of one `P` step on `x_i`, and `x_n` is the normal form. The
+    * machine, on the other hand, only ever produces `x_n`. Two things can
+    * therefore go missing, and both are checked here.
+    *
+    *  1. The strict intermediates `x_k` (`k < n`). Each of them is in the
+    *     domain of `P` — that is precisely why a further step was taken from
+    *     it — so it is enough that `P` and `a` cannot match the same value.
+    *     That is the common case: a step peels a wrapper that `a` rejects.
+    *
+    *  2. With several recursive alternatives, `P1 as S | ... | Pm as S | a`,
+    *     the naive search is a *tree* rather than a chain: `Chain` hands the
+    *     enclosing alternative to both of its halves, so when the whole
+    *     subtree under `P1` fails, `P2` is retried on the very same term, and
+    *     the leaves it leads to are candidates for `a` too. The machine
+    *     follows the leftmost path only, so we additionally require the steps
+    *     to be mutually exclusive, which collapses the tree back into that
+    *     path.
+    *
+    * When either check fails we give up rather than compile a machine and
+    * retry a failed run naively: that retry would perform every rewriting
+    * step a second time, which is not merely wasteful but observable, since
+    * transformations may have side effects. */
+  private def unmatchedIntermediates(step: Pat, post: Pat)(using Context): Opt[Message] =
+    // `recognizeShape` merges the steps into one disjunction, so we recover
+    // them from it. This is conservative in one direction: a *single* step
+    // written as a disjunction, `(P1 | P2) as S | a`, is checked too, even
+    // though it commits to its first applicable alternative and so stays a
+    // chain. Distinguishing the two would mean threading the step list down
+    // from `recognizeShape`; over-rejecting only costs the machine.
+    val steps = step match
+      case Or(alternatives) if alternatives.nonEmpty => alternatives
+      case step => step :: Nil
+    if steps.tails.exists:
+      case first :: rest => rest.exists(mayOverlap(first, _))
+      case Nil => false
+    then S(msg"Its recursive alternatives can rewrite the same term in more than one way, and the machine takes only the first.")
+    else if mayOverlap(step, post) then
+      S(msg"Its trailing alternatives can match a term that its step pattern can still rewrite, and the machine only ever produces normal forms.")
+    else N
+
+  private def warnUnmatchedIntermediates(reason: Message, loc: Opt[Loc]): Unit =
+    warn(msg"This fixed-point pattern is not supported by the machine compilation." -> loc,
+      reason -> N, msg"Falling back to the naive translation." -> N)
+
   private def compileMachine(stepPattern: SP, middles: Ls[SP], catchAll: Bool, requireProgress: Bool): Opt[Machine] =
     val (instantiated, context) = instantiateGroups((stepPattern :: middles) :: Nil)
     val entry = instantiated.head.head
@@ -367,23 +453,31 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
           val body = inst.body
           if mentions(body, inst) then S((inst, body)) else chase(body, visited + inst)
         case _ => N
-    chase(entry, Set.empty) match
-      case N =>
-        // The step pattern is not built from a recursive context. The fixed
-        // point degenerates to a flat contraction loop: keep applying the
-        // step pattern to its own output until it fails.
-        log(s"No recursive context; compiling a flat contraction loop.")
-        S(assemble(entry, Nil, post, requireProgress))
-      case S((ctxInst, body)) =>
-        log(s"Recursive context: ${ctxInst.showDbg}")
-        val alternatives = body match
-          case Or(alternatives) => alternatives
-          case pattern => pattern :: Nil
-        classify(ctxInst, alternatives).map: (redexAlternatives, classes) =>
-          val redexPattern = redexAlternatives match
-            case single :: Nil => single
-            case multiple => Or(multiple)
-          assemble(redexPattern, classes, post, requireProgress)
+    // A total post pattern — which the definition's trailing wildcard, when
+    // present, guarantees — always accepts the machine's own normal form, so
+    // no intermediate is ever consulted.
+    val missing = post.filterNot(_.isTotal).flatMap(unmatchedIntermediates(entry, _))
+    missing match
+      case S(reason) =>
+        warnUnmatchedIntermediates(reason, Loc(middles) orElse stepPattern.toLoc)
+        N
+      case N => chase(entry, Set.empty) match
+        case N =>
+          // The step pattern is not built from a recursive context. The fixed
+          // point degenerates to a flat contraction loop: keep applying the
+          // step pattern to its own output until it fails.
+          log(s"No recursive context; compiling a flat contraction loop.")
+          S(assemble(entry, Nil, post, requireProgress))
+        case S((ctxInst, body)) =>
+          log(s"Recursive context: ${ctxInst.showDbg}")
+          val alternatives = body match
+            case Or(alternatives) => alternatives
+            case pattern => pattern :: Nil
+          classify(ctxInst, alternatives).map: (redexAlternatives, classes) =>
+            val redexPattern = redexAlternatives match
+              case single :: Nil => single
+              case multiple => Or(multiple)
+            assemble(redexPattern, classes, post, requireProgress)
 
   /** Split the context's alternatives into the leading redex alternatives and
     * the trailing descent alternatives, validating the restrictions of the
@@ -477,7 +571,32 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     val compiled = instantiated.zip(links).map: (patterns, link) =>
       (patterns.head, postPattern(patterns.tail, link._4))
     given Context = context
-    S(assembleAlternating(compiled))
+    // The naive translation of a cycle tries link `i`'s alternatives against
+    // every intermediate reached after `i` steps, latest first; the machine
+    // only ever reaches the last one and consults the link whose step failed.
+    // The two agree either because the machine cannot fail — every link's
+    // alternatives are total — or, as in `compileMachine`, because no link's
+    // alternatives can match a term that link's own step can still rewrite.
+    // A mixture of the two is not enough: a partial link can fail on the final
+    // term while a total link would have accepted an earlier intermediate,
+    // which is why a total link is reported here rather than skipped.
+    def isTotal(post: Opt[Pat]): Bool = post.forall(_.isTotal)
+    if compiled.forall((_, post) => isTotal(post)) then S(assembleAlternating(compiled))
+    else
+      val offending = compiled.iterator.zip(links).collectFirst:
+        Function.unlift: (compiledLink, link) =>
+          val (step, post) = compiledLink
+          val (symbol, _, middles, _) = link
+          val reason =
+            if isTotal(post) then
+              S(msg"One of its links accepts any term, while another can fail on the final one.")
+            else post.flatMap(unmatchedIntermediates(step, _))
+          // A total link has no alternatives of its own to point at, so fall
+          // back to the whole body of the definition that link comes from.
+          reason.map((_, Loc(middles) orElse symbol.defn.flatMap(_.pattern.toLoc)))
+      offending match
+        case S((reason, loc)) => warnUnmatchedIntermediates(reason, loc); N
+        case N => S(assembleAlternating(compiled))
 
   /** Assemble the flat alternation loop for an indirect recursion cycle: in
     * phase `i`, step `i` is applied to the current term; on success the
@@ -485,9 +604,9 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     * the failing phase and exits. The failing link's alternatives then process
     * the current term — which is the original scrutinee when the very first
     * step fails, so zero steps are allowed, exactly as for the direct shape.
-    * When those alternatives don't match either, the run fails and the caller
-    * retries it with the naive translation, which performs the deepest-first
-    * backtracking through the intermediate terms. */
+    * When those alternatives don't match either, the run fails and so does the
+    * match: `compileAlternatingMachine` only assembles a machine for cycles
+    * whose earlier intermediates could not have matched anyway. */
   private def assembleAlternating(links: Ls[(Pat, Opt[Pat])])(using Context): Machine =
     // Like in `assemble`, every matcher gets its own compiler instance
     // because the matcher memoization is instance-bound.

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
@@ -36,6 +36,14 @@ object FixedPointCompiler:
     * wildcard. */
   private type Link = (PatternSymbol, Ls[Ls[SP]], Ls[SP], Bool)
 
+  /** What `compile` makes of a pattern: `N` when it is not fixed-point shaped
+    * at all, so the regular compilation should take over; `L` with the reason
+    * when the shape is recognized but rejected before any machine is built,
+    * which `unsupported` reports at the pattern that asked for it; `R(N)` when
+    * a build was attempted and gave up, having reported its own diagnostic
+    * with its own locations; and `R(S(_))` when it succeeded. */
+  private type Attempt[A] = Opt[Message \/ Opt[A]]
+
   /** Why a fixed-point definition cannot be machine-compiled, as the bits to
     * append to the warning. A rejection always names two patterns that are
     * not adjacent in the source, and a `Loc` is a single contiguous range, so
@@ -175,29 +183,27 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
               patternSymbol.fixedPointMachine match
                 case S(machine) => S(Outcome.Compiled(machine, outputPattern))
                 case N =>
-                  val shape = recognizeShape(stripAnnotations(defn.pattern))
-                  val recognized = shape.filter(_._1 is patternSymbol).flatMap:
-                    (_, steps, rest, requireProgress) =>
-                      classifyRest(rest).map((middles, catchAll) =>
-                        (steps, middles, catchAll, requireProgress))
-                  // The definition may instead be a link of an indirect
+                  // A self-recursive body is the definition's own fixed point;
+                  // otherwise the definition may be a link of an indirect
                   // recursion cycle.
-                  val cycle = if recognized.isDefined then N else recognizeCycle(patternSymbol)
-                  val machine = recognized match
-                    case S((steps, middles, catchAll, requireProgress)) =>
-                      scoped("ucs:fixpoint")(compileMachine(
-                        steps, middles, catchAll, requireProgress, pattern.toLoc))
-                    case N => cycle.flatMap: links =>
-                      scoped("ucs:fixpoint")(compileAlternatingMachine(links, pattern.toLoc))
+                  val machine: Attempt[Machine] =
+                    recognizeShape(stripAnnotations(defn.pattern)).map:
+                      (tailSymbol, steps, rest, requireProgress) =>
+                        if tailSymbol is patternSymbol then
+                          classifyRest(rest).map: (middles, catchAll) =>
+                            scoped("ucs:fixpoint")(compileMachine(
+                              steps, middles, catchAll, requireProgress, pattern.toLoc))
+                        else recognizeCycle(patternSymbol).map: links =>
+                          scoped("ucs:fixpoint")(compileAlternatingMachine(links, pattern.toLoc))
                   machine match
-                    case S(machine) =>
+                    case S(R(S(machine))) =>
                       patternSymbol.fixedPointMachine = S(machine)
                       S(Outcome.Compiled(machine, outputPattern))
-                    // Whenever a machine build was *attempted* and gave up, the
-                    // rejecting check has already reported a specific
-                    // diagnostic, so `unsupported` must not warn again.
-                    case N => unsupported(recognized.isDefined || cycle.isDefined,
-                      shape.isDefined, pattern.toLoc)
+                    // A machine build that was *attempted* and gave up has
+                    // already reported a specific diagnostic of its own.
+                    case S(R(N)) => S(Outcome.Unsupported)
+                    case S(L(reason)) => unsupported(reason, pattern.toLoc)
+                    case N => N
           case _ => N
     case body: (SP.Chain | SP.Composition) =>
       // The body-annotated form. The body must belong to the very definition
@@ -209,49 +215,43 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
         patternSymbol.defn.exists(defn =>
           (stripAnnotations(defn.pattern) eq body) &&
             defn.patternParams.isEmpty && defn.extractionParams.isEmpty)
-      recognizeShape(body) match
-        case S((patternSymbol, steps, rest, requireProgress)) if isOwnBody(patternSymbol) =>
-          val recognized = classifyRest(rest)
-          val machine = recognized.flatMap: (middles, catchAll) =>
+      val machine: Attempt[(PatternSymbol, Machine)] = recognizeShape(body).map:
+        case (patternSymbol, steps, rest, requireProgress) if isOwnBody(patternSymbol) =>
+          classifyRest(rest).map: (middles, catchAll) =>
             scoped("ucs:fixpoint")(compileMachine(
               steps, middles, catchAll, requireProgress, body.toLoc))
-          machine match
-            case S(machine) =>
-              patternSymbol.fixedPointMachine = S(machine)
-              S(Outcome.Compiled(machine, N))
-            case N => unsupported(recognized.isDefined, true, body.toLoc)
-        case S((tailSymbol, _, _, _)) =>
+              .map((patternSymbol, _))
+        case (tailSymbol, _, _, _) =>
           // The body may be a link of an indirect recursion cycle; its tail
           // then refers to the next link rather than the definition itself.
           // Locate the definition the body belongs to in the cycle and
           // rotate its link to the front.
-          val rotated = recognizeCycle(tailSymbol).flatMap: links =>
+          recognizeCycle(tailSymbol).flatMap: links =>
             links.indexWhere((symbol, _, _, _) =>
               symbol.defn.exists(defn => stripAnnotations(defn.pattern) eq body)) match
-              case -1 => N
-              case index => S(links.drop(index) ::: links.take(index))
-          val machine = rotated.flatMap: links =>
-            scoped("ucs:fixpoint")(compileAlternatingMachine(links, body.toLoc))
-              .map((links.head._1, _))
-          machine match
-            case S((owner, machine)) =>
-              owner.fixedPointMachine = S(machine)
-              S(Outcome.Compiled(machine, N))
-            case N => unsupported(rotated.isDefined, true, body.toLoc)
+              case -1 => L(
+                msg"This is not the body of any link of the recursion cycle through `${tailSymbol.nme}`.")
+              case index =>
+                val rotated = links.drop(index) ::: links.take(index)
+                R(scoped("ucs:fixpoint")(compileAlternatingMachine(rotated, body.toLoc))
+                  .map((rotated.head._1, _)))
+      machine match
+        case S(R(S((owner, machine)))) =>
+          owner.fixedPointMachine = S(machine)
+          S(Outcome.Compiled(machine, N))
+        case S(R(N)) => S(Outcome.Unsupported)
+        case S(L(reason)) => unsupported(reason, body.toLoc)
         case N => N
     case _ => N
 
-  /** Handle a pattern the machine compilation rejected: when it is
-    * fixed-point shaped, report a warning (unless the rejection point already
-    * did) and route the caller to the naive translation, which handles all
-    * such shapes; otherwise leave it to the regular efficient compilation. */
-  private def unsupported(alreadyWarned: Bool, shaped: Bool, loc: Opt[Loc]): Opt[Outcome] =
-    if alreadyWarned then S(Outcome.Unsupported)
-    else if shaped then
-      warn(msg"This fixed-point pattern is not supported by pattern compilation." -> loc,
-        msg"Falling back to the naive translation." -> N)
-      S(Outcome.Unsupported)
-    else N
+  /** Report a fixed-point-shaped pattern the machine compilation rejected
+    * before it got as far as building anything, and route the caller to the
+    * naive translation, which handles all such shapes. Rejections found during
+    * the build report themselves, with their own locations. */
+  private def unsupported(reason: Message, loc: Opt[Loc]): Opt[Outcome] =
+    warn(msg"This fixed-point pattern is not supported by pattern compilation." -> loc,
+      reason -> N, msg"Falling back to the naive translation." -> N)
+    S(Outcome.Unsupported)
 
   /** Remove `Annotated` wrappers (such as the `@compile` marking itself). */
   @tailrec private def stripAnnotations(pattern: SP): SP = pattern match
@@ -266,16 +266,21 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     case stripped => stripped :: Nil
 
   /** Classify the alternatives following the recursive ones into the middle
-    * alternatives and the optional trailing wildcard. */
-  private def classifyRest(rest: Ls[SP]): Opt[(Ls[SP], Bool)] =
-    if rest.isEmpty then N
+    * alternatives and the optional trailing wildcard, or say why they cannot
+    * be. */
+  private def classifyRest(rest: Ls[SP]): Message \/ (Ls[SP], Bool) =
+    if rest.isEmpty then
+      L(msg"It has no alternative besides its recursive ones, so it never matches.")
     else
       val catchAll = rest.last.isInstanceOf[SP.Wildcard]
       val middles = if catchAll then rest.init else rest
       // Reject non-trailing wildcards (they make later alternatives
       // unreachable) and chains (recursive alternatives must be leading).
-      if middles.exists(p => p.isInstanceOf[SP.Wildcard] || p.isInstanceOf[SP.Chain]) then N
-      else S((middles, catchAll))
+      if middles.exists(_.isInstanceOf[SP.Wildcard]) then
+        L(msg"A wildcard alternative makes the alternatives after it unreachable.")
+      else if middles.exists(_.isInstanceOf[SP.Chain]) then
+        L(msg"Its recursive alternatives must come before its other alternatives.")
+      else R((middles, catchAll))
 
   /** Recognize a fixed-point shape, discovering the pattern symbol `S` the
     * recursive alternatives refer to (the definition itself, or the next link
@@ -336,24 +341,30 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     * outright when their step does not apply, whereas `assembleAlternating`
     * has no notion of required progress and would let the failing link's
     * alternatives process the term regardless. */
-  private def recognizeCycle(start: PatternSymbol): Opt[Ls[Link]] =
-    @tailrec def walk(current: PatternSymbol, acc: Ls[Link]): Opt[Ls[Link]] =
+  private def recognizeCycle(start: PatternSymbol): Message \/ Ls[Link] =
+    @tailrec def walk(current: PatternSymbol, acc: Ls[Link]): Message \/ Ls[Link] =
       val linkOpt = current.defn match
         case S(defn) if defn.patternParams.isEmpty && defn.extractionParams.isEmpty =>
           recognizeShape(stripAnnotations(defn.pattern)) match
-            case S((next, steps, rest, requireProgress)) if !requireProgress =>
-              classifyRest(rest).map: (middles, catchAll) =>
+            case S((next, steps, rest, requireProgress)) =>
+              if requireProgress then L(
+                msg"`${current.nme}` requires its step to fire, which is not supported for indirect recursion.")
+              else classifyRest(rest).map: (middles, catchAll) =>
                 (next, (current, steps, middles, catchAll))
-            case _ => N
-        case _ => N
+            case N => L(msg"`${current.nme}` is not fixed-point shaped, so the recursion does not come back.")
+        case _ => L(msg"`${current.nme}` is not a parameterless pattern definition.")
       linkOpt match
-        case S((next, link)) =>
-          if next is start then S((link :: acc).reverse)
-          else if (next is current) || acc.exists(_._1 is next) then N
+        case R((next, link)) =>
+          if next is start then R((link :: acc).reverse)
+          else if (next is current) || acc.exists(_._1 is next) then
+            L(msg"The recursion through `${current.nme}` does not come back to `${start.nme}`.")
           else walk(next, link :: acc)
-        case N => N
-    // Cycles of length one are the direct shape, handled in `compile`.
-    walk(start, Nil).filter(_.sizeIs > 1)
+        case L(reason) => L(reason)
+    walk(start, Nil) match
+      // Cycles of length one are the direct shape, handled in `compile`.
+      case R(_ :: Nil) => L(
+        msg"`${start.nme}` recurses directly rather than through a cycle, so only its whole body can be compiled.")
+      case recognized => recognized
 
   /** Does `pattern` mention the given instantiation anywhere? Used to locate
     * the recursive occurrences of the context pattern (the "holes"). */

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
@@ -446,11 +446,10 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     // constructor term of a `FlatPattern.ClassLike` is never inspected by it.
     def flatten(head: Head): FlatPattern = head match
       case lit: syntax.Literal => FlatPattern.Lit(lit)
-      case sym: ClassSymbol => flattenClassLike(sym)
-      case sym: ModuleOrObjectSymbol => flattenClassLike(sym)
-    def flattenClassLike(sym: ClassSymbol | ModuleOrObjectSymbol): FlatPattern =
+      case head: ClassLikeHead => flattenClassLike(head)
+    def flattenClassLike(head: ClassLikeHead): FlatPattern =
       FlatPattern.ClassLike(
-        Compiler.reference(sym, N).getOrElse(Term.Error()), sym, N, false)(Tree.Dummy)
+        Compiler.preservedReference(head.constructor), head.symbol, N, false)(Tree.Dummy)
     (left.matchableHeads, right.matchableHeads) match
       case (S(leftHeads), S(rightHeads)) => leftHeads.exists: leftHead =>
         rightHeads.exists: rightHead =>

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
@@ -348,11 +348,11 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
         case S(defn) if defn.patternParams.isEmpty && defn.extractionParams.isEmpty =>
           recognizeShape(stripAnnotations(defn.pattern)) match
             case S((next, steps, rest, requireProgress)) =>
-              if requireProgress then L(
-                msg"`${current.nme}` cannot match without applying its recursive part at least " +
-                  msg"once, which is not supported when definitions recurse through one another.")
-              else classifyRest(rest).map: (middles, catchAll) =>
-                (next, (current, steps, middles, catchAll))
+              classifyRest(rest).flatMap: (middles, catchAll) =>
+                if requireProgress then L(
+                  msg"`${current.nme}` does not match unless its first pattern does, " +
+                    msg"which is not supported for mutually recursive definitions.")
+                else R((next, (current, steps, middles, catchAll)))
             case N => L(
               msg"`${current.nme}` does not recurse back, so this pattern applies once rather than repeatedly.")
         case _ => L(

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
@@ -233,7 +233,7 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
   private def unsupported(alreadyWarned: Bool, shaped: Bool, loc: Opt[Loc]): Opt[Outcome] =
     if alreadyWarned then S(Outcome.Unsupported)
     else if shaped then
-      warn(msg"This fixed-point pattern is not supported by the machine compilation." -> loc,
+      warn(msg"This fixed-point pattern is not supported by pattern compilation." -> loc,
         msg"Falling back to the naive translation." -> N)
       S(Outcome.Unsupported)
     else N
@@ -431,15 +431,15 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     if steps.tails.exists:
       case first :: rest => rest.exists(mayOverlap(first, _))
       case Nil => false
-    then S(msg"Its recursive alternatives can rewrite the same term in more than one way, and the machine takes only the first.")
+    then S(msg"Its recursive alternatives can rewrite the same term in more than one way.")
     else if mayOverlap(step, post) then
-      S(msg"Its trailing alternatives can match a term that its step pattern can still rewrite, and the machine only ever produces normal forms.")
+      S(msg"Its trailing alternatives can match a term that its recursive part can still rewrite.")
     else N
-
+  
   private def warnUnmatchedIntermediates(reason: Message, loc: Opt[Loc]): Unit =
-    warn(msg"This fixed-point pattern is not supported by the machine compilation." -> loc,
+    warn(msg"This fixed-point pattern is not supported by pattern compilation." -> loc,
       reason -> N, msg"Falling back to the naive translation." -> N)
-
+  
   private def compileMachine(stepPattern: SP, middles: Ls[SP], catchAll: Bool, requireProgress: Bool): Opt[Machine] =
     val (instantiated, context) = instantiateGroups((stepPattern :: middles) :: Nil)
     val entry = instantiated.head.head
@@ -589,7 +589,7 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
           val (symbol, _, middles, _) = link
           val reason =
             if isTotal(post) then
-              S(msg"One of its links accepts any term, while another can fail on the final one.")
+              S(msg"One of its recursive parts accepts any term, while another can fail on the final one.")
             else post.flatMap(unmatchedIntermediates(step, _))
           // A total link has no alternatives of its own to point at, so fall
           // back to the whole body of the definition that link comes from.
@@ -597,7 +597,7 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
       offending match
         case S((reason, loc)) => warnUnmatchedIntermediates(reason, loc); N
         case N => S(assembleAlternating(compiled))
-
+  
   /** Assemble the flat alternation loop for an indirect recursion cycle: in
     * phase `i`, step `i` is applied to the current term; on success the
     * machine moves to the next phase in the cycle, and on failure it records

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
@@ -31,6 +31,18 @@ object FixedPointCompiler:
     * exits when no branch of the split matches), then return `result`. */
   final case class Machine(params: ParamList, prelude: Ls[Statement], loop: Split, result: Term)
 
+  /** One link of an indirect recursion cycle: the definition it comes from,
+    * its steps, its trailing alternatives, and whether they end in a
+    * wildcard. */
+  private type Link = (PatternSymbol, Ls[SP], Ls[SP], Bool)
+
+  /** Why a fixed-point definition cannot be machine-compiled, as the bits to
+    * append to the warning. A rejection always names two patterns that are
+    * not adjacent in the source, and a `Loc` is a single contiguous range, so
+    * each gets a bit of its own rather than one message over a location
+    * spanning everything in between. */
+  private type Rejection = Ls[(Message, Opt[Loc])]
+
   /** The outcome of `compile` on a fixed-point-shaped pattern. */
   enum Outcome:
     /** The compiled machine, paired with the output sub-pattern of the
@@ -165,15 +177,16 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
                 case N =>
                   val shape = recognizeShape(stripAnnotations(defn.pattern))
                   val recognized = shape.filter(_._1 is patternSymbol).flatMap:
-                    (_, stepPattern, rest, requireProgress) =>
+                    (_, steps, rest, requireProgress) =>
                       classifyRest(rest).map((middles, catchAll) =>
-                        (stepPattern, middles, catchAll, requireProgress))
+                        (steps, middles, catchAll, requireProgress))
                   // The definition may instead be a link of an indirect
                   // recursion cycle.
                   val cycle = if recognized.isDefined then N else recognizeCycle(patternSymbol)
                   val machine = recognized match
-                    case S((stepPattern, middles, catchAll, requireProgress)) =>
-                      scoped("ucs:fixpoint")(compileMachine(stepPattern, middles, catchAll, requireProgress))
+                    case S((steps, middles, catchAll, requireProgress)) =>
+                      scoped("ucs:fixpoint")(compileMachine(
+                        steps, middles, catchAll, requireProgress, defn.pattern.toLoc))
                     case N => cycle.flatMap: links =>
                       scoped("ucs:fixpoint")(compileAlternatingMachine(links))
                   machine match
@@ -197,10 +210,11 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
           (stripAnnotations(defn.pattern) eq body) &&
             defn.patternParams.isEmpty && defn.extractionParams.isEmpty)
       recognizeShape(body) match
-        case S((patternSymbol, stepPattern, rest, requireProgress)) if isOwnBody(patternSymbol) =>
+        case S((patternSymbol, steps, rest, requireProgress)) if isOwnBody(patternSymbol) =>
           val recognized = classifyRest(rest)
           val machine = recognized.flatMap: (middles, catchAll) =>
-            scoped("ucs:fixpoint")(compileMachine(stepPattern, middles, catchAll, requireProgress))
+            scoped("ucs:fixpoint")(compileMachine(
+              steps, middles, catchAll, requireProgress, body.toLoc))
           machine match
             case S(machine) =>
               patternSymbol.fixedPointMachine = S(machine)
@@ -279,14 +293,21 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     *     first `P` step, so a run with zero steps is a match failure. The
     *     parentheses around `S | rest` are what distinguish it.
     *
-    * Return the symbol, the step pattern (the disjunction of the steps), the
-    * trailing alternatives (to be validated with `classifyRest`), and whether
-    * at least one step is required. */
-  private def recognizeShape(pattern: SP): Opt[(PatternSymbol, SP, Ls[SP], Bool)] =
+    * Return the symbol, the steps, the trailing alternatives (to be validated
+    * with `classifyRest`), and whether at least one step is required.
+    *
+    * The steps are returned one by one rather than merged into a disjunction
+    * because instantiation maps `|` to the flattening `or` combinator, after
+    * which nothing tells which source pattern an alternative came from — and
+    * the rejection checks in `unmatchedIntermediates` need to point at it.
+    * For the same reason a step that is itself written as a disjunction is
+    * split into its alternatives, which also keeps those checks as
+    * conservative as they were when they worked on the merged pattern. */
+  private def recognizeShape(pattern: SP): Opt[(PatternSymbol, Ls[SP], Ls[SP], Bool)] =
     pattern match
       case SP.Chain(stepPattern, tail) => disjuncts(tail) match
         case SP.Constructor(target, N) :: rest =>
-          target.resolvedSym.flatMap(_.asPat).map((_, stepPattern, rest, true))
+          target.resolvedSym.flatMap(_.asPat).map((_, disjuncts(stepPattern), rest, true))
         case _ => N
       case composition: SP.Composition => disjuncts(composition) match
         case SP.Chain(_, SP.Constructor(target, N)) :: _ =>
@@ -297,7 +318,7 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
               case SP.Chain(_, SP.Constructor(target, N)) => isSelf(target)
               case _ => false
             val steps = selfChains.collect { case SP.Chain(step, _) => step }
-            (symbol, steps.reduceLeft(SP.Composition(true, _, _)), rest, false)
+            (symbol, steps.flatMap(disjuncts), rest, false)
         case _ => N
       case _ => N
 
@@ -314,18 +335,14 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     * outright when their step does not apply, whereas `assembleAlternating`
     * has no notion of required progress and would let the failing link's
     * alternatives process the term regardless. */
-  private def recognizeCycle(start: PatternSymbol)
-      : Opt[Ls[(PatternSymbol, SP, Ls[SP], Bool)]] =
-    @tailrec def walk(
-        current: PatternSymbol,
-        acc: Ls[(PatternSymbol, SP, Ls[SP], Bool)]
-    ): Opt[Ls[(PatternSymbol, SP, Ls[SP], Bool)]] =
+  private def recognizeCycle(start: PatternSymbol): Opt[Ls[Link]] =
+    @tailrec def walk(current: PatternSymbol, acc: Ls[Link]): Opt[Ls[Link]] =
       val linkOpt = current.defn match
         case S(defn) if defn.patternParams.isEmpty && defn.extractionParams.isEmpty =>
           recognizeShape(stripAnnotations(defn.pattern)) match
-            case S((next, stepPattern, rest, requireProgress)) if !requireProgress =>
+            case S((next, steps, rest, requireProgress)) if !requireProgress =>
               classifyRest(rest).map: (middles, catchAll) =>
-                (next, (current, stepPattern, middles, catchAll))
+                (next, (current, steps, middles, catchAll))
             case _ => N
         case _ => N
       linkOpt match
@@ -370,6 +387,29 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
       if middles.isEmpty then N else S(Or(middles :+ Wildcard))
     else S(Or(middles))
 
+  /** A fixed-point definition's two halves — its steps, of which there is
+    * always at least one, and its trailing alternatives — with every source
+    * pattern paired with its instantiation. The rejection checks work on the
+    * instantiated patterns, while their diagnostics point at the source ones:
+    * instantiated patterns are rebuilt nodes, most of which carry no location,
+    * and a synonym's is its definition rather than its use. */
+  private case class Halves(steps: Ls[(SP, Pat)], alternatives: Ls[(SP, Pat)], catchAll: Bool):
+    /** The pattern the machine takes its rewriting steps with. */
+    val entry: Pat = steps.iterator.map(_._2).reduceLeft(_ or _)
+    /** The pattern processing the final normal form. */
+    val post: Opt[Pat] = postPattern(alternatives.map(_._2), catchAll)
+
+  /** Instantiate the halves of each definition, sharing one `Instantiator`
+    * across them all as `instantiateGroups` does. */
+  private def instantiateHalves(groups: Ls[(Ls[SP], Ls[SP], Bool)]): (Ls[Halves], Context) =
+    val (instantiated, context) =
+      instantiateGroups(groups.map((steps, middles, _) => steps ::: middles))
+    val halves = instantiated.zip(groups).map: (patterns, group) =>
+      val (steps, middles, catchAll) = group
+      val (stepPatterns, middlePatterns) = patterns.splitAt(steps.size)
+      Halves(steps.zip(stepPatterns), middles.zip(middlePatterns), catchAll)
+    (halves, context)
+
   /** Can a single value match both patterns? Conservatively `true` whenever
     * disjointness cannot be proved, reusing the same subtyping knowledge the
     * UCS normalizer applies to branch elimination. */
@@ -391,7 +431,7 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
 
   /** Whether the single post-pattern test the machine performs — against the
     * final normal form — accounts for the whole naive search, and if it does
-    * not, the reason to report.
+    * not, the rejection to report.
     *
     * The naive translation of `P as S | a` tries `a` against *every*
     * intermediate result, latest first: it returns `a(x_k)` for the largest
@@ -418,32 +458,47 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     * retry a failed run naively: that retry would perform every rewriting
     * step a second time, which is not merely wasteful but observable, since
     * transformations may have side effects. */
-  private def unmatchedIntermediates(step: Pat, post: Pat)(using Context): Opt[Message] =
-    // `recognizeShape` merges the steps into one disjunction, so we recover
-    // them from it. This is conservative in one direction: a *single* step
-    // written as a disjunction, `(P1 | P2) as S | a`, is checked too, even
-    // though it commits to its first applicable alternative and so stays a
-    // chain. Distinguishing the two would mean threading the step list down
-    // from `recognizeShape`; over-rejecting only costs the machine.
-    val steps = step match
-      case Or(alternatives) if alternatives.nonEmpty => alternatives
-      case step => step :: Nil
-    if steps.tails.exists:
-      case first :: rest => rest.exists(mayOverlap(first, _))
-      case Nil => false
-    then S(msg"Its recursive alternatives can rewrite the same term in more than one way.")
-    else if mayOverlap(step, post) then
-      S(msg"Its trailing alternatives can match a term that its recursive part can still rewrite.")
-    else N
+  private def unmatchedIntermediates(halves: Halves)(using Context): Opt[Rejection] =
+    // The check on the steps is conservative in one direction: a *single*
+    // step written as a disjunction, `(P1 | P2) as S | a`, arrives here split
+    // into two, even though it commits to its first applicable alternative and
+    // so stays a chain. Telling the two apart would mean having `recognizeShape`
+    // mark which alternatives belong to one step; over-rejecting only costs
+    // the machine.
+    val overlappingSteps = halves.steps.tails.flatMap:
+      case first :: rest => rest.iterator.map((first, _))
+      case Nil => Iterator.empty
+    .find((one, other) => mayOverlap(one._2, other._2))
+    overlappingSteps match
+      case S(((step, _), (other, _))) => S(
+        msg"Its recursive alternatives can rewrite the same term in more than one way: this step" -> step.toLoc ::
+        msg"and this one." -> other.toLoc :: Nil)
+      case N =>
+        // Two disjunctions overlap exactly when two of their alternatives do,
+        // so pairing them up loses no precision and lets the diagnostic name
+        // the two patterns actually in conflict.
+        val overlapping = for
+          (step, stepPattern) <- halves.steps.iterator
+          (alternative, alternativePattern) <- halves.alternatives.iterator
+          if mayOverlap(stepPattern, alternativePattern)
+        yield (step, alternative)
+        overlapping.nextOption().map: (step, alternative) =>
+          msg"A term this step can still rewrite" -> step.toLoc ::
+          msg"can already be matched by this trailing alternative." -> alternative.toLoc :: Nil
+
+  /** Report a rejection: the head bit states the failure and points at the
+    * pattern declaration, and the rejection's own bits point at the individual
+    * patterns at fault. */
+  private def warnUnmatchedIntermediates(rejection: Rejection, declaration: Opt[Loc]): Unit =
+    warn(msg"This fixed-point pattern is not supported by pattern compilation." -> declaration ::
+      rejection ::: (msg"Falling back to the naive translation." -> N) :: Nil*)
   
-  private def warnUnmatchedIntermediates(reason: Message, loc: Opt[Loc]): Unit =
-    warn(msg"This fixed-point pattern is not supported by pattern compilation." -> loc,
-      reason -> N, msg"Falling back to the naive translation." -> N)
-  
-  private def compileMachine(stepPattern: SP, middles: Ls[SP], catchAll: Bool, requireProgress: Bool): Opt[Machine] =
-    val (instantiated, context) = instantiateGroups((stepPattern :: middles) :: Nil)
-    val entry = instantiated.head.head
-    val post = postPattern(instantiated.head.tail, catchAll)
+  private def compileMachine(steps: Ls[SP], middles: Ls[SP], catchAll: Bool,
+      requireProgress: Bool, declaration: Opt[Loc]): Opt[Machine] =
+    val (halves, context) = instantiateHalves((steps, middles, catchAll) :: Nil)
+    val definition = halves.head
+    val entry = definition.entry
+    val post = definition.post
     given Context = context
     // Walk through synonym definitions until we find a self-recursive one:
     // that instantiation is the evaluation context.
@@ -456,10 +511,10 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     // A total post pattern — which the definition's trailing wildcard, when
     // present, guarantees — always accepts the machine's own normal form, so
     // no intermediate is ever consulted.
-    val missing = post.filterNot(_.isTotal).flatMap(unmatchedIntermediates(entry, _))
+    val missing = if post.forall(_.isTotal) then N else unmatchedIntermediates(definition)
     missing match
-      case S(reason) =>
-        warnUnmatchedIntermediates(reason, Loc(middles) orElse stepPattern.toLoc)
+      case S(rejection) =>
+        warnUnmatchedIntermediates(rejection, declaration)
         N
       case N => chase(entry, Set.empty) match
         case N =>
@@ -563,13 +618,13 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
       Split.LetSplit(symbol, make(() => Split.UseSplit(symbol)))
     else make(() => rest)
 
-  /** Compile an indirect recursion cycle. Each link contributes its step
-    * pattern and its trailing alternatives, turned into a post pattern as in
+  /** Compile an indirect recursion cycle. Each link contributes its steps and
+    * its trailing alternatives, turned into a post pattern as in
     * `compileMachine`. */
-  private def compileAlternatingMachine(links: Ls[(PatternSymbol, SP, Ls[SP], Bool)]): Opt[Machine] =
-    val (instantiated, context) = instantiateGroups(links.map((_, step, middles, _) => step :: middles))
-    val compiled = instantiated.zip(links).map: (patterns, link) =>
-      (patterns.head, postPattern(patterns.tail, link._4))
+  private def compileAlternatingMachine(links: Ls[Link]): Opt[Machine] =
+    val (halves, context) =
+      instantiateHalves(links.map((_, steps, middles, catchAll) => (steps, middles, catchAll)))
+    val compiled = halves.map(link => (link.entry, link.post))
     given Context = context
     // The naive translation of a cycle tries link `i`'s alternatives against
     // every intermediate reached after `i` steps, latest first; the machine
@@ -581,21 +636,27 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     // term while a total link would have accepted an earlier intermediate,
     // which is why a total link is reported here rather than skipped.
     def isTotal(post: Opt[Pat]): Bool = post.forall(_.isTotal)
-    if compiled.forall((_, post) => isTotal(post)) then S(assembleAlternating(compiled))
+    // A total link is at fault as a whole rather than through one of its
+    // patterns — its alternatives are just the wildcard — so the declaration
+    // it comes from is what the diagnostic points at.
+    def declarationOf(symbol: PatternSymbol): Opt[Loc] = symbol.defn.flatMap(_.pattern.toLoc)
+    if halves.forall(link => isTotal(link.post)) then S(assembleAlternating(compiled))
     else
-      val offending = compiled.iterator.zip(links).collectFirst:
-        Function.unlift: (compiledLink, link) =>
-          val (step, post) = compiledLink
-          val (symbol, _, middles, _) = link
-          val reason =
-            if isTotal(post) then
-              S(msg"One of its recursive parts accepts any term, while another can fail on the final one.")
-            else post.flatMap(unmatchedIntermediates(step, _))
-          // A total link has no alternatives of its own to point at, so fall
-          // back to the whole body of the definition that link comes from.
-          reason.map((_, Loc(middles) orElse symbol.defn.flatMap(_.pattern.toLoc)))
+      val zipped = halves.zip(links)
+      val offending = zipped.iterator.collectFirst:
+        Function.unlift: (link, source) =>
+          val (symbol, _, _, _) = source
+          if isTotal(link.post) then
+            // Not every link is total, or we would not be here.
+            zipped.collectFirst:
+              case (other, (otherSymbol, _, _, _)) if !isTotal(other.post) =>
+                msg"One of its recursive parts accepts any term:" -> declarationOf(symbol) ::
+                msg"while this one can fail on the final term." -> declarationOf(otherSymbol) :: Nil
+          else unmatchedIntermediates(link)
       offending match
-        case S((reason, loc)) => warnUnmatchedIntermediates(reason, loc); N
+        case S(rejection) =>
+          warnUnmatchedIntermediates(rejection, declarationOf(links.head._1))
+          N
         case N => S(assembleAlternating(compiled))
   
   /** Assemble the flat alternation loop for an indirect recursion cycle: in

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/FixedPointCompiler.scala
@@ -34,7 +34,7 @@ object FixedPointCompiler:
   /** One link of an indirect recursion cycle: the definition it comes from,
     * its steps, its trailing alternatives, and whether they end in a
     * wildcard. */
-  private type Link = (PatternSymbol, Ls[SP], Ls[SP], Bool)
+  private type Link = (PatternSymbol, Ls[Ls[SP]], Ls[SP], Bool)
 
   /** Why a fixed-point definition cannot be machine-compiled, as the bits to
     * append to the warning. A rejection always names two patterns that are
@@ -296,18 +296,18 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     * Return the symbol, the steps, the trailing alternatives (to be validated
     * with `classifyRest`), and whether at least one step is required.
     *
-    * The steps are returned one by one rather than merged into a disjunction
-    * because instantiation maps `|` to the flattening `or` combinator, after
-    * which nothing tells which source pattern an alternative came from — and
-    * the rejection checks in `unmatchedIntermediates` need to point at it.
-    * For the same reason a step that is itself written as a disjunction is
-    * split into its alternatives, which also keeps those checks as
-    * conservative as they were when they worked on the merged pattern. */
-  private def recognizeShape(pattern: SP): Opt[(PatternSymbol, Ls[SP], Ls[SP], Bool)] =
+    * A step is returned as the list of its own alternatives, and the steps are
+    * kept apart rather than merged into one disjunction: instantiation maps
+    * `|` to the flattening `or` combinator, which loses both the grouping the
+    * rejection checks depend on and the source pattern their diagnostics point
+    * at. The grouping matters because only *distinct* steps branch the naive
+    * search — a step written as a disjunction commits to the first of its
+    * alternatives that applies (see `unmatchedIntermediates`). */
+  private def recognizeShape(pattern: SP): Opt[(PatternSymbol, Ls[Ls[SP]], Ls[SP], Bool)] =
     pattern match
       case SP.Chain(stepPattern, tail) => disjuncts(tail) match
         case SP.Constructor(target, N) :: rest =>
-          target.resolvedSym.flatMap(_.asPat).map((_, disjuncts(stepPattern), rest, true))
+          target.resolvedSym.flatMap(_.asPat).map((_, disjuncts(stepPattern) :: Nil, rest, true))
         case _ => N
       case composition: SP.Composition => disjuncts(composition) match
         case SP.Chain(_, SP.Constructor(target, N)) :: _ =>
@@ -318,7 +318,7 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
               case SP.Chain(_, SP.Constructor(target, N)) => isSelf(target)
               case _ => false
             val steps = selfChains.collect { case SP.Chain(step, _) => step }
-            (symbol, steps.flatMap(disjuncts), rest, false)
+            (symbol, steps.map(disjuncts), rest, false)
         case _ => N
       case _ => N
 
@@ -388,26 +388,37 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     else S(Or(middles))
 
   /** A fixed-point definition's two halves — its steps, of which there is
-    * always at least one, and its trailing alternatives — with every source
-    * pattern paired with its instantiation. The rejection checks work on the
-    * instantiated patterns, while their diagnostics point at the source ones:
-    * instantiated patterns are rebuilt nodes, most of which carry no location,
-    * and a synonym's is its definition rather than its use. */
-  private case class Halves(steps: Ls[(SP, Pat)], alternatives: Ls[(SP, Pat)], catchAll: Bool):
+    * always at least one, each given as its own alternatives, and its trailing
+    * alternatives — with every source pattern paired with its instantiation.
+    * The rejection checks work on the instantiated patterns, while their
+    * diagnostics point at the source ones: instantiated patterns are rebuilt
+    * nodes, most of which carry no location, and a synonym's is its definition
+    * rather than its use. */
+  private case class Halves(steps: Ls[Ls[(SP, Pat)]], alternatives: Ls[(SP, Pat)], catchAll: Bool):
     /** The pattern the machine takes its rewriting steps with. */
-    val entry: Pat = steps.iterator.map(_._2).reduceLeft(_ or _)
+    val entry: Pat = steps.iterator.flatten.map(_._2).reduceLeft(_ or _)
     /** The pattern processing the final normal form. */
     val post: Opt[Pat] = postPattern(alternatives.map(_._2), catchAll)
 
+  /** Split `items` into consecutive runs of the given sizes. */
+  private def regroup[A](sizes: Ls[Int], items: Ls[A]): Ls[Ls[A]] = sizes match
+    case Nil => Nil
+    case size :: rest =>
+      val (group, remaining) = items.splitAt(size)
+      group :: regroup(rest, remaining)
+
   /** Instantiate the halves of each definition, sharing one `Instantiator`
     * across them all as `instantiateGroups` does. */
-  private def instantiateHalves(groups: Ls[(Ls[SP], Ls[SP], Bool)]): (Ls[Halves], Context) =
+  private def instantiateHalves(groups: Ls[(Ls[Ls[SP]], Ls[SP], Bool)]): (Ls[Halves], Context) =
     val (instantiated, context) =
-      instantiateGroups(groups.map((steps, middles, _) => steps ::: middles))
+      instantiateGroups(groups.map((steps, middles, _) => steps.flatten ::: middles))
     val halves = instantiated.zip(groups).map: (patterns, group) =>
       val (steps, middles, catchAll) = group
-      val (stepPatterns, middlePatterns) = patterns.splitAt(steps.size)
-      Halves(steps.zip(stepPatterns), middles.zip(middlePatterns), catchAll)
+      val sizes = steps.map(_.size)
+      val (stepPatterns, middlePatterns) = patterns.splitAt(sizes.sum)
+      val stepGroups = steps.zip(regroup(sizes, stepPatterns)).map((sources, instantiated) =>
+        sources.zip(instantiated))
+      Halves(stepGroups, middles.zip(middlePatterns), catchAll)
     (halves, context)
 
   /** Can a single value match both patterns? Conservatively `true` whenever
@@ -454,37 +465,41 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     *     to be mutually exclusive, which collapses the tree back into that
     *     path.
     *
+    *     Only *distinct* alternatives branch this way. A single step written
+    *     as a disjunction, `(P1 | P2) as S | a`, receives the continuation as
+    *     a whole: it commits to the first of its alternatives that applies and
+    *     does not reconsider when the rest of the chain fails, so it stays a
+    *     chain and needs no mutual exclusion of its own. That is why the steps
+    *     arrive here grouped, and are compared group by group. Both readings
+    *     are pinned in `RecursionAlternatives.mls`.
+    *
     * When either check fails we give up rather than compile a machine and
     * retry a failed run naively: that retry would perform every rewriting
     * step a second time, which is not merely wasteful but observable, since
     * transformations may have side effects. */
   private def unmatchedIntermediates(halves: Halves)(using Context): Opt[Rejection] =
-    // The check on the steps is conservative in one direction: a *single*
-    // step written as a disjunction, `(P1 | P2) as S | a`, arrives here split
-    // into two, even though it commits to its first applicable alternative and
-    // so stays a chain. Telling the two apart would mean having `recognizeShape`
-    // mark which alternatives belong to one step; over-rejecting only costs
-    // the machine.
+    // Two disjunctions overlap exactly when two of their alternatives do, so
+    // taking them apart loses no precision and lets the diagnostics name the
+    // two patterns actually in conflict.
+    def overlapping(left: Ls[(SP, Pat)], right: Ls[(SP, Pat)]): Opt[(SP, SP)] =
+      (for
+        (leftSource, leftPattern) <- left.iterator
+        (rightSource, rightPattern) <- right.iterator
+        if mayOverlap(leftPattern, rightPattern)
+      yield (leftSource, rightSource)).nextOption()
     val overlappingSteps = halves.steps.tails.flatMap:
-      case first :: rest => rest.iterator.map((first, _))
+      case first :: rest => rest.iterator.flatMap(overlapping(first, _))
       case Nil => Iterator.empty
-    .find((one, other) => mayOverlap(one._2, other._2))
+    .nextOption()
     overlappingSteps match
-      case S(((step, _), (other, _))) => S(
+      case S((step, other)) => S(
         msg"Its recursive alternatives can rewrite the same term in more than one way: this step" -> step.toLoc ::
         msg"and this one." -> other.toLoc :: Nil)
-      case N =>
-        // Two disjunctions overlap exactly when two of their alternatives do,
-        // so pairing them up loses no precision and lets the diagnostic name
-        // the two patterns actually in conflict.
-        val overlapping = for
-          (step, stepPattern) <- halves.steps.iterator
-          (alternative, alternativePattern) <- halves.alternatives.iterator
-          if mayOverlap(stepPattern, alternativePattern)
-        yield (step, alternative)
-        overlapping.nextOption().map: (step, alternative) =>
-          msg"A term this step can still rewrite" -> step.toLoc ::
-          msg"can already be matched by this trailing alternative." -> alternative.toLoc :: Nil
+      // Every alternative of every step is checked against the trailing
+      // alternatives: a strict intermediate is one some step produced, whichever.
+      case N => overlapping(halves.steps.flatten, halves.alternatives).map: (step, alternative) =>
+        msg"A term this step can still rewrite" -> step.toLoc ::
+        msg"can already be matched by this trailing alternative." -> alternative.toLoc :: Nil
 
   /** Report a rejection: the head bit states the failure and points at the
     * pattern declaration, and the rejection's own bits point at the individual
@@ -493,7 +508,7 @@ class FixedPointCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynt
     warn(msg"This fixed-point pattern is not supported by pattern compilation." -> declaration ::
       rejection ::: (msg"Falling back to the naive translation." -> N) :: Nil*)
   
-  private def compileMachine(steps: Ls[SP], middles: Ls[SP], catchAll: Bool,
+  private def compileMachine(steps: Ls[Ls[SP]], middles: Ls[SP], catchAll: Bool,
       requireProgress: Bool, declaration: Opt[Loc]): Opt[Machine] =
     val (halves, context) = instantiateHalves((steps, middles, catchAll) :: Nil)
     val definition = halves.head

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/Pattern.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/Pattern.scala
@@ -121,9 +121,11 @@ sealed abstract class Pattern[+K <: Kind.Complete] extends AutoLocated:
     */
   def isTotal(using Context, Raise): Bool =
     def loop(pattern: Pat, visiting: Set[Instantiation]): Bool = pattern match
-      case Or(Nil) => true // The wildcard.
+      // The units need no case of their own: `Wildcard` is `And(Nil)`, which
+      // requires nothing of a value, and `Never` is `Or(Nil)`, which offers it
+      // no alternative. Spelling them out separately is how they came to be
+      // read the wrong way round when the encoding was corrected.
       case Or(patterns) => patterns.exists(loop(_, visiting))
-      case And(Nil) => false // `Never`.
       case And(patterns) => patterns.forall(loop(_, visiting))
       case Rename(pattern, _) => loop(pattern, visiting)
       // A transformation matches whatever its input pattern matches.
@@ -167,13 +169,14 @@ sealed abstract class Pattern[+K <: Kind.Complete] extends AutoLocated:
       case Synonym(instantiation) =>
         if visiting contains instantiation then S(Set.empty)
         else loop(instantiation.body, visiting + instantiation)
-      case Or(Nil) => N // The wildcard matches every value.
+      // As in `isTotal`, the units fall out of the general cases: the empty
+      // disjunction is `Never`, covered by no head at all, and the empty
+      // conjunction is `Wildcard`, which no set of heads covers.
       // A disjunction needs every disjunct's cover, since a value may match
       // through any of them.
       case Or(patterns) => patterns.foldLeft(S(Set.empty): Opt[Set[Head]]):
         (accumulated, pattern) => accumulated.flatMap: heads =>
           loop(pattern, visiting).map(heads ++ _)
-      case And(Nil) => S(Set.empty) // `Never` matches no value.
       case And(patterns) =>
         // A conjunction, on the other hand, is covered by *any one* conjunct's
         // cover. Intersecting them would be unsound: `Parent & Sub` is covered

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/Pattern.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/Pattern.scala
@@ -113,6 +113,80 @@ sealed abstract class Pattern[+K <: Kind.Complete] extends AutoLocated:
         else loop(instantiation.body, visiting + instantiation)
     loop(this, Set.empty)
   
+  /** Whether this pattern matches every value. Only the plainly total shapes
+    * are recognized — a wildcard, possibly reached through synonyms, renamings
+    * or a transformation's input — since answering `false` is always safe.
+    * The dual of `matchableHeads`: total patterns are exactly those it can say
+    * the least about.
+    */
+  def isTotal(using Context, Raise): Bool =
+    def loop(pattern: Pat, visiting: Set[Instantiation]): Bool = pattern match
+      case Or(Nil) => true // The wildcard.
+      case Or(patterns) => patterns.exists(loop(_, visiting))
+      case And(Nil) => false // `Never`.
+      case And(patterns) => patterns.forall(loop(_, visiting))
+      case Rename(pattern, _) => loop(pattern, visiting)
+      // A transformation matches whatever its input pattern matches.
+      case Extract(pattern, _, _) => loop(pattern, visiting)
+      case Synonym(instantiation) =>
+        // A pattern that is total only through a cycle matches nothing.
+        !visiting.contains(instantiation) &&
+          loop(instantiation.body, visiting + instantiation)
+      case Literal(_) | ClassLike(_, _) | MatchedClassLike(_, _) |
+        Record(_) | Tuple(_, _) | Not(_) => false
+    loop(this, Set.empty)
+
+  /** An over-approximation of the heads of the values this pattern can match:
+    * `S(heads)` means the heads *cover* the pattern — every value matching it
+    * is an instance of one of these classes, or is one of these literals —
+    * whereas `N` means we know nothing and a value of any shape may match.
+    *
+    * Note that covering is deliberately weaker than "the head is one of
+    * these": a value matching `ClassLike(Parent)` may well have a subclass of
+    * `Parent` as its head. Covering is what deciding overlap needs, because a
+    * value matching two patterns is covered by a head of each, so two
+    * pointwise-disjoint covers witness that no value matches both.
+    *
+    * Unlike `heads`, which collects the heads that are *tested* somewhere in
+    * the pattern, this must account for every way a value can match, so it is
+    * careful to answer `N` for the wildcard and for structural (record and
+    * tuple) patterns, which values of unrelated classes match.
+    *
+    * Like `preservesOriginalScrutinee`, this is context-sensitive because
+    * `Synonym` nodes must look through instantiated pattern definitions.
+    * A cycle contributes no head: matching through it would take an infinite
+    * derivation, so a value matching the pattern matches it some other way.
+    */
+  def matchableHeads(using Context, Raise): Opt[Set[Head]] =
+    def loop(pattern: Pat, visiting: Set[Instantiation]): Opt[Set[Head]] = pattern match
+      case Literal(lit) => S(Set(lit))
+      case ClassLike(sym, _) => S(Set(sym))
+      case MatchedClassLike(sym, _) => S(Set(sym))
+      case Record(_) => N
+      case Tuple(_, _) => N
+      case Synonym(instantiation) =>
+        if visiting contains instantiation then S(Set.empty)
+        else loop(instantiation.body, visiting + instantiation)
+      case Or(Nil) => N // The wildcard matches every value.
+      // A disjunction needs every disjunct's cover, since a value may match
+      // through any of them.
+      case Or(patterns) => patterns.foldLeft(S(Set.empty): Opt[Set[Head]]):
+        (accumulated, pattern) => accumulated.flatMap: heads =>
+          loop(pattern, visiting).map(heads ++ _)
+      case And(Nil) => S(Set.empty) // `Never` matches no value.
+      case And(patterns) =>
+        // A conjunction, on the other hand, is covered by *any one* conjunct's
+        // cover. Intersecting them would be unsound: `Parent & Sub` is covered
+        // by `{Parent}` and by `{Sub}`, but by neither's intersection — covers
+        // are closed downwards, and that does not commute with intersection.
+        // The smallest cover is the most precise of the sound choices.
+        patterns.iterator.flatMap(loop(_, visiting)).minByOption(_.size)
+      case Not(_) => N
+      case Rename(pattern, _) => loop(pattern, visiting)
+      // A transformation matches exactly what its input pattern matches.
+      case Extract(pattern, _, _) => loop(pattern, visiting)
+    loop(this, Set.empty)
+
   /** Apply a partial function to every node in the pattern tree. Replace each
    *  node with the result of the partial function. If the partial function is
    *  not defined at a node, the node is left unchanged.

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/SplitCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/SplitCompiler.scala
@@ -1131,14 +1131,14 @@ class SplitCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynthesiz
     // (see `FixedPointCompiler`). Fixed-point-shaped patterns the machine
     // compilation does not support fall back to the naive translation.
     FixedPointCompiler().compile(pattern) match
-      case S(FixedPointCompiler.Outcome.Compiled(machine, outputPattern, fallback)) =>
+      case S(FixedPointCompiler.Outcome.Compiled(machine, outputPattern)) =>
         // A body-annotated definition is fully machine-compiled, so mirror
         // the eager diagnostics of `compilePatternImpl` here. At a match
         // site, the shorthand sub-pattern is matched naively and warns on
         // its own, and the definition itself has no extraction parameters.
         if pattern.isInstanceOf[SP.Chain] || pattern.isInstanceOf[SP.Composition] then
           warnOnDiscardedExtractionOutputs(pattern)
-        makeFixedPointMatchSplit(scrutinee, machine, outputPattern, outputNeeded, fallback)
+        makeFixedPointMatchSplit(scrutinee, machine, outputPattern, outputNeeded)
       case S(FixedPointCompiler.Outcome.Unsupported) =>
         makeMatchSplit(scrutinee, pattern, outputNeeded)
       case N => compilePatternImpl(scrutinee, pattern, outputNeeded)
@@ -1146,17 +1146,18 @@ class SplitCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynthesiz
   /** Embed a compiled fixed-point machine at a match site: bind the machine
     * as a local function, call it on the scrutinee, and destructure the
     * resulting `MatchSuccess`. The optional `outputPattern` comes from the
-    * output-matching shorthand `x is P(Q) === x is P as Q`. When
-    * `fallbackPattern` is given (non-catch-all definitions), a failed machine
-    * run is retried with the naive backtracking translation of the original
-    * pattern, which implements the deepest-first try order on intermediate
-    * results that the machine does not keep around. */
+    * output-matching shorthand `x is P(Q) === x is P as Q`.
+    *
+    * A machine is only ever built when it fully implements the pattern (see
+    * `FixedPointCompiler.rejectsOverlappingPost`), so a failed run simply
+    * fails the match. There is deliberately no naive retry here: it would
+    * redo every rewriting step the machine already performed, which is
+    * observable whenever a transformation has side effects. */
   private def makeFixedPointMatchSplit(
       scrutinee: Scrut,
       machine: FixedPointCompiler.Machine,
       outputPattern: Opt[SP],
-      outputNeeded: Bool,
-      fallbackPattern: Opt[SP]
+      outputNeeded: Bool
   ): MakeSplit = (makeConsequent, alternative) =>
     val matcherSymbol = TempSymbol(N, "fixedPointMatcher")
     val matcherBody = Term.Blk(
@@ -1169,15 +1170,11 @@ class SplitCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynthesiz
           case N => makeConsequent(outputSymbol, SeqMap.empty)
           case S(subPattern) =>
             makeMatchSplit(outputSymbol, subPattern, outputNeeded)(makeConsequent, Split.End)
-        val onFailure = fallbackPattern match
-          case S(original) =>
-            makeMatchSplit(scrutinee, original, outputNeeded)(makeConsequent, alternative)
-          case N => alternative
         Branch(
           resultSymbol.safeRef,
           matchSuccessPattern(S(outputSymbol.symbol :: Nil)),
           consequent
-        ) ~: onFailure)
+        ) ~: alternative)
 
   private def compilePatternImpl(scrutinee: Scrut, pattern: SP, outputNeeded: Bool): MakeSplit =
   (makeConsequent, alternative) => scoped("ucs:ups:compilation"):

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/SplitCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/SplitCompiler.scala
@@ -1146,7 +1146,7 @@ class SplitCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynthesiz
     * output-matching shorthand `x is P(Q) === x is P as Q`.
     *
     * A machine is only ever built when it fully implements the pattern (see
-    * `FixedPointCompiler.rejectsOverlappingPost`), so a failed run simply
+    * `FixedPointCompiler.unmatchedIntermediates`), so a failed run simply
     * fails the match. There is deliberately no naive retry here: it would
     * redo every rewriting step the machine already performed, which is
     * observable whenever a transformation has side effects. */

--- a/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/SplitCompiler.scala
+++ b/hkmc2/shared/src/main/scala/hkmc2/semantics/ups/SplitCompiler.scala
@@ -1118,9 +1118,6 @@ class SplitCompiler(using tl: TL)(using State, Ctx, Raise) extends TermSynthesiz
         msg"String patterns are not yet supported by efficient compilation." -> pattern.toLoc
       makeStringPrefixMatchSplit(scrutinee, pattern)
   
-  def compilePattern(scrutinee: Scrut, pattern: SP): MakeSplit =
-    compilePattern(scrutinee, pattern, true)
-
   /** This method handles the efficient and non-backtracking pattern compilation.
     * Note that we still have not supported accessing pattern parameters in the
     * naive pattern declaration in the efficient pattern compilation. */

--- a/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
+++ b/hkmc2/shared/src/test/mlscript/decls/Prelude.mls
@@ -90,8 +90,8 @@ declare val Promise
 
 // MLscript-specific types
 declare class Bool
-declare class Int
 declare class Num
+declare class Int extends Num
 declare class Str
 declare class Class
 

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/FixedPointPatterns.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/FixedPointPatterns.mls
@@ -376,5 +376,5 @@ pattern EvalAnnotatedStep = @compile (Ctx(Redex) as EvalAnnotatedStep) | _
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.375: 	pattern EvalAnnotatedStep = @compile (Ctx(Redex) as EvalAnnotatedStep) | _
 //│ ║         	                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── `EvalAnnotatedStep` recurses directly rather than through a cycle, so only its whole body can be compiled.
+//│ ╟── `EvalAnnotatedStep` is recursive and must be compiled as a whole (rather than just part of it).
 //│ ╙── Falling back to the naive translation.

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/FixedPointPatterns.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/FixedPointPatterns.mls
@@ -376,4 +376,5 @@ pattern EvalAnnotatedStep = @compile (Ctx(Redex) as EvalAnnotatedStep) | _
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.375: 	pattern EvalAnnotatedStep = @compile (Ctx(Redex) as EvalAnnotatedStep) | _
 //│ ║         	                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── `EvalAnnotatedStep` recurses directly rather than through a cycle, so only its whole body can be compiled.
 //│ ╙── Falling back to the naive translation.

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/FixedPointPatterns.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/FixedPointPatterns.mls
@@ -373,7 +373,7 @@ if term3 is EvalAnnotated(r) and r is Lit(n) then n
 :w
 // Only annotating the chained pattern doesn't work.
 pattern EvalAnnotatedStep = @compile (Ctx(Redex) as EvalAnnotatedStep) | _
-//│ ╔══[WARNING] This fixed-point pattern is not supported by the machine compilation.
+//│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.375: 	pattern EvalAnnotatedStep = @compile (Ctx(Redex) as EvalAnnotatedStep) | _
 //│ ║         	                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╙── Falling back to the naive translation.

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/IndirectRecursion.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/IndirectRecursion.mls
@@ -77,10 +77,10 @@ pattern PeelB = UnTag as PeelA | _
 // The machine keeps no intermediates, so the definition is compiled naively.
 :w
 fun runPeelA(x) = if x is @compile PeelA(y) then y
-//│ ╔══[WARNING] This fixed-point pattern is not supported by the machine compilation.
+//│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.71: 	pattern PeelB = UnTag as PeelA | _
 //│ ║        	                ^^^^^^^^^^^^^^^^^^
-//│ ╟── One of its links accepts any term, while another can fail on the final one.
+//│ ╟── One of its recursive parts accepts any term, while another can fail on the final one.
 //│ ╙── Falling back to the naive translation.
 
 :expect 42
@@ -154,7 +154,7 @@ fun atLeastOneSlow(x) = if x is AtLeastOneA(r) then r else "<no match>"
 
 :w
 fun atLeastOneFast(x) = if x is @compile AtLeastOneA(r) then r else "<no match>"
-//│ ╔══[WARNING] This fixed-point pattern is not supported by the machine compilation.
+//│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.156: 	fun atLeastOneFast(x) = if x is @compile AtLeastOneA(r) then r else "<no match>"
 //│ ║         	                                         ^^^^^^^^^^^^^
 //│ ╙── Falling back to the naive translation.

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/IndirectRecursion.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/IndirectRecursion.mls
@@ -78,8 +78,8 @@ pattern PeelB = UnTag as PeelA | _
 :w
 fun runPeelA(x) = if x is @compile PeelA(y) then y
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
-//│ ║  l.70: 	pattern PeelA = UnBox as PeelB | 42
-//│ ║        	                ^^^^^^^^^^^^^^^^^^^
+//│ ║  l.79: 	fun runPeelA(x) = if x is @compile PeelA(y) then y
+//│ ║        	                                   ^^^^^^^
 //│ ╟── One of its recursive parts accepts any term:
 //│ ║  l.71: 	pattern PeelB = UnTag as PeelA | _
 //│ ║        	                ^^^^^^^^^^^^^^^^^^

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/IndirectRecursion.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/IndirectRecursion.mls
@@ -78,9 +78,14 @@ pattern PeelB = UnTag as PeelA | _
 :w
 fun runPeelA(x) = if x is @compile PeelA(y) then y
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
+//│ ║  l.70: 	pattern PeelA = UnBox as PeelB | 42
+//│ ║        	                ^^^^^^^^^^^^^^^^^^^
+//│ ╟── One of its recursive parts accepts any term:
 //│ ║  l.71: 	pattern PeelB = UnTag as PeelA | _
 //│ ║        	                ^^^^^^^^^^^^^^^^^^
-//│ ╟── One of its recursive parts accepts any term, while another can fail on the final one.
+//│ ╟── while this one can fail on the final term.
+//│ ║  l.70: 	pattern PeelA = UnBox as PeelB | 42
+//│ ║        	                ^^^^^^^^^^^^^^^^^^^
 //│ ╙── Falling back to the naive translation.
 
 :expect 42
@@ -155,7 +160,7 @@ fun atLeastOneSlow(x) = if x is AtLeastOneA(r) then r else "<no match>"
 :w
 fun atLeastOneFast(x) = if x is @compile AtLeastOneA(r) then r else "<no match>"
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
-//│ ║  l.156: 	fun atLeastOneFast(x) = if x is @compile AtLeastOneA(r) then r else "<no match>"
+//│ ║  l.161: 	fun atLeastOneFast(x) = if x is @compile AtLeastOneA(r) then r else "<no match>"
 //│ ║         	                                         ^^^^^^^^^^^^^
 //│ ╙── Falling back to the naive translation.
 

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/IndirectRecursion.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/IndirectRecursion.mls
@@ -162,6 +162,7 @@ fun atLeastOneFast(x) = if x is @compile AtLeastOneA(r) then r else "<no match>"
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.161: 	fun atLeastOneFast(x) = if x is @compile AtLeastOneA(r) then r else "<no match>"
 //│ ║         	                                         ^^^^^^^^^^^^^
+//│ ╟── `AtLeastOneA` requires its step to fire, which is not supported for indirect recursion.
 //│ ╙── Falling back to the naive translation.
 
 // The first step cannot fire, so the match fails — it must not yield `7`.

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/IndirectRecursion.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/IndirectRecursion.mls
@@ -162,7 +162,7 @@ fun atLeastOneFast(x) = if x is @compile AtLeastOneA(r) then r else "<no match>"
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.161: 	fun atLeastOneFast(x) = if x is @compile AtLeastOneA(r) then r else "<no match>"
 //│ ║         	                                         ^^^^^^^^^^^^^
-//│ ╟── `AtLeastOneA` cannot match without applying its recursive part at least once, which is not supported when definitions recurse through one another.
+//│ ╟── `AtLeastOneA` does not match unless its first pattern does, which is not supported for mutually recursive definitions.
 //│ ╙── Falling back to the naive translation.
 
 // The first step cannot fire, so the match fails — it must not yield `7`.

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/IndirectRecursion.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/IndirectRecursion.mls
@@ -80,10 +80,10 @@ fun runPeelA(x) = if x is @compile PeelA(y) then y
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.79: 	fun runPeelA(x) = if x is @compile PeelA(y) then y
 //│ ║        	                                   ^^^^^^^
-//│ ╟── One of its recursive parts accepts any term:
+//│ ╟── One of its recursive parts accepts any term
 //│ ║  l.71: 	pattern PeelB = UnTag as PeelA | _
 //│ ║        	                ^^^^^^^^^^^^^^^^^^
-//│ ╟── while this one can fail on the final term.
+//│ ╟── while another can fail.
 //│ ║  l.70: 	pattern PeelA = UnBox as PeelB | 42
 //│ ║        	                ^^^^^^^^^^^^^^^^^^^
 //│ ╙── Falling back to the naive translation.
@@ -162,7 +162,7 @@ fun atLeastOneFast(x) = if x is @compile AtLeastOneA(r) then r else "<no match>"
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.161: 	fun atLeastOneFast(x) = if x is @compile AtLeastOneA(r) then r else "<no match>"
 //│ ║         	                                         ^^^^^^^^^^^^^
-//│ ╟── `AtLeastOneA` requires its step to fire, which is not supported for indirect recursion.
+//│ ╟── `AtLeastOneA` cannot match without applying its recursive part at least once, which is not supported when definitions recurse through one another.
 //│ ╙── Falling back to the naive translation.
 
 // The first step cannot fire, so the match fails — it must not yield `7`.

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/IndirectRecursion.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/IndirectRecursion.mls
@@ -70,7 +70,18 @@ makeStepsB of tagged
 pattern PeelA = UnBox as PeelB | 42
 pattern PeelB = UnTag as PeelA | _
 
+// This cycle mixes a link whose alternatives are partial (`42`) with one whose
+// alternatives are total (`_`): the machine can fail at `PeelA` on the final
+// term while `PeelB`'s wildcard would have accepted an earlier intermediate —
+// as it does just below, where the run ends on `7` but the result is `Tag(7)`.
+// The machine keeps no intermediates, so the definition is compiled naively.
+:w
 fun runPeelA(x) = if x is @compile PeelA(y) then y
+//│ ╔══[WARNING] This fixed-point pattern is not supported by the machine compilation.
+//│ ║  l.71: 	pattern PeelB = UnTag as PeelA | _
+//│ ║        	                ^^^^^^^^^^^^^^^^^^
+//│ ╟── One of its links accepts any term, while another can fail on the final one.
+//│ ╙── Falling back to the naive translation.
 
 :expect 42
 if Box(42) is PeelA(r) then r else "<no match>"
@@ -127,3 +138,40 @@ unwrapCycle1 of Box(Tag(0))
 unwrapCycle1 of Box(Bin(0)) // Stops at `Bin`.
 //│ = Bin(0)
 
+
+
+// ————— One-or-more links —————
+//
+// `step as (Next | _)` requires its step to fire — a run with zero steps is a
+// match failure — whereas the cycle machine tracks no progress and would let
+// the failing link's alternatives process the scrutinee anyway. Such cycles
+// are therefore compiled naively.
+
+pattern AtLeastOneA = UnBox as (AtLeastOneB | _)
+pattern AtLeastOneB = UnTag as (AtLeastOneA | _)
+
+fun atLeastOneSlow(x) = if x is AtLeastOneA(r) then r else "<no match>"
+
+:w
+fun atLeastOneFast(x) = if x is @compile AtLeastOneA(r) then r else "<no match>"
+//│ ╔══[WARNING] This fixed-point pattern is not supported by the machine compilation.
+//│ ║  l.156: 	fun atLeastOneFast(x) = if x is @compile AtLeastOneA(r) then r else "<no match>"
+//│ ║         	                                         ^^^^^^^^^^^^^
+//│ ╙── Falling back to the naive translation.
+
+// The first step cannot fire, so the match fails — it must not yield `7`.
+:expect "<no match>"
+atLeastOneSlow of 7
+//│ = "<no match>"
+
+:expect "<no match>"
+atLeastOneFast of 7
+//│ = "<no match>"
+
+:expect 42
+atLeastOneSlow of Box(Tag(42))
+//│ = 42
+
+:expect 42
+atLeastOneFast of Box(Tag(42))
+//│ = 42

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/NonCatchAll.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/NonCatchAll.mls
@@ -119,12 +119,13 @@ peelFast(excessiveWrapped42)
 
 // ————— Overlapping virtual classes —————
 
-// Virtual classes do not express their subtyping through `extends`, but the
-// overlap check must still know that every `Int` is a `Num`. The step turns an
-// integer into a string, on which the trailing `Num` alternative fails; the
-// naive translation then backtracks to that alternative at the original
-// integer. A machine would forget the original and incorrectly report no
-// match, so this definition must fall back to the naive translation.
+// The Prelude declares the virtual class `Int` as extending `Num`, so the
+// overlap check must know that every `Int` is a `Num` without a built-in
+// special case. The step turns an integer into a string, on which the trailing
+// `Num` alternative fails; the naive translation then backtracks to that
+// alternative at the original integer. A machine would forget the original
+// and incorrectly report no match, so this definition must fall back to the
+// naive translation.
 
 pattern IntToStr = Int => "done"
 pattern KeepOriginalInt = IntToStr as KeepOriginalInt | Num
@@ -137,13 +138,13 @@ if 42 is KeepOriginalInt(r) then r else "<no match>"
 :expect 42
 if 42 is @compile KeepOriginalInt(r) then r else "<no match>"
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
-//│ ║  l.138: 	if 42 is @compile KeepOriginalInt(r) then r else "<no match>"
+//│ ║  l.139: 	if 42 is @compile KeepOriginalInt(r) then r else "<no match>"
 //│ ║         	                  ^^^^^^^^^^^^^^^^^
 //│ ╟── A term this pattern can still rewrite
-//│ ║  l.130: 	pattern KeepOriginalInt = IntToStr as KeepOriginalInt | Num
+//│ ║  l.131: 	pattern KeepOriginalInt = IntToStr as KeepOriginalInt | Num
 //│ ║         	                          ^^^^^^^^
 //│ ╟── can also be matched by a trailing alternative.
-//│ ║  l.130: 	pattern KeepOriginalInt = IntToStr as KeepOriginalInt | Num
+//│ ║  l.131: 	pattern KeepOriginalInt = IntToStr as KeepOriginalInt | Num
 //│ ║         	                                                        ^^^
 //│ ╙── Falling back to the naive translation.
 //│ = 42
@@ -246,13 +247,13 @@ pattern AddStep =
 :w
 pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
-//│ ║  l.247: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
+//│ ║  l.248: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ║         	                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── A term this pattern can still rewrite
-//│ ║  l.247: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
+//│ ║  l.248: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ║         	                              ^^^^^^^
 //│ ╟── can also be matched by a trailing alternative.
-//│ ║  l.247: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
+//│ ║  l.248: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ║         	                                                     ^^^^^^^^^^^^
 //│ ╙── Falling back to the naive translation.
 

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/NonCatchAll.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/NonCatchAll.mls
@@ -216,10 +216,10 @@ pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.215: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ║         	                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── A term this step can still rewrite
+//│ ╟── A term this pattern can still rewrite
 //│ ║  l.215: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ║         	                              ^^^^^^^
-//│ ╟── can already be matched by this trailing alternative.
+//│ ╟── can also be matched by a trailing alternative.
 //│ ║  l.215: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ║         	                                                     ^^^^^^^^^^^^
 //│ ╙── Falling back to the naive translation.

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/NonCatchAll.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/NonCatchAll.mls
@@ -196,13 +196,14 @@ fastEvalToValue(stuck)
 // discards intermediates, the definition falls back to the naive
 // translation. Note that each reduction is still performed exactly once.
 //
-// TODO: support this properly. The hard part is that the machine would have
-// to decide *which* intermediate matches without materializing it: plugging
-// the focus back through the context spine allocates, and allocation is
-// observable — see the `new Add(...)` lines above. Tracking how far the
-// trailing alternatives match down the spine, as a residual updated when
-// frames are pushed and popped, would let the machine remember the last
-// matching decomposition in constant space and plug it once, at the end.
+// Supporting this properly would be difficult.
+// The hard part is that the machine would have to decide *which* intermediate matches
+// without materializing it: plugging the focus back through the context spine allocates,
+// and allocation is observable — see the `new Add(...)` lines above.
+// Tracking how far the trailing alternatives match down the spine,
+// as a residual updated when frames are pushed and popped,
+// would let the machine remember the last matching decomposition in constant space and plug it once,
+// at the end.
 
 
 pattern AddStep =
@@ -212,10 +213,10 @@ pattern AddStep =
 
 :w
 pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
-//│ ╔══[WARNING] This fixed-point pattern is not supported by the machine compilation.
+//│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.214: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ║         	                                                     ^^^^^^^^^^^^
-//│ ╟── Its trailing alternatives can match a term that its step pattern can still rewrite, and the machine only ever produces normal forms.
+//│ ╟── Its trailing alternatives can match a term that its recursive part can still rewrite.
 //│ ╙── Falling back to the naive translation.
 
 

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/NonCatchAll.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/NonCatchAll.mls
@@ -5,11 +5,20 @@
 //     pattern P = Q as P | a
 //
 // reads `(Q as P) | a`. The machine normalizes the scrutinee and matches
-// `a` against the final normal form. When `a` fails there, the naive
-// backtracking semantics applies: the latest intermediate result matching
+// `a` against the final normal form. The naive semantics is subtler: when
+// `a` fails on the normal form, the latest *intermediate* result matching
 // `a` is returned instead, and the whole match fails when there is none.
-// The compiled matcher implements this by retrying the failed machine run
-// with the naive translation, so allocations on that path appear twice.
+//
+// The machine keeps no intermediates around, so it only implements such a
+// definition when no intermediate could have matched `a` in the first place.
+// It suffices that `a` and the step pattern cannot match the same value —
+// every intermediate is, by construction, a term the step pattern rewrote —
+// and that is the usual case: a step peels a wrapper that `a` rejects. When
+// they do overlap, the definition is compiled naively, with a warning: the
+// alternative would be to run the machine and retry a failed run naively,
+// which performs every rewriting step twice. (With several recursive
+// alternatives, the steps must additionally be mutually exclusive; see
+// `RecursionAlternatives.mls`.)
 
 import "../../../mlscript-compile/Option.mls"
 
@@ -155,8 +164,9 @@ fastEvalToValue(sum)
 //│ = Some(6)
 
 // The stuck term reduces to `Add(Lit(3), Tag(9))`, which is not a value,
-// and neither is any intermediate result: the match fails. The failed
-// machine run is retried naively, so its allocations show up twice.
+// and neither is any intermediate result: the match fails. A `Value` is a
+// `Lit`, which `Ctx(Redex)` can never rewrite, so the machine implements
+// the definition on its own and the reduction is performed exactly once.
 let stuck = Add(Add(Lit(1), Lit(2)), Tag(9))
 //│ > new Lit(1)
 //│ > new Lit(2)
@@ -172,18 +182,27 @@ slowEvalToValue(stuck)
 //│ = None
 
 :expect None
-// TODO: Get rid of the unnecessary computation here.
 fastEvalToValue(stuck)
-//│ > new Lit(3)
-//│ > new Add(Lit(3), Tag(9))
 //│ > new Lit(3)
 //│ > new Add(Lit(3), Tag(9))
 //│ = None
 
 
-// —— FIXME: duplicated reductions when the default is not a wildcard!! ——
-
-// TODO: either reject this pattern with a warning or support it properly.
+// —— When the default overlaps the step: compiled naively ——
+//
+// Here the trailing alternative `Add(Lit, Lit)` *is* one of `AddStep`'s
+// redexes, so an intermediate result can match it — indeed the expected
+// results below are intermediates, not normal forms. Since the machine
+// discards intermediates, the definition falls back to the naive
+// translation. Note that each reduction is still performed exactly once.
+//
+// TODO: support this properly. The hard part is that the machine would have
+// to decide *which* intermediate matches without materializing it: plugging
+// the focus back through the context spine allocates, and allocation is
+// observable — see the `new Add(...)` lines above. Tracking how far the
+// trailing alternatives match down the spine, as a residual updated when
+// frames are pushed and popped, would let the machine remember the last
+// matching decomposition in constant space and plug it once, at the end.
 
 
 pattern AddStep =
@@ -191,7 +210,13 @@ pattern AddStep =
   | Add(AddStep, _)
   | Add(Lit, AddStep)
 
+:w
 pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
+//│ ╔══[WARNING] This fixed-point pattern is not supported by the machine compilation.
+//│ ║  l.214: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
+//│ ║         	                                                     ^^^^^^^^^^^^
+//│ ╟── Its trailing alternatives can match a term that its step pattern can still rewrite, and the machine only ever produces normal forms.
+//│ ╙── Falling back to the naive translation.
 
 
 let t1 = Add(Add(Lit(2), Lit(3)), Lit(1))
@@ -202,18 +227,10 @@ let t1 = Add(Add(Lit(2), Lit(3)), Lit(1))
 //│ > new Add(Add(Lit(2), Lit(3)), Lit(1))
 //│ t1 = Add(Add(Lit(2), Lit(3)), Lit(1))
 
-// Note that reductions are performed more than once.
 assert t1 is AddSteps(s), s
 //│ > reduce 2 + 3 = 5
 //│ > new Lit(5)
 //│ > new Add(Lit(5), Lit(1))
-//│ > reduce 5 + 1 = 6
-//│ > new Lit(6)
-//│ > reduce 2 + 3 = 5
-//│ > new Lit(5)
-//│ > new Add(Lit(5), Lit(1))
-//│ > reduce 5 + 1 = 6
-//│ > new Lit(6)
 //│ > reduce 5 + 1 = 6
 //│ > new Lit(6)
 //│ = Add(Lit(5), Lit(1))
@@ -223,17 +240,7 @@ let t2 = Add(t1, Lit(4))
 //│ > new Add(Add(Add(Lit(2), Lit(3)), Lit(1)), Lit(4))
 //│ t2 = Add(Add(Add(Lit(2), Lit(3)), Lit(1)), Lit(4))
 
-// It looks like the number of times each node is repeatedly reduced is
-// proportional to its size.
 assert t2 is AddSteps(s), s
-//│ > reduce 2 + 3 = 5
-//│ > new Lit(5)
-//│ > new Add(Lit(5), Lit(1))
-//│ > reduce 5 + 1 = 6
-//│ > new Lit(6)
-//│ > new Add(Lit(6), Lit(4))
-//│ > reduce 6 + 4 = 10
-//│ > new Lit(10)
 //│ > reduce 2 + 3 = 5
 //│ > new Lit(5)
 //│ > new Add(Lit(5), Lit(1))
@@ -241,13 +248,6 @@ assert t2 is AddSteps(s), s
 //│ > reduce 5 + 1 = 6
 //│ > new Lit(6)
 //│ > new Add(Lit(6), Lit(4))
-//│ > reduce 6 + 4 = 10
-//│ > new Lit(10)
-//│ > reduce 5 + 1 = 6
-//│ > new Lit(6)
-//│ > new Add(Lit(6), Lit(4))
-//│ > reduce 6 + 4 = 10
-//│ > new Lit(10)
 //│ > reduce 6 + 4 = 10
 //│ > new Lit(10)
 //│ = Add(Lit(6), Lit(4))

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/NonCatchAll.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/NonCatchAll.mls
@@ -214,7 +214,7 @@ pattern AddStep =
 :w
 pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
-//│ ║  l.214: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
+//│ ║  l.215: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ║         	                                                     ^^^^^^^^^^^^
 //│ ╟── Its trailing alternatives can match a term that its recursive part can still rewrite.
 //│ ╙── Falling back to the naive translation.

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/NonCatchAll.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/NonCatchAll.mls
@@ -215,8 +215,13 @@ pattern AddStep =
 pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.215: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
+//│ ║         	                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── A term this step can still rewrite
+//│ ║  l.215: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
+//│ ║         	                              ^^^^^^^
+//│ ╟── can already be matched by this trailing alternative.
+//│ ║  l.215: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ║         	                                                     ^^^^^^^^^^^^
-//│ ╟── Its trailing alternatives can match a term that its recursive part can still rewrite.
 //│ ╙── Falling back to the naive translation.
 
 

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/NonCatchAll.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/NonCatchAll.mls
@@ -117,6 +117,38 @@ peelFast(excessiveWrapped42)
 //│ = Some(Tag(42))
 
 
+// ————— Overlapping virtual classes —————
+
+// Virtual classes do not express their subtyping through `extends`, but the
+// overlap check must still know that every `Int` is a `Num`. The step turns an
+// integer into a string, on which the trailing `Num` alternative fails; the
+// naive translation then backtracks to that alternative at the original
+// integer. A machine would forget the original and incorrectly report no
+// match, so this definition must fall back to the naive translation.
+
+pattern IntToStr = Int => "done"
+pattern KeepOriginalInt = IntToStr as KeepOriginalInt | Num
+
+:expect 42
+if 42 is KeepOriginalInt(r) then r else "<no match>"
+//│ = 42
+
+:w
+:expect 42
+if 42 is @compile KeepOriginalInt(r) then r else "<no match>"
+//│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
+//│ ║  l.138: 	if 42 is @compile KeepOriginalInt(r) then r else "<no match>"
+//│ ║         	                  ^^^^^^^^^^^^^^^^^
+//│ ╟── A term this pattern can still rewrite
+//│ ║  l.130: 	pattern KeepOriginalInt = IntToStr as KeepOriginalInt | Num
+//│ ║         	                          ^^^^^^^^
+//│ ╟── can also be matched by a trailing alternative.
+//│ ║  l.130: 	pattern KeepOriginalInt = IntToStr as KeepOriginalInt | Num
+//│ ║         	                                                        ^^^
+//│ ╙── Falling back to the naive translation.
+//│ = 42
+
+
 
 // ————— With an evaluation-context step pattern —————
 
@@ -214,13 +246,13 @@ pattern AddStep =
 :w
 pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
-//│ ║  l.215: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
+//│ ║  l.247: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ║         	                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╟── A term this pattern can still rewrite
-//│ ║  l.215: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
+//│ ║  l.247: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ║         	                              ^^^^^^^
 //│ ╟── can also be matched by a trailing alternative.
-//│ ║  l.215: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
+//│ ║  l.247: 	pattern AddSteps = @compile ((AddStep as AddSteps) | Add(Lit, Lit))
 //│ ║         	                                                     ^^^^^^^^^^^^
 //│ ╙── Falling back to the naive translation.
 

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/RecursionAlternatives.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/RecursionAlternatives.mls
@@ -272,3 +272,50 @@ mixedSlow of Box(5)
 :expect Tag(5)
 mixedFast of Box(5)
 //│ = Tag(5)
+
+
+// ————— Overlapping steps under a trailing wildcard —————
+//
+// Mutual exclusion is only required because the trailing alternatives are
+// tried against every intermediate. A trailing wildcard accepts the machine's
+// own normal form, so no intermediate is ever consulted and the steps may
+// overlap freely. Note the middle alternative: without one there is no post
+// pattern at all, and the wildcard's own totality never gets asked about.
+
+pattern PeelOrRewrapTotal =
+  | UnBox as PeelOrRewrapTotal
+  | Rewrap as PeelOrRewrapTotal
+  | Tag(_)
+  | _
+
+fun peelOrRewrapTotalSlow(x) = if x is PeelOrRewrapTotal(r) then r else "<no match>"
+
+fun peelOrRewrapTotalFast(x) = if x is @compile PeelOrRewrapTotal(r) then r else "<no match>"
+
+:expect 5
+peelOrRewrapTotalSlow of Box(5)
+//│ = 5
+
+:expect 5
+peelOrRewrapTotalFast of Box(5)
+//│ = 5
+
+
+// Dually, a step that matches every value overlaps every other one. This is
+// only visible if the wildcard is read as matching everything rather than
+// nothing, which is the other half of the same distinction.
+
+pattern WildStep = _ as WildStep | UnTag as WildStep | Tag(_)
+
+:w
+fun wildStep(x) = if x is @compile WildStep(r) then r else "<no match>"
+//│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
+//│ ║  l.311: 	fun wildStep(x) = if x is @compile WildStep(r) then r else "<no match>"
+//│ ║         	                                   ^^^^^^^^^^
+//│ ╟── Some recursive alternatives can rewrite the same term in more than one way, including this one
+//│ ║  l.308: 	pattern WildStep = _ as WildStep | UnTag as WildStep | Tag(_)
+//│ ║         	                   ^
+//│ ╟── and this one.
+//│ ║  l.308: 	pattern WildStep = _ as WildStep | UnTag as WildStep | Tag(_)
+//│ ║         	                                   ^^^^^
+//│ ╙── Falling back to the naive translation.

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/RecursionAlternatives.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/RecursionAlternatives.mls
@@ -178,7 +178,7 @@ fun peelOrRewrapFast(x) = if x is @compile PeelOrRewrap(r) then r else "<no matc
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.177: 	fun peelOrRewrapFast(x) = if x is @compile PeelOrRewrap(r) then r else "<no match>"
 //│ ║         	                                           ^^^^^^^^^^^^^^
-//│ ╟── Its recursive alternatives can rewrite the same term in more than one way: this step
+//│ ╟── Some recursive alternatives can rewrite the same term in more than one way, including this one
 //│ ║  l.170: 	  | UnBox as PeelOrRewrap
 //│ ║         	    ^^^^^
 //│ ╟── and this one.
@@ -257,7 +257,7 @@ fun mixedFast(x) = if x is @compile MixedSteps(r) then r else "<no match>"
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.256: 	fun mixedFast(x) = if x is @compile MixedSteps(r) then r else "<no match>"
 //│ ║         	                                    ^^^^^^^^^^^^
-//│ ╟── Its recursive alternatives can rewrite the same term in more than one way: this step
+//│ ╟── Some recursive alternatives can rewrite the same term in more than one way, including this one
 //│ ║  l.249: 	  | (UnTag | UnBox) as MixedSteps
 //│ ║         	             ^^^^^
 //│ ╟── and this one.

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/RecursionAlternatives.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/RecursionAlternatives.mls
@@ -176,12 +176,8 @@ fun peelOrRewrapSlow(x) = if x is PeelOrRewrap(r) then r else "<no match>"
 :w
 fun peelOrRewrapFast(x) = if x is @compile PeelOrRewrap(r) then r else "<no match>"
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
-//│ ║  l.170: 	  | UnBox as PeelOrRewrap
-//│ ║         	    ^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.171: 	  | Rewrap as PeelOrRewrap
-//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.172: 	  | Tag(_)
-//│ ║         	^^^^^^^^^
+//│ ║  l.177: 	fun peelOrRewrapFast(x) = if x is @compile PeelOrRewrap(r) then r else "<no match>"
+//│ ║         	                                           ^^^^^^^^^^^^^^
 //│ ╟── Its recursive alternatives can rewrite the same term in more than one way: this step
 //│ ║  l.170: 	  | UnBox as PeelOrRewrap
 //│ ║         	    ^^^^^
@@ -259,17 +255,13 @@ fun mixedSlow(x) = if x is MixedSteps(r) then r else "<no match>"
 :w
 fun mixedFast(x) = if x is @compile MixedSteps(r) then r else "<no match>"
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
-//│ ║  l.253: 	  | (UnTag | UnBox) as MixedSteps
-//│ ║         	     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.254: 	  | Rewrap as MixedSteps
-//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.255: 	  | Tag(_)
-//│ ║         	^^^^^^^^^
+//│ ║  l.256: 	fun mixedFast(x) = if x is @compile MixedSteps(r) then r else "<no match>"
+//│ ║         	                                    ^^^^^^^^^^^^
 //│ ╟── Its recursive alternatives can rewrite the same term in more than one way: this step
-//│ ║  l.253: 	  | (UnTag | UnBox) as MixedSteps
+//│ ║  l.249: 	  | (UnTag | UnBox) as MixedSteps
 //│ ║         	             ^^^^^
 //│ ╟── and this one.
-//│ ║  l.254: 	  | Rewrap as MixedSteps
+//│ ║  l.250: 	  | Rewrap as MixedSteps
 //│ ║         	    ^^^^^^
 //│ ╙── Falling back to the naive translation.
 

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/RecursionAlternatives.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/RecursionAlternatives.mls
@@ -107,6 +107,12 @@ evalSloppyFast of Add(Add(Lit(1), Lit(2)), Tag(9))
 
 // ————— Without a catch-all —————
 
+// Without a trailing wildcard the alternatives are tried against every
+// intermediate result, not just the final one, so the machine — which keeps
+// no intermediates — is only used when no intermediate could have matched.
+// Here the steps only apply to boxes and tags, which `Lit(_)` rejects, so
+// nothing is lost and the machine is used.
+
 // Peel boxes and tags; the result must be a literal.
 pattern PeelToLit =
   | UnBox as PeelToLit
@@ -145,3 +151,41 @@ peelToLitSlow(input3)
 
 peelToLitFast(input3)
 //│ = 5
+
+
+// ————— Without a catch-all, with overlapping steps —————
+//
+// `UnBox` and `Rewrap` both apply to a box, so the naive search is a tree
+// rather than a chain: when the whole `UnBox` subtree fails, `Rewrap` is
+// retried on the *same* term, and the results it leads to are candidates too.
+// The machine only ever follows the first applicable step, so it would report
+// no match where the naive translation succeeds — hence the warning and the
+// fallback. This is what keeps `@compile` from changing the meaning of a
+// match; see also the overlap between step and alternatives in
+// `NonCatchAll.mls`.
+
+pattern Rewrap = Box(x) => Tag(x)
+
+pattern PeelOrRewrap =
+  | UnBox as PeelOrRewrap
+  | Rewrap as PeelOrRewrap
+  | Tag(_)
+
+fun peelOrRewrapSlow(x) = if x is PeelOrRewrap(r) then r else "<no match>"
+
+:w
+fun peelOrRewrapFast(x) = if x is @compile PeelOrRewrap(r) then r else "<no match>"
+//│ ╔══[WARNING] This fixed-point pattern is not supported by the machine compilation.
+//│ ║  l.172: 	  | Tag(_)
+//│ ║         	    ^^^^^
+//│ ╟── Its recursive alternatives can rewrite the same term in more than one way, and the machine takes only the first.
+//│ ╙── Falling back to the naive translation.
+
+// Unboxing leads to the bare `5`, which is not a tag; re-wrapping does match.
+:expect Tag(5)
+peelOrRewrapSlow of Box(5)
+//│ = Tag(5)
+
+:expect Tag(5)
+peelOrRewrapFast of Box(5)
+//│ = Tag(5)

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/RecursionAlternatives.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/RecursionAlternatives.mls
@@ -175,10 +175,10 @@ fun peelOrRewrapSlow(x) = if x is PeelOrRewrap(r) then r else "<no match>"
 
 :w
 fun peelOrRewrapFast(x) = if x is @compile PeelOrRewrap(r) then r else "<no match>"
-//│ ╔══[WARNING] This fixed-point pattern is not supported by the machine compilation.
+//│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.172: 	  | Tag(_)
 //│ ║         	    ^^^^^
-//│ ╟── Its recursive alternatives can rewrite the same term in more than one way, and the machine takes only the first.
+//│ ╟── Its recursive alternatives can rewrite the same term in more than one way.
 //│ ╙── Falling back to the naive translation.
 
 // Unboxing leads to the bare `5`, which is not a tag; re-wrapping does match.

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/RecursionAlternatives.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/RecursionAlternatives.mls
@@ -198,3 +198,85 @@ peelOrRewrapSlow of Box(5)
 :expect Tag(5)
 peelOrRewrapFast of Box(5)
 //│ = Tag(5)
+
+
+// ————— Overlapping steps *within* one recursive alternative —————
+//
+// Writing the same two steps as one disjunction, `(P | Q) as S`, is a
+// different pattern: the chain hands its continuation to the disjunction as a
+// whole, which commits to the first of its alternatives that applies and does
+// not reconsider when the rest of the chain fails. The naive search is then a
+// chain and not a tree, so the steps need not be mutually exclusive and the
+// machine — which likewise takes the first applicable step and never looks
+// back — implements it exactly. Only *distinct* recursive alternatives branch
+// the search, which is why `unmatchedIntermediates` compares the steps group
+// by group rather than alternative by alternative.
+
+pattern PeelOrRewrapJoined = (UnBox | Rewrap) as PeelOrRewrapJoined | Tag(_)
+
+fun joinedSlow(x) = if x is PeelOrRewrapJoined(r) then r else "<no match>"
+
+fun joinedFast(x) = if x is @compile PeelOrRewrapJoined(r) then r else "<no match>"
+
+// Unboxing wins and leads to the bare `5`, which is not a tag. Unlike
+// `peelOrRewrapSlow` above, re-wrapping is *not* retried, so there is no match
+// at all — and the compiled version agrees, without falling back.
+:expect "<no match>"
+joinedSlow of Box(5)
+//│ = "<no match>"
+
+:expect "<no match>"
+joinedFast of Box(5)
+//│ = "<no match>"
+
+// A later alternative is still reached when the earlier one does not apply,
+// and the choice is remade at every iteration.
+pattern PeelJoined = (UnBox | UnTag) as PeelJoined | 42
+
+fun peelJoinedSlow(x) = if x is PeelJoined(r) then r else "<no match>"
+
+fun peelJoinedFast(x) = if x is @compile PeelJoined(r) then r else "<no match>"
+
+:expect 42
+peelJoinedSlow of Box(Tag(42))
+//│ = 42
+
+:expect 42
+peelJoinedFast of Box(Tag(42))
+//│ = 42
+
+// The grouping is what is compared: these two steps do branch the search — the
+// joined one commits to `UnBox`, and when that leads nowhere `Rewrap` is
+// retried on the same term — so the definition is still rejected.
+
+pattern MixedSteps =
+  | (UnTag | UnBox) as MixedSteps
+  | Rewrap as MixedSteps
+  | Tag(_)
+
+fun mixedSlow(x) = if x is MixedSteps(r) then r else "<no match>"
+
+:w
+fun mixedFast(x) = if x is @compile MixedSteps(r) then r else "<no match>"
+//│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
+//│ ║  l.253: 	  | (UnTag | UnBox) as MixedSteps
+//│ ║         	     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.254: 	  | Rewrap as MixedSteps
+//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.255: 	  | Tag(_)
+//│ ║         	^^^^^^^^^
+//│ ╟── Its recursive alternatives can rewrite the same term in more than one way: this step
+//│ ║  l.253: 	  | (UnTag | UnBox) as MixedSteps
+//│ ║         	             ^^^^^
+//│ ╟── and this one.
+//│ ║  l.254: 	  | Rewrap as MixedSteps
+//│ ║         	    ^^^^^^
+//│ ╙── Falling back to the naive translation.
+
+:expect Tag(5)
+mixedSlow of Box(5)
+//│ = Tag(5)
+
+:expect Tag(5)
+mixedFast of Box(5)
+//│ = Tag(5)

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/RecursionAlternatives.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/RecursionAlternatives.mls
@@ -176,9 +176,18 @@ fun peelOrRewrapSlow(x) = if x is PeelOrRewrap(r) then r else "<no match>"
 :w
 fun peelOrRewrapFast(x) = if x is @compile PeelOrRewrap(r) then r else "<no match>"
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
+//│ ║  l.170: 	  | UnBox as PeelOrRewrap
+//│ ║         	    ^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.171: 	  | Rewrap as PeelOrRewrap
+//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ║  l.172: 	  | Tag(_)
+//│ ║         	^^^^^^^^^
+//│ ╟── Its recursive alternatives can rewrite the same term in more than one way: this step
+//│ ║  l.170: 	  | UnBox as PeelOrRewrap
 //│ ║         	    ^^^^^
-//│ ╟── Its recursive alternatives can rewrite the same term in more than one way.
+//│ ╟── and this one.
+//│ ║  l.171: 	  | Rewrap as PeelOrRewrap
+//│ ║         	    ^^^^^^
 //│ ╙── Falling back to the naive translation.
 
 // Unboxing leads to the bare `5`, which is not a tag; re-wrapping does match.

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/UnsupportedShapes.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/UnsupportedShapes.mls
@@ -34,6 +34,7 @@ if Box(Lit(7)) is @compile PeelOnce(r) then r else "<no match>"
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.33: 	if Box(Lit(7)) is @compile PeelOnce(r) then r else "<no match>"
 //│ ║        	                           ^^^^^^^^^^
+//│ ╟── `Rest` is not fixed-point shaped, so the recursion does not come back.
 //│ ╙── Falling back to the naive translation.
 //│ = Lit(7)
 
@@ -56,9 +57,9 @@ if nested is SumLits(r) then r else "<no match>"
 :expect Lit(10)
 if nested is @compile SumLits(r) then r else "<no match>"
 //│ ╔══[WARNING] The recursive context must occur as exactly one direct constructor argument.
-//│ ║  l.45: 	pattern TwoHoles(pattern H) = H | Pair(TwoHoles(H), TwoHoles(H))
+//│ ║  l.46: 	pattern TwoHoles(pattern H) = H | Pair(TwoHoles(H), TwoHoles(H))
 //│ ║        	        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ║  l.46: 	pattern SumLits = TwoHoles(Pair(Lit(a), Lit(b)) => Lit(a + b)) as SumLits | _
+//│ ║  l.47: 	pattern SumLits = TwoHoles(Pair(Lit(a), Lit(b)) => Lit(a + b)) as SumLits | _
 //│ ╙──      	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ = Lit(10)
 
@@ -91,6 +92,6 @@ reduce(Pair(Lit(1), Pair(Lit(3), Lit(2))))
 :expect Pair(Lit(1), Lit(2))
 if Pair(Lit(1), Lit(2)) is @compile Reduce(r) then r else "<no match>"
 //│ ╔══[WARNING] The recursive context has no redex alternative, so no rewriting step can apply.
-//│ ║  l.80: 	pattern Reduce = NoRedex(Sum) as Reduce | _
+//│ ║  l.81: 	pattern Reduce = NoRedex(Sum) as Reduce | _
 //│ ╙──      	                 ^^^^^^^^^^^
 //│ = Pair(Lit(1), Lit(2))

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/UnsupportedShapes.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/UnsupportedShapes.mls
@@ -34,7 +34,7 @@ if Box(Lit(7)) is @compile PeelOnce(r) then r else "<no match>"
 //│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.33: 	if Box(Lit(7)) is @compile PeelOnce(r) then r else "<no match>"
 //│ ║        	                           ^^^^^^^^^^
-//│ ╟── `Rest` is not fixed-point shaped, so the recursion does not come back.
+//│ ╟── `Rest` does not recurse back, so this pattern applies once rather than repeatedly.
 //│ ╙── Falling back to the naive translation.
 //│ = Lit(7)
 

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/UnsupportedShapes.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/UnsupportedShapes.mls
@@ -220,7 +220,7 @@ fun sideGo(x) = if x is @compile SideGo(r) then r else "<no match>"
 //│ ║  l.213: 	pattern SideSum = Pair(Lit(a), Lit(b)) => Lit(a + b)
 //│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ║  l.214: 	pattern SideCtx(pattern H) = H | Pair(SideCtx(H), SideUnBox)
-//│ ╙──       	^^^^^^^^^^^^^^^
+//│ ╙──       	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 // An alternative that is not a class pattern, so there is no constructor to
@@ -255,7 +255,7 @@ fun arityGo(x) = if x is @compile ArityGo(r) then r else "<no match>"
 //│ ║  l.244: 	pattern AritySum = Pair(Lit(a), Lit(b)) => Lit(a + b)
 //│ ║         	        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ║  l.245: 	pattern ArityCtx(pattern H) = H | Pair(ArityCtx(H))
-//│ ╙──       	^^^^^^^^^^^^^^^^
+//│ ╙──       	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //│ ╔══[COMPILATION ERROR] Expected two arguments, but found only one argument.
 //│ ║  l.245: 	pattern ArityCtx(pattern H) = H | Pair(ArityCtx(H))
 //│ ╙──       	                                       ^^^^^^^^^^
@@ -283,4 +283,4 @@ pattern CrashSum = Pair(Lit(a), Lit(b)) => Lit(a + b)
 pattern CrashCtx(pattern H) = H | Pair(CrashCtx(H), CrashUnBox)
 pattern CrashGo = CrashCtx(CrashSum) as CrashGo | _
 fun crashGo(x) = if x is @compile CrashGo(r) then r else "<no match>"
-//│ /!!!\ Uncaught error: java.lang.AssertionError: assertion failed: (List(UnsupportedShapes.mls:+282, UnsupportedShapes.mls:+279),ClassLike(class:Pair,Some(SeqMap(Ident(first) -> Synonym(Instantiation(pattern:CrashCtx,List(Synonym(Instantiation(pattern:CrashSum,List()))))), Ident(second) -> Synonym(Instantiation(pattern:CrashUnBox,List()))))))
+//│ /!!!\ Uncaught error: java.lang.AssertionError: assertion failed: (List(UnsupportedShapes.mls:+282, UnsupportedShapes.mls:+279),ClassLike(hkmc2.semantics.ups.Pattern$ClassLikeHead@3a,Some(SeqMap(Ident(first) -> Synonym(Instantiation(pattern:CrashCtx,List(Synonym(Instantiation(pattern:CrashSum,List()))))), Ident(second) -> Synonym(Instantiation(pattern:CrashUnBox,List()))))))

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/UnsupportedShapes.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/UnsupportedShapes.mls
@@ -95,3 +95,192 @@ if Pair(Lit(1), Lit(2)) is @compile Reduce(r) then r else "<no match>"
 //│ ║  l.81: 	pattern Reduce = NoRedex(Sum) as Reduce | _
 //│ ╙──      	                 ^^^^^^^^^^^
 //│ = Pair(Lit(1), Lit(2))
+
+
+// ————— Shapes turned down before any machine is built —————
+//
+// The recognition steps reject these outright, each with its own reason,
+// reported at the `@compile` that asked for a machine. Collected here so that
+// every such message has a test.
+
+
+// With nothing but recursive alternatives there is no way to finish a match:
+// `OnlyRecursive` matches nothing at all.
+pattern OnlyRecursive = UnBox as OnlyRecursive
+
+:expect "<no match>"
+if Box(Box(7)) is OnlyRecursive(r) then r else "<no match>"
+//│ = "<no match>"
+
+:w
+:expect "<no match>"
+if Box(Box(7)) is @compile OnlyRecursive(r) then r else "<no match>"
+//│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
+//│ ║  l.117: 	if Box(Box(7)) is @compile OnlyRecursive(r) then r else "<no match>"
+//│ ║         	                           ^^^^^^^^^^^^^^^
+//│ ╟── It has only recursive alternatives, so a match can never finish.
+//│ ╙── Falling back to the naive translation.
+//│ = "<no match>"
+
+
+// A wildcard before the end hides every alternative after it.
+pattern EarlyWildcard = UnBox as EarlyWildcard | _ | Lit(_)
+
+:w
+:expect 7
+if Box(7) is @compile EarlyWildcard(r) then r else "<no match>"
+//│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
+//│ ║  l.131: 	if Box(7) is @compile EarlyWildcard(r) then r else "<no match>"
+//│ ║         	                      ^^^^^^^^^^^^^^^
+//│ ╟── A wildcard alternative makes the alternatives after it unreachable.
+//│ ╙── Falling back to the naive translation.
+//│ = 7
+
+
+// The recursive alternatives have to lead; here one trails `Rest`.
+pattern LateRecursion = UnBox as LateRecursion | UnTag as Rest | _
+
+:w
+:expect 7
+if Box(7) is @compile LateRecursion(r) then r else "<no match>"
+//│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
+//│ ║  l.145: 	if Box(7) is @compile LateRecursion(r) then r else "<no match>"
+//│ ║         	                      ^^^^^^^^^^^^^^^
+//│ ╟── Its recursive alternatives must come before its other alternatives.
+//│ ╙── Falling back to the naive translation.
+//│ = 7
+
+
+// The recursion reaches a definition that takes parameters.
+pattern Extracting(first, second) = Pair(first, second)
+pattern ToExtracting = UnBox as Extracting | _
+
+:w
+:expect Box(7)
+if Box(7) is @compile ToExtracting(r) then r else "<no match>"
+//│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
+//│ ║  l.160: 	if Box(7) is @compile ToExtracting(r) then r else "<no match>"
+//│ ║         	                      ^^^^^^^^^^^^^^
+//│ ╟── The recursion goes through `Extracting`, which is not a parameterless pattern definition.
+//│ ╙── Falling back to the naive translation.
+//│ = Box(7)
+
+
+// The recursion wanders into a cycle that leaves out where it started.
+pattern WanderA = UnBox as WanderB | _
+pattern WanderB = UnTag as WanderC | _
+pattern WanderC = UnBox as WanderB | _
+
+:w
+:expect 7
+if Box(7) is @compile WanderA(r) then r else "<no match>"
+//│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
+//│ ║  l.176: 	if Box(7) is @compile WanderA(r) then r else "<no match>"
+//│ ║         	                      ^^^^^^^^^
+//│ ╟── The recursion goes through `WanderC` but never comes back to `WanderA`.
+//│ ╙── Falling back to the naive translation.
+//│ = 7
+
+
+// `@compile` on a single alternative of a definition that takes part in a
+// cycle: it has to cover the whole body.
+:w
+pattern PartOfCycleA = @compile (UnBox as PartOfCycleB) | _
+pattern PartOfCycleB = UnTag as PartOfCycleA | _
+//│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
+//│ ║  l.188: 	pattern PartOfCycleA = @compile (UnBox as PartOfCycleB) | _
+//│ ║         	                                 ^^^^^^^^^^^^^^^^^^^^^
+//│ ╟── `@compile` has to be placed on the whole body of a definition taking part in the recursion through `PartOfCycleB`.
+//│ ╙── Falling back to the naive translation.
+
+:expect 7
+if Box(Tag(7)) is PartOfCycleA(r) then r else "<no match>"
+//│ = 7
+
+
+// ————— Shapes the recursive context cannot have —————
+//
+// These are decided on the *instantiated* pattern, so their locations are
+// assembled from every definition it was built from. A location has to sit in
+// a single origin and each block is its own, so the definitions a context is
+// built from must share a block for these to be reported at all — see the
+// crash pinned at the end.
+
+
+// A side pattern that transforms its argument instead of only testing it.
+:w
+pattern SideUnBox = Box(x) => x
+pattern SideSum = Pair(Lit(a), Lit(b)) => Lit(a + b)
+pattern SideCtx(pattern H) = H | Pair(SideCtx(H), SideUnBox)
+pattern SideGo = SideCtx(SideSum) as SideGo | _
+fun sideGo(x) = if x is @compile SideGo(r) then r else "<no match>"
+//│ ╔══[WARNING] Side patterns of a context alternative must be transform-free.
+//│ ║  l.212: 	pattern SideUnBox = Box(x) => x
+//│ ║         	        ^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.213: 	pattern SideSum = Pair(Lit(a), Lit(b)) => Lit(a + b)
+//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.214: 	pattern SideCtx(pattern H) = H | Pair(SideCtx(H), SideUnBox)
+//│ ╙──       	^^^^^^^^^^^^^^^
+
+
+// An alternative that is not a class pattern, so there is no constructor to
+// descend through and put back together.
+:w
+pattern TupleSum = Pair(Lit(a), Lit(b)) => Lit(a + b)
+pattern TupleCtx(pattern H) = H | [TupleCtx(H), _]
+pattern TupleGo = TupleCtx(TupleSum) as TupleGo | _
+fun tupleGo(x) = if x is @compile TupleGo(r) then r else "<no match>"
+//│ ╔══[WARNING] This alternative is not supported by fixed-point pattern compilation.
+//│ ║  l.229: 	pattern TupleSum = Pair(Lit(a), Lit(b)) => Lit(a + b)
+//│ ║         	        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.230: 	pattern TupleCtx(pattern H) = H | [TupleCtx(H), _]
+//│ ╙──       	^^^^^^^^^^^^^^^^
+
+
+// Not every argument of the constructor is given, so the value could not be
+// put back together after a rewriting.
+:e
+:w
+pattern AritySum = Pair(Lit(a), Lit(b)) => Lit(a + b)
+pattern ArityCtx(pattern H) = H | Pair(ArityCtx(H))
+pattern ArityGo = ArityCtx(AritySum) as ArityGo | _
+fun arityGo(x) = if x is @compile ArityGo(r) then r else "<no match>"
+//│ ╔══[COMPILATION ERROR] Class `Pair` has 2 parameters.
+//│ ║  l.13: 	data class Pair(val first, val second)
+//│ ║        	                    ^^^^^^^^^^^^^^^^^
+//│ ╟── But 1 arguments were provided.
+//│ ║  l.245: 	pattern ArityCtx(pattern H) = H | Pair(ArityCtx(H))
+//│ ╙──       	                                       ^^^^^^^^^^
+//│ ╔══[WARNING] Cannot rebuild `Pair` because not all of its parameters are accessible.
+//│ ║  l.244: 	pattern AritySum = Pair(Lit(a), Lit(b)) => Lit(a + b)
+//│ ║         	        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//│ ║  l.245: 	pattern ArityCtx(pattern H) = H | Pair(ArityCtx(H))
+//│ ╙──       	^^^^^^^^^^^^^^^^
+//│ ╔══[COMPILATION ERROR] Expected two arguments, but found only one argument.
+//│ ║  l.245: 	pattern ArityCtx(pattern H) = H | Pair(ArityCtx(H))
+//│ ╙──       	                                       ^^^^^^^^^^
+
+
+// A rewriting alternative placed after one that descends.
+:w
+pattern OrderSum = Pair(Lit(a), Lit(b)) => Lit(a + b)
+pattern OrderCtx(pattern H) = H | Pair(OrderCtx(H), _) | Lit(_)
+pattern OrderGo = OrderCtx(OrderSum) as OrderGo | _
+fun orderGo(x) = if x is @compile OrderGo(r) then r else "<no match>"
+//│ ╔══[WARNING] Redex alternatives must precede all recursive context alternatives.
+//│ ║  l.268: 	pattern OrderGo = OrderCtx(OrderSum) as OrderGo | _
+//│ ╙──       	                  ^^^^^^^^^^^^^^^^^
+
+
+// Splitting those same definitions across blocks crashes while building the
+// location of the message: an instantiated pattern's location is assembled
+// from nodes belonging to different origins, which `AutoLocated` forbids.
+// Nothing about the definition itself is wrong.
+pattern CrashUnBox = Box(x) => x
+
+:fixme
+pattern CrashSum = Pair(Lit(a), Lit(b)) => Lit(a + b)
+pattern CrashCtx(pattern H) = H | Pair(CrashCtx(H), CrashUnBox)
+pattern CrashGo = CrashCtx(CrashSum) as CrashGo | _
+fun crashGo(x) = if x is @compile CrashGo(r) then r else "<no match>"
+//│ /!!!\ Uncaught error: java.lang.AssertionError: assertion failed: (List(UnsupportedShapes.mls:+282, UnsupportedShapes.mls:+279),ClassLike(class:Pair,Some(SeqMap(Ident(first) -> Synonym(Instantiation(pattern:CrashCtx,List(Synonym(Instantiation(pattern:CrashSum,List()))))), Ident(second) -> Synonym(Instantiation(pattern:CrashUnBox,List()))))))

--- a/hkmc2/shared/src/test/mlscript/ups/fixpoint/UnsupportedShapes.mls
+++ b/hkmc2/shared/src/test/mlscript/ups/fixpoint/UnsupportedShapes.mls
@@ -31,7 +31,7 @@ if Box(Lit(7)) is PeelOnce(r) then r else "<no match>"
 :w
 :expect Lit(7)
 if Box(Lit(7)) is @compile PeelOnce(r) then r else "<no match>"
-//│ ╔══[WARNING] This fixed-point pattern is not supported by the machine compilation.
+//│ ╔══[WARNING] This fixed-point pattern is not supported by pattern compilation.
 //│ ║  l.33: 	if Box(Lit(7)) is @compile PeelOnce(r) then r else "<no match>"
 //│ ║        	                           ^^^^^^^^^^
 //│ ╙── Falling back to the naive translation.


### PR DESCRIPTION
PR created by Claude Opus 2.8 under my directions.

---

A fixed-point definition without a trailing wildcard, `pattern S = P as S | a`, does not mean "normalize, then match `a`": since `|` is left-biased with backtracking and `Chain` hands the same alternative to both of its halves, `a` is tried against every intermediate result, latest first. The machine only ever produces the normal form, so `makeFixedPointMatchSplit` used to recover the missing candidates by re-running the whole pattern naively on a failed run.

That duplicated every rewriting step, which is observable as soon as a transformation has side effects, along three routes:

  - machine-then-naive, doubling the work of every failing run;
  - for a body-annotated definition, whose own `unapply` embeds machine plus fallback, the fallback's self-reference re-entered that `unapply`, giving a quadratic number of contractions;
  - a machine run that succeeded only to have the match-site output sub-pattern fail, since the `Split.End` consequent was filled with the fallback.

Instead, only ever compile a machine that is a complete implementation of the pattern, so a failed run simply fails the match. `unmatchedIntermediates` decides this before any machine is built, from two conditions: the step pattern and the trailing alternatives cannot match the same value — every strict intermediate is in the step's domain, so nothing else could have matched — and, with several recursive alternatives, the steps are mutually exclusive, without which the naive search is a tree whose other leaves the machine never visits. Definitions failing either check are rejected with a warning and compiled naively, which is the option the FIXME in NonCatchAll.mls asked for; supporting them properly needs the machine to identify the matching intermediate without materializing it, since plugging the focus back through the context spine allocates.

The decision rests on a new `Pattern.matchableHeads`, an over-approximation of the heads covering a pattern, fed to the UCS normalizer's own disjointness knowledge. Note that a cover is not intersected across a conjunction: covers are closed downwards, and that does not commute with intersection.

Two further bugs surfaced on the way, both of which could silently change the meaning of a match:

  - `areProvablyDisjoint` reported two occurrences of the same class as provably disjoint, because `isSubclassOf` is strict;
  - `recognizeCycle` discarded `requireProgress`, so a cycle link written `s as (Next | _)` was compiled as zero-or-more and accepted a scrutinee on which its very first step could not fire.